### PR TITLE
docs: add AWS Documentation MCP Server details to README and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ A server for managing and coordinating other AWS Labs MCP servers.
 
 [Learn more](src/core-mcp-server/README.md) | [Documentation](https://awslabs.github.io/mcp/servers/core-mcp-server/)
 
+### AWS Documentation MCP Server
+
+[![PyPI version](https://img.shields.io/pypi/v/awslabs.aws-documentation-mcp-server.svg)](https://pypi.org/project/awslabs.aws-documentation-mcp-server/)
+
+A server for accessing AWS documentation and best practices.
+
+- Search Documentation using the official AWS search API
+- Get content recommendations for AWS documentation pages
+- Convert documentation to markdown format
+
+[Learn more](src/aws-documentation-mcp-server/README.md) | [Documentation](https://awslabs.github.io/mcp/servers/aws-documentation-mcp-server/)
+
+
 ### Amazon Bedrock Knowledge Bases Retrieval MCP Server
 
 [![PyPI version](https://img.shields.io/pypi/v/awslabs.bedrock-kb-retrieval-mcp-server.svg)](https://pypi.org/project/awslabs.bedrock-kb-retrieval-mcp-server/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,18 @@ The Core MCP Server manages and coordinates other MCP servers in your environmen
 
 [Learn more about the Core MCP Server](servers/core-mcp-server.md)
 
+### AWS Documentation MCP Server
+
+The AWS Documentation MCP Server provides access to AWS documentation and best practices.
+
+**Features:**
+
+- Search Documentation using the official AWS search API
+- Get content recommendations for AWS documentation pages
+- Convert documentation to markdown format
+
+[Learn more about the AWS Documentation MCP Server](servers/aws-documentation-mcp-server.md)
+
 ### AWS CDK MCP Server
 
 The CDK MCP Server provides AWS Cloud Development Kit (CDK) best practices, infrastructure as code patterns, and security compliance with CDK Nag.

--- a/docs/servers/aws-documentation-mcp-server.md
+++ b/docs/servers/aws-documentation-mcp-server.md
@@ -1,0 +1,5 @@
+---
+title: AWS Documentation MCP Server
+---
+
+{%include "../../src/aws-documentation-mcp-server/README.md"%}


### PR DESCRIPTION
- Introduced a new section in README.md for the AWS Documentation MCP Server, highlighting its features and providing links to further documentation.
- Updated index.md to include an overview of the AWS Documentation MCP Server and its capabilities.
- Created a new documentation file for the AWS Documentation MCP Server, linking to its README for detailed information.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
