### PR TITLE
fix: add bandit exclusions for python cookiecutter

### DIFF
--- a/python/{{cookiecutter.project_domain | lower | replace(' ', '-') | replace('_', '-')}}-mcp-server/pyproject.toml
+++ b/python/{{cookiecutter.project_domain | lower | replace(' ', '-') | replace('_', '-')}}-mcp-server/pyproject.toml
@@ -77,3 +77,6 @@ update_changelog_on_bump = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["awslabs"]
+
+[tool.bandit]
+exclude_dirs = ["venv", "tests"]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add bandit exclusions in the pyproject.toml file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
