### PR TITLE
feat: add ruff pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,10 @@ repos:
     -   id: forbid-submodules
     -   id: pretty-format-json
     -   id: trailing-whitespace
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.4
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -16,31 +16,29 @@
 #     "tomlkit>=0.13.2"
 # ]
 # ///
+import click
 import datetime
 import json
 import logging
 import re
 import subprocess
 import sys
+import tomlkit
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, NewType, Protocol
 
-import click
-import tomlkit
 
 # Configure logging to stderr
-logging.basicConfig(
-    level=logging.DEBUG, format="%(levelname)s: %(message)s", stream=sys.stderr
-)
+logging.basicConfig(level=logging.DEBUG, format='%(levelname)s: %(message)s', stream=sys.stderr)
 
-Version = NewType("Version", str)
-Patch = NewType("Patch", str)
-GitHash = NewType("GitHash", str)
+Version = NewType('Version', str)
+Patch = NewType('Patch', str)
+GitHash = NewType('GitHash', str)
 
 
 class GitHashParamType(click.ParamType):
-    name = "git_hash"
+    name = 'git_hash'
 
     def convert(
         self, value: Any, param: click.Parameter | None, ctx: click.Context | None
@@ -49,18 +47,18 @@ class GitHashParamType(click.ParamType):
             return None
 
         if not (8 <= len(value) <= 40):
-            self.fail(f"Git hash must be between 8 and 40 characters, got {len(value)}")
+            self.fail(f'Git hash must be between 8 and 40 characters, got {len(value)}')
 
-        if not re.match(r"^[0-9a-fA-F]+$", value):
-            self.fail("Git hash must contain only hex digits (0-9, a-f)")
+        if not re.match(r'^[0-9a-fA-F]+$', value):
+            self.fail('Git hash must contain only hex digits (0-9, a-f)')
 
         try:
             # Verify hash exists in repo
             subprocess.run(
-                ["git", "rev-parse", "--verify", value], check=True, capture_output=True
+                ['git', 'rev-parse', '--verify', value], check=True, capture_output=True
             )
         except subprocess.CalledProcessError:
-            self.fail(f"Git hash {value} not found in repository")
+            self.fail(f'Git hash {value} not found in repository')
 
         return GitHash(value.lower())
 
@@ -71,14 +69,11 @@ GIT_HASH = GitHashParamType()
 class Package(Protocol):
     path: Path
 
-    def package_name(self) -> str:
-        ...
+    def package_name(self) -> str: ...
 
-    def package_version(self) -> str:
-        ...
+    def package_version(self) -> str: ...
 
-    def update_version(self, patch: Patch) -> str:
-        ...
+    def update_version(self, patch: Patch) -> str: ...
 
 
 @dataclass
@@ -86,19 +81,19 @@ class NpmPackage:
     path: Path
 
     def package_name(self) -> str:
-        with open(self.path / "package.json", "r", encoding="utf-8") as f:
-            return json.load(f)["name"]
+        with open(self.path / 'package.json', 'r', encoding='utf-8') as f:
+            return json.load(f)['name']
 
     def package_version(self) -> str:
-        with open(self.path / "package.json", "r", encoding="utf-8") as f:
-            return json.load(f)["version"]
+        with open(self.path / 'package.json', 'r', encoding='utf-8') as f:
+            return json.load(f)['version']
 
     def update_version(self, patch: Patch) -> str:
-        with open(self.path / "package.json", "r+", encoding="utf-8") as f:
+        with open(self.path / 'package.json', 'r+', encoding='utf-8') as f:
             data = json.load(f)
-            major, minor, _ = data["version"].split(".")
-            version = ".".join([major, minor, patch])
-            data["version"] = version
+            major, minor, _ = data['version'].split('.')
+            version = '.'.join([major, minor, patch])
+            data['version'] = version
             f.seek(0)
             json.dump(data, f, indent=2)
             f.truncate()
@@ -110,39 +105,39 @@ class PyPiPackage:
     path: Path
 
     def package_name(self) -> str:
-        with open(self.path / "pyproject.toml", encoding="utf-8") as f:
+        with open(self.path / 'pyproject.toml', encoding='utf-8') as f:
             toml_data = tomlkit.parse(f.read())
-            name = toml_data.get("project", {}).get("name")
+            name = toml_data.get('project', {}).get('name')
             if not name:
-                raise Exception("No name in pyproject.toml project section")
+                raise Exception('No name in pyproject.toml project section')
             return str(name)
 
     def package_version(self) -> str:
-        with open(self.path / "pyproject.toml", encoding="utf-8") as f:
+        with open(self.path / 'pyproject.toml', encoding='utf-8') as f:
             toml_data = tomlkit.parse(f.read())
-            version = toml_data.get("project", {}).get("version")
+            version = toml_data.get('project', {}).get('version')
             if not version:
-                raise Exception("No version in pyproject.toml project section")
+                raise Exception('No version in pyproject.toml project section')
             return str(version)
 
     def update_version(self, patch: Patch) -> str:
         # Update version in pyproject.toml
-        with open(self.path / "pyproject.toml", encoding="utf-8") as f:
+        with open(self.path / 'pyproject.toml', encoding='utf-8') as f:
             data = tomlkit.parse(f.read())
             # Access the version safely from tomlkit document
-            project_table = data.get("project")
+            project_table = data.get('project')
             if project_table is None:
-                raise Exception("No project section in pyproject.toml")
+                raise Exception('No project section in pyproject.toml')
 
-            version_str = str(project_table.get("version", ""))
-            major, minor, _ = version_str.split(".")
-            logging.debug(f"Major version: {major}")
-            version = ".".join([major, minor, patch])
+            version_str = str(project_table.get('version', ''))
+            major, minor, _ = version_str.split('.')
+            logging.debug(f'Major version: {major}')
+            version = '.'.join([major, minor, patch])
 
             # Update the version safely
-            project_table["version"] = version
+            project_table['version'] = version
 
-        with open(self.path / "pyproject.toml", "w", encoding="utf-8") as f:
+        with open(self.path / 'pyproject.toml', 'w', encoding='utf-8') as f:
             f.write(tomlkit.dumps(data))
         return version
 
@@ -150,11 +145,11 @@ class PyPiPackage:
 def has_changes(path: Path, git_hash: GitHash) -> bool:
     """Check if any files changed between current state and git hash"""
     try:
-        logging.debug(f"Checking changes in {path} since {git_hash}")
+        logging.debug(f'Checking changes in {path} since {git_hash}')
 
         # Get the repository root directory
         repo_root = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ['git', 'rev-parse', '--show-toplevel'],
             check=True,
             capture_output=True,
             text=True,
@@ -166,84 +161,78 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
 
             # Run git diff from repo root, but filter by package path
             output = subprocess.run(
-                ["git", "diff", "--name-only", git_hash, "--", str(rel_path)],
+                ['git', 'diff', '--name-only', git_hash, '--', str(rel_path)],
                 cwd=repo_root,  # Run from repo root
                 check=True,
                 capture_output=True,
                 text=True,
             )
 
-            logging.debug(f"Git command: git diff --name-only {git_hash} -- {rel_path}")
-            logging.debug(f"Working directory: {repo_root}")
+            logging.debug(f'Git command: git diff --name-only {git_hash} -- {rel_path}')
+            logging.debug(f'Working directory: {repo_root}')
 
             changed_files = [Path(f) for f in output.stdout.splitlines()]
-            logging.debug(f"Changed files: {changed_files}")
+            logging.debug(f'Changed files: {changed_files}')
 
             relevant_files = [
-                f
-                for f in changed_files
-                if f.suffix in [".py", ".ts", ".toml", ".lock", ".json"]
+                f for f in changed_files if f.suffix in ['.py', '.ts', '.toml', '.lock', '.json']
             ]
-            logging.debug(f"Relevant files: {relevant_files}")
+            logging.debug(f'Relevant files: {relevant_files}')
 
             return len(relevant_files) >= 1
         except ValueError:
             # Handle case where path is not relative to repo_root
-            logging.debug(f"Path error: {path} is not inside repo root {repo_root}")
-            logging.debug("Using absolute path as fallback")
+            logging.debug(f'Path error: {path} is not inside repo root {repo_root}')
+            logging.debug('Using absolute path as fallback')
 
             # Use absolute path as fallback
             output = subprocess.run(
-                ["git", "diff", "--name-only", git_hash],
+                ['git', 'diff', '--name-only', git_hash],
                 check=True,
                 capture_output=True,
                 text=True,
             )
 
             # Filter to only include files under the specified path
-            path_str = str(path).rstrip("/") + "/"
-            changed_files = [
-                Path(f) for f in output.stdout.splitlines() if f.startswith(path_str)
-            ]
+            path_str = str(path).rstrip('/') + '/'
+            changed_files = [Path(f) for f in output.stdout.splitlines() if f.startswith(path_str)]
 
             relevant_files = [
-                f
-                for f in changed_files
-                if f.suffix in [".py", ".ts", ".toml", ".lock", ".json"]
+                f for f in changed_files if f.suffix in ['.py', '.ts', '.toml', '.lock', '.json']
             ]
             return len(relevant_files) >= 1
     except subprocess.CalledProcessError as e:
-        logging.error(f"Error executing git command: {e}")
+        logging.error(f'Error executing git command: {e}')
         return False
 
 
 def gen_version() -> Version:
     """Generate release version based on current time"""
     now = datetime.datetime.now(datetime.UTC)
-    return Version(f"{now.year}.{now.month}.{gen_patch()}")
+    return Version(f'{now.year}.{now.month}.{gen_patch()}')
 
 
 def gen_patch() -> Patch:
     """Generate version based on current UTC timestamp"""
     now = datetime.datetime.now(datetime.UTC)
     # return Patch(f"{int(now.timestamp())}")
-    return Patch(f"{now.day:02d}{now.hour:02d}{now.minute:02d}")
+    return Patch(f'{now.day:02d}{now.hour:02d}{now.minute:02d}')
 
 
 def find_changed_packages(directory: Path, git_hash: GitHash) -> Iterator[Package]:
     # Debug info
-    logging.debug(f"Searching for changed packages in {directory} since {git_hash}")
+    logging.debug(f'Searching for changed packages in {directory} since {git_hash}')
 
     # List all PyPI packages
-    for path in directory.glob("*/pyproject.toml"):
-        logging.debug(f"Found PyPI package at {path.parent}")
+    for path in directory.glob('*/pyproject.toml'):
+        logging.debug(f'Found PyPI package at {path.parent}')
         # Check if it has relevant changes
         if has_changes(path.parent, git_hash):
             yield PyPiPackage(path.parent)
 
     # List all NPM packages
-    for path in directory.glob("*/package.json"):
-        logging.debug(f"Found NPM package at {path.parent}")
+    for path in directory.glob('*/package.json'):
+        logging.debug(f'Found NPM package at {path.parent}')
         # Check if it has relevant changes
         if has_changes(path.parent, git_hash):
             yield NpmPackage(path.parent)
@@ -254,11 +243,9 @@ def cli():
     pass
 
 
-@cli.command("update-packages")
-@click.option(
-    "--directory", type=click.Path(exists=True, path_type=Path), default=Path.cwd()
-)
-@click.argument("git_hash", type=GIT_HASH)
+@cli.command('update-packages')
+@click.option('--directory', type=click.Path(exists=True, path_type=Path), default=Path.cwd())
+@click.argument('git_hash', type=GIT_HASH)
 def update_packages(directory: Path, git_hash: GitHash) -> int:
     # Detect package type
     path = directory.resolve(strict=True)
@@ -268,47 +255,43 @@ def update_packages(directory: Path, git_hash: GitHash) -> int:
         name = package.package_name()
         version = package.update_version(patch)
 
-        click.echo(f"{name}@{version}")
+        click.echo(f'{name}@{version}')
 
     return 0
 
 
-@cli.command("generate-notes")
-@click.option(
-    "--directory", type=click.Path(exists=True, path_type=Path), default=Path.cwd()
-)
-@click.argument("git_hash", type=GIT_HASH)
+@cli.command('generate-notes')
+@click.option('--directory', type=click.Path(exists=True, path_type=Path), default=Path.cwd())
+@click.argument('git_hash', type=GIT_HASH)
 def generate_notes(directory: Path, git_hash: GitHash) -> int:
     # Detect package type
     path = directory.resolve(strict=True)
     release = gen_version()
 
-    click.echo(f"# Release: {release}")
-    click.echo("")
-    click.echo("## Updated packages")
+    click.echo(f'# Release: {release}')
+    click.echo('')
+    click.echo('## Updated packages')
     for package in find_changed_packages(path, git_hash):
         name = package.package_name()
         version = package.package_version()
-        click.echo(f"- {name}@{version}")
-    click.echo("")
+        click.echo(f'- {name}@{version}')
+    click.echo('')
 
     return 0
 
 
-@cli.command("generate-version")
+@cli.command('generate-version')
 def generate_version() -> int:
     # Detect package type
     click.echo(gen_version())
     return 0
 
 
-@cli.command("generate-matrix")
-@click.option(
-    "--directory", type=click.Path(exists=True, path_type=Path), default=Path.cwd()
-)
-@click.option("--npm", is_flag=True, default=False)
-@click.option("--pypi", is_flag=True, default=False)
-@click.argument("git_hash", type=GIT_HASH)
+@cli.command('generate-matrix')
+@click.option('--directory', type=click.Path(exists=True, path_type=Path), default=Path.cwd())
+@click.option('--npm', is_flag=True, default=False)
+@click.option('--pypi', is_flag=True, default=False)
+@click.argument('git_hash', type=GIT_HASH)
 def generate_matrix(directory: Path, git_hash: GitHash, pypi: bool, npm: bool) -> int:
     # Detect package type
     path = directory.resolve(strict=True)
@@ -325,5 +308,5 @@ def generate_matrix(directory: Path, git_hash: GitHash, pypi: bool, npm: bool) -
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(cli())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**
N/A

## Summary
Add `ruff` to the pre-commit checks.

### Changes

> Please provide a summary of what's being changed

The https://github.com/astral-sh/ruff-pre-commit have been added and fixes to files with their associated changes have been applied.

### User experience

> Please share what the user experience looks like before and after this change

Users will be able to have pre-commit checks run for the `ruff` and `ruff-format` hooks.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change? No</summary>

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
