### PR TITLE
Fix cost analysis server integration with Q CLI

### DIFF
--- a/src/core-mcp-server/awslabs/core_mcp_server/static/PROMPT_UNDERSTANDING.md
+++ b/src/core-mcp-server/awslabs/core_mcp_server/static/PROMPT_UNDERSTANDING.md
@@ -33,7 +33,7 @@ When a user presents a query, follow these steps to break it down:
 -Use `awslabs.cost-analasys-mcp-server`  for analyzing AWS service costs
   - get_pricing_from_web: Get pricing information from AWS pricing webpage
   - get_pricing_from_api: Get pricing information from AWS Price List API
-  - generate_cost_analysis_report: Generate a detailed cost analysis report based on pricing data
+  - generate_cost_report: Generate a detailed cost analysis report based on pricing data
 
 -Use `awslabs.aws-documentation-mcp-server` for requesting specific AWS documentation
     - Use `search_documentation` when: You need to find documentation about a specific AWS service or feature

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/report_generator.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/report_generator.py
@@ -1067,7 +1067,7 @@ async def _generate_csv_report(
     return csv_content
 
 
-async def generate_cost_analysis_report(
+async def generate_cost_report(
     pricing_data: Dict[str, Any],  # Required: Raw pricing data from AWS
     service_name: str,  # Required: Primary service name
     # Core parameters (simple, commonly used)

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -44,12 +44,12 @@ mcp = FastMCP(
        - If web scraping fails, MUST use get_pricing_from_api() to fetch data via AWS Pricing API
 
     3. For Bedrock Services:
-       - When analyzing Amazon Bedrock services, MUST also use get_bedrock_architecture_patterns()
+       - When analyzing Amazon Bedrock services, MUST also use get_bedrock_patterns()
        - This provides critical architecture patterns, component relationships, and cost considerations
        - Especially important for Knowledge Base, Agent, Guardrails, and Data Automation services
 
     4. Report Generation:
-       - MUST generate cost analysis report using retrieved data via generate_cost_analysis_report()
+       - MUST generate cost analysis report using retrieved data via generate_cost_report()
        - The report includes sections for:
          * Service Overview
          * Architecture Pattern (for Bedrock services)
@@ -247,10 +247,10 @@ async def get_pricing_from_api(service_code: str, region: str, ctx: Context) -> 
 
 
 @mcp.tool(
-    name='get_bedrock_architecture_patterns',
+    name='get_bedrock_patterns',
     description='Get architecture patterns for Amazon Bedrock applications, including component relationships and cost considerations',
 )
-async def get_bedrock_architecture_patterns(ctx: Optional[Context] = None) -> str:
+async def get_bedrock_patterns(ctx: Optional[Context] = None) -> str:
     """Get architecture patterns for Amazon Bedrock applications.
 
     This tool provides architecture patterns, component relationships, and cost considerations
@@ -287,7 +287,7 @@ Focus on the most impactful recommendations first. Do not limit yourself to a sp
 
 
 @mcp.tool(
-    name='generate_cost_analysis_report',
+    name='generate_cost_report',
     description="""Generate a detailed cost analysis report based on pricing data for one or more AWS services.
 
 This tool requires AWS pricing data and provides options for adding detailed cost information.
@@ -383,7 +383,7 @@ Example usage:
 ```
 """,
 )
-async def generate_cost_analysis_report_wrapper(
+async def generate_cost_report_wrapper(
     pricing_data: Dict[str, Any],  # Required: Raw pricing data from AWS
     service_name: str,  # Required: Primary service name
     # Core parameters (simple, commonly used)
@@ -416,7 +416,7 @@ async def generate_cost_analysis_report_wrapper(
     - ALWAYS list all assumptions and exclusions explicitly
 
     For Amazon Bedrock services, especially Knowledge Base, Agent, Guardrails, and Data Automation:
-    - Use get_bedrock_architecture_patterns() to understand component relationships and cost considerations
+    - Use get_bedrock_patterns() to understand component relationships and cost considerations
     - For Knowledge Base, account for OpenSearch Serverless minimum OCU requirements (2 OCUs, $345.60/month minimum)
     - For Agent, avoid double-counting foundation model costs (they're included in agent usage)
 
@@ -446,7 +446,7 @@ async def generate_cost_analysis_report_wrapper(
     """
     # Import and call the implementation from report_generator.py
     from awslabs.cost_analysis_mcp_server.report_generator import (
-        generate_cost_analysis_report,
+        generate_cost_report,
     )
 
     # 1. Extract services from pricing data and parameters
@@ -459,7 +459,7 @@ async def generate_cost_analysis_report_wrapper(
     if 'bedrock' in services.lower():
         try:
             # Get Bedrock architecture patterns
-            bedrock_patterns = await get_bedrock_architecture_patterns(ctx)
+            bedrock_patterns = await get_bedrock_patterns(ctx)
             architecture_patterns['bedrock'] = bedrock_patterns
         except Exception as e:
             if ctx:
@@ -495,7 +495,7 @@ async def generate_cost_analysis_report_wrapper(
             await ctx.warning(f'Could not prepare recommendations: {e}')
 
     # 6. Call the report generator with the enhanced data
-    return await generate_cost_analysis_report(
+    return await generate_cost_report(
         pricing_data=pricing_data,
         service_name=service_name,
         related_services=related_services,

--- a/src/cost-analysis-mcp-server/uv.lock
+++ b/src/cost-analysis-mcp-server/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cost-analysis-mcp-server"
-version = "0.0.62303"
+version = "0.0.81650"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** https://github.com/awslabs/mcp/issues/94

## Summary

### Changes

Fix cost analysis server integration with Q CLI

Integration with Q CLI failing because tool name is too long. Changed the tool names.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
