### PR TITLE
fix(toml): add ignore

### DIFF
--- a/src/aws-diagram-mcp-server/pyproject.toml
+++ b/src/aws-diagram-mcp-server/pyproject.toml
@@ -100,6 +100,7 @@ packages = ["awslabs"]
 [tool.bandit]
 # Skip specific issues
 skips = ["B102"]
+exclude_dirs = ["venv","tests"]
 
 # Per-file skips
 per_file_skips = { "awslabs/aws_diagram_mcp_server/diagrams.py" = ["B102"] }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**
- N/A

## Summary
- Align with other project's toml file to ignore these directories

### Changes

> Please provide a summary of what's being changed
- Bandit will ignore the ["venv","tests"] directories for the diagram mcp server


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
