### PR TITLE
fix: name of diagram package

### DIFF
--- a/src/aws-diagram-mcp-server/pyproject.toml
+++ b/src/aws-diagram-mcp-server/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aws-diagram-mcp-server"
+name = "awslabs.aws-diagram-mcp-server"
 version = "0.8.111004"
 description = "An MCP server that seamlessly creates diagrams using the Python diagrams package DSL"
 readme = "README.md"

--- a/src/aws-diagram-mcp-server/uv.lock
+++ b/src/aws-diagram-mcp-server/uv.lock
@@ -36,8 +36,8 @@ wheels = [
 ]
 
 [[package]]
-name = "aws-diagram-mcp-server"
-version = "0.8.0"
+name = "awslabs-aws-diagram-mcp-server"
+version = "0.8.111004"
 source = { editable = "." }
 dependencies = [
     { name = "bandit" },


### PR DESCRIPTION
Fixed missing namespace in package.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
