### PR TITLE
docs: fix incorrect title in AWS Diagram MCP Server documentation

### DIFF
--- a/docs/servers/aws-diagram-mcp-server.md
+++ b/docs/servers/aws-diagram-mcp-server.md
@@ -1,5 +1,5 @@
 ---
-title: AWS Documentation MCP Server
+title: AWS Diagram MCP Server
 ---
 
 {%include "../../src/aws-diagram-mcp-server/README.md"%}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** N/A

## Summary

Fix the incorrect title in the AWS Diagram MCP Server documentation.
The current title is "AWS Documentation MCP Server", but it should be "AWS Diagram MCP Server".

![image](https://github.com/user-attachments/assets/b0ffc008-0dd3-453f-84a6-cf6ad514bc7e)

### Changes

> Please provide a summary of what's being changed

Updated `docs/servers/aws-diagram-mcp-server.md` and tested.

<img width="978" alt="image" src="https://github.com/user-attachments/assets/1cd88511-ab36-469d-87c6-241d89f11b3b" />

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
