### PR TITLE
fix(docs): fix title and link for AWS Diagram MCP server docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ The Diagrams MCP Server provides the following capabilities:
 3. **Customization**: Customize diagram appearance, layout, and styling
 4. **Security**: Code scanning to ensure secure diagram generation
 
-[Learn more about the Cost Analysis MCP Server](servers/aws-documentation-mcp-server.md)
+[Learn more about the AWS Diagram MCP Server](servers/aws-diagram-mcp-server.md)
 
 ## Installation and Setup
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary

The title and link before the "Installation and Setup" section on the MCP documentation page (https://awslabs.github.io/mcp/) were incorrect. I updated both to properly reference the AWS Diagram MCP Server documentation.

### Changes


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
