### PR TITLE
fix(cfn_nag): suppress W89 and W92

### DIFF
--- a/src/lambda-mcp-server/examples/sample_functions/template.yml
+++ b/src/lambda-mcp-server/examples/sample_functions/template.yml
@@ -18,6 +18,13 @@ Resources:
       Runtime: python3.13
       Architectures:
         - arm64
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "Because this is an example, there is no requirement to run within a VPC"
+          - id: W92
+            reason: "Because this is an example, there is no requirement to reserve concurrency"
 
   CustomerIdFromEmail:
     Type: AWS::Serverless::Function
@@ -33,6 +40,13 @@ Resources:
       Runtime: python3.13
       Architectures:
         - arm64
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "Because this is an example, there is no requirement to run within a VPC"
+          - id: W92
+            reason: "Because this is an example, there is no requirement to reserve concurrency"
 
 Outputs:
 


### PR DESCRIPTION
**Issue number:**
N/A

## Summary

Suppress CFN Nag warnings

### Changes

> Please provide a summary of what's being changed

The warning to run a lambda with reserved concurrency and within a VPC is not required for this example.

### User experience

> Please share what the user experience looks like before and after this change

The `cfn_nag` will not throw warnings locally due to the added suppression.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change? No</summary>

**RFC issue number**:

N/A

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
