### PR TITLE
fix: type errors in generate_cost_report tool

### DIFF
--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/report_generator.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/report_generator.py
@@ -494,24 +494,32 @@ def _process_recommendations(
     return immediate_actions, best_practices
 
 
-def _format_value(key: str, value: Any) -> str:
+def _format_value(key: Any, value: Any) -> str:
     """Format a value based on its type and key name."""
-    if isinstance(value, (int, float)):
-        # Check if the field name suggests it's a monetary value
-        is_monetary = key.lower() == 'total' or any(
-            term in key.lower() for term in MONETARY_FIELDS
-        )
+    try:
+        # Ensure key is a string and handle None case
+        key_str = str(key).lower() if key is not None else ''
 
-        if key.lower() == 'total':
-            return f'**${value}**'
-        elif is_monetary:
-            return f'${value}'
+        if isinstance(value, (int, float)):
+            # Check if the field name suggests it's a monetary value
+            is_total = key_str == 'total'
+            is_monetary = is_total or any(
+                term in key_str for term in MONETARY_FIELDS if isinstance(term, str)
+            )
+
+            if is_total:
+                return f'**${value}**'
+            elif is_monetary:
+                return f'${value}'
+            return str(value)
+
+        elif isinstance(value, dict):
+            return 'See nested table below'
+
         return str(value)
-
-    elif isinstance(value, dict):
-        return 'See nested table below'
-
-    return str(value)
+    except Exception:
+        # Fallback to safe string conversion if any error occurs
+        return str(value)
 
 
 def _process_custom_sections(custom_cost_data: Dict) -> str:
@@ -634,24 +642,28 @@ async def _generate_custom_data_report(
     )
 
     # Add assumptions section
-    assumptions = custom_cost_data.get(
-        'assumptions',
-        [
-            'Standard configuration for all services',
-            'Default usage patterns based on typical workloads',
-            'No reserved instances or savings plans applied',
-        ],
-    )
+    default_assumptions = [
+        'Standard configuration for all services',
+        'Default usage patterns based on typical workloads',
+        'No reserved instances or savings plans applied',
+    ]
+
+    assumptions = custom_cost_data.get('assumptions', default_assumptions)
     assumptions_list = []
+
+    if assumptions is None:
+        assumptions = default_assumptions
+
     if isinstance(assumptions, str):
         # Handle case where assumptions is a string
         for line in assumptions.split('\n'):
-            if line.strip():
+            if line and line.strip():
                 assumptions_list.append(f'- {line.strip()}')
     elif isinstance(assumptions, list):
         # Handle case where assumptions is a list
         for assumption in assumptions:
-            assumptions_list.append(f'- {assumption}')
+            if assumption is not None:
+                assumptions_list.append(f'- {str(assumption).strip()}')
     report = report.replace('{assumptions_section}', '\n'.join(assumptions_list))
 
     # Add limitations and exclusions section

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -478,7 +478,6 @@ async def generate_cost_report_wrapper(
         elif 'recommendations' not in detailed_cost_data:
             # Create a default prompt based on the services and context
             architecture_patterns_str = 'Available' if architecture_patterns else 'Not provided'
-
             prompt = DEFAULT_RECOMMENDATION_PROMPT.format(
                 services=services,
                 architecture_patterns=architecture_patterns_str,

--- a/src/cost-analysis-mcp-server/tests/test_report_generator.py
+++ b/src/cost-analysis-mcp-server/tests/test_report_generator.py
@@ -300,6 +300,20 @@ class TestReportGenerator:
         assert _format_value('name', 'test') == 'test'
         assert _format_value('details', {'key': 'value'}) == 'See nested table below'
 
+    def test_format_value_edge_cases(self):
+        """Test formatting edge cases and invalid inputs."""
+        # Test with None key (converted to empty string)
+        assert _format_value('', 100) == '100'
+
+        # Test with boolean key (converted to string)
+        assert _format_value('true', 100) == '100'
+
+        # Test with None value
+        assert _format_value('key', None) == 'None'
+
+        # Test with numeric key (converted to string)
+        assert _format_value('123', 100) == '100'
+
     def test_process_custom_sections(self):
         """Test processing custom sections."""
         custom_data = {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**
https://github.com/awslabs/mcp/issues/148

## Summary

### Changes

Fix typeError by:

Adding proper type checking in _format_value function
Adding safe string conversion for keys
Adding error handling with try-catch block

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
