### PR TITLE
docs: fix incorrect url in AWS Terraform MCP Server documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,7 +123,7 @@ The Terraform MCP Server provides the following capabilities:
 - AWS-IA GenAI Modules
 - Terraform Workflow Execution
 
-[Learn more about the AWS Terraform MCP Server](servers/terrafrom-mcp-server.md)
+[Learn more about the AWS Terraform MCP Server](servers/terraform-mcp-server.md)
 
 ## Installation and Setup
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** N/A

## Summary

Fix the incorrect url in the AWS Terraform MCP Server documentation.
From `terrafrom` to `terraform`.

![image](https://github.com/user-attachments/assets/4151a659-396b-4cf4-a46e-846e4d487c28)

### Changes

> Please provide a summary of what's being changed

Updated `docs/index.md` and tested.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): N

**RFC issue number**: N/A

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
