### PR TITLE
fix(docs): Resolves #174 - broken image in docs

### DIFF
--- a/samples/mcp-integration-with-kb/README.md
+++ b/samples/mcp-integration-with-kb/README.md
@@ -13,7 +13,7 @@ The exact MCP server code leveraged can be found in the [src/bedrock-kb-retrieva
 
 ### Architecture
 
-![Architecture](./assets/simplified-mcp-flow-diagram.png)
+![Architecture](https://github.com/awslabs/mcp/blob/main/samples/mcp-integration-with-kb/assets/simplified-mcp-flow-diagram.png?raw=true)
 
 ## Setup
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #174

## Summary

### Changes

> Resolves broken image in docs

### User experience

![After change](https://github.com/user-attachments/assets/d5b9f7f4-3b88-45ec-a9d3-57c379383ca9)


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? No

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
