### PR TITLE
fix: doc image

### DIFF
--- a/samples/mcp-integration-with-kb/README.md
+++ b/samples/mcp-integration-with-kb/README.md
@@ -13,7 +13,7 @@ The exact MCP server code leveraged can be found in the [src/bedrock-kb-retrieva
 
 ### Architecture
 
-![Architecture](./assets/simplified-mcp-flow-diagram.png)
+![Architecture](https://github.com/awslabs/mcp/blob/main/samples/mcp-integration-with-kb/assets/simplified-mcp-flow-diagram.png?raw=true)
 
 ## Setup
 

--- a/src/aws-documentation-mcp-server/README.md
+++ b/src/aws-documentation-mcp-server/README.md
@@ -42,7 +42,7 @@ Example:
  - "look up documentation on S3 bucket naming rule. cite your sources"
  - "recommend content for page https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
 
-![AWS Documentation MCP Demo](basic-usage.gif)
+![AWS Documentation MCP Demo](https://github.com/awslabs/mcp/blob/main/src/aws-documentation-mcp-server/basic-usage.gif?raw=true)
 
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #174 

## Summary

### Changes

- Fixed broken basic-usage.gif in MkDocs site

### User experience

![After change, GIF renders as expected](https://github.com/user-attachments/assets/c6b74636-501b-459b-8499-f12850a5eb05)


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
