### PR TITLE
chore(pr): update pr template keyword

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 MD043 -->
-**Issue number:**
+Fixes
 
 ## Summary
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

Update the PR template -> update default keyword to automatically link an issue to a pr

See documentation: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue

## Summary

### Changes

> Please provide a summary of what's being changed

Updating the keyword to automatically linking an issue to a pr

### User experience

> Please share what the user experience looks like before and after this change

Users won't have to manually close issues if the issue is correctly attached

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
