### PR TITLE
fix: use GITHUB_OUTPUT instead

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Security check - Bandit
         id: bandit-check
         working-directory: src/${{ matrix.package }}
-        run: bandit -r --severity-level medium --confidence-level medium -f html -o bandit-report-${{ matrix.package }}.html -c "pyproject.toml" . || echo "::set-output name=status::failure"
+        run: bandit -r --severity-level medium --confidence-level medium -f html -o bandit-report-${{ matrix.package }}.html -c "pyproject.toml" . || echo "status=failure" >> $GITHUB_OUTPUT
 
       - name: Store Bandit as Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #125 

## Summary

### Changes

> Please provide a summary of what's being changed

The `set-output` command is deprecated and will be disabled soon. 
So, I've updated to use `$GITHUB_OUTPUT` instead.

### User experience

> Please share what the user experience looks like before and after this change

Nothing changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
`N`

**RFC issue number**:
closes #125

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
