### PR TITLE
chore(doc): Update README.md - src/aws-diagram-mcp-server/README.md

### DIFF
--- a/src/aws-diagram-mcp-server/README.md
+++ b/src/aws-diagram-mcp-server/README.md
@@ -69,13 +69,13 @@ The Diagrams MCP Server provides the following capabilities:
 ```python
 from diagrams import Diagram
 from diagrams.aws.compute import Lambda
-from diagrams.aws.database import DynamoDB
+from diagrams.aws.database import Dynamodb
 from diagrams.aws.network import APIGateway
 
 with Diagram("Serverless Application", show=False):
     api = APIGateway("API Gateway")
     function = Lambda("Function")
-    database = DynamoDB("DynamoDB")
+    database = Dynamodb("DynamoDB")
 
     api >> function >> database
 ```


### PR DESCRIPTION
Code snippet in src/aws-diagram-mcp-server/README.md was incorrectly refering the Dynamodb from diagrams.aws.package resulting in error -> ImportError: cannot import name 'DynamoDB' from 'diagrams.aws.database'

The diagrams package(https://diagrams.mingrammer.com/docs/nodes/aws) refers DynamoDB component  as diagrams.aws.database.dynamodb, DDB (alias) and not from diagrams.aws.database.DynamoDB.

changed code in documentation to reflect that.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
