### PR TITLE
docs: fix typo in cost-analysis-mcp-server readme

### DIFF
--- a/src/cost-analysis-mcp-server/README.md
+++ b/src/cost-analysis-mcp-server/README.md
@@ -49,7 +49,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
+or docker after a succesful `docker build -t awslabs/cost-analysis-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials


### PR DESCRIPTION
building docker image in cost-analysis mcp server should be called awslabs/cost-analysis-mcp-server and not awslabs/bedrock-kb-retrieval-mcp-server

innstroduced in https://github.com/awslabs/mcp/pull/204

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
