### PR TITLE
chore(docker): fix podman build

### DIFF
--- a/src/core-mcp-server/Dockerfile
+++ b/src/core-mcp-server/Dockerfile
@@ -27,10 +27,11 @@ ENV UV_PYTHON_PREFERENCE=only-system
 # Run without updating the uv.lock file like running with `--frozen`
 ENV UV_FROZEN=true
 
+# Copy the required files first
+COPY pyproject.toml uv.lock ./
+
 # Install the project's dependencies using the lockfile and settings
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     pip install uv && \
     uv sync --frozen --no-install-project --no-dev --no-editable
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #234 

Fix an issue where users can't build using podman.

This error occurs because Podman handles file permissions differently from Docker, particularly with bind mounts. The issue is that the container doesn't have the necessary permissions to access the files being mounted from the host system.

## Summary

### Changes

> Please provide a summary of what's being changed

- Removed the bind mounts (--mount=type=bind) for pyproject.toml and uv.lock files
- Added a COPY command to copy these files into the container before the RUN command
- Kept the cache mount which is still useful for caching dependencies

### User experience

> Please share what the user experience looks like before and after this change

None

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
