### PR TITLE
fix(terraform-mcp-server): encoding for static files

### DIFF
--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/resources/terraform_aws_provider_resources_listing.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/resources/terraform_aws_provider_resources_listing.py
@@ -39,7 +39,7 @@ async def terraform_aws_provider_assets_listing_impl() -> str:
         # Check if the static file exists
         if STATIC_RESOURCES_PATH.exists():
             # Read the static file content
-            with open(STATIC_RESOURCES_PATH, 'r') as f:
+            with open(STATIC_RESOURCES_PATH, 'r', encoding='utf-8') as f:
                 content = f.read()
             logger.info('Successfully loaded AWS Provider asset list')
             return content

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/resources/terraform_awscc_provider_resources_listing.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/resources/terraform_awscc_provider_resources_listing.py
@@ -39,7 +39,7 @@ async def terraform_awscc_provider_resources_listing_impl() -> str:
         # Check if the static file exists
         if STATIC_RESOURCES_PATH.exists():
             # Read the static file content
-            with open(STATIC_RESOURCES_PATH, 'r') as f:
+            with open(STATIC_RESOURCES_PATH, 'r', encoding='utf-8') as f:
                 content = f.read()
 
             logger.info(

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/scripts/generate_aws_provider_resources.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/scripts/generate_aws_provider_resources.py
@@ -372,6 +372,7 @@ async def fetch_aws_provider_page() -> ProviderResult:
                     prefix='terraform_aws_debug_playwright_',
                     suffix='.html',
                     mode='w',
+                    encoding='utf-8',
                     delete=False,
                 ) as temp_file:
                     temp_file.write(content)
@@ -1208,7 +1209,7 @@ async def main():
         args.output.parent.mkdir(parents=True, exist_ok=True)
 
         # Write markdown to output file
-        with open(args.output, 'w') as f:
+        with open(args.output, 'w', encoding='utf-8') as f:
             f.write('\n'.join(markdown))
 
         print(f'Successfully generated markdown file at: {args.output}')

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/scripts/generate_awscc_provider_resources.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/scripts/generate_awscc_provider_resources.py
@@ -317,7 +317,11 @@ async def fetch_awscc_provider_page():
 
             # Save HTML for debugging using tempfile for security
             with tempfile.NamedTemporaryFile(
-                prefix='terraform_awscc_debug_playwright_', suffix='.html', mode='w', delete=False
+                prefix='terraform_awscc_debug_playwright_',
+                suffix='.html',
+                mode='w',
+                encoding='utf-8',
+                delete=False,
             ) as temp_file:
                 temp_file.write(content)
                 debug_file_path = temp_file.name
@@ -1004,7 +1008,7 @@ async def main():
         args.output.parent.mkdir(parents=True, exist_ok=True)
 
         # Write markdown to output file
-        with open(args.output, 'w') as f:
+        with open(args.output, 'w', encoding='utf-8') as f:
             f.write('\n'.join(markdown))
 
         print(f'Successfully generated markdown file at: {args.output}')

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/static/__init__.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/static/__init__.py
@@ -3,20 +3,20 @@ from importlib import resources
 with (
     resources.files('awslabs.terraform_mcp_server.static')
     .joinpath('MCP_INSTRUCTIONS.md')
-    .open('r') as f
+    .open('r', encoding='utf-8') as f
 ):
     MCP_INSTRUCTIONS = f.read()
 
 with (
     resources.files('awslabs.terraform_mcp_server.static')
     .joinpath('TERRAFORM_WORKFLOW_GUIDE.md')
-    .open('r') as f
+    .open('r', encoding='utf-8') as f
 ):
     TERRAFORM_WORKFLOW_GUIDE = f.read()
 
 with (
     resources.files('awslabs.terraform_mcp_server.static')
     .joinpath('AWS_TERRAFORM_BEST_PRACTICES.md')
-    .open('r') as f
+    .open('r', encoding='utf-8') as f
 ):
     AWS_TERRAFORM_BEST_PRACTICES = f.read()

--- a/src/terraform-mcp-server/uv.lock
+++ b/src/terraform-mcp-server/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-terraform-mcp-server"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
For reading and writing static files, use encoding=utf-8. 
### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
