### PR TITLE
docs: add note regarding the performance hit of using the latest suffix in uvx based tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,13 @@ Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
 
 See individual server READMEs for specific requirements and configuration options.
 
+**Note about performance when using `uvx` _"@latest"_ suffix:**
+
+Using the _"@latest"_ suffix checks and downloads the latest MCP server package from pypi every time you start your MCP clients, but it comes with a cost of increased initial load times. If you want to minimize the initial load time, remove _"@latest"_ and manage your uv cache yourself using one of these approaches:
+
+ - `uv cache clean <tool>`: where {tool} is the mcp server you want to delete from cache and install again (e.g.: "awslabs.lambda-mcp-server") (remember to remove the '<>').
+ - `uvx <tool>@latest`: this will refresh the tool with the latest version and add it to the uv cache.
+
 ### Running MCP servers in containers
 
 _This example uses docker with the "awslabs.nova-canvas-mcp-server and can be repeated for each MCP server_


### PR DESCRIPTION
Fixes #196 

## Summary

### Changes

> Added a note in the readme.md regarding usage of the `@latest` suffix on uvx based tools and possible performance degradation versus not using it.

### User experience

> Users should be able to understand the implications of leaving the `@latest` or removing it altogether and what to do to always retrieve the latest mcp versions.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: 196

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
