### PR TITLE
fear: almost zero change in code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:   # default is the status check's name, not default settings
-        threshold: 0
+        threshold: 0.1 # due to an occasional codecov reporting descrapancy
 
 comment:
   require_changes: "coverage_drop"


### PR DESCRIPTION
Having zero code coverage occasionally fails the build even when there are no code lines to cover, so reducing the zero to a 0.1 % lowering

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
