### PR TITLE
fix: release multiple digests

### DIFF
--- a/.github/actions/build-and-push-container-image/action.yml
+++ b/.github/actions/build-and-push-container-image/action.yml
@@ -127,21 +127,21 @@ runs:
 
     - name: Export digest
       run: |
-        mkdir -p ${{ runner.temp }}/digests
+        mkdir -p ${{ runner.temp }}/digests/${{ inputs.image }}
         digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+        touch "${{ runner.temp }}/digests/${{ inputs.image }}/${digest#sha256:}"
       shell: bash
 
     - name: Upload digest
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: digests
-        path: ${{ runner.temp }}/digests/*
+        name: digests-${{ inputs.image }}
+        path: ${{ runner.temp }}/digests/${{ inputs.image }}/*
         if-no-files-found: error
         retention-days: 1
 
     - name: Create manifest list and push
-      working-directory: ${{ runner.temp }}/digests
+      working-directory: ${{ runner.temp }}/digests/${{ inputs.image }}
       env:
         IMAGE: ${{ inputs.image }}
         ALIAS: ${{ inputs.public-erc-registry-alias }}

--- a/src/lambda-mcp-server/awslabs/lambda_mcp_server/__init__.py
+++ b/src/lambda-mcp-server/awslabs/lambda_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """awslabs.lambda-mcp-server"""
 
-__version__ = '0.0.0'
+__version__ = '0.1.4'

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
@@ -11,4 +11,4 @@
 
 """awslabs.postgres-mcp-server"""
 
-__version__ = '0.1.0'
+__version__ = '0.0.3'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes when multiple docker image digests are uploaded as artifacts:

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
