### PR TITLE
fix: fix the reference path for AWS Location MCP Server

### DIFF
--- a/docs/servers/aws-location-mcp-server.md
+++ b/docs/servers/aws-location-mcp-server.md
@@ -2,4 +2,4 @@
 title: AWS Location Service MCP Server
 ---
 
-{%include "../../src/postgres-mcp-server/README.md"%}
+{%include "../../src/aws-location-mcp-server/README.md"%}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Fixed document path

### Changes

Fixed document path

### User experience

User will be able to refer to the correct document.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

N

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
