### PR TITLE
fix: Fixed the installation instructions in the CloudFormation MCP server

### DIFF
--- a/src/cfn-mcp-server/README.md
+++ b/src/cfn-mcp-server/README.md
@@ -30,11 +30,31 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
     "awslabs.cfn-mcp-server": {
       "command": "uvx",
       "args": [
-        "awslabs.aws-cfn-mcp-server@latest",
-        "--readonly" // Optional paramter if you would like to restrict the MCP to only read actions
+        "awslabs.cfn-mcp-server@latest"
       ],
       "env": {
-        "AWS_PROFILE": "your-named-profile",
+        "AWS_PROFILE": "your-named-profile"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+If you would like to prevent the MCP from taking any mutating actions (i.e. Create/Update/Delete Resource), you can specify the readonly flag as demonstrated below:
+
+```json
+{
+  "mcpServers": {
+    "awslabs.cfn-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "awslabs.cfn-mcp-server@latest",
+        "--readonly"
+      ],
+      "env": {
+        "AWS_PROFILE": "your-named-profile"
       },
       "disabled": false,
       "autoApprove": []


### PR DESCRIPTION
## Sumary

The wrong package was in the installation instructions and there were some typos in the json formatting. This makes the installation reference better for copy/paste and addresses the package issue

Resolves https://github.com/awslabs/mcp/issues/340

### Changes

> Fixed JSON format in README installation instructions

> Fixed package in mcp configuration in README

### User experience

> Before - installation would fail - see https://github.com/awslabs/mcp/issues/340

> After - copy pasting the configuration should work

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [y] I have performed a self-review of this change
* [y] Changes have been tested
* [y] Changes are documented

Is this a breaking change? (N)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
