### PR TITLE
feat: Change Search API endpoint to a RAG based endpoint

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server.py
@@ -41,7 +41,7 @@ logger.remove()
 logger.add(sys.stderr, level=os.getenv('FASTMCP_LOG_LEVEL', 'WARNING'))
 
 DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 ModelContextProtocol/1.0 (AWS Documentation Server)'
-SEARCH_API_URL = 'https://proxy.search.docs.aws.amazon.com/search'
+SEARCH_API_URL = 'https://public.knowledge-search.us-east-1.prod.mynah.aws.dev/general/search'
 RECOMMENDATIONS_API_URL = 'https://contentrecs-api.docs.aws.amazon.com/v1/recommendations'
 
 
@@ -241,7 +241,11 @@ async def search_documentation(
             response = await client.post(
                 SEARCH_API_URL,
                 json=request_body,
-                headers={'Content-Type': 'application/json', 'User-Agent': DEFAULT_USER_AGENT},
+                headers={
+                    'Content-Type': 'application/json', 
+                    'User-Agent': DEFAULT_USER_AGENT, 
+                    'x-amzn-requester': 'aws-doc-mcp'
+                },
                 timeout=30,
             )
         except httpx.HTTPError as e:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
This is changing the API endpoint used for the `search_documentation` tool of the aws-documentation-mcp-server.

This API fully supports the same functionality of the old endpoint, so no changes other than the endpoint itself is needed. 

### User experience

Unchanged

> Please share what the user experience looks like before and after this change

There should be no functional difference

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:
https://github.com/awslabs/mcp/discussions/353
Checklist:

* [ x] Migration process documented
* [ x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
