### PR TITLE
fix for issue: lambda_mcp_server limited to just 50 functions #364

### DIFF
--- a/src/lambda-mcp-server/awslabs/lambda_mcp_server/server.py
+++ b/src/lambda-mcp-server/awslabs/lambda_mcp_server/server.py
@@ -251,11 +251,34 @@ def filter_functions_by_tag(functions, tag_key, tag_value):
     return tagged_functions
 
 
+def get_all_lambda_functions(functions: list, marker: str = '', max_items: int = 50) -> list:
+    """Retrieve all Lambda functions using pagination.
+
+    Args:
+        functions: List to store the retrieved functions
+        marker: Marker for pagination
+        max_items: Maximum number of items to retrieve per page
+    
+    Returns:
+        List of all Lambda functions
+    """
+    query = {
+        'MaxItems': max_items,
+    }
+    if marker:
+        query['Marker'] = marker
+    response = lambda_client.list_functions(**query)
+    functions += response['Functions']
+    if len(response['Functions']) == max_items:
+        get_all_lambda_functions(functions, response['NextMarker'])
+    return functions
+
+
 def register_lambda_functions():
     """Register Lambda functions as individual tools."""
     try:
         logger.info('Registering Lambda functions as individual tools...')
-        functions = lambda_client.list_functions()
+        functions = get_all_lambda_functions([])
 
         # Get all functions
         all_functions = functions['Functions']


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes [lambda_mcp_server limited to just 50 functions #364](https://github.com/awslabs/mcp/issues/364)

## Summary

### Changes

> Updating `register_lambda_functions()` to support `list_functions` pagination.

### User experience

> Returned Lambda functions, prior to filtering, will include all functions in the given AWS account and region as opposed to just the first 50.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
