### PR TITLE
fix(doc): JSON syntax errors in mcp.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
       },
       "autoApprove": [],
       "disabled": false
-    }
+    },
     "awslabs.git-repo-research-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.git-repo-research-mcp-server@latest"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

This PR fixes a JSON syntax error in the README.md file by adding a missing comma between the memcached-mcp-server and git-repo-research-mcp-server blocks in the configuration example.

Similar to the fix in PR #363.


### User experience

User copies mcp.json to local and error occurs on loading q cli 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x ] Changes have been tested
* [x ] Changes are documented

Is this a breaking change? (Y/N) n

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
