### PR TITLE
fix: support read-only mode for dynamodb mcp

### DIFF
--- a/src/dynamodb-mcp-server/README.md
+++ b/src/dynamodb-mcp-server/README.md
@@ -74,6 +74,7 @@ Add the MCP to your favorite agentic tools. e.g. for Amazon Q Developer CLI MCP,
       "command": "uvx",
       "args": ["awslabs.dynamodb-mcp-server@latest"],
       "env": {
+        "DDB-MCP-READONLY": "true",
         "AWS_PROFILE": "default",
         "AWS_REGION": "us-west-2",
         "FASTMCP_LOG_LEVEL": "ERROR"

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
@@ -802,6 +802,25 @@ async def update_continuous_backups(
     return response['ContinuousBackupsDescription']
 
 
+@app.tool()
+@handle_exceptions
+async def list_imports(
+    next_token: str = Field(default=None, description='Token to fetch the next page of results.'),
+    region_name: str = Field(default=None, description='The aws region to run the tool'),
+) -> dict:
+    """Lists imports completed within the past 90 days."""
+    client = get_dynamodb_client(region_name)
+    params = {}
+    if next_token:
+        params['NextToken'] = next_token
+    params['PageSize'] = 25
+    response = client.list_imports(**params)
+    return {
+        'ImportSummaryList': response.get('ImportSummaryList', []),
+        'NextToken': response.get('NextToken'),
+    }
+
+
 def main():
     """Main entry point for the MCP server application."""
     app.run()

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
@@ -30,6 +30,7 @@ from awslabs.dynamodb_mcp_server.common import (
     UpdateTableInput,
     WarmThroughput,
     handle_exceptions,
+    mutation_check,
 )
 from botocore.config import Config
 from mcp.server.fastmcp import FastMCP
@@ -99,6 +100,7 @@ resource_arn: str = Field(description='The Amazon Resource Name (ARN) of the Dyn
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def put_resource_policy(
     resource_arn: str = resource_arn,
     policy: Union[str, Dict[str, Any]] = Field(
@@ -236,6 +238,7 @@ async def query(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def update_item(
     table_name: str = table_name,
     key: Dict[str, KeyAttributeValue] = key,
@@ -303,6 +306,7 @@ async def get_item(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def put_item(
     table_name: str = table_name,
     item: Dict[str, AttributeValue] = Field(
@@ -337,6 +341,7 @@ async def put_item(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def delete_item(
     table_name: str = table_name,
     key: Dict[str, KeyAttributeValue] = key,
@@ -370,6 +375,7 @@ async def delete_item(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def update_time_to_live(
     table_name: str = table_name,
     time_to_live_specification: TimeToLiveSpecification = Field(
@@ -387,6 +393,7 @@ async def update_time_to_live(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def update_table(
     table_name: str = table_name,
     attribute_definitions: List[AttributeDefinition] = Field(
@@ -483,6 +490,7 @@ async def list_tables(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def create_table(
     table_name: str = Field(
         description='The name of the table to create.',
@@ -536,6 +544,7 @@ async def describe_table(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def create_backup(
     table_name: str = table_name,
     backup_name: str = Field(
@@ -602,6 +611,7 @@ async def list_backups(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def restore_table_from_backup(
     backup_arn: str = Field(
         description='The Amazon Resource Name (ARN) associated with the backup.',
@@ -717,6 +727,7 @@ async def describe_continuous_backups(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def untag_resource(
     resource_arn: str = resource_arn,
     tag_keys: List[str] = Field(description='List of tags to remove.', min_length=1),
@@ -730,6 +741,7 @@ async def untag_resource(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def tag_resource(
     resource_arn: str = resource_arn,
     tags: List[Tag] = Field(description='Tags to be assigned.'),
@@ -762,6 +774,7 @@ async def list_tags_of_resource(
 
 @app.tool()
 @handle_exceptions
+@mutation_check
 async def delete_table(
     table_name: str = table_name,
     region_name: str = Field(default=None, description='The aws region to run the tool'),

--- a/src/dynamodb-mcp-server/tests/test_dynamodb_server.py
+++ b/src/dynamodb-mcp-server/tests/test_dynamodb_server.py
@@ -872,3 +872,18 @@ async def test_exception_handling(test_table):
     # Verify error is returned
     assert 'error' in error_result
     print(error_result)
+
+
+@pytest.mark.asyncio
+async def test_list_imports(test_table):
+    """Test listing imports for a table (should be empty with moto)."""
+    from awslabs.dynamodb_mcp_server.server import list_imports
+
+    # Call list_imports with no imports present
+    result = await list_imports(
+        region_name='us-west-2',
+        next_token=None,
+    )
+
+    # Should return a dict with ImportSummaryList and NextToken keys
+    assert isinstance(result, dict)

--- a/src/dynamodb-mcp-server/tests/test_readonly_delete_table.py
+++ b/src/dynamodb-mcp-server/tests/test_readonly_delete_table.py
@@ -1,0 +1,14 @@
+import pytest
+from awslabs.dynamodb_mcp_server import server
+
+
+@pytest.mark.asyncio
+async def test_delete_table_blocked_by_readonly(monkeypatch):
+    """Test that delete_table is blocked if DDB-MCP-READONLY is set to true."""
+    # Set the environment variable to simulate read-only mode
+    monkeypatch.setenv('DDB-MCP-READONLY', 'true')
+
+    # Call delete_table and expect an error
+    result = await server.delete_table(table_name='TestTable', region_name='us-west-2')
+    assert 'error' in result
+    assert 'DDB-MCP-READONLY' in result['error']


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

### Changes

1. Support read-only mode in dynamodb mcp
2. Support list import API

### User experience

1. User can set DDB-MCP-READONLY in MCP.json to disable mutation API
2. User can now list import from last 90 days.
3. 
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
No

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
