### PR TITLE
fix: remove SSE support from amazon-mq-mcp-server

### DIFF
--- a/src/amazon-mq-mcp-server/README.md
+++ b/src/amazon-mq-mcp-server/README.md
@@ -117,24 +117,6 @@ AWS_SESSION_TOKEN=<from the profile you set up>
 
 The Amazon MQ MCP Server supports several command-line arguments that can be used to configure its behavior:
 
-### `--sse`
-
-Use Server-Sent Events (SSE) transport instead of stdio. Default is False.
-
-Example:
-```bash
-uv run awslabs.amazon-mq-mcp-server --sse
-```
-
-### `--port PORT`
-
-Specifies the port number on which the server will listen. Default is 6274.
-
-Example:
-```bash
-uv run awslabs.amazon-mq-mcp-server --port 9000
-```
-
 ### `--allow-resource-creation`
 
 Allow tools that create resources in the user's AWS account. When this flag is enabled, the `create_broker` and `create_configuration` tools will be created for the MCP client, preventing the creation of new Amazon MQ resources. Default is False.

--- a/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/server.py
+++ b/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/server.py
@@ -110,14 +110,11 @@ def main():
     parser = argparse.ArgumentParser(
         description='An AWS Model Context Protocol (MCP) server for Lambda'
     )
-    parser.add_argument('--sse', action='store_true', help='Use SSE transport')
     parser.add_argument(
         '--allow-resource-creation',
         action='store_true',
         help='Hide tools that create resources on user AWS account',
     )
-    parser.add_argument('--port', type=int, default=8888, help='Port to run the server on')
-
     args = parser.parse_args()
 
     tool_configuration = {
@@ -157,11 +154,7 @@ def main():
     )
     generator.generate()
 
-    if args.sse:
-        mcp.settings.port = args.port
-        mcp.run(transport='sse')
-    else:
-        mcp.run()
+    mcp.run()
 
 
 if __name__ == '__main__':

--- a/src/amazon-mq-mcp-server/tests/test_server.py
+++ b/src/amazon-mq-mcp-server/tests/test_server.py
@@ -259,23 +259,6 @@ class TestMain:
     @patch('boto3.Session')
     @patch('awslabs.amazon_mq_mcp_server.server.mcp')
     @patch('argparse.ArgumentParser.parse_args')
-    def test_main_sse(self, mock_parse_args, mock_mcp, mock_session):
-        """Test main function with SSE transport."""
-        # Set up the mock
-        mock_parse_args.return_value = MagicMock(sse=True, port=8888)
-
-        # Call the function
-        main()
-
-        # Check that mcp.run was called with the correct transport
-        mock_mcp.run.assert_called_once_with(transport='sse')
-
-        # Check that mcp.settings.port was set
-        assert mock_mcp.settings.port == 8888
-
-    @patch('boto3.Session')
-    @patch('awslabs.amazon_mq_mcp_server.server.mcp')
-    @patch('argparse.ArgumentParser.parse_args')
     def test_main_stdio(self, mock_parse_args, mock_mcp, mock_session):
         """Test main function with stdio transport."""
         # Set up the mock

--- a/src/amazon-mq-mcp-server/uv.lock
+++ b/src/amazon-mq-mcp-server/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-mq-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Remove SSE support from amazon-mq-mcp-server

SSE is being deprecated in favor of Streamable HTTP. It doesn't have good support in general.

### Changes

> Please provide a summary of what's being changed

Remove SSE support from amazon-mq-mcp-server

### User experience

> Please share what the user experience looks like before and after this change

User won't be able to start SSE protocol for this MCP server.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
Y

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
