### PR TITLE
Fix multiple typos in documentation and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ _This example uses docker with the "awslabs.nova-canvas-mcp-server and can be re
 - Optionally save sensitive environmental variables in a file:
 
   ```.env
-  # contents of a .env file with ficticious AWS temporary credentials
+  # contents of a .env file with fictitious AWS temporary credentials
   AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE
   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk

--- a/src/amazon-kendra-index-mcp-server/README.md
+++ b/src/amazon-kendra-index-mcp-server/README.md
@@ -40,7 +40,7 @@ An AWS Labs Model Context Protocol (MCP) server for Amazon Kendra. This MCP serv
 ### IAM Configuration
 
 1. Provision a user in your AWS account IAM
-2. Attach a policy that contains at a minimum the `kendra:Query` and `kendra:ListIndices` permissions. Alternatively the AWS Managed `AmazonKendraFullAccess` policy can be attached. Always follow the prinicpal or least priveledge when granting users permissions. See the [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkendra.html) for more information on IAM permissions for Amazon Kendra.
+2. Attach a policy that contains at a minimum the `kendra:Query` and `kendra:ListIndices` permissions. Alternatively the AWS Managed `AmazonKendraFullAccess` policy can be attached. Always follow the principal or least priveledge when granting users permissions. See the [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkendra.html) for more information on IAM permissions for Amazon Kendra.
 3. Use `aws configure` on your environment to configure the credentials (access ID and access key)
 
 ### Installation

--- a/src/amazon-kendra-index-mcp-server/README.md
+++ b/src/amazon-kendra-index-mcp-server/README.md
@@ -65,7 +65,7 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
       }
 }
 ```
-or docker after a succesful `docker build -t awslabs/amazon-kendra-index-mcp-server.`:
+or docker after a successful `docker build -t awslabs/amazon-kendra-index-mcp-server.`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/amazon-kendra-index-mcp-server/README.md
+++ b/src/amazon-kendra-index-mcp-server/README.md
@@ -68,7 +68,7 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
 or docker after a successful `docker build -t awslabs/amazon-kendra-index-mcp-server.`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=<from the profile you set up>
 AWS_SECRET_ACCESS_KEY=<from the profile you set up>
 AWS_SESSION_TOKEN=<from the profile you set up>

--- a/src/amazon-kendra-index-mcp-server/README.md
+++ b/src/amazon-kendra-index-mcp-server/README.md
@@ -40,7 +40,7 @@ An AWS Labs Model Context Protocol (MCP) server for Amazon Kendra. This MCP serv
 ### IAM Configuration
 
 1. Provision a user in your AWS account IAM
-2. Attach a policy that contains at a minimum the `kendra:Query` and `kendra:ListIndices` permissions. Alternatively the AWS Managed `AmazonKendraFullAccess` policy can be attached. Always follow the principal or least priveledge when granting users permissions. See the [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkendra.html) for more information on IAM permissions for Amazon Kendra.
+2. Attach a policy that contains at a minimum the `kendra:Query` and `kendra:ListIndices` permissions. Alternatively the AWS Managed `AmazonKendraFullAccess` policy can be attached. Always follow the principal or least privilege when granting users permissions. See the [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkendra.html) for more information on IAM permissions for Amazon Kendra.
 3. Use `aws configure` on your environment to configure the credentials (access ID and access key)
 
 ### Installation

--- a/src/amazon-mq-mcp-server/README.md
+++ b/src/amazon-mq-mcp-server/README.md
@@ -87,7 +87,7 @@ If you would like to specify a flag (for example, to allow creation of resources
 or docker after a successful `docker build -t awslabs/amazon-mq-mcp-server .`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=<from the profile you set up>
 AWS_SECRET_ACCESS_KEY=<from the profile you set up>
 AWS_SESSION_TOKEN=<from the profile you set up>

--- a/src/amazon-mq-mcp-server/README.md
+++ b/src/amazon-mq-mcp-server/README.md
@@ -84,7 +84,7 @@ If you would like to specify a flag (for example, to allow creation of resources
 ```
 
 
-or docker after a succesful `docker build -t awslabs/amazon-mq-mcp-server .`:
+or docker after a successful `docker build -t awslabs/amazon-mq-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/amazon-sns-sqs-mcp-server/README.md
+++ b/src/amazon-sns-sqs-mcp-server/README.md
@@ -60,7 +60,7 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/amazon-sns-sqs-mcp-server.`:
+or docker after a successful `docker build -t awslabs/amazon-sns-sqs-mcp-server.`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/amazon-sns-sqs-mcp-server/README.md
+++ b/src/amazon-sns-sqs-mcp-server/README.md
@@ -63,7 +63,7 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
 or docker after a successful `docker build -t awslabs/amazon-sns-sqs-mcp-server.`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=<from the profile you set up>
 AWS_SECRET_ACCESS_KEY=<from the profile you set up>
 AWS_SESSION_TOKEN=<from the profile you set up>

--- a/src/aurora-dsql-mcp-server/README.md
+++ b/src/aurora-dsql-mcp-server/README.md
@@ -59,7 +59,7 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
 
 Either manually:
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=<from the profile you set up>
 AWS_SECRET_ACCESS_KEY=<from the profile you set up>
 AWS_SESSION_TOKEN=<from the profile you set up>

--- a/src/aws-diagram-mcp-server/README.md
+++ b/src/aws-diagram-mcp-server/README.md
@@ -32,7 +32,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/aws-diagram-mcp-server .`:
+or docker after a successful `docker build -t awslabs/aws-diagram-mcp-server .`:
 
 ```json
   {

--- a/src/aws-documentation-mcp-server/README.md
+++ b/src/aws-documentation-mcp-server/README.md
@@ -37,7 +37,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/aws-documentation-mcp-server .`:
+or docker after a successful `docker build -t awslabs/aws-documentation-mcp-server .`:
 
 ```json
   {

--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -97,7 +97,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
+or docker after a successful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -100,7 +100,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 or docker after a successful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk

--- a/src/cdk-mcp-server/README.md
+++ b/src/cdk-mcp-server/README.md
@@ -156,7 +156,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/cdk-mcp-server .`:
+or docker after a successful `docker build -t awslabs/cdk-mcp-server .`:
 
 ```json
   {

--- a/src/cfn-mcp-server/README.md
+++ b/src/cfn-mcp-server/README.md
@@ -63,7 +63,7 @@ If you would like to prevent the MCP from taking any mutating actions (i.e. Crea
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/cfn-mcp-server .`:
+or docker after a successful `docker build -t awslabs/cfn-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/cfn-mcp-server/README.md
+++ b/src/cfn-mcp-server/README.md
@@ -66,7 +66,7 @@ If you would like to prevent the MCP from taking any mutating actions (i.e. Crea
 or docker after a successful `docker build -t awslabs/cfn-mcp-server .`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/errors.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/errors.py
@@ -86,6 +86,6 @@ class ServerError(Exception):
     def __init__(self, log):
         """Call super."""
         # Call the base class constructor with the parameters it needs
-        super().__init__('An internal error occured while processing your request')
+        super().__init__('An internal error occurred while processing your request')
         print(log)
         self.type = 'server'

--- a/src/core-mcp-server/README.md
+++ b/src/core-mcp-server/README.md
@@ -45,7 +45,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/core-mcp-server .`:
+or docker after a successful `docker build -t awslabs/core-mcp-server .`:
 
 ```json
   {

--- a/src/cost-analysis-mcp-server/README.md
+++ b/src/cost-analysis-mcp-server/README.md
@@ -58,7 +58,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 or docker after a successful `docker build -t awslabs/cost-analysis-mcp-server .`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk

--- a/src/cost-analysis-mcp-server/README.md
+++ b/src/cost-analysis-mcp-server/README.md
@@ -55,7 +55,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/cost-analysis-mcp-server .`:
+or docker after a successful `docker build -t awslabs/cost-analysis-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/dynamodb-mcp-server/README.md
+++ b/src/dynamodb-mcp-server/README.md
@@ -86,7 +86,7 @@ Add the MCP to your favorite agentic tools. e.g. for Amazon Q Developer CLI MCP,
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/dynamodb-mcp-server .`:
+or docker after a successful `docker build -t awslabs/dynamodb-mcp-server .`:
 
 ```json
   {

--- a/src/lambda-mcp-server/README.md
+++ b/src/lambda-mcp-server/README.md
@@ -99,7 +99,7 @@ AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R
 
 NOTE: Your credentials will need to be kept refreshed from your host
 
-The `AWS_PROFILE` and the `AWS_REGION` are optional, their defualt values are `default` and `us-east-1`.
+The `AWS_PROFILE` and the `AWS_REGION` are optional, their default values are `default` and `us-east-1`.
 
 You can specify `FUNCTION_PREFIX`, `FUNCTION_LIST`, or both. If both are empty, all functions pass the name check.
 After the name check, if both `FUNCTION_TAG_KEY` and `FUNCTION_TAG_VALUE` are set, functions are further filtered by tag (with key=value).

--- a/src/lambda-mcp-server/README.md
+++ b/src/lambda-mcp-server/README.md
@@ -58,7 +58,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 or docker after a successful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk

--- a/src/lambda-mcp-server/README.md
+++ b/src/lambda-mcp-server/README.md
@@ -55,7 +55,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
+or docker after a successful `docker build -t awslabs/bedrock-kb-retrieval-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/nova-canvas-mcp-server/README.md
+++ b/src/nova-canvas-mcp-server/README.md
@@ -61,7 +61,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 or docker after a successful `docker build -t awslabs/nova-canvas-mcp-server .`:
 
 ```file
-# ficticious `.env` file with AWS temporary credentials
+# fictitious `.env` file with AWS temporary credentials
 AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_SESSION_TOKEN=AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk

--- a/src/nova-canvas-mcp-server/README.md
+++ b/src/nova-canvas-mcp-server/README.md
@@ -58,7 +58,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/nova-canvas-mcp-server .`:
+or docker after a successful `docker build -t awslabs/nova-canvas-mcp-server .`:
 
 ```file
 # ficticious `.env` file with AWS temporary credentials

--- a/src/terraform-mcp-server/README.md
+++ b/src/terraform-mcp-server/README.md
@@ -81,7 +81,7 @@ Here are some ways you can work with MCP across AWS, and we'll be adding support
 }
 ```
 
-or docker after a succesful `docker build -t awslabs/terraform-mcp-server .`:
+or docker after a successful `docker build -t awslabs/terraform-mcp-server .`:
 
 ```json
   {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes multiple spelling errors throughout the codebase

## Summary

This PR fixes multiple spelling errors found throughout the codebase:

- `occured` → `occurred` in error message
- `succesful` → `successful` in README files (14 instances)
- `ficticious` → `fictitious` in README files (10 instances)
- `prinicpal` → `principal` in README file (1 instance)
- `priveledge` → `privilege` in README file (1 instance)
- `defualt` → `default` in README file (1 instance)

### Changes

This PR corrects spelling errors in documentation and error messages across multiple MCP server README files and one Python error handling file. The changes are purely cosmetic and do not affect any functionality. All corrections follow standard English spelling conventions.

### User experience

**Before**: There were spelling mistakes in docs and error messages.
**After**: Fixed the typos so everything reads properly now.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): **N**

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).