### PR TITLE
fix: Fix Q related Issues

### DIFF
--- a/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/aws_service_mcp_generator.py
+++ b/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/aws_service_mcp_generator.py
@@ -241,9 +241,9 @@ class AWSToolGenerator:
             param_shape = input_shape.members[param_name]
             # Skip documentation if flag is set
             if self.skip_param_documentation:
-                param_documentation = ('',)
+                param_documentation = ''
             else:
-                param_documentation = (getattr(param_shape, 'documentation', ''),)
+                param_documentation = getattr(param_shape, 'documentation', '')
             is_required = param_name in input_shape.required_members
             res.append((param_name, param_shape.type_name, is_required, param_documentation))
         return res

--- a/src/amazon-mq-mcp-server/tests/test_aws_service_mcp_generator.py
+++ b/src/amazon-mq-mcp-server/tests/test_aws_service_mcp_generator.py
@@ -486,7 +486,7 @@ class TestAWSToolGenerator(unittest.TestCase):
         )
 
         # Verify that documentation is included when skip_param_documentation=False
-        self.assertEqual(params_with_docs[0][3], ('Test documentation',))
+        self.assertEqual(params_with_docs[0][3], 'Test documentation')
 
         # Verify that documentation is empty when skip_param_documentation=True
         self.assertEqual(params_without_docs[0][3], ('',))

--- a/src/amazon-mq-mcp-server/tests/test_aws_service_mcp_generator.py
+++ b/src/amazon-mq-mcp-server/tests/test_aws_service_mcp_generator.py
@@ -489,7 +489,7 @@ class TestAWSToolGenerator(unittest.TestCase):
         self.assertEqual(params_with_docs[0][3], 'Test documentation')
 
         # Verify that documentation is empty when skip_param_documentation=True
-        self.assertEqual(params_without_docs[0][3], ('',))
+        self.assertEqual(params_without_docs[0][3], '')
 
 
 def test_hello_world():

--- a/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/generator.py
+++ b/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/generator.py
@@ -247,9 +247,9 @@ class AWSToolGenerator:
             param_shape = input_shape.members[param_name]
             # Skip documentation if flag is set
             if self.skip_param_documentation:
-                param_documentation = ('',)
+                param_documentation = ''
             else:
-                param_documentation = (getattr(param_shape, 'documentation', ''),)
+                param_documentation = getattr(param_shape, 'documentation', '')
             is_required = param_name in input_shape.required_members
             res.append((param_name, param_shape.type_name, is_required, param_documentation))
         return res

--- a/src/amazon-sns-sqs-mcp-server/tests/test_generator.py
+++ b/src/amazon-sns-sqs-mcp-server/tests/test_generator.py
@@ -506,7 +506,7 @@ class TestAWSToolGenerator(unittest.TestCase):
         )
 
         # Verify that documentation is included when skip_param_documentation=False
-        self.assertEqual(params_with_docs[0][3], ('Test documentation',))
+        self.assertEqual(params_with_docs[0][3], 'Test documentation')
 
         # Verify that documentation is empty when skip_param_documentation=True
         self.assertEqual(params_without_docs[0][3], ('',))

--- a/src/amazon-sns-sqs-mcp-server/tests/test_generator.py
+++ b/src/amazon-sns-sqs-mcp-server/tests/test_generator.py
@@ -509,7 +509,7 @@ class TestAWSToolGenerator(unittest.TestCase):
         self.assertEqual(params_with_docs[0][3], 'Test documentation')
 
         # Verify that documentation is empty when skip_param_documentation=True
-        self.assertEqual(params_without_docs[0][3], ('',))
+        self.assertEqual(params_without_docs[0][3], '')
 
     @patch('awslabs.amazon_sns_sqs_mcp_server.generator.boto3.Session')
     def test_boto3_client_getter(self, mock_session):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary



```
- Q CLI was giving us this issue:
Amazon Q is having trouble responding right now:
   0: unhandled error (ValidationException)
   1: service error
   2: unhandled error (ValidationException)
   3: Error { code: "ValidationException", message: "Improperly formed request.", aws_request_id: "3ea24471-777f-4114-8adc-f965c7ac75e6" }

Location:
   crates/chat-cli/src/cli/chat/mod.rs:1008

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
>

```

After a dive deep, we were able to figure out its because of the signature of the function

It does not like signatures that look like this:

```
Generated signature for operation 'confirm_subscription':
(Token: str, TopicArn: str, AuthenticateOnUnsubscribe: typing.Annotated[str | None, FieldInfo(annotation=NoneType, required=True, description=('',))] = None, region: typing.Annotated[str, FieldInfo(annotation=NoneType, required=True, description='AWS region')] = 'us-east-1') 

```

It does not like the description field tuple field, changing it.

```
Generated signature for operation 'confirm_subscription':
(Token: str, TopicArn: str, AuthenticateOnUnsubscribe: typing.Annotated[str | None, FieldInfo(annotation=NoneType, required=True, description='')] = None, region: typing.Annotated[str, FieldInfo(annotation=NoneType, required=True, description='AWS region')] = 'us-east-1')
```


### Changes

> Please provide a summary of what's being changed

This change fixes the annotation

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
