### PR TITLE
docs: add ECS MCP Server to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A suite of specialized MCP servers that help you get the most out of AWS, wherev
     - [Amazon Neptune MCP Server](#amazon-neptune-mcp-server)
     - [Amazon DocumentDB MCP Server](#amazon-documentdb-mcp-server)
     - [Amazon EKS MCP Server](#amazon-eks-mcp-server)
+    - [Amazon ECS MCP Server](#amazon-ecs-mcp-server)
     - [Use Cases for the Servers](#use-cases-for-the-servers)
   - [Installation and Setup](#installation-and-setup)
     - [Running MCP servers in containers](#running-mcp-servers-in-containers)
@@ -393,6 +394,21 @@ A Model Context Protocol (MCP) server for Amazon EKS that enables generative AI 
 - Security-First Design: Configurable read-only mode, sensitive data access controls, and IAM integration for proper permissions management
 
 [Learn more](src/eks-mcp-server/README.md) | [Documentation](https://awslabs.github.io/mcp/servers/eks-mcp-server/)
+
+### Amazon ECS MCP Server
+
+[![PyPI version](https://img.shields.io/pypi/v/awslabs.ecs-mcp-server.svg)](https://pypi.org/project/awslabs.ecs-mcp-server/)
+
+A Model Context Protocol (MCP) server for containerizing applications, deploying applications to Amazon Elastic Container Service (ECS), troubleshooting ECS deployments, and managing ECS resources.
+
+- Containerization Guidance: Generate Dockerfile and container configurations for web applications
+- ECS Deployment: Create AWS infrastructure needed to deploy containerized applications
+- Load Balancer Integration: Automatically configure Application Load Balancers (ALBs)
+- Resource Management: List and explore ECS resources such as task definitions, services, clusters, and tasks
+- Comprehensive Troubleshooting: Diagnose and resolve common ECS deployment issues
+- Security Best Practices: Implement AWS security best practices for container deployments
+
+[Learn more](src/ecs-mcp-server/README.md) | [Documentation](https://awslabs.github.io/mcp/servers/ecs-mcp-server/)
 
 ### Amazon MQ MCP Server
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes
Adds ECS MCP Server to list of servers in the README.md

### User experience
NA

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [Y] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
