### PR TITLE
fix(doc): rename lambda-mcp-server to lambda-tool-mcp-server

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,9 +89,9 @@ The Cost Analysis MCP Server enables AI assistants to analyze the cost of AWS se
 
 [Learn more about the Cost Analysis MCP Server](servers/cost-analysis-mcp-server.md)
 
-### AWS Lambda MCP Server
+### AWS Lambda Tool MCP Server
 
-The AWS Lambda MCP Server enables AI assistants to select and run AWS Lambda functions as MCP tools.
+The AWS Lambda Tool MCP Server enables AI assistants to select and run AWS Lambda functions as MCP tools.
 
 **Features:**
 
@@ -100,7 +100,7 @@ The AWS Lambda MCP Server enables AI assistants to select and run AWS Lambda fun
 - Filter functions by name, tag, or both
 - Use AWS credentials to invoke the Lambda functions
 
-[Learn more about the AWS Lambda MCP Server](servers/lambda-mcp-server.md)
+[Learn more about the AWS Lambda Tool MCP Server](servers/lambda-tool-mcp-server.md)
 
 ### Amazon Aurora DSQL MCP Server
 

--- a/docs/servers/lambda-mcp-server.md
+++ b/docs/servers/lambda-mcp-server.md
@@ -1,5 +1,0 @@
----
-title: AWS Lambda MCP Server
----
-
-{%include "../../src/lambda-mcp-server/README.md"%}

--- a/docs/servers/lambda-tool-mcp-server.md
+++ b/docs/servers/lambda-tool-mcp-server.md
@@ -1,0 +1,5 @@
+---
+title: AWS Lambda MCP Server
+---
+
+{%include "../../src/lambda-tool-mcp-server/README.md"%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ nav:
     - Cost Analysis MCP Server: servers/cost-analysis-mcp-server.md
     - Amazon Nova Canvas MCP Server: servers/nova-canvas-mcp-server.md
     - AWS Documentation MCP Server: servers/aws-documentation-mcp-server.md
-    - AWS Lambda MCP Server: servers/lambda-mcp-server.md
+    - AWS Lambda Tool MCP Server: servers/lambda-tool-mcp-server.md
     - AWS Diagram MCP Server: servers/aws-diagram-mcp-server.md
     - AWS Terraform MCP Server: servers/terraform-mcp-server.md
     - Git Repo Research MCP Server: servers/git-repo-research-mcp-server.md

--- a/src/lambda-tool-mcp-server/README.md
+++ b/src/lambda-tool-mcp-server/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda MCP Server
+# AWS Lambda Tool MCP Server
 
 A Model Context Protocol (MCP) server for AWS Lambda to select and run Lambda function as MCP tools without code changes.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
