### PR TITLE
fix(cfn-mcp-server): Updating ProgressEvent.StatusMessage to properly account for failed events

### DIFF
--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/cloud_control_utils.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/cloud_control_utils.py
@@ -38,7 +38,8 @@ def progress_event(response_event) -> dict[str, str]:
     response = {
         'status': response_event['OperationStatus'],
         'resource_type': response_event['TypeName'],
-        'is_complete': response_event['OperationStatus'] == 'SUCCESS',
+        'is_complete': response_event['OperationStatus'] == 'SUCCESS'
+        or response_event['OperationStatus'] == 'FAILED',
         'request_token': response_event['RequestToken'],
     }
 

--- a/src/cfn-mcp-server/tests/test_cloud_control_utils.py
+++ b/src/cfn-mcp-server/tests/test_cloud_control_utils.py
@@ -106,3 +106,32 @@ class TestUtils:
         }
 
         assert progress_event(request) == response
+
+    async def test_progress_event_failed(self):
+        """Testing mapping progress event with all props."""
+        request = {
+            'OperationStatus': 'FAILED',
+            'TypeName': 'AWS::CodeStarConnections::Connection',
+            'RequestToken': '25',
+            'Identifier': 'id',
+            'StatusMessage': 'good job',
+            'ResourceModel': 'model',
+            'ErrorCode': 'NONE',
+            'EventTime': '25',
+            'RetryAfter': '10',
+        }
+
+        response = {
+            'status': 'FAILED',
+            'resource_type': 'AWS::CodeStarConnections::Connection',
+            'is_complete': True,
+            'request_token': '25',
+            'identifier': 'id',
+            'status_message': 'good job',
+            'resource_info': 'model',
+            'error_code': 'NONE',
+            'event_time': '25',
+            'retry_after': '10',
+        }
+
+        assert progress_event(request) == response


### PR DESCRIPTION
… account for failed events

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
- the is_complete field is returned to the LLM to indicate if a request has finished processing. We found that on a failure this is returned as false and we suspect this causes the LLM to start retrying when it should not be.

### Changes
- fixed the value that is being returned

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change
Before: is_complete was returned as false for a failed event to the LLM and in one instance, the LLM started retrying. We suspect the is_complete field caused the retries. 

After: is_complete should be set to true

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [y] I have performed a self-review of this change
* [y] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (N)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
