### PR TITLE
fix(ecs-mcp-server): fix circular dependency in ecs infrastructure template

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/templates/ecs_infrastructure.json
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/templates/ecs_infrastructure.json
@@ -113,6 +113,16 @@
   },
   "Resources": {
     "ALBAccessLogsBucket": {
+      "Metadata": {
+        "checkov": {
+          "skip": [
+            {
+              "comment": "S3 bucket causing circular dependency",
+              "id": "CKV_AWS_18"
+            }
+          ]
+        }
+      },
       "Properties": {
         "AccessControl": "Private",
         "BucketName": {
@@ -126,12 +136,6 @@
               "Status": "Enabled"
             }
           ]
-        },
-        "LoggingConfiguration": {
-          "DestinationBucketName": {
-            "Ref": "ALBAccessLogsBucket"
-          },
-          "LogFilePrefix": "s3-access-logs/"
         },
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,


### PR DESCRIPTION


<!-- markdownlint-disable MD041 MD043 -->
Fixes the circular dependency in the CloudFormation template between the ALBAccessLogsBucket and ALBAccessLogsBucketPolicy resources.

## Summary

Looking at the template, the issue is that:
1. The ALBAccessLogsBucket resource (S3 bucket for ALB access logs) has a LoggingConfiguration property that references
itself. It's trying to log its own access logs to itself, which creates a circular reference.
2. The ALBAccessLogsBucketPolicy resource depends on the bucket, but the bucket also depends on the policy being in place
for its logging configuration.
This creates a "chicken and egg" problem where:
• The bucket needs the policy to be created first
• The policy needs the bucket to be created first
To fix this, we  remove the self-referential logging configuration from the S3 bucket

### Changes

> Please provide a summary of what's being changed
Disabling s3 access logs

### User experience

> Please share what the user experience looks like before and after this change

Before, create_ecs_infrastructure would fail to create cfn stack.  Now cfn stacks will create.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented - N/A
* [ ] Implement warnings (if it can live side by side) - N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
