### PR TITLE
fix: (eks-mcp-server) update README section for write permissions

### DIFF
--- a/src/eks-mcp-server/README.md
+++ b/src/eks-mcp-server/README.md
@@ -55,30 +55,35 @@ For read operations, the following permissions are required:
 
 ### Write Operations Policy
 
-For write operations, the following permissions are required:
-
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "cloudformation:CreateStack",
-        "cloudformation:UpdateStack",
-        "cloudformation:DeleteStack",
-        "iam:PutRolePolicy"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/CreatedBy": "EksMcpServer"
-        }
+For write operations, we recommend the following IAM policies to ensure successful deployment of EKS clusters using the CloudFormation template in `/awslabs/eks_mcp_server/templates/eks-templates/eks-with-vpc.yaml`:
+- [**IAMFullAccess**](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/IAMFullAccess.html): Enables creation and management of IAM roles and policies required for cluster operation
+- [**AmazonVPCFullAccess**](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonVPCFullAccess.html): Allows creation and configuration of VPC resources including subnets, route tables, internet gateways, and NAT gateways
+- [**AWSCloudFormationFullAccess**](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSCloudFormationFullAccess.html): Provides permissions to create, update, and delete CloudFormation stacks that orchestrate the deployment
+- **EKS Full Access (provided below)**: Required for creating and managing EKS clusters, including control plane configuration, node groups, and add-ons
+   ```
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "eks:*",
+        "Resource": "*"
       }
-    }
-  ]
-}
-```
+    ]
+  }
+   ```
+
+
+**Important Security Note**: Users should exercise caution when `--allow-write` and `--allow-sensitive-data-access` modes are enabled with these broad permissions, as this combination grants significant privileges to the MCP server. Only enable these flags when necessary and in trusted environments. For production use, consider creating more restrictive custom policies.
+
+### Kubernetes API Access Requirements
+
+All Kubernetes API operations will only work when one of the following conditions is met:
+
+1. The user's principal (IAM role/user) actually created the EKS cluster being accessed
+2. An EKS Access Entry has been configured for the user's principal
+
+If you encounter authorization errors when using Kubernetes API operations, verify that an access entry has been properly configured for your principal.
 
 ## Quickstart
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

1. Managing resources through CloudFormation requires many more permissions than what is in the recommended write operations policy. The user needs permissions for all of the resources in the template. The permissions were only allowing the user to initiate stack creation, but deployment would fail for resources in the stack. 

   Updating the README to suggest using EKS full access (`eks:*`) and managed policies for the rest of the services in the cfn template.

2. `"aws:RequestTag/CreatedBy": "EksMcpServer"` also only allows CreateStack (it should be `ResourceTag`) - that condition gets removed with this change.
3. Highlighting that k8s APIs would only work when the user's principal actually created the cluster or has an EKS access entry in place. 


### User experience

1. The generate and deploy workflow using the MCP tool `manage_eks_stacks` should successfully deploy the EKS cluster and all associated resources in the template
2. CFN stack operations should work with the new recommended policies
3. Users will be less confused if they run into auth issues with existing clusters 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: #305 

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
