### PR TITLE
docs: Clarify AWS MCP Servers are fully open source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS MCP Servers
 
-A suite of specialized MCP servers that help you get the most out of AWS, wherever you use MCP.
+AWS MCP Servers are a suite of fully open-source specialized servers that implement the Model Context Protocol (MCP) to connect AI assistants with supported AWS services.
 
 [![GitHub](https://img.shields.io/badge/github-awslabs/mcp-blue.svg?style=flat&logo=github)](https://github.com/awslabs/mcp)
 [![License](https://img.shields.io/badge/license-Apache--2.0-brightgreen)](LICENSE)


### PR DESCRIPTION
We recently received feedback from users expressing confusion about the pricing model for AWS MCP Servers. This PR addresses that feedback by refining the language in the README to make it clearer that AWS MCP Servers are fully open-source.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
This PR makes it clear that AWS MCP Servers are fully open-source.

### Changes

> Please provide a summary of what's being changed

Updated the description of AWS MCP Servers in the README.

### User experience

> Please share what the user experience looks like before and after this change

After this change, it's clear to users that AWS MCP Servers are fully open source.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)
No

**RFC issue number**:

Checklist:

* [-] Migration process documented
* [-] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
