### PR TITLE
change (back) to status 202 for notifications

### DIFF
--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -310,7 +310,7 @@ class MCPLambdaHandler:
                 if isinstance(body, dict) and 'id' not in body:
                     logger.debug('Request is a notification')
                     return {
-                        'statusCode': 204,
+                        'statusCode': 202,
                         'body': '',
                         'headers': {'Content-Type': 'application/json', 'MCP-Version': '0.6'},
                     }

--- a/src/mcp-lambda-handler/tests/test_lambda_handler.py
+++ b/src/mcp-lambda-handler/tests/test_lambda_handler.py
@@ -412,7 +412,7 @@ def test_handle_request_notification():
     event = make_lambda_event(req)
     context = None
     resp = handler.handle_request(event, context)
-    assert resp['statusCode'] == 204
+    assert resp['statusCode'] == 202
     assert resp['body'] == ''
     assert resp['headers']['Content-Type'] == 'application/json'
 
@@ -445,7 +445,7 @@ def test_handle_request_delete_session():
     event['headers'].pop('mcp-session-id')
     resp = handler.handle_request(event, None)
     # NOTE: Accepting 202 here, but double check this is correct per the MCP spec
-    assert resp['statusCode'] in (204, 400, 404)
+    assert resp['statusCode'] in (202, 204, 400, 404)
 
 
 def test_handle_request_unsupported_content_type():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

When the server sends a notification, it will send an empty payload with status code 202. This was previously changed from 202 to 204, this now reverts that change.

## Background

This change addresses a discrepancy between standard JSON-RPC conventions and the MCP specification requirements:

**Standard JSON-RPC over HTTP:** Notifications (which don't expect a response) typically return `204 No Content` since there's no content to return after successful processing.

**MCP Specification Requirement:** The MCP spec (2025-03-26) explicitly requires `202 Accepted` for the Streamable HTTP transport: *"If the server accepts the input, the server MUST return HTTP status code 202 Accepted with no body"* ([spec reference](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/))

## Why MCP uses 202 instead of 204

The semantic difference is important in the MCP context:
- `204 No Content` = "request processed successfully, no content to return"  
- `202 Accepted` = "request accepted for processing, processing may not be complete"

MCP's Streamable HTTP transport supports bidirectional communication where:
1. The server may later send notifications/requests back to the client via SSE
2. Processing might be asynchronous 
3. The "accepted for processing" semantic of 202 is more accurate than "completed with no content"

## Resolution

This change ensures compliance with the MCP specification by using `202 Accepted` for all accepted input in the Streamable HTTP transport, including notifications.

Fixes: [link to issue if applicable]
Spec reference: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/

## Summary
Spec says: 
"If the server accepts the input, the server MUST return HTTP status code 202 Accepted with no body."
(https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)

### Changes

```
                # Check if this is a notification (no id field)
                if isinstance(body, dict) and 'id' not in body:
                    logger.debug('Request is a notification')
                    return {
                        'statusCode': 202,
                        'body': '',
                        'headers': {'Content-Type': 'application/json', 'MCP-Version': '0.6'},
                    }
```

### User experience

Prevents errors with Strands-Agents MCP client.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

### Test results: 

pytest
================================================== test session starts ===================================================
platform darwin -- Python 3.12.10, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/mikegc/Documents/cont/mcp/src/mcp-lambda-handler
configfile: pyproject.toml
testpaths: tests
collected 40 items                                                                                                       

tests/test_lambda_handler.py ........................................                                              [100%]

==================================================== warnings summary ====================================================
../../.direnv/python-3.12.10/lib/python3.12/site-packages/_pytest/config/__init__.py:1441
  /Users/mikegc/Documents/cont/mcp/.direnv/python-3.12.10/lib/python3.12/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

../../.direnv/python-3.12.10/lib/python3.12/site-packages/_pytest/config/__init__.py:1441
  /Users/mikegc/Documents/cont/mcp/.direnv/python-3.12.10/lib/python3.12/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 40 passed, 2 warnings in 0.13s =============================================
