### PR TITLE
fix: Lambda functions not registering in MCP Server

### DIFF
--- a/src/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/server.py
+++ b/src/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/server.py
@@ -299,9 +299,9 @@ def register_lambda_functions():
 
 def main():
     """Run the MCP server with CLI argument support."""
-    mcp.run()
-
     register_lambda_functions()
+
+    mcp.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

This Pull Request addresses an issue where `awslabs.lambda-tool-mcp-server` fails to discover and register Lambda functions as MCP tools when run via `uvx awslabs.lambda-tool-mcp-server@latest` (e.g., in environments like Cursor). The core change involves reordering function calls in the `main()` function of `servers/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/server.py` to ensure Lambda functions are registered before the MCP server starts its blocking operation.

Specifically, the `register_lambda_functions()` call is moved to execute before `mcp.run()`.

### User experience

**Before this change:**

When running `awslabs.lambda-tool-mcp-server` via `uvx awslabs.lambda-tool-mcp-server@latest` (e.g., in Cursor):
The server logs indicate successful startup and credential loading, but then report "Found 0 tools" without any attempt to list or filter Lambda functions. This prevents the integration with AI models as the Lambda functions are not exposed as MCP tools.

Example log snippet:
```log
INFO:__main__:AWS_PROFILE: my-profile
INFO:__main__:AWS_REGION: ap-northeast-1
INFO:__main__:FUNCTION_PREFIX: MCPTool
INFO:__main__:FUNCTION_LIST: []
INFO:__main__:FUNCTION_TAG_KEY: MCPTool
INFO:__main__:FUNCTION_TAG_VALUE: true
INFO:__main__:FUNCTION_INPUT_SCHEMA_ARN_TAG_KEY: None
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials

```
(Note: The logs indicating "Registering Lambda functions as individual tools..." are missing, as the program execution effectively stopped or blocked here.)

**After this change:**

When running `awslabs.lambda-tool-mcp-server` via `uvx awslabs.lambda-tool-mcp-server@latest` (e.g., in Cursor):
Lambda functions are correctly discovered, filtered, and registered as MCP tools. The server will start with the expected tools available for use.

Example log snippet (similar to direct `server.py` execution):
```log
INFO:__main__:AWS_PROFILE: my-profile
INFO:__main__:AWS_REGION: ap-northeast-1
INFO:__main__:FUNCTION_PREFIX: MCPTool
INFO:__main__:FUNCTION_LIST: []
INFO:__main__:FUNCTION_TAG_KEY: MCPTool
INFO:__main__:FUNCTION_TAG_VALUE: true
INFO:__main__:FUNCTION_INPUT_SCHEMA_ARN_TAG_KEY: None
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:__main__:Registering Lambda functions as individual tools...
INFO:__main__:Total Lambda functions found: 16
INFO:__main__:4 Lambda functions found after name filtering.
INFO:__main__:Filtering functions by tag key-value pair: MCPTool=true
INFO:__main__:4 Lambda functions found with tag MCPTool=true.
INFO:__main__:No schema tag environment variable provided (FUNCTION_INPUT_SCHEMA_ARN_TAG_KEY ).
...
INFO:__main__:Lambda functions registered successfully as individual tools.
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (Confirmed by local execution of the modified source code, and understanding the root cause from diff analysis)
* [ ] Changes are documented (No specific documentation changes required for this fix, as the bug is in the server's internal startup logic. The fix itself makes the existing documentation implicitly correct.)

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
