### PR TITLE
fix: (eks-mcp-server) get_pod_logs should handle getting logs when there are multiple containers

### DIFF
--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_apis.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_apis.py
@@ -407,22 +407,26 @@ class K8sApis:
             Pod logs as a string
         """
         try:
-            # Get the Pod resource using the dynamic client
-            pod_resource = self.dynamic_client.resources.get(api_version='v1', kind='Pod')
+            from kubernetes import client
 
-            # Prepare parameters for the log subresource
+            # Create CoreV1Api client
+            core_v1_api = client.CoreV1Api(self.api_client)
+
+            # Prepare parameters for the read_namespaced_pod_log method
             params = {}
             if container_name:
                 params['container'] = container_name
             if since_seconds:
-                params['sinceSeconds'] = since_seconds
+                params['since_seconds'] = since_seconds
             if tail_lines:
-                params['tailLines'] = tail_lines
+                params['tail_lines'] = tail_lines
             if limit_bytes:
-                params['limitBytes'] = limit_bytes
+                params['limit_bytes'] = limit_bytes
 
-            # Call the log subresource (note: singular 'log', not 'logs')
-            logs_response = pod_resource.log.get(name=pod_name, namespace=namespace, **params)
+            # Call the read_namespaced_pod_log method
+            logs_response = core_v1_api.read_namespaced_pod_log(
+                name=pod_name, namespace=namespace, **params
+            )
 
             return logs_response
 

--- a/src/eks-mcp-server/tests/test_k8s_apis.py
+++ b/src/eks-mcp-server/tests/test_k8s_apis.py
@@ -419,69 +419,69 @@ class TestK8sApisOperations:
 
     def test_get_pod_logs(self, k8s_apis):
         """Test get_pod_logs method."""
-        # Mock the dynamic client and resources
-        mock_resource = MagicMock()
-        mock_log = MagicMock()
-        mock_resource.log = mock_log
-        mock_resources = MagicMock()
-        mock_resources.get.return_value = mock_resource
-        k8s_apis.dynamic_client.resources = mock_resources
+        # Mock the CoreV1Api client
+        with patch('kubernetes.client') as mock_client:
+            # Create mock CoreV1Api
+            mock_core_v1_api = MagicMock()
+            mock_client.CoreV1Api.return_value = mock_core_v1_api
 
-        # Mock log.get to return logs
-        mock_log.get.return_value = 'log line 1\nlog line 2\n'
+            # Mock read_namespaced_pod_log to return logs
+            mock_core_v1_api.read_namespaced_pod_log.return_value = 'log line 1\nlog line 2\n'
 
-        # Get pod logs with all parameters
-        logs = k8s_apis.get_pod_logs(
-            pod_name='test-pod',
-            namespace='test-namespace',
-            container_name='test-container',
-            since_seconds=60,
-            tail_lines=100,
-            limit_bytes=1024,
-        )
+            # Get pod logs with all parameters
+            logs = k8s_apis.get_pod_logs(
+                pod_name='test-pod',
+                namespace='test-namespace',
+                container_name='test-container',
+                since_seconds=60,
+                tail_lines=100,
+                limit_bytes=1024,
+            )
 
-        # Verify the result
-        assert logs == 'log line 1\nlog line 2\n'
+            # Verify the result
+            assert logs == 'log line 1\nlog line 2\n'
 
-        # Verify the dynamic client was used correctly
-        mock_resources.get.assert_called_once_with(api_version='v1', kind='Pod')
-        mock_log.get.assert_called_once_with(
-            name='test-pod',
-            namespace='test-namespace',
-            container='test-container',
-            sinceSeconds=60,
-            tailLines=100,
-            limitBytes=1024,
-        )
+            # Verify CoreV1Api was created with the correct API client
+            mock_client.CoreV1Api.assert_called_once_with(k8s_apis.api_client)
+
+            # Verify read_namespaced_pod_log was called with the correct parameters
+            mock_core_v1_api.read_namespaced_pod_log.assert_called_once_with(
+                name='test-pod',
+                namespace='test-namespace',
+                container='test-container',
+                since_seconds=60,
+                tail_lines=100,
+                limit_bytes=1024,
+            )
 
     def test_get_pod_logs_minimal(self, k8s_apis):
         """Test get_pod_logs method with minimal parameters."""
-        # Mock the dynamic client and resources
-        mock_resource = MagicMock()
-        mock_log = MagicMock()
-        mock_resource.log = mock_log
-        mock_resources = MagicMock()
-        mock_resources.get.return_value = mock_resource
-        k8s_apis.dynamic_client.resources = mock_resources
+        # Mock the CoreV1Api client
+        with patch('kubernetes.client') as mock_client:
+            # Create mock CoreV1Api
+            mock_core_v1_api = MagicMock()
+            mock_client.CoreV1Api.return_value = mock_core_v1_api
 
-        # Mock log.get to return logs
-        mock_log.get.return_value = 'log line 1\nlog line 2\n'
+            # Mock read_namespaced_pod_log to return logs
+            mock_core_v1_api.read_namespaced_pod_log.return_value = 'log line 1\nlog line 2\n'
 
-        # Get pod logs with minimal parameters
-        logs = k8s_apis.get_pod_logs(
-            pod_name='test-pod',
-            namespace='test-namespace',
-        )
+            # Get pod logs with minimal parameters
+            logs = k8s_apis.get_pod_logs(
+                pod_name='test-pod',
+                namespace='test-namespace',
+            )
 
-        # Verify the result
-        assert logs == 'log line 1\nlog line 2\n'
+            # Verify the result
+            assert logs == 'log line 1\nlog line 2\n'
 
-        # Verify the dynamic client was used correctly
-        mock_resources.get.assert_called_once_with(api_version='v1', kind='Pod')
-        mock_log.get.assert_called_once_with(
-            name='test-pod',
-            namespace='test-namespace',
-        )
+            # Verify CoreV1Api was created with the correct API client
+            mock_client.CoreV1Api.assert_called_once_with(k8s_apis.api_client)
+
+            # Verify read_namespaced_pod_log was called with the correct parameters
+            mock_core_v1_api.read_namespaced_pod_log.assert_called_once_with(
+                name='test-pod',
+                namespace='test-namespace',
+            )
 
     def _create_mock_event(self):
         """Create a mock event for testing."""


### PR DESCRIPTION

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Replacing the direct call to the logs subresource in `get_pod_logs` with a call to CoreV1Api, similar to the python example here: https://github.com/kubernetes-client/python/blob/master/examples/pod_logs.py#L47. It seems like the dynamic client did not handle the `container` param we supplied previously.

### User experience

`get_pod_logs` should work when the pod has 1 to many containers (with `container_name` specified when there are multiple containers). Previously, it would only work when there was one container.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**: #488 

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
