### PR TITLE
fix(logs): fix useragent setting and add contributions link

### DIFF
--- a/src/cloudwatch-logs-mcp-server/CHANGELOG.md
+++ b/src/cloudwatch-logs-mcp-server/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.0.1] - 2025-06-02
+
+### Fixed
+
+- Fix MCP user agent being added so users can identify requests from this server in CloudTrail
+
+## [0.0.0] - 2025-05-29
+
 ### Added
 
 - Initial project setup

--- a/src/cloudwatch-logs-mcp-server/README.md
+++ b/src/cloudwatch-logs-mcp-server/README.md
@@ -88,3 +88,7 @@ Example for Amazon Q Developer CLI (~/.aws/amazonq/mcp.json):
   }
 }
 ```
+
+## Contributing
+
+Contributions are welcome! Please see the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the monorepo root for guidelines.

--- a/src/cloudwatch-logs-mcp-server/awslabs/cloudwatch_logs_mcp_server/__init__.py
+++ b/src/cloudwatch-logs-mcp-server/awslabs/cloudwatch_logs_mcp_server/__init__.py
@@ -11,4 +11,4 @@
 
 """awslabs.cloudwatch-logs-mcp-server"""
 
-MCP_SERVER_VERSION = '0.0.0'
+MCP_SERVER_VERSION = '0.0.1'

--- a/src/cloudwatch-logs-mcp-server/awslabs/cloudwatch_logs_mcp_server/server.py
+++ b/src/cloudwatch-logs-mcp-server/awslabs/cloudwatch_logs_mcp_server/server.py
@@ -55,10 +55,10 @@ config = Config(user_agent_extra=f'awslabs/mcp/cloudwatch-logs-mcp-server/{MCP_S
 try:
     if aws_profile := os.environ.get('AWS_PROFILE'):
         logs_client = boto3.Session(profile_name=aws_profile, region_name=aws_region).client(
-            'logs'
+            'logs', config=config
         )
     else:
-        logs_client = boto3.Session(region_name=aws_region).client('logs')
+        logs_client = boto3.Session(region_name=aws_region).client('logs', config=config)
 except Exception as e:
     logger.error(f'Error creating cloudwatch logs client: {str(e)}')
     raise

--- a/src/cloudwatch-logs-mcp-server/tests/test_server.py
+++ b/src/cloudwatch-logs-mcp-server/tests/test_server.py
@@ -31,7 +31,7 @@ from awslabs.cloudwatch_logs_mcp_server.server import (
 )
 from moto import mock_aws
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 
 @pytest_asyncio.fixture
@@ -539,7 +539,7 @@ class TestAWSProfileInitialization:
             mock_session_class.assert_called_with(
                 profile_name='test-profile', region_name='us-west-2'
             )
-            mock_session_instance.client.assert_called_with('logs')
+            mock_session_instance.client.assert_called_with('logs', config=ANY)
 
     def test_logs_client_without_aws_profile(self, monkeypatch):
         """Test logs client initialization when AWS_PROFILE is not set."""
@@ -561,7 +561,7 @@ class TestAWSProfileInitialization:
             mock_session_class.assert_called_with(region_name='us-east-1')
 
             # Verify client method was called with 'logs'
-            mock_session_instance.client.assert_called_with('logs')
+            mock_session_instance.client.assert_called_with('logs', config=ANY)
 
     def test_logs_client_initialization_exception(self, monkeypatch):
         """Test that initialization exception is properly raised and logged."""

--- a/src/cloudwatch-logs-mcp-server/uv.lock
+++ b/src/cloudwatch-logs-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-logs-mcp-server"
-version = "0.0.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
* Fix user agent and add contributions link to readme

### User experience

* Users can find requests from this MCP server in cloudtrail using UserAgent

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: #430 

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
