### PR TITLE
Add sanitization for sensitive data in aws-serverless-mcp-server

### DIFF
--- a/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/tools/sam/sam_local_invoke.py
+++ b/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/tools/sam/sam_local_invoke.py
@@ -17,6 +17,7 @@ import json
 import os
 import tempfile
 from awslabs.aws_serverless_mcp_server.utils.process import run_command
+from awslabs.aws_serverless_mcp_server.utils.security import ResponseSanitizer
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
@@ -163,12 +164,14 @@ class SamLocalInvokeTool:
                     # If not valid JSON, keep as string
                     pass
 
-                return {
+                result = {
                     'success': True,
                     'message': f"Successfully invoked resource '{resource_name}' locally.",
                     'logs': stderr.decode(),
                     'function_output': function_output,
                 }
+                # Apply sanitization to prevent leaking sensitive data
+                return ResponseSanitizer.sanitize(result)
             finally:
                 # Clean up temporary event file if created
                 if temp_event_file and os.path.exists(temp_event_file):

--- a/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/tools/sam/sam_logs.py
+++ b/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/tools/sam/sam_logs.py
@@ -14,6 +14,7 @@
 """SAM logs tool for AWS Serverless MCP Server."""
 
 from awslabs.aws_serverless_mcp_server.utils.process import run_command
+from awslabs.aws_serverless_mcp_server.utils.security import ResponseSanitizer
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
@@ -128,11 +129,13 @@ class SamLogsTool:
             stdout, stderr = await run_command(cmd)
             message = 'Successfully fetched logs'
 
-            return {
+            result = {
                 'success': True,
                 'message': message,
                 'output': stdout.decode(),
             }
+            # Apply sanitization to prevent leaking sensitive data
+            return ResponseSanitizer.sanitize(result)
         except Exception as e:
             error_message = getattr(e, 'stderr', str(e))
             logger.error(f'Error fetching logs for resource: {error_message}')

--- a/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/utils/security.py
+++ b/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/utils/security.py
@@ -1,0 +1,82 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+
+"""Security utilities for the AWS Serverless MCP Server."""
+
+import re
+from typing import Any, Dict, List
+
+
+class ResponseSanitizer:
+    """Sanitizes responses to prevent sensitive information leakage in CloudWatch logs and Lambda outputs."""
+
+    # Patterns for sensitive data commonly found in serverless environments
+    PATTERNS = {
+        "aws_access_key": r"\b[A-Z0-9]{20}\b",
+        "aws_secret_key": r"\b[A-Za-z0-9/+=]{40}\b",
+        "password": r"(?i)password\s*[=:]\s*[^\s]+",
+        "private_key": r"-----BEGIN (?:RSA|DSA|EC|OPENSSH) PRIVATE KEY-----",
+        "aws_account_id": r"\b\d{12}\b",
+        "api_key": r"(?i)(api[_-]?key|x-api-key)\s*[:=]\s*[a-zA-Z0-9_-]+",
+    }
+
+    @classmethod
+    def sanitize(cls, response: Any) -> Any:
+        """
+        Sanitizes a response to remove sensitive information.
+
+        Args:
+            response: The response to sanitize
+
+        Returns:
+            Any: The sanitized response
+        """
+        if isinstance(response, dict):
+            return cls._sanitize_dict(response)
+        elif isinstance(response, list):
+            return [cls.sanitize(item) for item in response]
+        elif isinstance(response, str):
+            return cls._sanitize_string(response)
+        else:
+            return response
+
+    @classmethod
+    def _sanitize_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Sanitizes a dictionary recursively.
+
+        Args:
+            data: The dictionary to sanitize
+
+        Returns:
+            Dict[str, Any]: The sanitized dictionary
+        """
+        result = {}
+        for key, value in data.items():
+            result[key] = cls.sanitize(value)
+        return result
+
+    @classmethod
+    def _sanitize_string(cls, text: str) -> str:
+        """
+        Sanitizes a string to remove sensitive information.
+
+        Args:
+            text: The string to sanitize
+
+        Returns:
+            str: The sanitized string
+        """
+        for pattern_name, pattern in cls.PATTERNS.items():
+            text = re.sub(pattern, f"[REDACTED {pattern_name.upper()}]", text)
+        return text

--- a/src/aws-serverless-mcp-server/tests/test_response_sanitization.py
+++ b/src/aws-serverless-mcp-server/tests/test_response_sanitization.py
@@ -1,0 +1,216 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+
+"""Tests for the response sanitization framework."""
+
+import unittest
+from awslabs.aws_serverless_mcp_server.utils.security import ResponseSanitizer
+
+
+class TestResponseSanitizer(unittest.TestCase):
+    """Tests for the ResponseSanitizer class."""
+
+    def test_sanitize_string(self):
+        """Test sanitizing a string with various sensitive patterns."""
+        # Test AWS access key
+        text = "My access key is AKIAIOSFODNN7EXAMPLE"
+        sanitized = ResponseSanitizer._sanitize_string(text)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", sanitized)
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", sanitized)
+
+        # Test AWS secret key
+        text = "My secret key is wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        sanitized = ResponseSanitizer._sanitize_string(text)
+        self.assertNotIn("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", sanitized)
+        self.assertIn("[REDACTED AWS_SECRET_KEY]", sanitized)
+
+        # Test password
+        text = "password=mysecretpassword"
+        sanitized = ResponseSanitizer._sanitize_string(text)
+        self.assertNotIn("password=mysecretpassword", sanitized)
+        self.assertIn("[REDACTED PASSWORD]", sanitized)
+
+        # Test AWS account ID
+        text = "Account ID: 123456789012"
+        sanitized = ResponseSanitizer._sanitize_string(text)
+        self.assertNotIn("123456789012", sanitized)
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", sanitized)
+
+        # Test API key
+        text = "api_key=sk-proj-abcdef123456"
+        sanitized = ResponseSanitizer._sanitize_string(text)
+        self.assertNotIn("api_key=sk-proj-abcdef123456", sanitized)
+        self.assertIn("[REDACTED API_KEY]", sanitized)
+
+    def test_sanitize_cloudwatch_logs(self):
+        """Test sanitizing CloudWatch logs output."""
+        logs = """
+        2024-01-15 10:30:00 START RequestId: 123e4567-e89b-12d3-a456-426614174000
+        2024-01-15 10:30:01 Environment variables: AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+        2024-01-15 10:30:01 Environment variables: AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        2024-01-15 10:30:02 Processing account 123456789012
+        2024-01-15 10:30:03 API_KEY=sk-proj-abcdef123456
+        2024-01-15 10:30:04 END RequestId: 123e4567-e89b-12d3-a456-426614174000
+        """
+
+        sanitized = ResponseSanitizer._sanitize_string(logs)
+
+        # Check that sensitive data is redacted
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", sanitized)
+        self.assertNotIn("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", sanitized)
+        self.assertNotIn("123456789012", sanitized)
+        self.assertNotIn("sk-proj-abcdef123456", sanitized)
+
+        # Check that redacted markers are present
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", sanitized)
+        self.assertIn("[REDACTED AWS_SECRET_KEY]", sanitized)
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", sanitized)
+        self.assertIn("[REDACTED API_KEY]", sanitized)
+
+        # Check that non-sensitive data is preserved
+        self.assertIn("START RequestId", sanitized)
+        self.assertIn("END RequestId", sanitized)
+        self.assertIn("Environment variables", sanitized)
+
+    def test_sanitize_dict(self):
+        """Test sanitizing a dictionary with nested sensitive data."""
+        data = {
+            "success": True,
+            "message": "Function executed successfully",
+            "output": "Account 123456789012 processed",
+            "environment": {
+                "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+                "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "API_KEY": "api_key=sk-proj-abcdef123456"
+            },
+            "logs": [
+                "Processing started",
+                "Found password=mysecretpassword",
+                "Processing complete"
+            ]
+        }
+
+        sanitized = ResponseSanitizer.sanitize(data)
+
+        # Check that structure is preserved
+        self.assertEqual(sanitized["success"], True)
+        self.assertEqual(sanitized["message"], "Function executed successfully")
+
+        # Check that sensitive data is redacted
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", sanitized["output"])
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", sanitized["environment"]["AWS_ACCESS_KEY_ID"])
+        self.assertIn("[REDACTED AWS_SECRET_KEY]", sanitized["environment"]["AWS_SECRET_ACCESS_KEY"])
+        self.assertIn("[REDACTED API_KEY]", sanitized["environment"]["API_KEY"])
+        self.assertIn("[REDACTED PASSWORD]", sanitized["logs"][1])
+
+        # Check that non-sensitive data is preserved
+        self.assertEqual(sanitized["logs"][0], "Processing started")
+        self.assertEqual(sanitized["logs"][2], "Processing complete")
+
+    def test_sanitize_lambda_invocation_response(self):
+        """Test sanitizing a typical Lambda invocation response."""
+        response = {
+            "success": True,
+            "message": "Successfully invoked resource 'MyFunction' locally.",
+            "logs": """START RequestId: 123e4567-e89b-12d3-a456-426614174000 Version: $LATEST
+[INFO] 2024-01-15 10:30:00 Connecting to database with password=db_secret_password
+[INFO] 2024-01-15 10:30:01 Using API key: api-key=1234567890abcdef
+[INFO] 2024-01-15 10:30:02 Processing account 123456789012
+END RequestId: 123e4567-e89b-12d3-a456-426614174000
+REPORT RequestId: 123e4567-e89b-12d3-a456-426614174000 Duration: 150.00 ms Billed Duration: 200 ms Memory Size: 128 MB Max Memory Used: 64 MB""",
+            "function_output": {
+                "statusCode": 200,
+                "body": "Success",
+                "headers": {
+                    "X-Account-Id": "123456789012",
+                    "X-Api-Key": "Bearer AKIAIOSFODNN7EXAMPLE"
+                }
+            }
+        }
+
+        sanitized = ResponseSanitizer.sanitize(response)
+
+        # Check that sensitive data in logs is redacted
+        self.assertNotIn("db_secret_password", str(sanitized))
+        self.assertNotIn("1234567890abcdef", str(sanitized))
+        self.assertNotIn("123456789012", str(sanitized))
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", str(sanitized))
+
+        # Check that redacted markers are present
+        self.assertIn("[REDACTED PASSWORD]", sanitized["logs"])
+        self.assertIn("[REDACTED API_KEY]", sanitized["logs"])
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", sanitized["logs"])
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", str(sanitized["function_output"]))
+
+        # Check that non-sensitive data is preserved
+        self.assertEqual(sanitized["success"], True)
+        self.assertEqual(sanitized["function_output"]["statusCode"], 200)
+        self.assertEqual(sanitized["function_output"]["body"], "Success")
+        self.assertIn("START RequestId", sanitized["logs"])
+        self.assertIn("REPORT RequestId", sanitized["logs"])
+
+    def test_sanitize_list(self):
+        """Test sanitizing a list with sensitive data."""
+        data = [
+            "Regular log entry",
+            "Found AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+            {"password": "password=secret123"},
+            ["Account", "123456789012", "processed"]
+        ]
+
+        sanitized = ResponseSanitizer.sanitize(data)
+
+        # Check that sensitive data is redacted
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", str(sanitized))
+        self.assertNotIn("secret123", str(sanitized))
+        self.assertNotIn("123456789012", str(sanitized))
+
+        # Check that redacted markers are present
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", sanitized[1])
+        self.assertIn("[REDACTED PASSWORD]", str(sanitized[2]))
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", sanitized[3][1])
+
+        # Check that non-sensitive data is preserved
+        self.assertEqual(sanitized[0], "Regular log entry")
+        self.assertEqual(sanitized[3][0], "Account")
+        self.assertEqual(sanitized[3][2], "processed")
+
+    def test_sanitize_non_string_types(self):
+        """Test that non-string types pass through unchanged."""
+        # Test integers
+        self.assertEqual(ResponseSanitizer.sanitize(123), 123)
+
+        # Test floats
+        self.assertEqual(ResponseSanitizer.sanitize(123.45), 123.45)
+
+        # Test booleans
+        self.assertEqual(ResponseSanitizer.sanitize(True), True)
+        self.assertEqual(ResponseSanitizer.sanitize(False), False)
+
+        # Test None
+        self.assertEqual(ResponseSanitizer.sanitize(None), None)
+
+    def test_sanitize_empty_structures(self):
+        """Test sanitizing empty structures."""
+        # Empty string
+        self.assertEqual(ResponseSanitizer.sanitize(""), "")
+
+        # Empty dict
+        self.assertEqual(ResponseSanitizer.sanitize({}), {})
+
+        # Empty list
+        self.assertEqual(ResponseSanitizer.sanitize([]), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/aws-serverless-mcp-server/tests/test_sam_tools_sanitization.py
+++ b/src/aws-serverless-mcp-server/tests/test_sam_tools_sanitization.py
@@ -1,0 +1,270 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+
+"""Tests for SAM tools sanitization."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from awslabs.aws_serverless_mcp_server.tools.sam.sam_logs import SamLogsTool
+from awslabs.aws_serverless_mcp_server.tools.sam.sam_local_invoke import SamLocalInvokeTool
+from mcp.server.fastmcp import FastMCP, Context
+
+
+class TestSamToolsSanitization(unittest.IsolatedAsyncioTestCase):
+    """Tests for sanitization in SAM tools."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mcp = MagicMock(spec=FastMCP)
+        self.mcp.tool = MagicMock(return_value=lambda x: x)
+        self.ctx = MagicMock(spec=Context)
+        self.ctx.info = AsyncMock()
+
+    @patch('awslabs.aws_serverless_mcp_server.tools.sam.sam_logs.run_command')
+    async def test_sam_logs_sanitization(self, mock_run_command):
+        """Test that sam_logs properly sanitizes CloudWatch logs output."""
+        # Mock CloudWatch logs output containing sensitive data
+        mock_stdout = b"""
+2024-01-15T10:30:00.000Z START RequestId: 550e8400-e29b-41d4-a716-446655440000 Version: $LATEST
+2024-01-15T10:30:01.000Z [INFO] Loading configuration...
+2024-01-15T10:30:01.000Z [INFO] AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+2024-01-15T10:30:01.000Z [INFO] AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+2024-01-15T10:30:02.000Z [INFO] Processing account 123456789012
+2024-01-15T10:30:02.000Z [INFO] Connecting to database with password=supersecretdbpass
+2024-01-15T10:30:03.000Z [INFO] Using API_KEY=sk-proj-1234567890abcdef
+2024-01-15T10:30:04.000Z [INFO] Processing complete
+2024-01-15T10:30:04.000Z END RequestId: 550e8400-e29b-41d4-a716-446655440000
+2024-01-15T10:30:04.000Z REPORT RequestId: 550e8400-e29b-41d4-a716-446655440000 Duration: 4000.00 ms Billed Duration: 4000 ms Memory Size: 128 MB Max Memory Used: 75 MB
+"""
+        mock_stderr = b""
+        mock_run_command.return_value = (mock_stdout, mock_stderr)
+
+        # Create tool instance with sensitive data access allowed
+        tool = SamLogsTool(self.mcp, allow_sensitive_data_access=True)
+
+        # Execute the tool
+        result = await tool.handle_sam_logs(
+            self.ctx,
+            resource_name="MyFunction",
+            stack_name="my-stack"
+        )
+
+        # Verify the command was called
+        mock_run_command.assert_called_once()
+
+        # Check that sensitive data is sanitized
+        output = result['output']
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", output)
+        self.assertNotIn("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", output)
+        self.assertNotIn("123456789012", output)
+        self.assertNotIn("supersecretdbpass", output)
+        self.assertNotIn("sk-proj-1234567890abcdef", output)
+
+        # Check that redacted markers are present
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", output)
+        self.assertIn("[REDACTED AWS_SECRET_KEY]", output)
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", output)
+        self.assertIn("[REDACTED PASSWORD]", output)
+        self.assertIn("[REDACTED API_KEY]", output)
+
+        # Check that non-sensitive data is preserved
+        self.assertIn("START RequestId", output)
+        self.assertIn("END RequestId", output)
+        self.assertIn("REPORT RequestId", output)
+        self.assertIn("Processing complete", output)
+        self.assertIn("Loading configuration", output)
+
+    @patch('awslabs.aws_serverless_mcp_server.tools.sam.sam_logs.run_command')
+    async def test_sam_logs_access_denied(self, mock_run_command):
+        """Test that sam_logs returns error when sensitive data access is not allowed."""
+        # Create tool instance with sensitive data access denied
+        tool = SamLogsTool(self.mcp, allow_sensitive_data_access=False)
+
+        # Execute the tool
+        result = await tool.handle_sam_logs(
+            self.ctx,
+            resource_name="MyFunction",
+            stack_name="my-stack"
+        )
+
+        # Verify the command was not called
+        mock_run_command.assert_not_called()
+
+        # Check that error is returned
+        self.assertFalse(result['success'])
+        self.assertIn("Sensitive data access is not allowed", result['error'])
+
+    @patch('awslabs.aws_serverless_mcp_server.tools.sam.sam_local_invoke.run_command')
+    async def test_sam_local_invoke_sanitization(self, mock_run_command):
+        """Test that sam_local_invoke properly sanitizes Lambda function output."""
+        # Mock Lambda function output containing sensitive data
+        mock_stdout = b'{"statusCode": 200, "body": "{\\"message\\": \\"Success\\", \\"accountId\\": \\"123456789012\\", \\"apiKey\\": \\"AKIAIOSFODNN7EXAMPLE\\"}"}'
+        mock_stderr = b"""
+START RequestId: 550e8400-e29b-41d4-a716-446655440000 Version: $LATEST
+[INFO] Environment: AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+[INFO] Processing with password=mydbpassword
+[INFO] Using x-api-key=sk-1234567890
+END RequestId: 550e8400-e29b-41d4-a716-446655440000
+REPORT RequestId: 550e8400-e29b-41d4-a716-446655440000 Duration: 100.00 ms Billed Duration: 100 ms Memory Size: 128 MB Max Memory Used: 50 MB
+"""
+        mock_run_command.return_value = (mock_stdout, mock_stderr)
+
+        # Create tool instance
+        tool = SamLocalInvokeTool(self.mcp)
+
+        # Execute the tool
+        result = await tool.handle_sam_local_invoke(
+            self.ctx,
+            project_directory="/path/to/project",
+            resource_name="MyFunction"
+        )
+
+        # Verify the command was called
+        mock_run_command.assert_called_once()
+
+        # Check that sensitive data in function output is sanitized
+        function_output = str(result['function_output'])
+        self.assertNotIn("123456789012", function_output)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", function_output)
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", function_output)
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", function_output)
+
+        # Check that sensitive data in logs is sanitized
+        logs = result['logs']
+        self.assertNotIn("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", logs)
+        self.assertNotIn("mydbpassword", logs)
+        self.assertNotIn("sk-1234567890", logs)
+        self.assertIn("[REDACTED AWS_SECRET_KEY]", logs)
+        self.assertIn("[REDACTED PASSWORD]", logs)
+        self.assertIn("[REDACTED API_KEY]", logs)
+
+        # Check that non-sensitive data is preserved
+        self.assertIn("START RequestId", logs)
+        self.assertIn("END RequestId", logs)
+        self.assertIn("REPORT RequestId", logs)
+        self.assertEqual(result['success'], True)
+        self.assertIn("Successfully invoked", result['message'])
+
+    @patch('awslabs.aws_serverless_mcp_server.tools.sam.sam_local_invoke.run_command')
+    async def test_sam_local_invoke_with_event_data_sanitization(self, mock_run_command):
+        """Test that sam_local_invoke sanitizes even when event data is provided."""
+        # Mock Lambda function output
+        mock_stdout = b'{"message": "Processed event", "account": "123456789012"}'
+        mock_stderr = b"""
+START RequestId: 550e8400-e29b-41d4-a716-446655440000 Version: $LATEST
+[INFO] Received event with API key: api_key=secret123
+END RequestId: 550e8400-e29b-41d4-a716-446655440000
+"""
+        mock_run_command.return_value = (mock_stdout, mock_stderr)
+
+        # Create tool instance
+        tool = SamLocalInvokeTool(self.mcp)
+
+        # Execute the tool with event data
+        result = await tool.handle_sam_local_invoke(
+            self.ctx,
+            project_directory="/path/to/project",
+            resource_name="MyFunction",
+            event_data='{"key": "value"}'
+        )
+
+        # Check that sensitive data is sanitized
+        function_output = str(result['function_output'])
+        logs = result['logs']
+
+        self.assertNotIn("123456789012", function_output)
+        self.assertNotIn("secret123", logs)
+        self.assertIn("[REDACTED AWS_ACCOUNT_ID]", function_output)
+        self.assertIn("[REDACTED API_KEY]", logs)
+
+    @patch('awslabs.aws_serverless_mcp_server.tools.sam.sam_local_invoke.run_command')
+    async def test_sam_local_invoke_error_handling(self, mock_run_command):
+        """Test that sam_local_invoke handles errors properly without leaking sensitive data."""
+        # Mock an error that contains sensitive data
+        mock_run_command.side_effect = Exception("Failed to invoke: Invalid AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE")
+
+        # Create tool instance
+        tool = SamLocalInvokeTool(self.mcp)
+
+        # Execute the tool
+        result = await tool.handle_sam_local_invoke(
+            self.ctx,
+            project_directory="/path/to/project",
+            resource_name="MyFunction"
+        )
+
+        # Check that error is returned
+        self.assertFalse(result['success'])
+        self.assertIn("Failed to invoke resource locally", result['message'])
+
+        # Check that sensitive data is NOT sanitized in error messages
+        # (since we're not sanitizing error responses)
+        self.assertIn("AKIAIOSFODNN7EXAMPLE", result['error'])
+
+    @patch('awslabs.aws_serverless_mcp_server.tools.sam.sam_logs.run_command')
+    async def test_sam_logs_with_multiple_sensitive_patterns(self, mock_run_command):
+        """Test sam_logs with logs containing multiple types of sensitive data."""
+        # Mock complex CloudWatch logs with various sensitive patterns
+        mock_stdout = b"""
+2024-01-15T10:30:00.000Z [INFO] Initializing Lambda function
+2024-01-15T10:30:01.000Z [INFO] Environment variables loaded:
+2024-01-15T10:30:01.000Z [INFO]   AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+2024-01-15T10:30:01.000Z [INFO]   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+2024-01-15T10:30:01.000Z [INFO]   DB_PASSWORD=password:mysupersecretpassword
+2024-01-15T10:30:01.000Z [INFO]   API_KEY=x-api-key:sk-proj-abcdef1234567890
+2024-01-15T10:30:02.000Z [INFO] Processing request for account 123456789012
+2024-01-15T10:30:02.000Z [INFO] Connecting to RDS instance in account 987654321098
+2024-01-15T10:30:03.000Z [INFO] Request processed successfully
+2024-01-15T10:30:03.000Z [INFO] Cleaning up resources
+"""
+        mock_stderr = b""
+        mock_run_command.return_value = (mock_stdout, mock_stderr)
+
+        # Create tool instance
+        tool = SamLogsTool(self.mcp, allow_sensitive_data_access=True)
+
+        # Execute the tool
+        result = await tool.handle_sam_logs(
+            self.ctx,
+            resource_name="MyFunction",
+            stack_name="my-stack"
+        )
+
+        # Check that all sensitive patterns are sanitized
+        output = result['output']
+
+        # AWS credentials
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", output)
+        self.assertNotIn("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", output)
+
+        # Passwords
+        self.assertNotIn("mysupersecretpassword", output)
+
+        # API keys
+        self.assertNotIn("sk-proj-abcdef1234567890", output)
+
+        # Account IDs
+        self.assertNotIn("123456789012", output)
+        self.assertNotIn("987654321098", output)
+
+        # Check redacted markers
+        self.assertIn("[REDACTED AWS_ACCESS_KEY]", output)
+        self.assertIn("[REDACTED AWS_SECRET_KEY]", output)
+        self.assertIn("[REDACTED PASSWORD]", output)
+        self.assertIn("[REDACTED API_KEY]", output)
+        self.assertEqual(output.count("[REDACTED AWS_ACCOUNT_ID]"), 2)  # Should redact both account IDs
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…rver

- Add ResponseSanitizer class to redact AWS credentials, passwords, account IDs and API keys
- Integrate sanitization into sam_logs and sam_local_invoke tools
- Add test coverage for sanitization patterns
- Only sanitize when --allow-sensitive-data flag is enabled

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
