### PR TITLE
feat: sam_build_tool now runs in parallel by default

### DIFF
--- a/src/aws-serverless-mcp-server/README.md
+++ b/src/aws-serverless-mcp-server/README.md
@@ -210,6 +210,7 @@ You should have AWS SAM CLI installed and configured in your environment.
 - `build_dir`: The absolute path to a directory where the built artifacts are stored
 - `use_container` (default: false): Use a container to build the function
 - `no_use_container` (default: false): Run build in local machine instead of Docker container
+- `parallel` (default: true): Build your AWS SAM application in parallel
 - `container_env_vars`: Environment variables to pass to the build container
 - `container_env_var_file`: Absolute path to a JSON file containing container environment variables
 - `build_image`: The URI of the container image that you want to pull for the build

--- a/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/tools/sam/sam_build.py
+++ b/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/tools/sam/sam_build.py
@@ -57,6 +57,10 @@ class SamBuildTool:
                 where the key is the resource and environment variable, and the value is the environment variable's value.
                 For example: --container-env-var Function1.GITHUB_TOKEN=TOKEN1 --container-env-var Function2.GITHUB_TOKEN=TOKEN2.""",
         ),
+        parallel: bool = Field(
+            default=True,
+            description='Build your AWS SAM application in parallel.',
+        ),
         container_env_vars: Optional[Dict[str, str]] = Field(
             default=None, description='Environment variables to pass to the build container.'
         ),
@@ -98,11 +102,13 @@ class SamBuildTool:
         This command compiles your Lambda function code, creates deployment artifacts, and prepares your application for deployment and local testing.
         It creates a .aws-sam directory that structures your application in a format and location that sam local and sam deploy require.
 
+        By default, the functions and layers are built in parallel for faster builds.
+
         Best Practices:
-        - Don’t edit any code under the .aws-sam/build directory. Instead, update your original source code in
+        - Don't edit any code under the .aws-sam/build directory. Instead, update your original source code in
         your project folder and run sam build to update the .aws-sam/build directory.
         - When you modify your original files, run sam build to update the .aws-sam/build directory.
-        - You may want the AWS SAM CLI to reference your project’s original root directory
+        - You may want the AWS SAM CLI to reference your project's original root directory
         instead of the .aws-sam directory, such as when developing and testing with sam local. Delete the .aws-sam directory
         or the AWS SAM template in the .aws-sam directory to have the AWS SAM CLI recognize your original project directory as
         the root project directory. When ready, run sam build again to create the .aws-sam directory.
@@ -135,6 +141,8 @@ class SamBuildTool:
             cmd.append('--no-use-container')
         if use_container:
             cmd.append('--use-container')
+        if parallel:
+            cmd.append('--parallel')
         if parameter_overrides:
             cmd.extend(['--parameter-overrides', parameter_overrides])
         if region:

--- a/src/aws-serverless-mcp-server/tests/test_sam_build.py
+++ b/src/aws-serverless-mcp-server/tests/test_sam_build.py
@@ -192,3 +192,92 @@ class TestSamBuild:
             assert result['success'] is False
             assert 'Failed to build SAM project' in result['message']
             assert error_message in result['message']
+
+    @pytest.mark.asyncio
+    async def test_sam_build_with_parallel_default(self):
+        """Test SAM build with default parallel parameter (True)."""
+        # Mock the subprocess.run function
+        mock_result = MagicMock()
+        mock_result.stdout = b'Successfully built SAM project'
+        mock_result.stderr = b''
+
+        with patch(
+            'awslabs.aws_serverless_mcp_server.tools.sam.sam_build.run_command',
+            return_value=(mock_result.stdout, mock_result.stderr),
+        ) as mock_run:
+            # Call the function with default parallel parameter (True)
+            result = await SamBuildTool(MagicMock()).handle_sam_build(
+                AsyncMock(),
+                project_directory=os.path.join(tempfile.gettempdir(), 'test-project'),
+                template_file=None,
+                base_dir=None,
+                build_dir=None,
+                use_container=False,
+                no_use_container=False,
+                container_env_vars=None,
+                container_env_var_file=None,
+                build_image=None,
+                debug=False,
+                manifest=None,
+                parameter_overrides=None,
+                region=None,
+                save_params=False,
+                profile=None,
+            )
+
+            # Verify the result
+            assert result['success'] is True
+            assert 'SAM project built successfully' in result['message']
+
+            # Verify run_command was called with the correct arguments
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            cmd = args[0]
+
+            # Check that --parallel flag is included by default
+            assert '--parallel' in cmd
+
+    @pytest.mark.asyncio
+    async def test_sam_build_with_parallel_disabled(self):
+        """Test SAM build with parallel parameter set to False."""
+        # Mock the subprocess.run function
+        mock_result = MagicMock()
+        mock_result.stdout = b'Successfully built SAM project'
+        mock_result.stderr = b''
+
+        with patch(
+            'awslabs.aws_serverless_mcp_server.tools.sam.sam_build.run_command',
+            return_value=(mock_result.stdout, mock_result.stderr),
+        ) as mock_run:
+            # Call the function with parallel=False
+            result = await SamBuildTool(MagicMock()).handle_sam_build(
+                AsyncMock(),
+                project_directory=os.path.join(tempfile.gettempdir(), 'test-project'),
+                template_file=None,
+                base_dir=None,
+                build_dir=None,
+                use_container=False,
+                no_use_container=False,
+                parallel=False,
+                container_env_vars=None,
+                container_env_var_file=None,
+                build_image=None,
+                debug=False,
+                manifest=None,
+                parameter_overrides=None,
+                region=None,
+                save_params=False,
+                profile=None,
+            )
+
+            # Verify the result
+            assert result['success'] is True
+            assert 'SAM project built successfully' in result['message']
+
+            # Verify run_command was called with the correct arguments
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            cmd = args[0]
+
+            # Check that --parallel flag is NOT included when disabled
+            assert '--parallel' not in cmd


### PR DESCRIPTION
## Summary

Ensure that builds for sam applications are in parallel.

### User experience

Speed up in user experience for parallel builds whenever there are multiple build-able resources in the SAM template.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N): N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
