### PR TITLE
fix: remove test for equality of __version__

### DIFF
--- a/src/stepfunctions-tool-mcp-server/tests/test_server.py
+++ b/src/stepfunctions-tool-mcp-server/tests/test_server.py
@@ -1,23 +1,23 @@
 """Tests for the Step Functions Tool MCP Server."""
 
-from awslabs.stepfunctions_tool_mcp_server.server import __version__
 
+# https://github.com/awslabs/mcp/issues/167
+# https://github.com/awslabs/mcp/issues/425
+# def test_version_matches_pyproject():
+#     """Test that the version in server.py matches pyproject.toml."""
+#     import pathlib
+#     import tomli
 
-def test_version_matches_pyproject():
-    """Test that the version in server.py matches pyproject.toml."""
-    import pathlib
-    import tomli
+#     # Read pyproject.toml
+#     pyproject_path = pathlib.Path(__file__).parent.parent / 'pyproject.toml'
+#     with open(pyproject_path, 'rb') as f:
+#         pyproject = tomli.load(f)
 
-    # Read pyproject.toml
-    pyproject_path = pathlib.Path(__file__).parent.parent / 'pyproject.toml'
-    with open(pyproject_path, 'rb') as f:
-        pyproject = tomli.load(f)
+#     # Get version from pyproject.toml
+#     pyproject_version = pyproject['project']['version']
 
-    # Get version from pyproject.toml
-    pyproject_version = pyproject['project']['version']
-
-    # Verify versions match
-    assert __version__ == pyproject_version, (
-        f'Version mismatch: server.py has version {__version__}, '
-        f'but pyproject.toml has version {pyproject_version}'
-    )
+#     # Verify versions match
+#     assert __version__ == pyproject_version, (
+#         f'Version mismatch: server.py has version {__version__}, '
+#         f'but pyproject.toml has version {pyproject_version}'
+#     )


### PR DESCRIPTION
Fixes #500 

## Summary

During the release, versions are bumped only for the `pyproject.toml` files.

### Changes

Disabled a test checking for equality on the `__version__`.

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
