### PR TITLE
fix: CODEOWNERS for lambda-tool-mcp-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@ NOTICE                                @awslabs/mcp-admins
 /src/dynamodb-mcp-server              @erbenmo                         @awslabs/mcp-admins
 /src/ecs-mcp-server                   @karanbokil @matthewgoodman13    @awslabs/mcp-admins
 /src/git-repo-research-mcp-server     @jonslo                          @awslabs/mcp-admins
-/src/lambda-mcp-server                @danilop @jsamuel1               @awslabs/mcp-admins
+/src/lambda-tool-mcp-server           @danilop @jsamuel1               @awslabs/mcp-admins
 /src/memcached-mcp-server             @seaofawareness                  @awslabs/mcp-admins
 #/src/nova-canvas-mcp-server          @awslabs/mcp-maintainers         @awslabs/mcp-admins
 /src/postgres-mcp-server              @kennthhz                        @awslabs/mcp-admins


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
