### PR TITLE
Use the to_regclass function for table name lookup

### DIFF
--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -294,7 +294,7 @@ async def get_table_schema(
         FROM
             pg_attribute a
         WHERE
-            a.attrelid = :table_name::regclass
+            a.attrelid = to_regclass(:table_name)
             AND a.attnum > 0
             AND NOT a.attisdropped
         ORDER BY a.attnum


### PR DESCRIPTION
Use the to_regclass function instead of the regclass cast so the query doesn't throw an error for tables that do not exist

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed
If the MCP Client sends a table name to the get_table_schema tool and the table name does not exist, an error is thrown. This is because the the regclass cast throws an error. Using the to_regclass function instead, a null is returned for missing tables allowing the query to return an empty set without error. 

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
