### PR TITLE
fix: invalid JSON for cloudwatch-logs-mcp-server example

### DIFF
--- a/src/cloudwatch-logs-mcp-server/README.md
+++ b/src/cloudwatch-logs-mcp-server/README.md
@@ -51,7 +51,7 @@ Example for Amazon Q Developer CLI (~/.aws/amazonq/mcp.json):
       "timeout": 60,
       "command": "uvx",
       "args": [
-        "awslabs.cloudwatch-logs-mcp-server@latest",
+        "awslabs.cloudwatch-logs-mcp-server@latest"
       ],
       "env": {
         "AWS_PROFILE": "[The AWS Profile Name to use for AWS access]",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

- Fix the training comma in in the `awslabs.cloudwatch-logs-mcp-server` example under `Installation`. The JSON in the example is currently no valid

### User experience

- Before this change it was not possible to copy the example and have it working without any edits

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
