### PR TITLE
fix(dynamodb-mcp-server): improve documentation for DynamoDB attribute value format

### DIFF
--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
@@ -52,7 +52,6 @@ from pydantic import Field
 from typing import Any, Dict, List, Literal, Union
 
 
-
 app = FastMCP(
     name='dynamodb-server',
     instructions="""The official MCP Server for interacting with AWS DynamoDB
@@ -89,7 +88,7 @@ is the data type and the value is the data itself:
 
 - NS: Number Set (array of strings representing numbers)
   Example: {"NS": ["42.2", "-19", "7.5", "3.14"]}
-  
+
 - BS: Binary Set (array of Base64-encoded binary data objects)
   Example: {"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]}
 
@@ -140,8 +139,8 @@ expression_attribute_names: Dict[str, str] = Field(
     default=None, description='Substitution tokens for attribute names in an expression.'
 )
 expression_attribute_values: Dict[str, AttributeValue] = Field(
-    default=None, 
-    description='Values that can be substituted in an expression. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).'
+    default=None,
+    description='Values that can be substituted in an expression. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).',
 )
 select: Select = Field(
     default=None,
@@ -149,8 +148,8 @@ select: Select = Field(
 )
 limit: int = Field(default=None, description='The maximum number of items to evaluate', ge=1)
 exclusive_start_key: Dict[str, KeyAttributeValue] = Field(
-    default=None, 
-    description='Use the LastEvaluatedKey from the previous call. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).'
+    default=None,
+    description='Use the LastEvaluatedKey from the previous call. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).',
 )
 
 billing_mode: Literal['PROVISIONED', 'PAY_PER_REQUEST'] = Field(

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
@@ -52,10 +52,54 @@ from pydantic import Field
 from typing import Any, Dict, List, Literal, Union
 
 
+
 app = FastMCP(
     name='dynamodb-server',
-    instructions='The official MCP Server for interacting with AWS DynamoDB',
-    version='0.1.1',
+    instructions="""The official MCP Server for interacting with AWS DynamoDB
+
+IMPORTANT: DynamoDB Attribute Value Format
+-----------------------------------------
+When working with DynamoDB, all attribute values must be specified with their data types.
+Each attribute value is represented as a dictionary with a single key-value pair where the key
+is the data type and the value is the data itself:
+
+- S: String
+  Example: {"S": "Hello"}
+
+- N: Number (sent as a string)
+  Example: {"N": "123.45"}
+
+- B: Binary data (Base64-encoded)
+  Example: {"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"}
+
+- BOOL: Boolean value
+  Example: {"BOOL": true}
+
+- NULL: Null value
+  Example: {"NULL": true}
+
+- L: List of AttributeValue objects
+  Example: {"L": [{"S": "Cookies"}, {"S": "Coffee"}, {"N": "3.14159"}]}
+
+- M: Map of attribute name/value pairs
+  Example: {"M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}}}
+
+- SS: String Set (array of strings)
+  Example: {"SS": ["Giraffe", "Hippo", "Zebra"]}
+
+- NS: Number Set (array of strings representing numbers)
+  Example: {"NS": ["42.2", "-19", "7.5", "3.14"]}
+  
+- BS: Binary Set (array of Base64-encoded binary data objects)
+  Example: {"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]}
+
+Common usage examples:
+- Primary key: {"userId": {"S": "user123"}}
+- Composite key: {"userId": {"S": "user123"}, "timestamp": {"N": "1612345678"}}
+- Expression attribute values: {":minScore": {"N": "100"}, ":active": {"BOOL": true}}
+- Complete item: {"userId": {"S": "user123"}, "score": {"N": "100"}, "data": {"B": "binarydata=="}}
+""",
+    version='0.1.2',
 )
 
 
@@ -81,7 +125,9 @@ index_name = Field(
     default=None,
     description='The name of a GSI',
 )
-key: Dict[str, KeyAttributeValue] = Field(description='The primary key of an item')
+key: Dict[str, KeyAttributeValue] = Field(
+    description='The primary key of an item. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).'
+)
 filter_expression: str = Field(
     default=None,
     description='Filter conditions expression that DynamoDB applies to filter out data',
@@ -94,7 +140,8 @@ expression_attribute_names: Dict[str, str] = Field(
     default=None, description='Substitution tokens for attribute names in an expression.'
 )
 expression_attribute_values: Dict[str, AttributeValue] = Field(
-    default=None, description='Values that can be substituted in an expression'
+    default=None, 
+    description='Values that can be substituted in an expression. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).'
 )
 select: Select = Field(
     default=None,
@@ -102,7 +149,8 @@ select: Select = Field(
 )
 limit: int = Field(default=None, description='The maximum number of items to evaluate', ge=1)
 exclusive_start_key: Dict[str, KeyAttributeValue] = Field(
-    default=None, description='Use the LastEvaluatedKey from the previous call.'
+    default=None, 
+    description='Use the LastEvaluatedKey from the previous call. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).'
 )
 
 billing_mode: Literal['PROVISIONED', 'PAY_PER_REQUEST'] = Field(
@@ -324,7 +372,7 @@ async def get_item(
 async def put_item(
     table_name: str = table_name,
     item: Dict[str, AttributeValue] = Field(
-        description='A map of attribute name/value pairs, one for each attribute.'
+        description='A map of attribute name/value pairs, one for each attribute. Must use DynamoDB attribute value format (see IMPORTANT note about DynamoDB Attribute Value Format).'
     ),
     condition_expression: str = Field(
         default=None,


### PR DESCRIPTION
## Summary
This documentation improvement helps agents understand how to properly format attribute values when interacting with the DynamoDB MCP server.

### Changes
- Add comprehensive explanation of DynamoDB attribute value formats with examples
- Clarify parameter descriptions to explicitly reference required format
- Update version from 0.1.1 to 0.1.2

### User experience

None

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

fixes #564