### PR TITLE
docs: add DocDB mcp client config for Q Developer CLI & troubleshoot guide for MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,21 @@ Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
 
 See individual server READMEs for specific requirements and configuration options.
 
+If you have problems with MCP configuration or want to check if the appropriate parameters are in place, you can try the following:
+
+```shell
+# Run MCP server manually with timeout 15s
+$ timeout 15s uv tool run <MCP Name> <args> 2>&1 || echo "Command completed or timed out"
+
+# Example (Aurora MySQL MCP Server)
+$ timeout 15s uv tool run awslabs.mysql-mcp-server --resource_arn <Your Resource ARN> --secret_arn <Your Secret ARN> ... 2>&1 || echo "Command completed or timed out"
+
+# If the arguments are not set appropriately, you may see the following message:
+usage: awslabs.mysql-mcp-server [-h] --resource_arn RESOURCE_ARN --secret_arn SECRET_ARN --database DATABASE
+                                --region REGION --readonly READONLY
+awslabs.mysql-mcp-server: error: the following arguments are required: --resource_arn, --secret_arn, --database, --region, --readonly
+```
+
 **Note about performance when using `uvx` *"@latest"* suffix:**
 
 Using the *"@latest"* suffix checks and downloads the latest MCP server package from pypi every time you start your MCP clients, but it comes with a cost of increased initial load times. If you want to minimize the initial load time, remove *"@latest"* and manage your uv cache yourself using one of these approaches:

--- a/src/documentdb-mcp-server/README.md
+++ b/src/documentdb-mcp-server/README.md
@@ -164,6 +164,30 @@ insert_result = await use_mcp_tool(
 # ValueError: "Operation not permitted: Server is configured in read-only mode. Use --allow-write flag when starting the server to enable write operations."
 ```
 
+### Configure in your MCP client
+
+Configure the MCP server in your MCP client configuration (e.g., for Amazon Q Developer CLI, edit ~/.aws/amazonq/mcp.json):
+
+```json
+{
+  "mcpServers": {
+    "awslabs.documentdb-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "awslabs.documentdb-mcp-server@latest",
+      ],
+      "env": {
+        "AWS_PROFILE": "your-aws-profile",
+        "AWS_REGION": "us-east-1",
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
 ## Prerequisites
 
 - Network access to your DocumentDB cluster


### PR DESCRIPTION
- Add config for Q Developer CLI
- Add arguments trouble shooting for Q Developer CLI

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

- Add DocumentDB MCP client config at README.md because there's no MCP client (e.g. Q Developer CLI) config
- Add arguments trouble shooting for Q Developer CLI

### User experience

> Please share what the user experience looks like before and after this change

- I can't find the any guide about client config, so I thought it was not possible to use the DocumentDB MCP in the Q Developer CLI. Additionally, I wasted a lot of time trying to connect the MCP to the Q Developer CLI.
  - Through changes to the relevant documentation, users can now easily set up the MCP for document db.
- Add a guide to help users manually run the MCP if it is not executing or if the MCP is stuck in the "Still Loading" state.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
