### PR TITLE
shortened search_repositories_on_github to search_repos_on_github so …

### DIFF
--- a/src/git-repo-research-mcp-server/README.md
+++ b/src/git-repo-research-mcp-server/README.md
@@ -87,12 +87,12 @@ search_research_repository(
 ) -> Dict
 ```
 
-### search_repositories_on_github
+### search_repos_on_github
 
 Searches for GitHub repositories based on keywords, scoped to AWS organizations.
 
 ```python
-search_repositories_on_github(
+search_repos_on_github(
     keywords: List[str],
     num_results: int = 5
 ) -> Dict

--- a/src/git-repo-research-mcp-server/awslabs/git_repo_research_mcp_server/server.py
+++ b/src/git-repo-research-mcp-server/awslabs/git_repo_research_mcp_server/server.py
@@ -78,7 +78,7 @@ Perform semantic search within an indexed repository.
 ### delete_research_repository
 Delete an indexed repository.
 
-### search_repositories_on_github
+### search_repos_on_github
 Search for GitHub repositories based on keywords, scoped to specific organizations.
 
 ### access_file
@@ -150,7 +150,7 @@ delete_research_repository(repository_name_or_path="repo_name")
 
 ### Searching for GitHub Repositories
 ```
-search_repositories_on_github(
+search_repos_on_github(
     keywords=["serverless", "lambda"],
     num_results=10
 )
@@ -666,7 +666,7 @@ async def mcp_search_repository(
         raise
 
 
-@mcp.tool(name='search_repositories_on_github')
+@mcp.tool(name='search_repos_on_github')
 async def mcp_search_github_repos(
     ctx: Context,
     keywords: List[str] = Field(description='List of keywords to search for GitHub repositories'),

--- a/src/git-repo-research-mcp-server/tests/test_rest_github_search.py
+++ b/src/git-repo-research-mcp-server/tests/test_rest_github_search.py
@@ -18,7 +18,7 @@ import pytest
 
 # Import the server functions
 from awslabs.git_repo_research_mcp_server.server import (
-    mcp_search_github_repos as search_repositories_on_github,
+    mcp_search_github_repos as search_repos_on_github,
 )
 
 
@@ -42,7 +42,7 @@ async def test_github_repository_search_live():
 
     # Test searching for "aws lambda serverless"
     # This should return repositories from AWS organizations related to Lambda and serverless
-    search_result = await search_repositories_on_github(
+    search_result = await search_repos_on_github(
         ctx, keywords=['aws', 'lambda', 'serverless'], num_results=5
     )
 
@@ -89,7 +89,7 @@ async def test_github_repository_search_no_results_live():
     ctx = MockContext()
 
     # Test with a very specific query that is unlikely to have repositories
-    search_result = await search_repositories_on_github(
+    search_result = await search_repos_on_github(
         ctx, keywords=['unlikely123456789', 'nonexistentrepo987654321'], num_results=5
     )
 
@@ -118,12 +118,12 @@ async def test_github_repository_search_with_limit_live():
     ctx = MockContext()
 
     # Small number of results
-    small_result = await search_repositories_on_github(
+    small_result = await search_repos_on_github(
         ctx, keywords=['aws', 'dynamodb'], num_results=2
     )
 
     # Larger number of results
-    large_result = await search_repositories_on_github(
+    large_result = await search_repos_on_github(
         ctx, keywords=['aws', 'dynamodb'], num_results=5
     )
 
@@ -154,7 +154,7 @@ async def test_github_repository_order_by_stars_live():
     ctx = MockContext()
 
     # Search for popular AWS repositories
-    search_result = await search_repositories_on_github(
+    search_result = await search_repos_on_github(
         ctx, keywords=['aws', 'cdk'], num_results=10
     )
 


### PR DESCRIPTION
…that fully qualified name awslabsgit_repo_research_mcp_server___search_repos_on_github is under 64 chars

<!-- markdownlint-disable MD041 MD043 -->
Fixes
https://github.com/awslabs/mcp/issues/570

## Summary

### Changes

shortened search_repositories_on_github to search_repos_on_github so that fully qualified name awslabsgit_repo_research_mcp_server___search_repos_on_github is under 64 chars

### User experience

When user installs MCP server in Q Developer and similar tools warning goes away and search works
 - search_repositories_on_github (tool name exceeds max length of 64 when combined with server name)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

No

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
