### PR TITLE
fix: jumphost creation uses default vpc and subnets to simplify exper…

### DIFF
--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/connect.py
@@ -19,7 +19,7 @@ from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
 from botocore.exceptions import ClientError
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 
 async def _configure_security_groups(
@@ -252,18 +252,20 @@ async def get_ssh_tunnel_command_cc(
 @handle_exceptions
 async def create_jump_host_cc(
     cache_cluster_id: str,
-    subnet_id: str,
-    security_group_id: str,
     key_name: str,
+    subnet_id: Optional[str] = None,
+    security_group_id: Optional[str] = None,
     instance_type: str = 't3.small',
 ) -> Dict[str, Any]:
     """Creates an EC2 jump host instance to access an ElastiCache cluster via SSH tunnel.
 
     Args:
         cache_cluster_id (str): ID of the ElastiCache cluster to connect to
-        subnet_id (str): ID of the subnet to launch the EC2 instance in (must be public)
-        security_group_id (str): ID of the security group to assign to the EC2 instance
         key_name (str): Name of the EC2 key pair to use for SSH access
+        subnet_id (str, optional): ID of the subnet to launch the EC2 instance in (must be public).
+            If not provided and cache uses default VPC, will auto-select a default subnet.
+        security_group_id (str, optional): ID of the security group to assign to the EC2 instance.
+            If not provided and cache uses default VPC, will use the default security group.
         instance_type (str, optional): EC2 instance type. Defaults to "t3.small"
 
     Returns:
@@ -306,6 +308,59 @@ async def create_jump_host_cc(
         )['CacheSubnetGroups'][0]
         cache_vpc_id = cache_subnet_group['VpcId']
 
+        # Check if cache is in default VPC
+        vpcs = ec2_client.describe_vpcs(VpcIds=[cache_vpc_id])['Vpcs']
+        cache_vpc = vpcs[0] if vpcs else None
+        is_default_vpc = cache_vpc and cache_vpc.get('IsDefault', False)
+
+        # Auto-select subnet if not provided and cache is in default VPC
+        if not subnet_id and is_default_vpc:
+            # Get default subnets in the default VPC
+            subnets = ec2_client.describe_subnets(
+                Filters=[
+                    {'Name': 'vpc-id', 'Values': [cache_vpc_id]},
+                    {'Name': 'default-for-az', 'Values': ['true']},
+                ]
+            )['Subnets']
+
+            if subnets:
+                # Pick the first available default subnet
+                subnet_id = subnets[0]['SubnetId']
+            else:
+                # Fallback to any public subnet in the VPC
+                all_subnets = ec2_client.describe_subnets(
+                    Filters=[{'Name': 'vpc-id', 'Values': [cache_vpc_id]}]
+                )['Subnets']
+
+                for subnet in all_subnets:
+                    if subnet.get('MapPublicIpOnLaunch', False):
+                        subnet_id = subnet['SubnetId']
+                        break
+
+        # Auto-select security group if not provided and cache is in default VPC
+        if not security_group_id and is_default_vpc:
+            # Get the default security group for the VPC
+            security_groups = ec2_client.describe_security_groups(
+                Filters=[
+                    {'Name': 'vpc-id', 'Values': [cache_vpc_id]},
+                    {'Name': 'group-name', 'Values': ['default']},
+                ]
+            )['SecurityGroups']
+
+            if security_groups:
+                security_group_id = security_groups[0]['GroupId']
+
+        # Validate required parameters after auto-selection
+        if not subnet_id:
+            raise ValueError(
+                'subnet_id is required. Either provide a subnet_id or ensure the cache cluster is in the default VPC with default subnets available.'
+            )
+
+        if not security_group_id:
+            raise ValueError(
+                'security_group_id is required. Either provide a security_group_id or ensure the cache cluster is in the default VPC.'
+            )
+
         # Get subnet details and verify it's public
         subnet_response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
         subnet = subnet_response['Subnets'][0]
@@ -318,6 +373,7 @@ async def create_jump_host_cc(
             )
 
         # Check if subnet is public by looking for route to internet gateway
+        # or if it's a default subnet in the default VPC (which are automatically public)
         route_tables = ec2_client.describe_route_tables(
             Filters=[{'Name': 'association.subnet-id', 'Values': [subnet_id]}]
         )['RouteTables']
@@ -331,9 +387,21 @@ async def create_jump_host_cc(
             if is_public:
                 break
 
+        # If not found via route table, check if it's a default subnet in default VPC
+        if not is_public:
+            # Check if this is the default VPC
+            vpcs = ec2_client.describe_vpcs(VpcIds=[subnet_vpc_id])['Vpcs']
+            vpc = vpcs[0] if vpcs else None
+
+            if vpc and vpc.get('IsDefault', False):
+                # In default VPC, check if this is a default subnet
+                # Default subnets have MapPublicIpOnLaunch set to True
+                if subnet.get('DefaultForAz', False) or subnet.get('MapPublicIpOnLaunch', False):
+                    is_public = True
+
         if not is_public:
             raise ValueError(
-                f'Subnet {subnet_id} is not public (no route to internet gateway found). '
+                f'Subnet {subnet_id} is not public (no route to internet gateway found and not a default subnet in default VPC). '
                 'The subnet must be public to allow SSH access to the jump host.'
             )
 

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/connect.py
@@ -19,7 +19,7 @@ from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
 from botocore.exceptions import ClientError
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 
 async def _configure_security_groups(
@@ -281,18 +281,20 @@ async def get_ssh_tunnel_command_rg(
 @handle_exceptions
 async def create_jump_host_rg(
     replication_group_id: str,
-    subnet_id: str,
-    security_group_id: str,
     key_name: str,
+    subnet_id: Optional[str] = None,
+    security_group_id: Optional[str] = None,
     instance_type: str = 't3.small',
 ) -> Dict[str, Any]:
     """Creates an EC2 jump host instance to access an ElastiCache replication group via SSH tunnel.
 
     Args:
         replication_group_id (str): ID of the ElastiCache replication group to connect to
-        subnet_id (str): ID of the subnet to launch the EC2 instance in (must be public)
-        security_group_id (str): ID of the security group to assign to the EC2 instance
         key_name (str): Name of the EC2 key pair to use for SSH access
+        subnet_id (str, optional): ID of the subnet to launch the EC2 instance in (must be public).
+            If not provided and replication group uses default VPC, will auto-select a default subnet.
+        security_group_id (str, optional): ID of the security group to assign to the EC2 instance.
+            If not provided and replication group uses default VPC, will use the default security group.
         instance_type (str, optional): EC2 instance type. Defaults to "t3.small"
 
     Returns:
@@ -346,6 +348,59 @@ async def create_jump_host_rg(
         )['CacheSubnetGroups'][0]
         cache_vpc_id = cache_subnet_group['VpcId']
 
+        # Check if replication group is in default VPC
+        vpcs = ec2_client.describe_vpcs(VpcIds=[cache_vpc_id])['Vpcs']
+        cache_vpc = vpcs[0] if vpcs else None
+        is_default_vpc = cache_vpc and cache_vpc.get('IsDefault', False)
+
+        # Auto-select subnet if not provided and replication group is in default VPC
+        if not subnet_id and is_default_vpc:
+            # Get default subnets in the default VPC
+            subnets = ec2_client.describe_subnets(
+                Filters=[
+                    {'Name': 'vpc-id', 'Values': [cache_vpc_id]},
+                    {'Name': 'default-for-az', 'Values': ['true']},
+                ]
+            )['Subnets']
+
+            if subnets:
+                # Pick the first available default subnet
+                subnet_id = subnets[0]['SubnetId']
+            else:
+                # Fallback to any public subnet in the VPC
+                all_subnets = ec2_client.describe_subnets(
+                    Filters=[{'Name': 'vpc-id', 'Values': [cache_vpc_id]}]
+                )['Subnets']
+
+                for subnet in all_subnets:
+                    if subnet.get('MapPublicIpOnLaunch', False):
+                        subnet_id = subnet['SubnetId']
+                        break
+
+        # Auto-select security group if not provided and replication group is in default VPC
+        if not security_group_id and is_default_vpc:
+            # Get the default security group for the VPC
+            security_groups = ec2_client.describe_security_groups(
+                Filters=[
+                    {'Name': 'vpc-id', 'Values': [cache_vpc_id]},
+                    {'Name': 'group-name', 'Values': ['default']},
+                ]
+            )['SecurityGroups']
+
+            if security_groups:
+                security_group_id = security_groups[0]['GroupId']
+
+        # Validate required parameters after auto-selection
+        if not subnet_id:
+            raise ValueError(
+                'subnet_id is required. Either provide a subnet_id or ensure the replication group is in the default VPC with default subnets available.'
+            )
+
+        if not security_group_id:
+            raise ValueError(
+                'security_group_id is required. Either provide a security_group_id or ensure the replication group is in the default VPC.'
+            )
+
         # Get subnet details and verify it's public
         subnet_response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
         subnet = subnet_response['Subnets'][0]
@@ -358,6 +413,7 @@ async def create_jump_host_rg(
             )
 
         # Check if subnet is public by looking for route to internet gateway
+        # or if it's a default subnet in the default VPC (which are automatically public)
         route_tables = ec2_client.describe_route_tables(
             Filters=[{'Name': 'association.subnet-id', 'Values': [subnet_id]}]
         )['RouteTables']
@@ -381,10 +437,21 @@ async def create_jump_host_rg(
             if is_public:
                 break
 
-        # Raise error if no route to internet gateway found
+        # If not found via route table, check if it's a default subnet in default VPC
+        if not is_public:
+            # Check if this is the default VPC
+            vpcs = ec2_client.describe_vpcs(VpcIds=[subnet_vpc_id])['Vpcs']
+            vpc = vpcs[0] if vpcs else None
+
+            if vpc and vpc.get('IsDefault', False):
+                # In default VPC, check if this is a default subnet
+                # Default subnets have MapPublicIpOnLaunch set to True
+                if subnet.get('DefaultForAz', False) or subnet.get('MapPublicIpOnLaunch', False):
+                    is_public = True
+
         if not is_public:
             raise ValueError(
-                f'Subnet {subnet_id} is not public (no route to internet gateway found). '
+                f'Subnet {subnet_id} is not public (no route to internet gateway found and not a default subnet in default VPC). '
                 'The subnet must be public to allow SSH access to the jump host.'
             )
 

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/connect.py
@@ -19,7 +19,7 @@ from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
 from botocore.exceptions import ClientError
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 
 async def _configure_security_groups(
@@ -273,18 +273,20 @@ async def get_ssh_tunnel_command_serverless(
 @handle_exceptions
 async def create_jump_host_serverless(
     serverless_cache_name: str,
-    subnet_id: str,
-    security_group_id: str,
     key_name: str,
+    subnet_id: Optional[str] = None,
+    security_group_id: Optional[str] = None,
     instance_type: str = 't3.small',
 ) -> Dict[str, Any]:
     """Creates an EC2 jump host instance to access an ElastiCache serverless cache via SSH tunnel.
 
     Args:
         serverless_cache_name (str): Name of the ElastiCache serverless cache to connect to
-        subnet_id (str): ID of the subnet to launch the EC2 instance in (must be public)
-        security_group_id (str): ID of the security group to assign to the EC2 instance
         key_name (str): Name of the EC2 key pair to use for SSH access
+        subnet_id (str, optional): ID of the subnet to launch the EC2 instance in (must be public).
+            If not provided and serverless cache uses default VPC, will auto-select a default subnet.
+        security_group_id (str, optional): ID of the security group to assign to the EC2 instance.
+            If not provided and serverless cache uses default VPC, will use the default security group.
         instance_type (str, optional): EC2 instance type. Defaults to "t3.small"
 
     Returns:
@@ -337,6 +339,59 @@ async def create_jump_host_serverless(
         subnet_response = ec2_client.describe_subnets(SubnetIds=[serverless_cache['SubnetIds'][0]])
         cache_vpc_id = subnet_response['Subnets'][0]['VpcId']
 
+        # Check if serverless cache is in default VPC
+        vpcs = ec2_client.describe_vpcs(VpcIds=[cache_vpc_id])['Vpcs']
+        cache_vpc = vpcs[0] if vpcs else None
+        is_default_vpc = cache_vpc and cache_vpc.get('IsDefault', False)
+
+        # Auto-select subnet if not provided and serverless cache is in default VPC
+        if not subnet_id and is_default_vpc:
+            # Get default subnets in the default VPC
+            subnets = ec2_client.describe_subnets(
+                Filters=[
+                    {'Name': 'vpc-id', 'Values': [cache_vpc_id]},
+                    {'Name': 'default-for-az', 'Values': ['true']},
+                ]
+            )['Subnets']
+
+            if subnets:
+                # Pick the first available default subnet
+                subnet_id = subnets[0]['SubnetId']
+            else:
+                # Fallback to any public subnet in the VPC
+                all_subnets = ec2_client.describe_subnets(
+                    Filters=[{'Name': 'vpc-id', 'Values': [cache_vpc_id]}]
+                )['Subnets']
+
+                for subnet in all_subnets:
+                    if subnet.get('MapPublicIpOnLaunch', False):
+                        subnet_id = subnet['SubnetId']
+                        break
+
+        # Auto-select security group if not provided and serverless cache is in default VPC
+        if not security_group_id and is_default_vpc:
+            # Get the default security group for the VPC
+            security_groups = ec2_client.describe_security_groups(
+                Filters=[
+                    {'Name': 'vpc-id', 'Values': [cache_vpc_id]},
+                    {'Name': 'group-name', 'Values': ['default']},
+                ]
+            )['SecurityGroups']
+
+            if security_groups:
+                security_group_id = security_groups[0]['GroupId']
+
+        # Validate required parameters after auto-selection
+        if not subnet_id:
+            raise ValueError(
+                'subnet_id is required. Either provide a subnet_id or ensure the serverless cache is in the default VPC with default subnets available.'
+            )
+
+        if not security_group_id:
+            raise ValueError(
+                'security_group_id is required. Either provide a security_group_id or ensure the serverless cache is in the default VPC.'
+            )
+
         # Get subnet details and verify it's public
         subnet_response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
         subnet = subnet_response['Subnets'][0]
@@ -349,6 +404,7 @@ async def create_jump_host_serverless(
             )
 
         # Check if subnet is public by looking for route to internet gateway
+        # or if it's a default subnet in the default VPC (which are automatically public)
         route_tables = ec2_client.describe_route_tables(
             Filters=[{'Name': 'association.subnet-id', 'Values': [subnet_id]}]
         )['RouteTables']
@@ -362,10 +418,21 @@ async def create_jump_host_serverless(
             if is_public:
                 break
 
-        # Raise error if no route to internet gateway found
+        # If not found via route table, check if it's a default subnet in default VPC
+        if not is_public:
+            # Check if this is the default VPC
+            vpcs = ec2_client.describe_vpcs(VpcIds=[subnet_vpc_id])['Vpcs']
+            vpc = vpcs[0] if vpcs else None
+
+            if vpc and vpc.get('IsDefault', False):
+                # In default VPC, check if this is a default subnet
+                # Default subnets have MapPublicIpOnLaunch set to True
+                if subnet.get('DefaultForAz', False) or subnet.get('MapPublicIpOnLaunch', False):
+                    is_public = True
+
         if not is_public:
             raise ValueError(
-                f'Subnet {subnet_id} is not public (no route to internet gateway found). '
+                f'Subnet {subnet_id} is not public (no route to internet gateway found and not a default subnet in default VPC). '
                 'The subnet must be public to allow SSH access to the jump host.'
             )
 

--- a/src/elasticache-mcp-server/tests/tools/cc/test_connect.py
+++ b/src/elasticache-mcp-server/tests/tools/cc/test_connect.py
@@ -368,9 +368,9 @@ async def test_create_jump_host_cc_success():
     ):
         result = await create_jump_host_cc(
             'cluster-1',
+            'my-key',
             'subnet-1234',
             'sg-1234',
-            'my-key',
             't3.micro',
         )
 
@@ -422,9 +422,9 @@ async def test_create_jump_host_cc_private_subnet():
     ):
         result = await create_jump_host_cc(
             'cluster-1',
+            'my-key',
             'subnet-1234',
             'sg-1234',
-            'my-key',
         )
 
         assert 'error' in result
@@ -456,10 +456,410 @@ async def test_create_jump_host_cc_invalid_key():
     ):
         result = await create_jump_host_cc(
             'cluster-1',
+            'invalid-key',
             'subnet-1234',
             'sg-1234',
-            'invalid-key',
         )
 
         assert 'error' in result
         assert "Key pair 'invalid-key' not found" in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_cc_default_vpc_default_subnet():
+    """Test jump host creation with default subnet in default VPC."""
+    # Mock clients
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'my-key'}]}
+
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-1234'}]
+    }
+
+    # Mock subnet in default VPC with no IGW route (but is default subnet)
+    mock_ec2.describe_subnets.return_value = {
+        'Subnets': [
+            {
+                'VpcId': 'vpc-1234',
+                'DefaultForAz': True,  # This is a default subnet
+                'MapPublicIpOnLaunch': True,
+            }
+        ]
+    }
+    # No internet gateway route in route table
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {
+        'Vpcs': [{'IsDefault': True}]  # This is the default VPC
+    }
+
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new1234'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.cc.connect._configure_security_groups',
+            return_value=(True, 'vpc-1234', 6379),
+        ),
+    ):
+        result = await create_jump_host_cc(
+            'cluster-1',
+            'my-key',
+            'subnet-1234',
+            'sg-1234',
+            't3.micro',
+        )
+
+        # Should succeed because it's a default subnet in default VPC
+        assert result['InstanceId'] == 'i-new1234'
+        assert result['PublicIpAddress'] == '1.2.3.4'
+        assert result['InstanceType'] == 't3.micro'
+        assert result['SubnetId'] == 'subnet-1234'
+        assert result['SecurityGroupId'] == 'sg-1234'
+        assert result['CacheClusterId'] == 'cluster-1'
+        assert result['SecurityGroupsConfigured'] is True
+        assert result['CachePort'] == 6379
+        assert result['VpcId'] == 'vpc-1234'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_cc_default_vpc_map_public_ip():
+    """Test jump host creation with subnet that has MapPublicIpOnLaunch in default VPC."""
+    # Mock clients
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'my-key'}]}
+
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-1234'}]
+    }
+
+    # Mock subnet in default VPC with MapPublicIpOnLaunch but not DefaultForAz
+    mock_ec2.describe_subnets.return_value = {
+        'Subnets': [
+            {
+                'VpcId': 'vpc-1234',
+                'DefaultForAz': False,  # Not a default subnet
+                'MapPublicIpOnLaunch': True,  # But has MapPublicIpOnLaunch
+            }
+        ]
+    }
+    # No internet gateway route in route table
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {
+        'Vpcs': [{'IsDefault': True}]  # This is the default VPC
+    }
+
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new1234'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.cc.connect._configure_security_groups',
+            return_value=(True, 'vpc-1234', 6379),
+        ),
+    ):
+        result = await create_jump_host_cc(
+            'cluster-1',
+            'subnet-1234',
+            'sg-1234',
+            'my-key',
+            't3.micro',
+        )
+
+        # Should succeed because MapPublicIpOnLaunch is True in default VPC
+        assert result['InstanceId'] == 'i-new1234'
+        assert result['PublicIpAddress'] == '1.2.3.4'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_cc_non_default_vpc_private_subnet():
+    """Test jump host creation with private subnet in non-default VPC."""
+    # Mock clients
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'my-key'}]}
+
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-1234'}]
+    }
+
+    # Mock subnet in non-default VPC
+    mock_ec2.describe_subnets.return_value = {
+        'Subnets': [
+            {
+                'VpcId': 'vpc-1234',
+                'DefaultForAz': False,
+                'MapPublicIpOnLaunch': False,
+            }
+        ]
+    }
+    # No internet gateway route
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+
+    # Mock VPC as non-default VPC
+    mock_ec2.describe_vpcs.return_value = {
+        'Vpcs': [{'IsDefault': False}]  # This is NOT the default VPC
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        result = await create_jump_host_cc(
+            'cluster-1',
+            'my-key',
+            'subnet-1234',
+            'sg-1234',
+        )
+
+        # Should fail because it's not public and not in default VPC
+        assert 'error' in result
+        assert 'Subnet subnet-1234 is not public' in result['error']
+        assert 'not a default subnet in default VPC' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_cc_default_vpc_non_default_subnet():
+    """Test jump host creation with non-default subnet in default VPC."""
+    # Mock clients
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'my-key'}]}
+
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-1234'}]
+    }
+
+    # Mock non-default subnet in default VPC (should still fail)
+    mock_ec2.describe_subnets.return_value = {
+        'Subnets': [
+            {
+                'VpcId': 'vpc-1234',
+                'DefaultForAz': False,  # Not a default subnet
+                'MapPublicIpOnLaunch': False,  # No auto-assign public IP
+            }
+        ]
+    }
+    # No internet gateway route
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {
+        'Vpcs': [{'IsDefault': True}]  # This is the default VPC
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        result = await create_jump_host_cc(
+            'cluster-1',
+            'my-key',
+            'subnet-1234',
+            'sg-1234',
+        )
+
+        # Should fail because it's not a default subnet (even though in default VPC)
+        assert 'error' in result
+        assert 'Subnet subnet-1234 is not public' in result['error']
+        assert 'not a default subnet in default VPC' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_cc_auto_select_defaults():
+    """Test jump host creation with auto-selection of subnet and security group in default VPC."""
+    # Mock clients
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'my-key'}]}
+
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-default'}]
+    }
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {
+        'Vpcs': [{'IsDefault': True}]  # This is the default VPC
+    }
+
+    # Mock default subnets available
+    mock_ec2.describe_subnets.side_effect = [
+        # First call for auto-selecting default subnets
+        {
+            'Subnets': [
+                {
+                    'SubnetId': 'subnet-auto-selected',
+                    'VpcId': 'vpc-default',
+                    'DefaultForAz': True,
+                    'MapPublicIpOnLaunch': True,
+                }
+            ]
+        },
+        # Second call for validating the selected subnet
+        {
+            'Subnets': [
+                {
+                    'SubnetId': 'subnet-auto-selected',
+                    'VpcId': 'vpc-default',
+                    'DefaultForAz': True,
+                    'MapPublicIpOnLaunch': True,
+                }
+            ]
+        },
+    ]
+
+    # Mock default security group available
+    mock_ec2.describe_security_groups.side_effect = [
+        # First call for auto-selecting default security group
+        {
+            'SecurityGroups': [
+                {
+                    'GroupId': 'sg-auto-selected',
+                    'GroupName': 'default',
+                    'VpcId': 'vpc-default',
+                }
+            ]
+        },
+        # Second call for validating the selected security group
+        {
+            'SecurityGroups': [
+                {
+                    'GroupId': 'sg-auto-selected',
+                    'IpPermissions': [],
+                }
+            ]
+        },
+    ]
+
+    # Mock route table shows it's public (has IGW route)
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-1234'}]}]
+    }
+
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new1234'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.cc.connect._configure_security_groups',
+            return_value=(True, 'vpc-default', 6379),
+        ),
+    ):
+        # Call without subnet_id and security_group_id - should auto-select
+        result = await create_jump_host_cc(
+            'cluster-1',
+            'my-key',  # Only provide required key_name
+        )
+
+        # Should succeed with auto-selected values
+        assert result['InstanceId'] == 'i-new1234'
+        assert result['PublicIpAddress'] == '1.2.3.4'
+        assert result['SubnetId'] == 'subnet-auto-selected'  # Auto-selected
+        assert result['SecurityGroupId'] == 'sg-auto-selected'  # Auto-selected
+        assert result['CacheClusterId'] == 'cluster-1'
+        assert result['SecurityGroupsConfigured'] is True
+        assert result['CachePort'] == 6379
+        assert result['VpcId'] == 'vpc-default'

--- a/src/elasticache-mcp-server/tests/tools/cc/test_connect_additional.py
+++ b/src/elasticache-mcp-server/tests/tools/cc/test_connect_additional.py
@@ -415,12 +415,12 @@ async def test_create_jump_host_cc_main_route_table():
             return_value=mock_elasticache,
         ),
     ):
-        result = await create_jump_host_cc('cluster-1', 'subnet-123', 'sg-123', 'test-key')
+        result = await create_jump_host_cc('cluster-1', 'test-key', 'subnet-123', 'sg-123')
 
         # Should fail because subnet is not public
         assert 'error' in result
         assert (
-            'Subnet subnet-123 is not public (no route to internet gateway found)'
+            'Subnet subnet-123 is not public (no route to internet gateway found and not a default subnet in default VPC)'
             in result['error']
         )
 

--- a/src/elasticache-mcp-server/tests/tools/rg/test_connect_optional_fields.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_connect_optional_fields.py
@@ -1,0 +1,571 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for optional fields in replication group create_jump_host_rg function."""
+
+import pytest
+from awslabs.elasticache_mcp_server.tools.rg.connect import create_jump_host_rg
+from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_auto_select_subnet_default_vpc():
+    """Test auto-selection of subnet when not provided in default VPC."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for auto-selection scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-default'}]
+    }
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': True}]}
+
+    # Mock subnet response for auto-selection (default VPC)
+    mock_ec2.describe_subnets.side_effect = [
+        {
+            'Subnets': [
+                {'SubnetId': 'subnet-default-1', 'DefaultForAz': True, 'MapPublicIpOnLaunch': True}
+            ]
+        },  # Default subnets lookup
+        {
+            'Subnets': [
+                {'VpcId': 'vpc-default', 'DefaultForAz': True, 'MapPublicIpOnLaunch': True}
+            ]
+        },  # Selected subnet details
+    ]
+
+    # Mock security groups for default VPC
+    mock_ec2.describe_security_groups.side_effect = [
+        {
+            'SecurityGroups': [{'GroupId': 'sg-default', 'GroupName': 'default'}]
+        },  # Default security group lookup
+        {'SecurityGroups': [{'IpPermissions': []}]},  # Security group details for SSH rule check
+    ]
+
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.rg.connect._configure_security_groups',
+            return_value=(True, 'vpc-default', 6379),
+        ),
+    ):
+        # Call without subnet_id and security_group_id (should auto-select)
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            # subnet_id not provided - should auto-select
+            # security_group_id not provided - should auto-select
+            instance_type='t3.micro',  # Custom instance type
+        )
+
+        # Verify successful creation with auto-selected values
+        assert result['InstanceId'] == 'i-new'
+        assert result['PublicIpAddress'] == '1.2.3.4'
+        assert result['InstanceType'] == 't3.micro'
+        assert result['SubnetId'] == 'subnet-default-1'  # Auto-selected
+        assert result['SecurityGroupId'] == 'sg-default'  # Auto-selected
+        assert result['ReplicationGroupId'] == 'rg-test'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_auto_select_fallback_public_subnet():
+    """Test auto-selection fallback to public subnet when no default subnets."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for fallback scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-default'}]
+    }
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': True}]}
+
+    # Mock subnet response for fallback scenario (default VPC)
+    mock_ec2.describe_subnets.side_effect = [
+        {'Subnets': []},  # No default subnets found
+        {
+            'Subnets': [
+                {'SubnetId': 'subnet-public-1', 'MapPublicIpOnLaunch': True},
+                {'SubnetId': 'subnet-private-1', 'MapPublicIpOnLaunch': False},
+            ]
+        },  # All subnets lookup for fallback
+        {
+            'Subnets': [{'VpcId': 'vpc-default', 'MapPublicIpOnLaunch': True}]
+        },  # Selected subnet details
+    ]
+
+    # Mock security groups for default VPC
+    mock_ec2.describe_security_groups.side_effect = [
+        {
+            'SecurityGroups': [{'GroupId': 'sg-default', 'GroupName': 'default'}]
+        },  # Default security group lookup
+        {'SecurityGroups': [{'IpPermissions': []}]},  # Security group details for SSH rule check
+    ]
+
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.rg.connect._configure_security_groups',
+            return_value=(True, 'vpc-default', 6379),
+        ),
+    ):
+        # Call without subnet_id and security_group_id (should auto-select)
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            # subnet_id not provided - should fallback to public subnet
+            # security_group_id not provided - should auto-select
+        )
+
+        # Verify successful creation with fallback subnet
+        assert result['InstanceId'] == 'i-new'
+        assert result['SubnetId'] == 'subnet-public-1'  # Fallback to public subnet
+        assert result['SecurityGroupId'] == 'sg-default'  # Auto-selected
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_non_default_vpc_requires_params():
+    """Test that non-default VPC requires explicit subnet_id and security_group_id."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for non-default VPC scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-custom'}]
+    }
+
+    # Mock VPC as non-default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': False}]}
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        # Call without subnet_id (should fail for non-default VPC)
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            # subnet_id not provided - should fail for non-default VPC
+        )
+
+        # Should fail with appropriate error message
+        assert 'error' in result
+        assert 'subnet_id is required' in result['error']
+        assert 'ensure the replication group is in the default VPC' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_non_default_vpc_requires_security_group():
+    """Test that non-default VPC requires explicit security_group_id."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for non-default VPC scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-custom'}]
+    }
+
+    # Mock VPC as non-default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': False}]}
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        # Call with subnet_id but without security_group_id (should fail for non-default VPC)
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            subnet_id='subnet-custom',
+            # security_group_id not provided - should fail for non-default VPC
+        )
+
+        # Should fail with appropriate error message
+        assert 'error' in result
+        assert 'security_group_id is required' in result['error']
+        assert 'ensure the replication group is in the default VPC' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_custom_instance_type():
+    """Test create_jump_host_rg with custom instance type."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-123'}]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+    }
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.rg.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test with custom instance type
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            subnet_id='subnet-123',
+            security_group_id='sg-123',
+            instance_type='t3.large',  # Custom instance type
+        )
+
+        # Verify custom instance type is used
+        assert result['InstanceType'] == 't3.large'
+
+        # Verify run_instances was called with correct instance type
+        mock_ec2.run_instances.assert_called_once()
+        call_args = mock_ec2.run_instances.call_args[1]
+        assert call_args['InstanceType'] == 't3.large'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_default_instance_type():
+    """Test create_jump_host_rg with default instance type."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-123'}]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+    }
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.rg.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test without specifying instance_type (should use default)
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            subnet_id='subnet-123',
+            security_group_id='sg-123',
+            # instance_type not provided - should use default 't3.small'
+        )
+
+        # Verify default instance type is used
+        assert result['InstanceType'] == 't3.small'
+
+        # Verify run_instances was called with default instance type
+        mock_ec2.run_instances.assert_called_once()
+        call_args = mock_ec2.run_instances.call_args[1]
+        assert call_args['InstanceType'] == 't3.small'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_all_optional_params_provided():
+    """Test create_jump_host_rg with all optional parameters explicitly provided."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-123'}]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+    }
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.rg.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test with all optional parameters explicitly provided
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            subnet_id='subnet-custom',
+            security_group_id='sg-custom',
+            instance_type='t3.xlarge',
+        )
+
+        # Verify all provided values are used
+        assert result['InstanceId'] == 'i-new'
+        assert result['SubnetId'] == 'subnet-custom'
+        assert result['SecurityGroupId'] == 'sg-custom'
+        assert result['InstanceType'] == 't3.xlarge'
+
+        # Verify run_instances was called with provided values
+        mock_ec2.run_instances.assert_called_once()
+        call_args = mock_ec2.run_instances.call_args[1]
+        assert call_args['InstanceType'] == 't3.xlarge'
+        assert call_args['NetworkInterfaces'][0]['SubnetId'] == 'subnet-custom'
+        assert call_args['NetworkInterfaces'][0]['Groups'] == ['sg-custom']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_rg_main_route_table_check():
+    """Test create_jump_host_rg with main route table check for public subnet."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-123'}]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+
+    # No explicit route table association, but main route table has IGW
+    mock_ec2.describe_route_tables.side_effect = [
+        {'RouteTables': []},  # First call for subnet-specific route table
+        {
+            'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+        },  # Second call for main route table with IGW
+    ]
+
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.rg.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test with subnet that uses main route table
+        result = await create_jump_host_rg(
+            replication_group_id='rg-test',
+            key_name='test-key',
+            subnet_id='subnet-123',
+            security_group_id='sg-123',
+        )
+
+        # Should succeed because main route table has IGW
+        assert result['InstanceId'] == 'i-new'
+        assert result['SubnetId'] == 'subnet-123'
+        assert result['SecurityGroupId'] == 'sg-123'

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_connect_additional.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_connect_additional.py
@@ -312,7 +312,7 @@ async def test_create_jump_host_serverless_vpc_mismatch():
             return_value=mock_elasticache,
         ),
     ):
-        result = await create_jump_host_serverless('cache-1', 'subnet-123', 'sg-123', 'test-key')
+        result = await create_jump_host_serverless('cache-1', 'test-key', 'subnet-123', 'sg-123')
         assert 'error' in result
         assert (
             'Subnet VPC (vpc-456) does not match serverless cache VPC (vpc-123)' in result['error']
@@ -356,12 +356,12 @@ async def test_create_jump_host_serverless_main_route_table():
             return_value=mock_elasticache,
         ),
     ):
-        result = await create_jump_host_serverless('cache-1', 'subnet-123', 'sg-123', 'test-key')
+        result = await create_jump_host_serverless('cache-1', 'test-key', 'subnet-123', 'sg-123')
 
         # Should fail because subnet is not public
         assert 'error' in result
         assert (
-            'Subnet subnet-123 is not public (no route to internet gateway found)'
+            'Subnet subnet-123 is not public (no route to internet gateway found and not a default subnet in default VPC)'
             in result['error']
         )
 
@@ -486,7 +486,7 @@ async def test_create_jump_host_serverless_missing_key_name():
             return_value=mock_elasticache,
         ),
     ):
-        result = await create_jump_host_serverless('cache-1', 'subnet-123', 'sg-123', '')
+        result = await create_jump_host_serverless('cache-1', '', 'subnet-123', 'sg-123')
         assert 'error' in result
         assert 'key_name is required' in result['error']
 

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_connect_optional_fields.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_connect_optional_fields.py
@@ -1,0 +1,481 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for optional fields in serverless cache create_jump_host_serverless function."""
+
+import pytest
+from awslabs.elasticache_mcp_server.tools.serverless.connect import create_jump_host_serverless
+from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_auto_select_subnet_default_vpc():
+    """Test auto-selection of subnet when not provided in default VPC."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for auto-selection scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    # Mock subnet response for cache VPC (default VPC)
+    mock_ec2.describe_subnets.side_effect = [
+        {'Subnets': [{'VpcId': 'vpc-default'}]},  # Cache VPC lookup
+        {
+            'Subnets': [
+                {'SubnetId': 'subnet-default-1', 'DefaultForAz': True, 'MapPublicIpOnLaunch': True}
+            ]
+        },  # Default subnets lookup
+        {
+            'Subnets': [
+                {'VpcId': 'vpc-default', 'DefaultForAz': True, 'MapPublicIpOnLaunch': True}
+            ]
+        },  # Selected subnet details
+    ]
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': True}]}
+
+    # Mock security groups for default VPC
+    mock_ec2.describe_security_groups.side_effect = [
+        {
+            'SecurityGroups': [{'GroupId': 'sg-default', 'GroupName': 'default'}]
+        },  # Default security group lookup
+        {'SecurityGroups': [{'IpPermissions': []}]},  # Security group details for SSH rule check
+    ]
+
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.serverless.connect._configure_security_groups',
+            return_value=(True, 'vpc-default', 6379),
+        ),
+    ):
+        # Call without subnet_id and security_group_id (should auto-select)
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            # subnet_id not provided - should auto-select
+            # security_group_id not provided - should auto-select
+            instance_type='t3.micro',  # Custom instance type
+        )
+
+        # Verify successful creation with auto-selected values
+        assert result['InstanceId'] == 'i-new'
+        assert result['PublicIpAddress'] == '1.2.3.4'
+        assert result['InstanceType'] == 't3.micro'
+        assert result['SubnetId'] == 'subnet-default-1'  # Auto-selected
+        assert result['SecurityGroupId'] == 'sg-default'  # Auto-selected
+        assert result['ServerlessCacheName'] == 'cache-1'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_auto_select_fallback_public_subnet():
+    """Test auto-selection fallback to public subnet when no default subnets."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for fallback scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    # Mock subnet response for cache VPC (default VPC)
+    mock_ec2.describe_subnets.side_effect = [
+        {'Subnets': [{'VpcId': 'vpc-default'}]},  # Cache VPC lookup
+        {'Subnets': []},  # No default subnets found
+        {
+            'Subnets': [
+                {'SubnetId': 'subnet-public-1', 'MapPublicIpOnLaunch': True},
+                {'SubnetId': 'subnet-private-1', 'MapPublicIpOnLaunch': False},
+            ]
+        },  # All subnets lookup for fallback
+        {
+            'Subnets': [{'VpcId': 'vpc-default', 'MapPublicIpOnLaunch': True}]
+        },  # Selected subnet details
+    ]
+
+    # Mock VPC as default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': True}]}
+
+    # Mock security groups for default VPC
+    mock_ec2.describe_security_groups.side_effect = [
+        {
+            'SecurityGroups': [{'GroupId': 'sg-default', 'GroupName': 'default'}]
+        },  # Default security group lookup
+        {'SecurityGroups': [{'IpPermissions': []}]},  # Security group details for SSH rule check
+    ]
+
+    mock_ec2.describe_route_tables.return_value = {'RouteTables': [{'Routes': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.serverless.connect._configure_security_groups',
+            return_value=(True, 'vpc-default', 6379),
+        ),
+    ):
+        # Call without subnet_id and security_group_id (should auto-select)
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            # subnet_id not provided - should fallback to public subnet
+            # security_group_id not provided - should auto-select
+        )
+
+        # Verify successful creation with fallback subnet
+        assert result['InstanceId'] == 'i-new'
+        assert result['SubnetId'] == 'subnet-public-1'  # Fallback to public subnet
+        assert result['SecurityGroupId'] == 'sg-default'  # Auto-selected
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_non_default_vpc_requires_params():
+    """Test that non-default VPC requires explicit subnet_id and security_group_id."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for non-default VPC scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    # Mock subnet response for cache VPC (non-default VPC)
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-custom'}]}
+
+    # Mock VPC as non-default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': False}]}
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        # Call without subnet_id (should fail for non-default VPC)
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            # subnet_id not provided - should fail for non-default VPC
+        )
+
+        # Should fail with appropriate error message
+        assert 'error' in result
+        assert 'subnet_id is required' in result['error']
+        assert 'ensure the serverless cache is in the default VPC' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_non_default_vpc_requires_security_group():
+    """Test that non-default VPC requires explicit security_group_id."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses for non-default VPC scenario
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    # Mock subnet response for cache VPC (non-default VPC)
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-custom'}]}
+
+    # Mock VPC as non-default VPC
+    mock_ec2.describe_vpcs.return_value = {'Vpcs': [{'IsDefault': False}]}
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        # Call with subnet_id but without security_group_id (should fail for non-default VPC)
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            subnet_id='subnet-custom',
+            # security_group_id not provided - should fail for non-default VPC
+        )
+
+        # Should fail with appropriate error message
+        assert 'error' in result
+        assert 'security_group_id is required' in result['error']
+        assert 'ensure the serverless cache is in the default VPC' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_custom_instance_type():
+    """Test create_jump_host_serverless with custom instance type."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+    }
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.serverless.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test with custom instance type
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            subnet_id='subnet-123',
+            security_group_id='sg-123',
+            instance_type='t3.large',  # Custom instance type
+        )
+
+        # Verify custom instance type is used
+        assert result['InstanceType'] == 't3.large'
+
+        # Verify run_instances was called with correct instance type
+        mock_ec2.run_instances.assert_called_once()
+        call_args = mock_ec2.run_instances.call_args[1]
+        assert call_args['InstanceType'] == 't3.large'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_default_instance_type():
+    """Test create_jump_host_serverless with default instance type."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+    }
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.serverless.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test without specifying instance_type (should use default)
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            subnet_id='subnet-123',
+            security_group_id='sg-123',
+            # instance_type not provided - should use default 't3.small'
+        )
+
+        # Verify default instance type is used
+        assert result['InstanceType'] == 't3.small'
+
+        # Verify run_instances was called with default instance type
+        mock_ec2.run_instances.assert_called_once()
+        call_args = mock_ec2.run_instances.call_args[1]
+        assert call_args['InstanceType'] == 't3.small'
+
+
+@pytest.mark.asyncio
+async def test_create_jump_host_serverless_all_optional_params_provided():
+    """Test create_jump_host_serverless with all optional parameters explicitly provided."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    # Mock responses
+    mock_ec2.describe_key_pairs.return_value = {'KeyPairs': [{'KeyName': 'test-key'}]}
+
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {
+                'SecurityGroupIds': ['sg-cache'],
+                'SubnetIds': ['subnet-cache'],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    mock_ec2.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123'}]}
+    mock_ec2.describe_route_tables.return_value = {
+        'RouteTables': [{'Routes': [{'GatewayId': 'igw-123'}]}]
+    }
+    mock_ec2.describe_security_groups.return_value = {'SecurityGroups': [{'IpPermissions': []}]}
+    mock_ec2.describe_images.return_value = {
+        'Images': [{'ImageId': 'ami-123', 'CreationDate': '2023-01-01'}]
+    }
+    mock_ec2.run_instances.return_value = {'Instances': [{'InstanceId': 'i-new'}]}
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{'PublicIpAddress': '1.2.3.4'}]}]
+    }
+
+    with (
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.tools.serverless.connect._configure_security_groups',
+            return_value=(True, 'vpc-123', 6379),
+        ),
+    ):
+        # Test with all optional parameters explicitly provided
+        result = await create_jump_host_serverless(
+            serverless_cache_name='cache-1',
+            key_name='test-key',
+            subnet_id='subnet-custom',
+            security_group_id='sg-custom',
+            instance_type='t3.xlarge',
+        )
+
+        # Verify all provided values are used
+        assert result['InstanceId'] == 'i-new'
+        assert result['SubnetId'] == 'subnet-custom'
+        assert result['SecurityGroupId'] == 'sg-custom'
+        assert result['InstanceType'] == 't3.xlarge'
+
+        # Verify run_instances was called with provided values
+        mock_ec2.run_instances.assert_called_once()
+        call_args = mock_ec2.run_instances.call_args[1]
+        assert call_args['InstanceType'] == 't3.xlarge'
+        assert call_args['NetworkInterfaces'][0]['SubnetId'] == 'subnet-custom'
+        assert call_args['NetworkInterfaces'][0]['Groups'] == ['sg-custom']

--- a/src/elasticache-mcp-server/uv.lock
+++ b/src/elasticache-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-elasticache-mcp-server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
…ience

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Jumphost creation uses default vpc and subnets to simplify experience

### Changes

Jumphost creation uses default vpc and subnets when customers don't pass in subnet and security group parameters

### User experience

Jumphost creation uses default vpc and subnets when customers don't pass in subnet and security group parameters

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N
**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
