### PR TITLE
feat: Session id with query param

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -195,10 +195,12 @@ async def search_documentation(
         'locales': ['en_us'],
     }
 
+    search_url_with_session = f'{SEARCH_API_URL}?session={SESSION_UUID}'
+
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
-                SEARCH_API_URL,
+                search_url_with_session,
                 json=request_body,
                 headers={
                     'Content-Type': 'application/json',
@@ -320,7 +322,7 @@ async def recommend(
     url_str = str(url)
     logger.debug(f'Getting recommendations for: {url_str}')
 
-    recommendation_url = f'{RECOMMENDATIONS_API_URL}?path={url_str}'
+    recommendation_url = f'{RECOMMENDATIONS_API_URL}?path={url_str}&session={SESSION_UUID}'
 
     async with httpx.AsyncClient() as client:
         try:

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -159,10 +159,11 @@ async def get_available_services(
         Markdown content of the AWS China documentation about available services
     """
     url_str = 'https://docs.amazonaws.cn/en_us/aws/latest/userguide/services.html'
+    url_with_session = f'{url_str}?session={SESSION_UUID}'
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(
-                url_str,
+                url_with_session,
                 follow_redirects=True,
                 headers={'User-Agent': DEFAULT_USER_AGENT},
                 timeout=30,

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -40,10 +40,12 @@ async def read_documentation_impl(
     """The implementation of the read_documentation tool."""
     logger.debug(f'Fetching documentation from {url_str}')
 
+    url_with_session = f'{url_str}?session={session_uuid}'
+
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(
-                url_str,
+                url_with_session,
                 follow_redirects=True,
                 headers={
                     'User-Agent': DEFAULT_USER_AGENT,

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -60,6 +60,9 @@ class TestReadDocumentation:
                 assert '# Test\n\nThis is a test.' in result
                 mock_get.assert_called_once()
                 mock_extract.assert_called_once()
+                called_url = mock_get.call_args[0][0]
+                assert '?session=' in called_url
+                assert called_url.startswith('https://docs.aws.amazon.com/test.html?session=')
 
     @pytest.mark.asyncio
     async def test_read_documentation_error(self):
@@ -140,6 +143,12 @@ class TestSearchDocumentation:
             assert results[1].title == 'Test 2'
             assert results[1].context == 'This is test 2.'
             mock_post.assert_called_once()
+
+            called_url = mock_post.call_args[0][0]
+            assert '?session=' in called_url
+            assert called_url.startswith(
+                'https://proxy.search.docs.aws.amazon.com/search?session='
+            )
 
     @pytest.mark.asyncio
     async def test_search_documentation_http_error(self):
@@ -263,6 +272,13 @@ class TestRecommend:
             assert results[1].title == 'Recommendation 2'
             assert results[1].context == 'This is recommendation 2.'
             mock_get.assert_called_once()
+
+            called_url = mock_get.call_args[0][0]
+            assert '?path=' in called_url
+            assert '&session=' in called_url
+            assert called_url.startswith(
+                'https://contentrecs-api.docs.aws.amazon.com/v1/recommendations?path=https://docs.aws.amazon.com/test&session='
+            )
 
     @pytest.mark.asyncio
     async def test_recommend_http_error(self):

--- a/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
@@ -133,6 +133,8 @@ class TestGetAvailableServices:
                 assert '# AWS Services in China\n\nAvailable services list.' in result
                 mock_get.assert_called_once()
                 mock_extract.assert_called_once()
+                called_url = mock_get.call_args[0][0]
+                assert '?session=' in called_url
 
     @pytest.mark.asyncio
     async def test_get_available_services_error(self):

--- a/src/aws-documentation-mcp-server/tests/test_server_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_utils.py
@@ -71,7 +71,7 @@ class TestReadDocumentationImpl:
 
                         # Verify the mock was called correctly
                         mock_client.get.assert_called_once_with(
-                            url,
+                            f'{url}?session=test-uuid',
                             follow_redirects=True,
                             headers={
                                 'User-Agent': DEFAULT_USER_AGENT,

--- a/src/aws-documentation-mcp-server/uv.lock
+++ b/src/aws-documentation-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-documentation-mcp-server"
-version = "1.1.9999999999999999999"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Updating the tools in this MCP server to include a Query Parameter with the session UUID for tracking purposes. Last week a similiar PR was created that used authorization headers, but the logging team has rediscovered that they cannot track custom headers in their logging system for GET requests so we're shifting back to the query param approach.

### User experience

The URLs that users use to GET and POST to using this tool will now have a query param. No functional changes will result from this changed.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
