### PR TITLE
feat(cost-analysis-mcp-server): Add support for different AWS Pricing API endpoints and improve logging

### DIFF
--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/consts.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/consts.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""awslabs MCP Cost Analysis mcp server constants.
+
+This module provides constant values for analyzing AWS service costs.
+"""
+
+import os
+
+
+MCP_SERVER_NAME = 'awslabs.cost-analysis-mcp-server'
+
+# Environment parameters
+AWS_REGION = os.environ.get('AWS_REGION', 'us-east-1')
+AWS_PROFILE = os.environ.get('AWS_PROFILE')
+LOG_LEVEL = os.getenv('FASTMCP_LOG_LEVEL', 'WARNING')
+
+# Supported AWS Pricing API regions
+PRICING_API_REGIONS = {
+    'classic': ['us-east-1', 'eu-central-1', 'ap-southeast-1'],
+    'china': ['cn-northwest-1'],
+}

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/pricing_client.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/pricing_client.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""awslabs MCP Cost Analysis mcp server pricing client.
+
+This module provides utilities for creating boto3 pricing clients.
+"""
+
+import boto3
+import sys
+from awslabs.cost_analysis_mcp_server import __version__, consts
+from botocore.config import Config
+from loguru import logger
+from typing import Any, Optional
+
+
+# Set up logging
+logger.remove()
+logger.add(sys.stderr, level=consts.LOG_LEVEL)
+
+
+def get_pricing_region(requested_region: Optional[str] = None) -> str:
+    """Determine the appropriate AWS Pricing API region.
+
+    The AWS Pricing API is only available in specific regions:
+    - Classic partition: us-east-1, eu-central-1, ap-southeast-1
+    - China partition: cn-northwest-1
+
+    This function maps the requested region to the nearest pricing endpoint
+    based on region prefixes.
+
+    Args:
+        requested_region: The AWS region requested by the user (default: None)
+
+    Returns:
+        The appropriate pricing API region
+    """
+    # If no region specified, check environment variable
+    if not requested_region:
+        requested_region = consts.AWS_REGION
+
+    # If the requested region is already a pricing region, use it directly
+    all_pricing_regions = (
+        consts.PRICING_API_REGIONS['classic'] + consts.PRICING_API_REGIONS['china']
+    )
+    if requested_region in all_pricing_regions:
+        logger.debug(f'Using pricing region directly: {requested_region}')
+        return requested_region
+
+    # Map regions based on prefix to nearest pricing endpoint
+    if requested_region.startswith('cn-'):
+        # China regions
+        pricing_region = 'cn-northwest-1'
+    elif requested_region.startswith(('eu-', 'me-', 'af-')):
+        # Europe, Middle East, and Africa regions
+        pricing_region = 'eu-central-1'
+    elif requested_region.startswith('ap-'):
+        # Asia Pacific regions
+        pricing_region = 'ap-southeast-1'
+    else:
+        # Default to US East (covers us-, ca-, sa- and any unknown regions)
+        pricing_region = 'us-east-1'
+
+    if pricing_region != requested_region:
+        logger.info(
+            f'Region {requested_region} does not have pricing API. Using {pricing_region} instead.'
+        )
+
+    return pricing_region
+
+
+def create_pricing_client(profile: Optional[str] = None, region: Optional[str] = None) -> Any:
+    """Create an AWS Pricing API client.
+
+    Args:
+        profile: AWS profile name to use (default: None, uses AWS_PROFILE or default profile)
+        region: AWS region name (default: None, uses AWS_REGION env var or nearest pricing region)
+
+    Returns:
+        boto3 pricing client
+    """
+    session = boto3.Session(profile_name=profile if profile else consts.AWS_PROFILE)
+
+    # Determine the appropriate pricing region
+    pricing_region = get_pricing_region(region)
+
+    config = Config(
+        region_name=pricing_region,
+        user_agent_extra=f'awslabs/mcp/{consts.MCP_SERVER_NAME}/{__version__}',
+    )
+
+    logger.debug(f'Creating pricing client for region: {pricing_region}')
+    return session.client('pricing', config=config)

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -17,10 +17,11 @@
 This server provides tools for analyzing AWS service costs across different user tiers.
 """
 
-import boto3
 import os
 import sys
+from awslabs.cost_analysis_mcp_server import consts
 from awslabs.cost_analysis_mcp_server.cdk_analyzer import analyze_cdk_project
+from awslabs.cost_analysis_mcp_server.pricing_client import create_pricing_client
 from awslabs.cost_analysis_mcp_server.static.patterns import BEDROCK
 from awslabs.cost_analysis_mcp_server.terraform_analyzer import analyze_terraform_project
 from bs4 import BeautifulSoup
@@ -33,7 +34,7 @@ from typing import Any, Dict, List, Optional
 
 # Set up logging
 logger.remove()
-logger.add(sys.stderr, level=os.getenv('FASTMCP_LOG_LEVEL', 'WARNING'))
+logger.add(sys.stderr, level=consts.LOG_LEVEL)
 
 
 class PricingFilter(BaseModel):
@@ -273,9 +274,7 @@ async def get_pricing_from_api(
         Dictionary containing pricing information from AWS Pricing API
     """
     try:
-        pricing_client = boto3.Session(profile_name=profile_name).client(
-            'pricing', region_name='us-east-1'
-        )
+        pricing_client = create_pricing_client()
 
         # Start with the region filter
         region_filter = {'Field': 'regionCode', 'Type': 'TERM_MATCH', 'Value': region}

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -18,21 +18,22 @@ This server provides tools for analyzing AWS service costs across different user
 """
 
 import boto3
-import logging
 import os
+import sys
 from awslabs.cost_analysis_mcp_server.cdk_analyzer import analyze_cdk_project
 from awslabs.cost_analysis_mcp_server.static.patterns import BEDROCK
 from awslabs.cost_analysis_mcp_server.terraform_analyzer import analyze_terraform_project
 from bs4 import BeautifulSoup
 from httpx import AsyncClient
+from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, Dict, List, Optional
 
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger.remove()
+logger.add(sys.stderr, level=os.getenv('FASTMCP_LOG_LEVEL', 'WARNING'))
 
 
 class PricingFilter(BaseModel):
@@ -101,7 +102,7 @@ mcp = FastMCP(
     IMPORTANT: Steps MUST be executed in this exact order. Each step must be attempted
     before moving to the next fallback mechanism. The report is particularly focused on
     serverless services and pay-as-you-go pricing models.""",
-    dependencies=['pydantic', 'boto3', 'beautifulsoup4', 'websearch'],
+    dependencies=['pydantic', 'loguru', 'boto3', 'beautifulsoup4', 'websearch'],
 )
 
 profile_name = os.getenv('AWS_PROFILE', 'default')

--- a/src/cost-analysis-mcp-server/pyproject.toml
+++ b/src/cost-analysis-mcp-server/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.23.0",
     "typing-extensions>=4.8.0",
+    "loguru>=0.7.3",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/cost-analysis-mcp-server/tests/test_pricing_client.py
+++ b/src/cost-analysis-mcp-server/tests/test_pricing_client.py
@@ -1,0 +1,123 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pricing client module."""
+
+import pytest
+from awslabs.cost_analysis_mcp_server.pricing_client import (
+    create_pricing_client,
+    get_pricing_region,
+)
+from unittest.mock import Mock, patch
+
+
+class TestGetPricingRegion:
+    """Tests for the get_pricing_region function."""
+
+    @pytest.mark.parametrize(
+        'region,expected',
+        [
+            # Direct pricing regions
+            ('us-east-1', 'us-east-1'),
+            ('eu-central-1', 'eu-central-1'),
+            ('ap-southeast-1', 'ap-southeast-1'),
+            ('cn-northwest-1', 'cn-northwest-1'),
+            # US/Americas regions
+            ('us-west-2', 'us-east-1'),
+            ('ca-central-1', 'us-east-1'),
+            ('sa-east-1', 'us-east-1'),
+            # Europe/Middle East/Africa regions
+            ('eu-west-1', 'eu-central-1'),
+            ('me-south-1', 'eu-central-1'),
+            ('af-south-1', 'eu-central-1'),
+            # Asia Pacific regions
+            ('ap-east-1', 'ap-southeast-1'),
+            # China regions
+            ('cn-north-1', 'cn-northwest-1'),
+            # Unknown regions default to us-east-1
+            ('unknown-region', 'us-east-1'),
+        ],
+    )
+    def test_region_mapping(self, region, expected):
+        """Test region mapping to pricing endpoints."""
+        assert get_pricing_region(region) == expected
+
+    @pytest.mark.parametrize(
+        'env_region,expected',
+        [
+            ('eu-west-1', 'eu-central-1'),
+            ('us-east-1', 'us-east-1'),
+            ('ap-northeast-1', 'ap-southeast-1'),
+        ],
+    )
+    def test_uses_aws_region_env_var(self, env_region, expected, monkeypatch):
+        """Test AWS_REGION env var is used when no region specified."""
+        monkeypatch.setattr('awslabs.cost_analysis_mcp_server.consts.AWS_REGION', env_region)
+        assert get_pricing_region() == expected
+
+
+class TestCreatePricingClient:
+    """Tests for the create_pricing_client function."""
+
+    @pytest.mark.parametrize(
+        'profile,region,expected_profile,expected_region',
+        [
+            (None, None, None, 'us-east-1'),
+            ('test-profile', None, 'test-profile', 'us-east-1'),
+            (None, 'eu-west-1', None, 'eu-central-1'),
+            ('my-profile', 'ap-northeast-1', 'my-profile', 'ap-southeast-1'),
+            (None, 'us-east-1', None, 'us-east-1'),  # Direct pricing region
+        ],
+    )
+    @patch('awslabs.cost_analysis_mcp_server.pricing_client.boto3.Session')
+    def test_create_client_parameters(
+        self, mock_session, profile, region, expected_profile, expected_region
+    ):
+        """Test creating pricing client with various parameter combinations."""
+        # Setup mocks
+        mock_session_instance = Mock()
+        mock_client = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.return_value = mock_client
+
+        # Call function
+        result = create_pricing_client(profile=profile, region=region)
+
+        # Verify session creation
+        mock_session.assert_called_once_with(profile_name=expected_profile)
+
+        # Verify client creation
+        mock_session_instance.client.assert_called_once()
+        call_args = mock_session_instance.client.call_args
+        assert call_args[0][0] == 'pricing'
+
+        # Verify config
+        config = call_args[1]['config']
+        assert config.region_name == expected_region
+        assert 'awslabs/mcp/' in config.user_agent_extra
+
+        assert result == mock_client
+
+    @patch('awslabs.cost_analysis_mcp_server.pricing_client.boto3.Session')
+    def test_uses_env_profile_when_none_specified(self, mock_session, monkeypatch):
+        """Test that AWS_PROFILE environment variable is used when no profile specified."""
+        monkeypatch.setattr('awslabs.cost_analysis_mcp_server.consts.AWS_PROFILE', 'env-profile')
+
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.return_value = Mock()
+
+        create_pricing_client()
+
+        mock_session.assert_called_once_with(profile_name='env-profile')

--- a/src/cost-analysis-mcp-server/uv.lock
+++ b/src/cost-analysis-mcp-server/uv.lock
@@ -42,6 +42,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "bs4" },
+    { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "pytest" },
@@ -63,6 +64,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.36.20" },
     { name = "bs4", specifier = ">=0.0.2" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pytest", specifier = ">=7.4.0" },
@@ -448,6 +450,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -1123,4 +1138,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

This PR introduces two key improvements to the cost analysis MCP server:

1. **Multi-region AWS Pricing API support**: Added intelligent region mapping to use the appropriate AWS Pricing API endpoints based on user's region
2. **Enhanced logging**: Migrated from Python's standard logging to loguru for better log formatting and control

**Key additions:**
- Pricing Client now specifies `user_agent_extra` for better tracking of MCP server usage
- New `pricing_client.py` module with region-aware pricing client creation
- New `consts.py` module for centralized configuration constants
- Comprehensive test suite for pricing client functionality
- Support for AWS Pricing API regions: `us-east-1`, `eu-central-1`, `ap-southeast-1`, and `cn-northwest-1`
### User experience

> Please share what the user experience looks like before and after this change

**Before:**
- Pricing API calls were hardcoded to use `us-east-1` regardless of user's region
- Basic logging with limited formatting options
- Users in other regions experienced suboptimal performance due to cross-region API calls

**After:**
- Automatic region mapping to the nearest AWS Pricing API endpoint:
  - China regions (`cn-*`) → `cn-northwest-1`
  - Europe/Middle East/Africa regions (`eu-*`, `me-*`, `af-*`) → `eu-central-1`
  - Asia Pacific regions (`ap-*`) → `ap-southeast-1`
  - US/Americas and unknown regions → `us-east-1`
- Improved logging with loguru providing better formatting and configurable log levels
- Better performance for users in non-US regions through optimized endpoint selection

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? No

**RFC issue number**: N/A

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
