### PR TITLE
aws-documentation-mcp-server: Add support for custom SSL certificates…

### DIFF
--- a/src/aws-documentation-mcp-server/CHANGELOG.md
+++ b/src/aws-documentation-mcp-server/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add support for custom SSL certificates through environment variables (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`).
 
 ### Added
 

--- a/src/aws-documentation-mcp-server/README.md
+++ b/src/aws-documentation-mcp-server/README.md
@@ -32,7 +32,8 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
       "args": ["awslabs.aws-documentation-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR",
-        "AWS_DOCUMENTATION_PARTITION": "aws"
+        "AWS_DOCUMENTATION_PARTITION": "aws",
+        "SSL_CERT_FILE": "/path/to/cert.pem"
       },
       "disabled": false,
       "autoApprove": []
@@ -42,6 +43,8 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
 ```
 
 > **Note**: Set `AWS_DOCUMENTATION_PARTITION` to `aws-cn` to query AWS China documentation instead of global AWS documentation.
+>
+> **Note**: For environments with self-signed certificates, you can set one of these environment variables to point to your certificate file: `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, or `CURL_CA_BUNDLE`.
 
 or docker after a successful `docker build -t mcp/aws-documentation .`:
 
@@ -58,6 +61,10 @@ or docker after a successful `docker build -t mcp/aws-documentation .`:
         "FASTMCP_LOG_LEVEL=ERROR",
         "--env",
         "AWS_DOCUMENTATION_PARTITION=aws",
+        "--env",
+        "SSL_CERT_FILE=/path/to/cert.pem",
+        "--volume",
+        "/path/to/cert.pem:/path/to/cert.pem:ro",
         "mcp/aws-documentation:latest"
       ],
       "env": {},

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -14,6 +14,7 @@
 """awslabs AWS Documentation MCP Server implementation."""
 
 import httpx
+import os
 import json
 import re
 import uuid
@@ -26,6 +27,7 @@ from awslabs.aws_documentation_mcp_server.models import (
 from awslabs.aws_documentation_mcp_server.server_utils import (
     DEFAULT_USER_AGENT,
     read_documentation_impl,
+    get_ssl_verify
 )
 
 # Import utility functions
@@ -197,7 +199,7 @@ async def search_documentation(
 
     search_url_with_session = f'{SEARCH_API_URL}?session={SESSION_UUID}'
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=get_ssl_verify()) as client:
         try:
             response = await client.post(
                 search_url_with_session,
@@ -324,7 +326,7 @@ async def recommend(
 
     recommendation_url = f'{RECOMMENDATIONS_API_URL}?path={url_str}&session={SESSION_UUID}'
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=get_ssl_verify()) as client:
         try:
             response = await client.get(
                 recommendation_url,

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -14,11 +14,13 @@
 """awslabs AWS China Documentation MCP Server implementation."""
 
 import httpx
+import os
 import re
 import uuid
 from awslabs.aws_documentation_mcp_server.server_utils import (
     DEFAULT_USER_AGENT,
     read_documentation_impl,
+    get_ssl_verify
 )
 
 # Import utility functions
@@ -160,7 +162,7 @@ async def get_available_services(
     """
     url_str = 'https://docs.amazonaws.cn/en_us/aws/latest/userguide/services.html'
     url_with_session = f'{url_str}?session={SESSION_UUID}'
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=get_ssl_verify()) as client:
         try:
             response = await client.get(
                 url_with_session,


### PR DESCRIPTION
aws-documentation-mcp-server: Add support for custom SSL certificates…
## Summary
Self-signed certificates cause the tool requests to fail. Updated httpx calls to reference one of the well-known SSL env variables, if exists. If not, it defaults to True (Encryption stands).

### Changes
- Added a new helper function under utils: get_ssl_verify; fetches certificate from well-known ssl env vars.
- Updated all httpx calls with the verify parameter; verify=get_ssl_verify()

### User experience
- Seamless if no self-signed certificate in the chain.
- Resolves Error "CERTIFICATE_VERIFY_FAILED" if self-signed certificate in the chain. User is expected to reference their certificate via one of the well-known SSL env vars: `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`
- (optional) on macos, the certificate can be fetched using this command: `security find-certificate -c AXA-Proxy-ROOT-CA`
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ Y ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ Y ] I have performed a self-review of this change
* [ Y ] Changes have been tested
* [ Y ] Changes are documented

Is this a breaking change? (Y/N)
N
**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
