### PR TITLE
fix: only log to stderr + stop creating extra .log file

### DIFF
--- a/src/finch-mcp-server/awslabs/finch_mcp_server/consts.py
+++ b/src/finch-mcp-server/awslabs/finch_mcp_server/consts.py
@@ -24,8 +24,6 @@ import sys
 # Server name
 SERVER_NAME = 'finch_mcp_server'
 
-# Log file name
-LOG_FILE = 'finch_server.log'
 
 # VM states
 VM_STATE_RUNNING = 'running'

--- a/src/finch-mcp-server/awslabs/finch_mcp_server/server.py
+++ b/src/finch-mcp-server/awslabs/finch_mcp_server/server.py
@@ -23,7 +23,7 @@ purposes only and are not meant for production use cases.
 import os
 import re
 import sys
-from awslabs.finch_mcp_server.consts import LOG_FILE, SERVER_NAME
+from awslabs.finch_mcp_server.consts import SERVER_NAME
 
 # Import Pydantic models for input validation
 from awslabs.finch_mcp_server.models import Result
@@ -136,20 +136,10 @@ def sensitive_data_filter(record):
 # Remove all default handlers then add our own
 logger.remove()
 
-log_level = os.environ.get('FASTMCP_LOG_LEVEL', 'INFO').upper()
-logger.add(
-    LOG_FILE,
-    rotation='10 MB',
-    retention=7,
-    level=log_level,
-    format='{time:YYYY-MM-DD HH:mm:ss} | {level} | {name}:{function}:{line} | {message}',
-    filter=sensitive_data_filter,
-)
-
-# Add a handler for stderr
+# Standard MCP logging pattern - only log to stderr
 logger.add(
     sys.stderr,
-    level=log_level,
+    level=os.environ.get('FASTMCP_LOG_LEVEL', 'INFO'),
     format='{time:YYYY-MM-DD HH:mm:ss} | {level} | {message}',
     filter=sensitive_data_filter,
 )
@@ -438,7 +428,6 @@ def main(enable_aws_resource_write: bool = False):
     set_enable_aws_resource_write(enable_aws_resource_write)
 
     logger.info('Starting Finch MCP server')
-    logger.info(f'Logs will be written to: {LOG_FILE}')
     mcp.run(transport='stdio')
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

- Logging file changes related to issue #725 
- Improves logging to be more in line with MCP standard

### Changes

- Only logs to stderr instead of logging to stderr and a logging file. 
- No longer creates logging file in working directory. 

### User experience

> Can expect typical MCP server logging

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
