### PR TITLE
feat(dataprocessing-mcp-server): Add Athena Query, Workgroup and Cata…

### DIFF
--- a/src/aws-dataprocessing-mcp-server/README.md
+++ b/src/aws-dataprocessing-mcp-server/README.md
@@ -43,6 +43,23 @@ For read operations, the following permissions are required:
         "cloudwatch:GetMetricData",
         "logs:DescribeLogGroups",
         "logs:DescribeLogStreams",
+        "athena:BatchGetQueryExecution",
+        "athena:GetQueryExecution",
+        "athena:GetQueryResults",
+        "athena:GetQueryRuntimeStatistics",
+        "athena:ListQueryExecutions",
+        "athena:BatchGetNamedQuery",
+        "athena:GetNamedQuery",
+        "athena:ListNamedQueries",
+        "athena:GetDataCatalog",
+        "athena:ListDataCatalogs",
+        "athena:GetDatabase",
+        "athena:GetTableMetadata",
+        "athena:ListDatabases",
+        "athena:ListTableMetadata",
+        "athena:GetWorkGroup",
+        "athena:ListWorkGroups"
+        "sts:GetCallerIdentity"
       ],
       "Resource": "*"
     }
@@ -216,6 +233,26 @@ Specifies the AWS region where Glue,EMR clusters or Athena are managed, which wi
 | manage_aws_glue_connections | Manage AWS Glue Data Catalog connections | create-connection, delete-connection, get-connection, list-connections, update-connection | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
 | manage_aws_glue_partitions | Manage AWS Glue Data Catalog partitions | create-partition, delete-partition, get-partition, list-partitions, update-partition | --allow-write flag for create/delete/update operations, database and table must exist, appropriate AWS permissions |
 | manage_aws_glue_catalog | Manage AWS Glue Data Catalog | create-catalog, delete-catalog, get-catalog, list-catalogs, import-catalog-to-glue | --allow-write flag for create/delete/import operations, appropriate AWS permissions |
+
+### Athena Query Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_athena_query_executions | Execute and manage AWS Athena SQL queries | batch-get-query-execution, get-query-execution, get-query-results, get-query-runtime-statistics, list-query-executions, start-query-execution, stop-query-execution | --allow-write flag for start/stop operations, appropriate AWS permissions |
+| manage_aws_athena_named_queries | Manage saved SQL queries in AWS Athena | batch-get-named-query, create-named-query, delete-named-query, get-named-query, list-named-queries, update-named-query | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
+
+### Athena Data Catalog Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_athena_data_catalogs | Manage AWS Athena data catalogs | create-data-catalog, delete-data-catalog, get-data-catalog, list-data-catalogs, update-data-catalog | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
+| manage_aws_athena_databases_and_tables | Manage AWS Athena databases and tables | get-database, get-table-metadata, list-databases, list-table-metadata | Appropriate AWS permissions for Athena database operations |
+
+### Athena WorkGroup Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_athena_workgroups | Manage AWS Athena workgroups | create-work-group, delete-work-group, get-work-group, list-work-groups, update-work-group | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
 
 
 ## Version

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/__init__.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_data_catalog_handler.py
@@ -1,0 +1,603 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AthenaDataCatalogHandler for Data Processing MCP Server."""
+
+import json
+from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
+    CreateDataCatalogResponse,
+    DeleteDataCatalogResponse,
+    GetDatabaseResponse,
+    GetDataCatalogResponse,
+    GetTableMetadataResponse,
+    ListDatabasesResponse,
+    ListDataCatalogsResponse,
+    ListTableMetadataResponse,
+    UpdateDataCatalogResponse,
+)
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field
+from typing import Any, Dict, Optional, Union
+
+
+class AthenaDataCatalogHandler:
+    """Handler for Amazon Athena Data Catalog operations."""
+
+    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+        """Initialize the Athena Data Catalog handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.athena_client = AwsHelper.create_boto3_client('athena')
+
+        # Register tools
+        self.mcp.tool(name='manage_aws_athena_data_catalogs')(self.manage_aws_athena_data_catalogs)
+        self.mcp.tool(name='manage_aws_athena_databases_and_tables')(
+            self.manage_aws_athena_databases_and_tables
+        )
+
+    async def manage_aws_athena_data_catalogs(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-data-catalog, delete-data-catalog, get-data-catalog, list-data-catalogs, update-data-catalog. Choose read-only operations when write access is disabled.',
+        ),
+        name: Optional[str] = Field(
+            None,
+            description='Name of the data catalog (required for create-data-catalog, delete-data-catalog, get-data-catalog, update-data-catalog). The catalog name must be unique for the AWS account and can use a maximum of 127 alphanumeric, underscore, at sign, or hyphen characters.',
+        ),
+        type: Optional[str] = Field(
+            None,
+            description='Type of the data catalog (required for create-data-catalog and update-data-catalog). Valid values: LAMBDA, GLUE, HIVE, FEDERATED.',
+        ),
+        description: Optional[str] = Field(
+            None,
+            description='Description of the data catalog (optional for create-data-catalog and update-data-catalog).',
+        ),
+        parameters: Optional[Dict[str, str]] = Field(
+            None,
+            description="Parameters for the data catalog (optional for create-data-catalog and update-data-catalog). Format depends on catalog type (e.g., for LAMBDA: 'metadata-function=lambda_arn,record-function=lambda_arn' or 'function=lambda_arn').",
+        ),
+        tags: Optional[Dict[str, str]] = Field(
+            None,
+            description='Tags for the data catalog (optional for create-data-catalog).',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for list-data-catalogs operation (range: 2-50).',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for list-data-catalogs operation.',
+        ),
+        work_group: Optional[str] = Field(
+            None,
+            description='The name of the workgroup (required if making an IAM Identity Center request).',
+        ),
+        delete_catalog_only: Optional[bool] = Field(
+            None,
+            description='For delete-data-catalog operation, whether to delete only the Athena Data Catalog (true) or also its resources (false). Only applicable for FEDERATED catalogs.',
+        ),
+    ) -> Union[
+        CreateDataCatalogResponse,
+        DeleteDataCatalogResponse,
+        GetDataCatalogResponse,
+        ListDataCatalogsResponse,
+        UpdateDataCatalogResponse,
+    ]:
+        """Manage AWS Athena data catalogs with both read and write operations.
+
+        This tool provides operations for managing Athena data catalogs, including creating,
+        retrieving, listing, updating, and deleting data catalogs. Data catalogs are used to
+        organize and access data sources in Athena, enabling you to query data across various
+        sources like AWS Glue Data Catalog, Apache Hive metastores, or federated sources.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-data-catalog, delete-data-catalog, and update-data-catalog operations
+        - Appropriate AWS permissions for Athena data catalog operations
+
+        ## Operations
+        - **create-data-catalog**: Create a new data catalog
+        - **delete-data-catalog**: Delete an existing data catalog
+        - **get-data-catalog**: Get information about a single data catalog
+        - **list-data-catalogs**: List all data catalogs
+        - **update-data-catalog**: Update an existing data catalog
+
+        ## Usage Tips
+        - Use list-data-catalogs to find available data catalogs
+        - Data catalogs can be of type LAMBDA, GLUE, HIVE, or FEDERATED
+        - Parameters are specific to the type of data catalog
+
+        ## Example
+        ```
+        # List all data catalogs
+        {'operation': 'list-data-catalogs', 'max_results': 10}
+
+        # Create a Glue data catalog
+        {
+            'operation': 'create-data-catalog',
+            'name': 'my-glue-catalog',
+            'type': 'GLUE',
+            'description': 'My Glue Data Catalog',
+            'parameters': {'catalog-id': '123456789012'},
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            name: Name of the data catalog
+            type: Type of the data catalog (LAMBDA, GLUE, HIVE, FEDERATED)
+            description: Description of the data catalog
+            parameters: Parameters for the data catalog
+            tags: Tags for the data catalog
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+            work_group: The name of the workgroup
+            delete_catalog_only: Whether to delete only the Athena Data Catalog
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation in [
+                'create-data-catalog',
+                'delete-data-catalog',
+                'update-data-catalog',
+            ]:
+                error_message = f'Operation {operation} is not allowed without write access'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == 'create-data-catalog':
+                    return CreateDataCatalogResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        name='',
+                        operation='create-data-catalog',
+                    )
+                elif operation == 'delete-data-catalog':
+                    return DeleteDataCatalogResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        name='',
+                        operation='delete-data-catalog',
+                    )
+                elif operation == 'update-data-catalog':
+                    return UpdateDataCatalogResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        name='',
+                        operation='update-data-catalog',
+                    )
+
+            if operation == 'create-data-catalog':
+                if name is None or type is None:
+                    raise ValueError(
+                        'name and type are required for create-data-catalog operation'
+                    )
+
+                # Prepare parameters
+                params = {
+                    'Name': name,
+                    'Type': type,
+                }
+
+                if description is not None:
+                    params['Description'] = description
+
+                if parameters is not None:
+                    params['Parameters'] = json.dumps(parameters)
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags('AthenaDataCatalog', tags)
+                aws_tags = AwsHelper.convert_tags_to_aws_format(resource_tags)
+                params['Tags'] = aws_tags
+
+                # Create data catalog
+                self.athena_client.create_data_catalog(**params)
+
+                return CreateDataCatalogResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully created data catalog {name}',
+                        )
+                    ],
+                    name=name,
+                    operation='create-data-catalog',
+                )
+
+            elif operation == 'delete-data-catalog':
+                if name is None:
+                    raise ValueError('name is required for delete-data-catalog operation')
+
+                # Prepare parameters
+                params = {'Name': name}
+                if delete_catalog_only is not None:
+                    params['DeleteCatalogOnly'] = str(delete_catalog_only).lower()
+
+                # Delete data catalog
+                response = self.athena_client.delete_data_catalog(**params)
+                status = response.get('DataCatalog', {}).get('Status', '')
+                if status == 'DELETE_FAILED':
+                    return DeleteDataCatalogResponse(
+                        isError=True,
+                        content=[
+                            TextContent(
+                                type='text',
+                                text='Data Catalog delete operation failed',
+                            )
+                        ],
+                        name=name,
+                        operation='delete-data-catalog',
+                    )
+                else:
+                    return DeleteDataCatalogResponse(
+                        isError=False,
+                        content=[
+                            TextContent(
+                                type='text',
+                                text=f'Successfully deleted data catalog {name}',
+                            )
+                        ],
+                        name=name,
+                        operation='delete-data-catalog',
+                    )
+
+            elif operation == 'get-data-catalog':
+                if name is None:
+                    raise ValueError('name is required for get-data-catalog operation')
+
+                # Prepare parameters
+                params = {'Name': name}
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # Get data catalog
+                response = self.athena_client.get_data_catalog(**params)
+
+                return GetDataCatalogResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved data catalog {name}',
+                        )
+                    ],
+                    data_catalog=response.get('DataCatalog', {}),
+                    operation='get-data-catalog',
+                )
+
+            elif operation == 'list-data-catalogs':
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # List data catalogs
+                response = self.athena_client.list_data_catalogs(**params)
+
+                data_catalogs = response.get('DataCatalogsSummary', [])
+                return ListDataCatalogsResponse(
+                    isError=False,
+                    content=[TextContent(type='text', text='Successfully listed data catalogs')],
+                    data_catalogs=data_catalogs,
+                    count=len(data_catalogs),
+                    next_token=response.get('NextToken'),
+                    operation='list-data-catalogs',
+                )
+
+            elif operation == 'update-data-catalog':
+                if name is None:
+                    raise ValueError('name is required for update-data-catalog operation')
+                # Prepare parameters
+                params = {'Name': name}
+
+                if type is not None:
+                    params['Type'] = type
+
+                if description is not None:
+                    params['Description'] = description
+
+                if parameters is not None:
+                    params['Parameters'] = json.dumps(parameters)
+
+                # Update data catalog
+                self.athena_client.update_data_catalog(**params)
+
+                return UpdateDataCatalogResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully updated data catalog {name}',
+                        )
+                    ],
+                    name=name,
+                    operation='update-data-catalog',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: create-data-catalog, delete-data-catalog, get-data-catalog, list-data-catalogs, update-data-catalog'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetDataCatalogResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    data_catalog={},
+                    operation='get-data-catalog',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_athena_data_catalogs: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetDataCatalogResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                data_catalog={},
+                operation='get-data-catalog',
+            )
+
+    async def manage_aws_athena_databases_and_tables(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: get-database, get-table-metadata, list-databases, list-table-metadata. These are read-only operations.',
+        ),
+        catalog_name: str = Field(
+            ...,
+            description='Name of the data catalog.',
+        ),
+        database_name: Optional[str] = Field(
+            None,
+            description='Name of the database (required for get-database, get-table-metadata, list-table-metadata).',
+        ),
+        table_name: Optional[str] = Field(
+            None,
+            description='Name of the table (required for get-table-metadata).',
+        ),
+        expression: Optional[str] = Field(
+            None,
+            description='Expression to filter tables (optional for list-table-metadata). A regex pattern that pattern-matches table names.',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for list-databases (range: 1-50) and list-table-metadata (range: 1-50) operations.',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for list-databases and list-table-metadata operations.',
+        ),
+        work_group: Optional[str] = Field(
+            None,
+            description='The name of the workgroup (required if making an IAM Identity Center request).',
+        ),
+    ) -> Union[
+        GetDatabaseResponse,
+        GetTableMetadataResponse,
+        ListDatabasesResponse,
+        ListTableMetadataResponse,
+    ]:
+        """Manage AWS Athena databases and tables with read operations.
+
+        This tool provides operations for retrieving information about databases and tables
+        in Athena data catalogs. These are read-only operations that do not modify any resources.
+
+        ## Requirements
+        - Appropriate AWS permissions for Athena database and table operations
+
+        ## Operations
+        - **get-database**: Get information about a single database
+        - **get-table-metadata**: Get metadata for a specific table
+        - **list-databases**: List all databases in a data catalog
+        - **list-table-metadata**: List metadata for all tables in a database
+
+        ## Usage Tips
+        - Use list-databases to find available databases in a data catalog
+        - Use list-table-metadata to find available tables in a database
+        - The expression parameter for list-table-metadata supports filtering tables by name pattern
+
+        ## Example
+        ```
+        # List all databases in a catalog
+        {'operation': 'list-databases', 'catalog_name': 'AwsDataCatalog', 'max_results': 10}
+
+        # Get metadata for a specific table
+        {
+            'operation': 'get-table-metadata',
+            'catalog_name': 'AwsDataCatalog',
+            'database_name': 'my_database',
+            'table_name': 'my_table',
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            catalog_name: Name of the data catalog
+            database_name: Name of the database
+            table_name: Name of the table
+            expression: Expression to filter tables
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+            work_group: The name of the workgroup
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if operation == 'get-database':
+                if database_name is None:
+                    raise ValueError('database_name is required for get-database operation')
+
+                # Prepare parameters
+                params = {
+                    'CatalogName': catalog_name,
+                    'DatabaseName': database_name,
+                }
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # Get database
+                response = self.athena_client.get_database(**params)
+
+                return GetDatabaseResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved database {database_name} from catalog {catalog_name}',
+                        )
+                    ],
+                    database=response.get('Database', {}),
+                    operation='get-database',
+                )
+
+            elif operation == 'get-table-metadata':
+                if database_name is None or table_name is None:
+                    raise ValueError(
+                        'database_name and table_name are required for get-table-metadata operation'
+                    )
+
+                # Prepare parameters
+                params = {
+                    'CatalogName': catalog_name,
+                    'DatabaseName': database_name,
+                    'TableName': table_name,
+                }
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # Get table metadata
+                response = self.athena_client.get_table_metadata(**params)
+
+                return GetTableMetadataResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved metadata for table {table_name} in database {database_name} from catalog {catalog_name}',
+                        )
+                    ],
+                    table_metadata=response.get('TableMetadata', {}),
+                    operation='get-table-metadata',
+                )
+
+            elif operation == 'list-databases':
+                # Prepare parameters
+                params: Dict[str, Any] = {'CatalogName': catalog_name}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # List databases
+                response = self.athena_client.list_databases(**params)
+
+                database_list = response.get('DatabaseList', [])
+                return ListDatabasesResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully listed databases in catalog {catalog_name}',
+                        )
+                    ],
+                    database_list=database_list,
+                    count=len(database_list),
+                    next_token=response.get('NextToken'),
+                    operation='list-databases',
+                )
+
+            elif operation == 'list-table-metadata':
+                if database_name is None:
+                    raise ValueError('database_name is required for list-table-metadata operation')
+
+                # Prepare parameters
+                params: Dict[str, Any] = {
+                    'CatalogName': catalog_name,
+                    'DatabaseName': database_name,
+                }
+                if expression is not None:
+                    params['Expression'] = expression
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # List table metadata
+                response = self.athena_client.list_table_metadata(**params)
+
+                table_metadata_list = response.get('TableMetadataList', [])
+                return ListTableMetadataResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully listed table metadata in database {database_name} from catalog {catalog_name}',
+                        )
+                    ],
+                    table_metadata_list=table_metadata_list,
+                    count=len(table_metadata_list),
+                    next_token=response.get('NextToken'),
+                    operation='list-table-metadata',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: get-database, get-table-metadata, list-databases, list-table-metadata'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetDatabaseResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    database={},
+                    operation='get-database',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_athena_databases_and_tables: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetDatabaseResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                database={},
+                operation='get-database',
+            )

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_query_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_query_handler.py
@@ -1,0 +1,750 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AthenaQueryHandler for Data Processing MCP Server."""
+
+from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
+    BatchGetNamedQueryResponse,
+    BatchGetQueryExecutionResponse,
+    CreateNamedQueryResponse,
+    DeleteNamedQueryResponse,
+    GetNamedQueryResponse,
+    GetQueryExecutionResponse,
+    GetQueryResultsResponse,
+    GetQueryRuntimeStatisticsResponse,
+    ListNamedQueriesResponse,
+    ListQueryExecutionsResponse,
+    StartQueryExecutionResponse,
+    StopQueryExecutionResponse,
+    UpdateNamedQueryResponse,
+)
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field
+from typing import Any, Dict, List, Optional, Union
+
+
+class AthenaQueryHandler:
+    """Handler for Amazon Athena Query operations."""
+
+    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+        """Initialize the Athena Query handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.athena_client = AwsHelper.create_boto3_client('athena')
+
+        # Register tools
+        self.mcp.tool(name='manage_aws_athena_query_executions')(self.manage_aws_athena_queries)
+        self.mcp.tool(name='manage_aws_athena_named_queries')(self.manage_aws_athena_named_queries)
+
+    async def manage_aws_athena_queries(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: batch-get-query-execution, get-query-execution, get-query-results, get-query-runtime-statistics, list-query-executions, start-query-execution, stop-query-execution. Choose read-only operations when write access is disabled.',
+        ),
+        query_execution_id: Optional[str] = Field(
+            None,
+            description='ID of the query execution (required for get-query-execution, get-query-results, get-query-runtime-statistics, stop-query-execution).',
+        ),
+        query_execution_ids: Optional[List[str]] = Field(
+            None,
+            description='List of query execution IDs (required for batch-get-query-execution, max 50 IDs).',
+        ),
+        query_string: Optional[str] = Field(
+            None,
+            description='The SQL query string to execute (required for start-query-execution).',
+        ),
+        client_request_token: Optional[str] = Field(
+            None,
+            description='A unique case-sensitive string used to ensure the request to create the query is idempotent (optional for start-query-execution).',
+        ),
+        query_execution_context: Optional[Dict[str, str]] = Field(
+            None,
+            description='Context for the query execution, such as database name and catalog (optional for start-query-execution).',
+        ),
+        result_configuration: Optional[Dict[str, Any]] = Field(
+            None,
+            description='Configuration for query results, such as output location and encryption (optional for start-query-execution).',
+        ),
+        work_group: Optional[str] = Field(
+            None,
+            description='The name of the workgroup in which the query is being started (optional for start-query-execution, list-query-executions).',
+        ),
+        execution_parameters: Optional[List[str]] = Field(
+            None,
+            description='Execution parameters for parameterized queries (optional for start-query-execution).',
+        ),
+        result_reuse_configuration: Optional[Dict[str, Any]] = Field(
+            None,
+            description='Specifies the query result reuse behavior for the query (optional for start-query-execution).',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return (1-1000 for get-query-results, 0-50 for list-query-executions).',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for get-query-results and list-query-executions operations.',
+        ),
+        query_result_type: Optional[str] = Field(
+            None,
+            description='Type of query results to return: DATA_ROWS (default) or DATA_MANIFEST (optional for get-query-results).',
+        ),
+    ) -> Union[
+        BatchGetQueryExecutionResponse,
+        GetQueryExecutionResponse,
+        GetQueryResultsResponse,
+        GetQueryRuntimeStatisticsResponse,
+        ListQueryExecutionsResponse,
+        StartQueryExecutionResponse,
+        StopQueryExecutionResponse,
+    ]:
+        """Execute and manage AWS Athena SQL queries.
+
+        This tool provides comprehensive operations for AWS Athena query management, including
+        starting new queries, monitoring execution status, retrieving results, and analyzing
+        performance statistics.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag if start-query-execution contains any write operation for example DDL commands, Insert, Update, Delete Commands or any flag updates
+        - Appropriate AWS permissions for Athena query operations
+
+        ## Operations
+        - **batch-get-query-execution**: Get details for up to 50 query executions by their IDs
+        - **get-query-execution**: Get complete information about a single query execution
+        - **get-query-results**: Retrieve the results of a completed query
+        - **get-query-runtime-statistics**: Get performance statistics for a query execution
+        - **list-query-executions**: List available query execution IDs (up to 50)
+        - **start-query-execution**: Execute a new SQL query
+        - **stop-query-execution**: Cancel a running query
+
+        ## Example
+        ```python
+        # Start a new query
+        response = await manage_aws_athena_queries(
+            operation='start-query-execution',
+            query_string='SELECT * FROM my_database.my_table LIMIT 10',
+            query_execution_context={'Database': 'my_database', 'Catalog': 'my_catalog'},
+            work_group='primary',
+        )
+
+        # Get the query results
+        results = await manage_aws_athena_queries(
+            operation='get-query-results', query_execution_id=response.query_execution_id
+        )
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            query_execution_id: ID of the query execution
+            query_execution_ids: List of query execution IDs (max 50)
+            query_string: The SQL query string to execute
+            client_request_token: Unique token for idempotent requests
+            query_execution_context: Context with database and catalog information
+            result_configuration: Configuration for query results location and encryption
+            work_group: The name of the workgroup
+            execution_parameters: Parameters for parameterized queries
+            result_reuse_configuration: Query result reuse behavior configuration
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+            query_result_type: Type of query results to return (DATA_ROWS or DATA_MANIFEST)
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Athena Query Handler - Tool: manage_aws_athena_queries - Operation: {operation}',
+            )
+
+            if not self.allow_write and operation in [
+                'start-query-execution',
+            ]:
+                error_message = (
+                    f'Operation {operation} for select query is only allowed without write access'
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if (
+                    operation == 'start-query-execution'
+                    and query_string
+                    and (
+                        'select' not in query_string.lower()
+                        or 'create table as select' in query_string.lower()
+                    )
+                ):
+                    return StartQueryExecutionResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        query_execution_id='',
+                        operation='start-query-execution',
+                    )
+
+            if operation == 'batch-get-query-execution':
+                if query_execution_ids is None:
+                    raise ValueError(
+                        'query_execution_ids is required for batch-get-query-execution operation'
+                    )
+
+                # Get batch query executions
+                response = self.athena_client.batch_get_query_execution(
+                    QueryExecutionIds=query_execution_ids
+                )
+
+                query_executions = response.get('QueryExecutions', [])
+                unprocessed_ids = response.get('UnprocessedQueryExecutionIds', [])
+                return BatchGetQueryExecutionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text='Successfully retrieved query executions',
+                        )
+                    ],
+                    query_executions=query_executions,
+                    unprocessed_query_execution_ids=unprocessed_ids,
+                    operation='batch-get-query-execution',
+                )
+
+            elif operation == 'get-query-execution':
+                if query_execution_id is None:
+                    raise ValueError(
+                        'query_execution_id is required for get-query-execution operation'
+                    )
+
+                # Get query execution
+                response = self.athena_client.get_query_execution(
+                    QueryExecutionId=query_execution_id
+                )
+
+                return GetQueryExecutionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved query execution {query_execution_id}',
+                        )
+                    ],
+                    query_execution_id=query_execution_id,
+                    query_execution=response.get('QueryExecution', {}),
+                    operation='get-query-execution',
+                )
+
+            elif operation == 'get-query-results':
+                if query_execution_id is None:
+                    raise ValueError(
+                        'query_execution_id is required for get-query-results operation'
+                    )
+
+                # Prepare parameters
+                params: Dict[str, Any] = {'QueryExecutionId': query_execution_id}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if query_result_type is not None:
+                    params['QueryResultType'] = query_result_type
+
+                # Get query results
+                response = self.athena_client.get_query_results(**params)
+
+                return GetQueryResultsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved query results for {query_execution_id}',
+                        )
+                    ],
+                    query_execution_id=query_execution_id,
+                    result_set=response.get('ResultSet', {}),
+                    next_token=response.get('NextToken'),
+                    update_count=response.get('UpdateCount'),
+                    operation='get-query-results',
+                )
+
+            elif operation == 'get-query-runtime-statistics':
+                if query_execution_id is None:
+                    raise ValueError(
+                        'query_execution_id is required for get-query-runtime-statistics operation'
+                    )
+
+                # Get query runtime statistics
+                response = self.athena_client.get_query_runtime_statistics(
+                    QueryExecutionId=query_execution_id
+                )
+
+                return GetQueryRuntimeStatisticsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved query runtime statistics for {query_execution_id}',
+                        )
+                    ],
+                    query_execution_id=query_execution_id,
+                    statistics=response.get('QueryRuntimeStatistics', {}),
+                    operation='get-query-runtime-statistics',
+                )
+
+            elif operation == 'list-query-executions':
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # List query executions
+                response = self.athena_client.list_query_executions(**params)
+
+                query_execution_ids_res: List[str] = response.get('QueryExecutionIds', [])
+                return ListQueryExecutionsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(type='text', text='Successfully listed query executions')
+                    ],
+                    query_execution_ids=query_execution_ids_res,
+                    count=len(query_execution_ids_res),
+                    next_token=response.get('NextToken'),
+                    operation='list-query-executions',
+                )
+
+            elif operation == 'start-query-execution':
+                if query_string is None:
+                    raise ValueError(
+                        'query_string is required for start-query-execution operation'
+                    )
+
+                # Prepare parameters
+                params = {'QueryString': query_string}
+
+                if client_request_token is not None:
+                    params['ClientRequestToken'] = client_request_token
+
+                if query_execution_context is not None:
+                    params['QueryExecutionContext'] = query_execution_context
+
+                if result_configuration is not None:
+                    params['ResultConfiguration'] = result_configuration
+
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                if execution_parameters is not None:
+                    params['ExecutionParameters'] = execution_parameters
+
+                if result_reuse_configuration is not None:
+                    params['ResultReuseConfiguration'] = result_reuse_configuration
+
+                # Start query execution
+                response = self.athena_client.start_query_execution(**params)
+
+                return StartQueryExecutionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(type='text', text='Successfully started query execution')
+                    ],
+                    query_execution_id=response.get('QueryExecutionId', ''),
+                    operation='start-query-execution',
+                )
+
+            elif operation == 'stop-query-execution':
+                if query_execution_id is None:
+                    raise ValueError(
+                        'query_execution_id is required for stop-query-execution operation'
+                    )
+
+                # Stop query execution
+                self.athena_client.stop_query_execution(QueryExecutionId=query_execution_id)
+
+                return StopQueryExecutionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully stopped query execution {query_execution_id}',
+                        )
+                    ],
+                    query_execution_id=query_execution_id,
+                    operation='stop-query-execution',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: batch-get-query-execution, get-query-execution, get-query-results, get-query-runtime-statistics, list-query-executions, start-query-execution, stop-query-execution'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetQueryExecutionResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    query_execution_id='',
+                    query_execution={},
+                    operation='get-query-execution',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_athena_queries: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetQueryExecutionResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                query_execution_id=query_execution_id or '',
+                query_execution={},
+                operation='get-query-execution',
+            )
+
+    async def manage_aws_athena_named_queries(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: batch-get-named-query, create-named-query, delete-named-query, get-named-query, list-named-queries, update-named-query. Choose read-only operations when write access is disabled.',
+        ),
+        named_query_id: Optional[str] = Field(
+            None,
+            description='ID of the named query (required for get-named-query, delete-named-query, update-named-query).',
+        ),
+        named_query_ids: Optional[List[str]] = Field(
+            None,
+            description='List of named query IDs (required for batch-get-named-query, max 50 IDs).',
+        ),
+        name: Optional[str] = Field(
+            None,
+            description='Name of the named query (required for create-named-query and update-named-query).',
+        ),
+        description: Optional[str] = Field(
+            None,
+            description='Description of the named query (optional for create-named-query and update-named-query, max 1024 chars).',
+        ),
+        database: Optional[str] = Field(
+            None,
+            description='Database context for the named query (required for create-named-query, optional for update-named-query).',
+        ),
+        query_string: Optional[str] = Field(
+            None,
+            description='The SQL query string (required for create-named-query and update-named-query).',
+        ),
+        client_request_token: Optional[str] = Field(
+            None,
+            description='A unique case-sensitive string used to ensure the request to create the query is idempotent (optional for create-named-query).',
+        ),
+        work_group: Optional[str] = Field(
+            None,
+            description='The name of the workgroup (optional for create-named-query and list-named-queries).',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for list-named-queries operation.',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for list-named-queries operation.',
+        ),
+    ) -> Union[
+        BatchGetNamedQueryResponse,
+        CreateNamedQueryResponse,
+        DeleteNamedQueryResponse,
+        GetNamedQueryResponse,
+        ListNamedQueriesResponse,
+        UpdateNamedQueryResponse,
+    ]:
+        """Manage saved SQL queries in AWS Athena.
+
+        This tool provides operations for creating, retrieving, updating, and deleting named queries
+        in AWS Athena. Named queries are saved SQL statements that can be easily reused, shared with
+        team members, and executed without having to rewrite complex queries.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-named-query, delete-named-query, and update-named-query operations
+        - Appropriate AWS permissions for Athena named query operations
+
+        ## Operations
+        - **batch-get-named-query**: Get details for up to 50 named queries by their IDs
+        - **create-named-query**: Save a new SQL query with a name and description
+        - **delete-named-query**: Remove a saved query
+        - **get-named-query**: Retrieve a single named query by ID
+        - **list-named-queries**: List available named query IDs
+        - **update-named-query**: Modify an existing named query
+
+        ## Example
+        ```python
+        # Create a named query
+        create_response = await manage_aws_athena_named_queries(
+            operation='create-named-query',
+            name='Daily Active Users',
+            description='Query to calculate daily active users',
+            database='analytics',
+            query_string='SELECT date, COUNT(DISTINCT user_id) AS active_users FROM user_events GROUP BY date ORDER BY date DESC',
+            work_group='primary',
+        )
+
+        # Later, retrieve the named query
+        query = await manage_aws_athena_named_queries(
+            operation='get-named-query', named_query_id=create_response.named_query_id
+        )
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            named_query_id: ID of the named query
+            named_query_ids: List of named query IDs (max 50)
+            name: Name of the named query
+            description: Description of the named query (max 1024 chars)
+            database: Database context for the named query
+            query_string: The SQL query string
+            client_request_token: Unique token for idempotent requests
+            work_group: The name of the workgroup
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Athena Query Handler - Tool: manage_aws_athena_named_queries - Operation: {operation}',
+            )
+
+            if not self.allow_write and operation in [
+                'create-named-query',
+                'delete-named-query',
+                'update-named-query',
+            ]:
+                error_message = f'Operation {operation} is not allowed without write access'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == 'create-named-query':
+                    return CreateNamedQueryResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        named_query_id='',
+                        operation='create-named-query',
+                    )
+                elif operation == 'delete-named-query':
+                    return DeleteNamedQueryResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        named_query_id='',
+                        operation='delete-named-query',
+                    )
+                elif operation == 'update-named-query':
+                    return UpdateNamedQueryResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        named_query_id='',
+                        operation='update-named-query',
+                    )
+
+            if operation == 'batch-get-named-query':
+                if named_query_ids is None:
+                    raise ValueError(
+                        'named_query_ids is required for batch-get-named-query operation'
+                    )
+
+                # Get batch named queries
+                response = self.athena_client.batch_get_named_query(NamedQueryIds=named_query_ids)
+
+                named_queries = response.get('NamedQueries', [])
+                unprocessed_ids = response.get('UnprocessedNamedQueryIds', [])
+                return BatchGetNamedQueryResponse(
+                    isError=False,
+                    content=[
+                        TextContent(type='text', text='Successfully retrieved named queries')
+                    ],
+                    named_queries=named_queries,
+                    unprocessed_named_query_ids=unprocessed_ids,
+                    operation='batch-get-named-query',
+                )
+
+            elif operation == 'create-named-query':
+                if name is None or query_string is None or database is None:
+                    raise ValueError(
+                        'name, query_string, and database are required for create-named-query operation'
+                    )
+
+                # Prepare parameters
+                params = {
+                    'Name': name,
+                    'QueryString': query_string,
+                    'Database': database,
+                }
+
+                if description is not None:
+                    params['Description'] = description
+
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                if client_request_token is not None:
+                    params['ClientRequestToken'] = client_request_token
+
+                # Create named query
+                response = self.athena_client.create_named_query(**params)
+
+                return CreateNamedQueryResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully created named query {name}',
+                        )
+                    ],
+                    named_query_id=response.get('NamedQueryId', ''),
+                    operation='create-named-query',
+                )
+
+            elif operation == 'delete-named-query':
+                if named_query_id is None:
+                    raise ValueError('named_query_id is required for delete-named-query operation')
+
+                # Delete named query
+                self.athena_client.delete_named_query(NamedQueryId=named_query_id)
+
+                return DeleteNamedQueryResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully deleted named query {named_query_id}',
+                        )
+                    ],
+                    named_query_id=named_query_id,
+                    operation='delete-named-query',
+                )
+
+            elif operation == 'get-named-query':
+                if named_query_id is None:
+                    raise ValueError('named_query_id is required for get-named-query operation')
+
+                # Get named query
+                response = self.athena_client.get_named_query(NamedQueryId=named_query_id)
+
+                return GetNamedQueryResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved named query {named_query_id}',
+                        )
+                    ],
+                    named_query_id=named_query_id,
+                    named_query=response.get('NamedQuery', {}),
+                    operation='get-named-query',
+                )
+
+            elif operation == 'list-named-queries':
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if work_group is not None:
+                    params['WorkGroup'] = work_group
+
+                # List named queries
+                response = self.athena_client.list_named_queries(**params)
+
+                named_query_ids_res = response.get('NamedQueryIds', [])
+                return ListNamedQueriesResponse(
+                    isError=False,
+                    content=[TextContent(type='text', text='Successfully listed named queries')],
+                    named_query_ids=named_query_ids_res,
+                    count=len(named_query_ids_res),
+                    next_token=response.get('NextToken'),
+                    operation='list-named-queries',
+                )
+
+            elif operation == 'update-named-query':
+                if named_query_id is None:
+                    raise ValueError('named_query_id is required for update-named-query operation')
+
+                # Prepare parameters
+                params = {'NamedQueryId': named_query_id}
+
+                if name is not None:
+                    params['Name'] = name
+
+                if description is not None:
+                    params['Description'] = description
+
+                if database is not None:
+                    params['Database'] = database
+
+                if query_string is not None:
+                    params['QueryString'] = query_string
+
+                # Update named query
+                self.athena_client.update_named_query(**params)
+
+                return UpdateNamedQueryResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully updated named query {named_query_id}',
+                        )
+                    ],
+                    named_query_id=named_query_id,
+                    operation='update-named-query',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: batch-get-named-query, create-named-query, delete-named-query, get-named-query, list-named-queries, update-named-query'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetNamedQueryResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    named_query_id='',
+                    named_query={'': ''},
+                    operation='get-named-query',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_athena_named_queries: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetNamedQueryResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                named_query_id=named_query_id or '',
+                named_query={},
+                operation='get-named-query',
+            )

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_workgroup_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_workgroup_handler.py
@@ -1,0 +1,352 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
+    CreateWorkGroupResponse,
+    DeleteWorkGroupResponse,
+    GetWorkGroupResponse,
+    ListWorkGroupsResponse,
+    UpdateWorkGroupResponse,
+)
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field
+from typing import Any, Dict, Optional, Union
+
+
+class AthenaWorkGroupHandler:
+    """Handler for Amazon Athena WorkGroup operations."""
+
+    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+        """Initialize the Athena WorkGroup handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.athena_client = AwsHelper.create_boto3_client('athena')
+
+        # Register tools
+        self.mcp.tool(name='manage_aws_athena_workgroups')(self.manage_aws_athena_workgroups)
+
+    async def manage_aws_athena_workgroups(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-work-group, delete-work-group, get-work-group, list-work-groups, update-work-group. Choose read-only operations when write access is disabled.',
+        ),
+        name: Optional[str] = Field(
+            None,
+            description='Name of the workgroup (required for create-work-group, delete-work-group, get-work-group, update-work-group).',
+        ),
+        description: Optional[str] = Field(
+            None,
+            description='Description of the workgroup (optional for create-work-group and update-work-group).',
+        ),
+        configuration: Optional[Dict[str, Any]] = Field(
+            None,
+            description='Configuration for the workgroup, including result configuration, enforcement options, etc. (optional for create-work-group and update-work-group).',
+        ),
+        state: Optional[str] = Field(
+            None,
+            description='State of the workgroup: ENABLED or DISABLED (optional for create-work-group and update-work-group).',
+        ),
+        tags: Optional[Dict[str, str]] = Field(
+            None,
+            description="Tags for the workgroup (optional for create-work-group). Example {'ResourceType': 'Workgroup'}",
+        ),
+        recursive_delete_option: Optional[bool] = Field(
+            None,
+            description='Whether to recursively delete the workgroup and its contents (optional for delete-work-group).',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for list-work-groups operation.',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for list-work-groups operation.',
+        ),
+    ) -> Union[
+        CreateWorkGroupResponse,
+        DeleteWorkGroupResponse,
+        GetWorkGroupResponse,
+        ListWorkGroupsResponse,
+        UpdateWorkGroupResponse,
+    ]:
+        """Manage AWS Athena workgroups with both read and write operations.
+
+        This tool provides operations for managing Athena workgroups, including creating,
+        retrieving, listing, updating, and deleting workgroups. Workgroups allow you to
+        isolate queries for different user groups and control query execution settings.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-work-group, delete-work-group, and update-work-group operations
+        - Appropriate AWS permissions for Athena workgroup operations
+
+        ## Operations
+        - **create-work-group**: Create a new workgroup
+        - **delete-work-group**: Delete an existing workgroup
+        - **get-work-group**: Get information about a single workgroup
+        - **list-work-groups**: List all workgroups
+        - **update-work-group**: Update an existing workgroup
+
+        ## Usage Tips
+        - Use workgroups to isolate different user groups and control costs
+        - Configure workgroup settings to enforce query limits and output locations
+        - Use tags to organize and track workgroups
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            name: Name of the workgroup
+            description: Description of the workgroup
+            configuration: Configuration for the workgroup
+            state: State of the workgroup (ENABLED or DISABLED)
+            tags: Tags for the workgroup
+            recursive_delete_option: Whether to recursively delete the workgroup
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation in [
+                'create-work-group',
+                'delete-work-group',
+                'update-work-group',
+            ]:
+                error_message = f'Operation {operation} is not allowed without write access'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == 'create-work-group':
+                    return CreateWorkGroupResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        work_group_name='',
+                        operation='create-work-group',
+                    )
+                elif operation == 'delete-work-group':
+                    return DeleteWorkGroupResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        work_group_name='',
+                        operation='delete-work-group',
+                    )
+                elif operation == 'update-work-group':
+                    return UpdateWorkGroupResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        work_group_name='',
+                        operation='update-work-group',
+                    )
+
+            if operation == 'create-work-group':
+                if name is None:
+                    raise ValueError('name is required for create-work-group operation')
+
+                # Prepare parameters
+                params = {'Name': name}
+
+                if description is not None:
+                    params['Description'] = description
+
+                if configuration is not None:
+                    params['Configuration'] = configuration
+
+                if state is not None:
+                    params['State'] = state
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags('AthenaWorkgroup', tags)
+                aws_tags = AwsHelper.convert_tags_to_aws_format(resource_tags)
+                params['Tags'] = aws_tags
+
+                # Create workgroup
+                self.athena_client.create_work_group(**params)
+
+                return CreateWorkGroupResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully created Athena workgroup {name} with MCP management tags',
+                        )
+                    ],
+                    work_group_name=name,
+                    operation='create-work-group',
+                )
+
+            elif operation == 'delete-work-group':
+                if name is None:
+                    raise ValueError('name is required for delete-work-group operation')
+
+                # Verify that the workgroup is managed by MCP before deleting
+                workgroup_tags = AwsHelper.get_resource_tags_athena_workgroup(
+                    self.athena_client, name
+                )
+                if not AwsHelper.verify_resource_managed_by_mcp(workgroup_tags):
+                    error_message = f'Cannot delete workgroup {name} - it is not managed by the MCP server (missing required tags)'
+                    log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                    return DeleteWorkGroupResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        work_group_name=name,
+                        operation='delete-work-group',
+                    )
+
+                # Prepare parameters
+                params = {'WorkGroup': name}
+
+                if recursive_delete_option is not None:
+                    params['RecursiveDeleteOption'] = recursive_delete_option
+
+                # Delete workgroup
+                self.athena_client.delete_work_group(**params)
+
+                return DeleteWorkGroupResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully deleted MCP-managed Athena workgroup {name}',
+                        )
+                    ],
+                    work_group_name=name,
+                    operation='delete-work-group',
+                )
+
+            elif operation == 'get-work-group':
+                if name is None:
+                    raise ValueError('name is required for get-work-group operation')
+
+                # Get workgroup
+                response = self.athena_client.get_work_group(WorkGroup=name)
+
+                return GetWorkGroupResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved workgroup {name}',
+                        )
+                    ],
+                    work_group=response.get('WorkGroup', {}),
+                    operation='get-work-group',
+                )
+
+            elif operation == 'list-work-groups':
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+
+                # List workgroups
+                response = self.athena_client.list_work_groups(**params)
+
+                work_groups = response.get('WorkGroups', [])
+                return ListWorkGroupsResponse(
+                    isError=False,
+                    content=[TextContent(type='text', text='Successfully listed workgroups')],
+                    work_groups=work_groups,
+                    count=len(work_groups),
+                    next_token=response.get('NextToken'),
+                    operation='list-work-groups',
+                )
+
+            elif operation == 'update-work-group':
+                if name is None:
+                    raise ValueError('name is required for update-work-group operation')
+
+                # Verify that the workgroup is managed by MCP before deleting
+                workgroup_tags = AwsHelper.get_resource_tags_athena_workgroup(
+                    self.athena_client, name
+                )
+                if not AwsHelper.verify_resource_managed_by_mcp(workgroup_tags):
+                    error_message = f'Cannot update workgroup {name} - it is not managed by the MCP server (missing required tags)'
+                    log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                    return UpdateWorkGroupResponse(
+                        isError=True,
+                        content=[
+                            TextContent(
+                                type='text',
+                                text=error_message,
+                            )
+                        ],
+                        work_group_name=name,
+                        operation='update-work-group',
+                    )
+
+                # Prepare parameters
+                params = {'WorkGroup': name}
+
+                if description is not None:
+                    params['Description'] = description
+
+                if configuration is not None:
+                    params['ConfigurationUpdates'] = configuration
+
+                if state is not None:
+                    params['State'] = state
+
+                # Update workgroup
+                self.athena_client.update_work_group(**params)
+
+                return UpdateWorkGroupResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully updated workgroup {name}',
+                        )
+                    ],
+                    work_group_name=name,
+                    operation='update-work-group',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: create-work-group, delete-work-group, get-work-group, list-work-groups, update-work-group'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetWorkGroupResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    work_group={},
+                    operation='get-work-group',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_athena_workgroups: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetWorkGroupResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                work_group={},
+                operation='get-work-group',
+            )

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/athena_models.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/athena_models.py
@@ -1,0 +1,276 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Response models for Query Management
+from mcp.types import CallToolResult
+from pydantic import Field
+from typing import Any, Dict, List, Optional
+
+
+class BatchGetQueryExecutionResponse(CallToolResult):
+    """Response model for batch get query execution operation."""
+
+    query_executions: List[Dict[str, Any]] = Field(..., description='List of query executions')
+    unprocessed_query_execution_ids: List[Dict[str, Any]] = Field(
+        ..., description='List of unprocessed query execution IDs'
+    )
+    operation: str = Field(default='batch-get-query-execution', description='Operation performed')
+
+
+class GetQueryExecutionResponse(CallToolResult):
+    """Response model for get query execution operation."""
+
+    query_execution_id: str = Field(..., description='ID of the query execution')
+    query_execution: Dict[str, Any] = Field(
+        ...,
+        description='Query execution details including ID, SQL query, statement type, result configuration, execution context, status, statistics, and workgroup',
+    )
+    operation: str = Field(default='get-query-execution', description='Operation performed')
+
+
+class GetQueryResultsResponse(CallToolResult):
+    """Response model for get query results operation."""
+
+    query_execution_id: str = Field(..., description='ID of the query execution')
+    result_set: Dict[str, Any] = Field(
+        ...,
+        description='Query result set containing column information and rows of data',
+    )
+    next_token: Optional[str] = Field(
+        None, description='Token for pagination of large result sets'
+    )
+    update_count: Optional[int] = Field(
+        None,
+        description='Number of rows inserted with CREATE TABLE AS SELECT, INSERT INTO, or UPDATE statements',
+    )
+    operation: str = Field(default='get-query-results', description='Operation performed')
+
+
+class GetQueryRuntimeStatisticsResponse(CallToolResult):
+    """Response model for get query runtime statistics operation."""
+
+    query_execution_id: str = Field(..., description='ID of the query execution')
+    statistics: Dict[str, Any] = Field(
+        ...,
+        description='Query runtime statistics including timeline, row counts, and execution stages',
+    )
+    operation: str = Field(
+        default='get-query-runtime-statistics', description='Operation performed'
+    )
+
+
+class ListQueryExecutionsResponse(CallToolResult):
+    """Response model for list query executions operation."""
+
+    query_execution_ids: List[str] = Field(..., description='List of query execution IDs')
+    count: int = Field(..., description='Number of query executions found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list-query-executions', description='Operation performed')
+
+
+class StartQueryExecutionResponse(CallToolResult):
+    """Response model for start query execution operation."""
+
+    query_execution_id: str = Field(..., description='ID of the started query execution')
+    operation: str = Field(default='start-query-execution', description='Operation performed')
+
+
+class StopQueryExecutionResponse(CallToolResult):
+    """Response model for stop query execution operation."""
+
+    query_execution_id: str = Field(..., description='ID of the stopped query execution')
+    operation: str = Field(default='stop-query-execution', description='Operation performed')
+
+
+# Response models for Named Query Operations
+
+
+class BatchGetNamedQueryResponse(CallToolResult):
+    """Response model for batch get named query operation."""
+
+    named_queries: List[Dict[str, Any]] = Field(..., description='List of named queries')
+    unprocessed_named_query_ids: List[Dict[str, Any]] = Field(
+        ..., description='List of unprocessed named query IDs'
+    )
+    operation: str = Field(default='batch-get-named-query', description='Operation performed')
+
+
+class CreateNamedQueryResponse(CallToolResult):
+    """Response model for create named query operation."""
+
+    named_query_id: str = Field(..., description='ID of the created named query')
+    operation: str = Field(default='create-named-query', description='Operation performed')
+
+
+class DeleteNamedQueryResponse(CallToolResult):
+    """Response model for delete named query operation."""
+
+    named_query_id: str = Field(..., description='ID of the deleted named query')
+    operation: str = Field(default='delete-named-query', description='Operation performed')
+
+
+class GetNamedQueryResponse(CallToolResult):
+    """Response model for get named query operation."""
+
+    named_query_id: str = Field(..., description='ID of the named query')
+    named_query: Dict[str, Any] = Field(
+        ...,
+        description='Named query details including name, description, database, query string, ID, and workgroup',
+    )
+    operation: str = Field(default='get-named-query', description='Operation performed')
+
+
+class ListNamedQueriesResponse(CallToolResult):
+    """Response model for list named queries operation."""
+
+    named_query_ids: List[str] = Field(..., description='List of named query IDs')
+    count: int = Field(..., description='Number of named queries found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list-named-queries', description='Operation performed')
+
+
+class UpdateNamedQueryResponse(CallToolResult):
+    """Response model for update named query operation."""
+
+    named_query_id: str = Field(..., description='ID of the updated named query')
+    operation: str = Field(default='update-named-query', description='Operation performed')
+
+
+# Response models for Data Catalog Operations
+
+
+class CreateDataCatalogResponse(CallToolResult):
+    """Response model for create data catalog operation."""
+
+    name: str = Field(..., description='Name of the created data catalog')
+    operation: str = Field(default='create', description='Operation performed')
+
+
+class DeleteDataCatalogResponse(CallToolResult):
+    """Response model for delete data catalog operation."""
+
+    name: str = Field(..., description='Name of the deleted data catalog')
+    operation: str = Field(default='delete', description='Operation performed')
+
+
+class GetDataCatalogResponse(CallToolResult):
+    """Response model for get data catalog operation."""
+
+    data_catalog: Dict[str, Any] = Field(
+        ...,
+        description='Data catalog details including name, type, description, parameters, status, and connection type',
+    )
+    operation: str = Field(default='get', description='Operation performed')
+
+
+class ListDataCatalogsResponse(CallToolResult):
+    """Response model for list data catalogs operation."""
+
+    data_catalogs: List[Dict[str, Any]] = Field(
+        ...,
+        description='List of data catalog summaries, each containing catalog name, type, status, connection type, and error information',
+    )
+    count: int = Field(..., description='Number of data catalogs found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class UpdateDataCatalogResponse(CallToolResult):
+    """Response model for update data catalog operation."""
+
+    name: str = Field(..., description='Name of the updated data catalog')
+    operation: str = Field(default='update', description='Operation performed')
+
+
+class GetDatabaseResponse(CallToolResult):
+    """Response model for get database operation."""
+
+    database: Dict[str, Any] = Field(
+        ..., description='Database details including name, description, and parameters'
+    )
+    operation: str = Field(default='get', description='Operation performed')
+
+
+class GetTableMetadataResponse(CallToolResult):
+    """Response model for get table metadata operation."""
+
+    table_metadata: Dict[str, Any] = Field(
+        ...,
+        description='Table metadata details including name, create time, last access time, table type, columns, partition keys, and parameters',
+    )
+    operation: str = Field(default='get', description='Operation performed')
+
+
+class ListDatabasesResponse(CallToolResult):
+    """Response model for list databases operation."""
+
+    database_list: List[Dict[str, Any]] = Field(
+        ...,
+        description='List of databases, each containing name, description, and parameters',
+    )
+    count: int = Field(..., description='Number of databases found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class ListTableMetadataResponse(CallToolResult):
+    """Response model for list table metadata operation."""
+
+    table_metadata_list: List[Dict[str, Any]] = Field(
+        ...,
+        description='List of table metadata, each containing name, create time, last access time, table type, columns, partition keys, and parameters',
+    )
+    count: int = Field(..., description='Number of tables found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+# Response models for WorkGroup Operations
+
+
+class CreateWorkGroupResponse(CallToolResult):
+    """Response model for create work group operation."""
+
+    work_group_name: str = Field(..., description='Name of the created work group')
+    operation: str = Field(default='create', description='Operation performed')
+
+
+class DeleteWorkGroupResponse(CallToolResult):
+    """Response model for delete work group operation."""
+
+    work_group_name: str = Field(..., description='Name of the deleted work group')
+    operation: str = Field(default='delete', description='Operation performed')
+
+
+class GetWorkGroupResponse(CallToolResult):
+    """Response model for get work group operation."""
+
+    work_group: Dict[str, Any] = Field(..., description='Work group details')
+    operation: str = Field(default='get', description='Operation performed')
+
+
+class ListWorkGroupsResponse(CallToolResult):
+    """Response model for list work groups operation."""
+
+    work_groups: List[Dict[str, Any]] = Field(..., description='List of work groups')
+    count: int = Field(..., description='Number of work groups found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class UpdateWorkGroupResponse(CallToolResult):
+    """Response model for update work group operation."""
+
+    work_group_name: str = Field(..., description='Name of the updated work group')
+    operation: str = Field(default='update', description='Operation performed')

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/server.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/server.py
@@ -24,6 +24,15 @@ Environment Variables:
 """
 
 import argparse
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_data_catalog_handler import (
+    AthenaDataCatalogHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_query_handler import (
+    AthenaQueryHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_workgroup_handler import (
+    AthenaWorkGroupHandler,
+)
 from awslabs.aws_dataprocessing_mcp_server.handlers.glue.data_catalog_handler import (
     GlueDataCatalogHandler,
 )
@@ -65,11 +74,29 @@ It enables you to create, manage, and monitor data processing workflows.
 2. Update table schema: `manage_aws_glue_tables(operation='update-table', database_name='my-database', table_name='my-table', table_input={'StorageDescriptor': {'Columns': [{'Name': 'id', 'Type': 'int'}, {'Name': 'name', 'Type': 'string'}, {'Name': 'email', 'Type': 'string'}]}})`
 3. Update connection properties: `manage_aws_glue_connections(operation='update-connection', connection_name='my-connection', connection_input={'ConnectionProperties': {'JDBC_CONNECTION_URL': 'jdbc:mysql://new-host:port/db'}})`
 
-### Cleaning Up Resources
+### Cleaning Up Data Catalog Resources
 1. Delete a partition: `manage_aws_glue_partitions(operation='delete-partition', database_name='my-database', table_name='my-table', partition_values=['2023-01'])`
 2. Delete a table: `manage_aws_glue_tables(operation='delete-table', database_name='my-database', table_name='my-table')`
 3. Delete a connection: `manage_aws_glue_connections(operation='delete-connection', connection_name='my-connection')`
 4. Delete a database: `manage_aws_glue_databases(operation='delete-database', database_name='my-database')`
+
+### Running Athena Queries
+1. Execute a query: `manage_aws_athena_queries(operation='start-query-execution', query='SELECT * FROM my_table', work_group='my-workgroup')`
+2. Get query results: `manage_aws_athena_queries(operation='get-query-results', query_execution_id='query-id')`
+3. Get query execution details: `manage_aws_athena_queries(operation='get-query-execution', query_execution_id='query-id')`
+4. Stop a running query: `manage_aws_athena_queries(operation='stop-query-execution', query_execution_id='query-id')`
+5. Get query runtime statistics: `manage_aws_athena_queries(operation='get-query-runtime-statistics', query_execution_id='query-id')`
+
+### Creating Athena Named Queries
+1. Create a named query: `manage_aws_athena_named_queries(operation='create-named-query', name='my-query', database='my-database', query_string='SELECT * FROM my_table', work_group='my-workgroup')`
+2. Get a named query: `manage_aws_athena_named_queries(operation='get-named-query', named_query_id='query-id')`
+3. Delete a named query: `manage_aws_athena_named_queries(operation='delete-named-query', named_query_id='query-id')`
+4. List named queries: `manage_aws_athena_named_queries(operation='list-named-queries', work_group='my-workgroup')`
+5. Update a named query: `manage_aws_athena_named_queries(operation='update-named-query', named_query_id='query-id', name='updated-name', query_string='SELECT * FROM my_table LIMIT 10')`
+
+### Athena Workgroup and Data Catalog
+1. Create a workgroup: `manage_aws_athena_workgroups(operation='create-work-group', work_group_name='my-workgroup', configuration={...})`
+2. Manage data catalogs: `manage_aws_athena_data_catalogs(operation='create-data-catalog', name='my-catalog', type='GLUE', parameters={...})`
 
 """
 
@@ -135,6 +162,23 @@ def main():
 
     # Initialize handlers - all tools are always registered, access control is handled within tools
     GlueDataCatalogHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+
+    AthenaQueryHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+
+    AthenaDataCatalogHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    AthenaWorkGroupHandler(
         mcp,
         allow_write=allow_write,
         allow_sensitive_data_access=allow_sensitive_data_access,

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/athena/__init__.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/athena/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_data_catalog_handler.py
@@ -1,0 +1,554 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+import pytest
+from awslabs.dataprocessing_mcp_server.handlers.athena.athena_data_catalog_handler import (
+    AthenaDataCatalogHandler,
+)
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def mock_athena_client():
+    """Create a mock Athena client instance for testing."""
+    return Mock()
+
+
+@pytest.fixture
+def mock_aws_helper():
+    """Create a mock AwsHelper instance for testing."""
+    with patch(
+        'awslabs.dataprocessing_mcp_server.handlers.athena.athena_data_catalog_handler.AwsHelper'
+    ) as mock:
+        mock.create_boto3_client.return_value = Mock()
+        mock.prepare_resource_tags.return_value = {'ManagedBy': 'MCP'}
+        mock.convert_tags_to_aws_format.return_value = [{'Key': 'ManagedBy', 'Value': 'MCP'}]
+        yield mock
+
+
+@pytest.fixture
+def handler(mock_aws_helper):
+    """Create a mock AthenaDataCatalogHandler instance for testing."""
+    mcp = Mock()
+    return AthenaDataCatalogHandler(mcp, allow_write=True)
+
+
+@pytest.fixture
+def read_only_handler(mock_aws_helper):
+    """Create a mock AthenaDataCatalogHandler instance with read-only access for testing."""
+    mcp = Mock()
+    return AthenaDataCatalogHandler(mcp, allow_write=False)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock context instance for testing."""
+    return Mock(spec=Context)
+
+
+# Initialization Tests
+
+
+def test_initialization_parameters(mock_aws_helper):
+    """Test initialization of parameters for AthenaDataCatalogHandler object."""
+    mcp = Mock()
+    handler = AthenaDataCatalogHandler(mcp, allow_write=True, allow_sensitive_data_access=True)
+
+    assert handler.allow_write
+    assert handler.allow_sensitive_data_access
+    assert handler.mcp == mcp
+
+
+def test_initialization_registers_tools(mock_aws_helper):
+    """Test that initialization registers the tools with the MCP server."""
+    mcp = Mock()
+    AthenaDataCatalogHandler(mcp)
+
+    mcp.tool.assert_any_call(name='manage_aws_athena_data_catalogs')
+    mcp.tool.assert_any_call(name='manage_aws_athena_databases_and_tables')
+
+
+# Data Catalog Tests
+
+
+@pytest.mark.asyncio
+async def test_create_data_catalog_success(handler, mock_athena_client):
+    """Test successful creation of a data catalog."""
+    handler.athena_client = mock_athena_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx,
+        operation='create-data-catalog',
+        name='test-catalog',
+        type='GLUE',
+        description='Test catalog',
+        parameters={'catalog-id': '123456789012'},
+        tags={'Environment': 'Test'},
+    )
+
+    assert not response.isError
+    assert response.name == 'test-catalog'
+    assert response.operation == 'create-data-catalog'
+    mock_athena_client.create_data_catalog.assert_called_once()
+    # Verify parameters were passed correctly
+    call_args = mock_athena_client.create_data_catalog.call_args[1]
+    assert call_args['Name'] == 'test-catalog'
+    assert call_args['Type'] == 'GLUE'
+    assert call_args['Description'] == 'Test catalog'
+    assert call_args['Parameters'] == json.dumps({'catalog-id': '123456789012'})
+    assert call_args['Tags'] == [{'Key': 'ManagedBy', 'Value': 'MCP'}]
+
+
+@pytest.mark.asyncio
+async def test_create_data_catalog_missing_parameters(handler):
+    """Test that create data catalog fails when required parameters are missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_data_catalogs(
+            ctx, operation='create-data-catalog', name=None, type=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_data_catalog_without_write_permission(read_only_handler):
+    """Test that creating a data catalog fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_data_catalogs(
+        ctx, operation='create-data-catalog', name='test-catalog', type='GLUE'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_delete_data_catalog_success(handler, mock_athena_client):
+    """Test successful deletion of a data catalog."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.delete_data_catalog.return_value = {
+        'DataCatalog': {'Status': 'DELETE_SUCCESSFUL'}
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx, operation='delete-data-catalog', name='test-catalog', delete_catalog_only=True
+    )
+
+    assert not response.isError
+    assert response.name == 'test-catalog'
+    assert response.operation == 'delete-data-catalog'
+    mock_athena_client.delete_data_catalog.assert_called_once_with(
+        Name='test-catalog', DeleteCatalogOnly='true'
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_data_catalog_failure(handler, mock_athena_client):
+    """Test handling of a failed data catalog deletion."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.delete_data_catalog.return_value = {
+        'DataCatalog': {'Status': 'DELETE_FAILED'}
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx, operation='delete-data-catalog', name='test-catalog'
+    )
+
+    assert response.isError
+    assert response.name == 'test-catalog'
+    assert response.operation == 'delete-data-catalog'
+    assert 'Data Catalog delete operation failed' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_delete_data_catalog_missing_parameters(handler):
+    """Test that delete data catalog fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_data_catalogs(
+            ctx, operation='delete-data-catalog', name=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_data_catalog_without_write_permission(read_only_handler):
+    """Test that deleting a data catalog fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_data_catalogs(
+        ctx, operation='delete-data-catalog', name='test-catalog'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_data_catalog_success(handler, mock_athena_client):
+    """Test successful retrieval of a data catalog."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_data_catalog.return_value = {
+        'DataCatalog': {
+            'Name': 'test-catalog',
+            'Type': 'GLUE',
+            'Description': 'Test catalog',
+            'Parameters': {'catalog-id': '123456789012'},
+        }
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx, operation='get-data-catalog', name='test-catalog', work_group='primary'
+    )
+
+    assert not response.isError
+    assert response.operation == 'get-data-catalog'
+    assert response.data_catalog['Name'] == 'test-catalog'
+    assert response.data_catalog['Type'] == 'GLUE'
+    mock_athena_client.get_data_catalog.assert_called_once_with(
+        Name='test-catalog', WorkGroup='primary'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_data_catalog_missing_parameters(handler):
+    """Test that get data catalog fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_data_catalogs(ctx, operation='get-data-catalog', name=None)
+
+
+@pytest.mark.asyncio
+async def test_list_data_catalogs_success(handler, mock_athena_client):
+    """Test successful listing of data catalogs."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.list_data_catalogs.return_value = {
+        'DataCatalogsSummary': [
+            {'CatalogName': 'catalog1', 'Type': 'GLUE'},
+            {'CatalogName': 'catalog2', 'Type': 'LAMBDA'},
+        ],
+        'NextToken': 'next-token',
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx,
+        operation='list-data-catalogs',
+        max_results=10,
+        next_token='token',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert response.operation == 'list-data-catalogs'
+    assert len(response.data_catalogs) == 2
+    assert response.count == 2
+    assert response.next_token == 'next-token'
+    mock_athena_client.list_data_catalogs.assert_called_once_with(
+        MaxResults=10, NextToken='token', WorkGroup='primary'
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_data_catalog_success(handler, mock_athena_client):
+    """Test successful update of a data catalog."""
+    handler.athena_client = mock_athena_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx,
+        operation='update-data-catalog',
+        name='test-catalog',
+        type='GLUE',
+        description='Updated catalog',
+        parameters={'catalog-id': '987654321098'},
+    )
+
+    assert not response.isError
+    assert response.name == 'test-catalog'
+    assert response.operation == 'update-data-catalog'
+    mock_athena_client.update_data_catalog.assert_called_once()
+    # Verify parameters were passed correctly
+    call_args = mock_athena_client.update_data_catalog.call_args[1]
+    assert call_args['Name'] == 'test-catalog'
+    assert call_args['Type'] == 'GLUE'
+    assert call_args['Description'] == 'Updated catalog'
+    assert call_args['Parameters'] == json.dumps({'catalog-id': '987654321098'})
+
+
+@pytest.mark.asyncio
+async def test_update_data_catalog_missing_parameters(handler):
+    """Test that update data catalog fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_data_catalogs(
+            ctx, operation='update-data-catalog', name=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_data_catalog_without_write_permission(read_only_handler):
+    """Test that updating a data catalog fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_data_catalogs(
+        ctx, operation='update-data-catalog', name='test-catalog', description='Updated catalog'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_invalid_data_catalog_operation(handler):
+    """Test that running manage_aws_athena_data_catalogs with an invalid operation results in an error."""
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(ctx, operation='invalid-operation')
+
+    assert response.isError
+    assert 'Invalid operation' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_data_catalog_client_error_handling(handler, mock_athena_client):
+    """Test error handling when Athena client raises an exception."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_data_catalog.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'}},
+        'GetDataCatalog',
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_data_catalogs(
+        ctx, operation='get-data-catalog', name='test-catalog'
+    )
+
+    assert response.isError
+    assert 'Error in manage_aws_athena_data_catalogs' in response.content[0].text
+
+
+# Database and Table Tests
+
+
+@pytest.mark.asyncio
+async def test_get_database_success(handler, mock_athena_client):
+    """Test successful retrieval of a database."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_database.return_value = {
+        'Database': {
+            'Name': 'test-db',
+            'Description': 'Test database',
+            'Parameters': {'created-by': 'test-user'},
+        }
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_databases_and_tables(
+        ctx,
+        operation='get-database',
+        catalog_name='test-catalog',
+        database_name='test-db',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert response.operation == 'get-database'
+    assert response.database['Name'] == 'test-db'
+    mock_athena_client.get_database.assert_called_once_with(
+        CatalogName='test-catalog', DatabaseName='test-db', WorkGroup='primary'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_database_missing_parameters(handler):
+    """Test that get database fails when database_name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_databases_and_tables(
+            ctx, operation='get-database', catalog_name='test-catalog', database_name=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_table_metadata_success(handler, mock_athena_client):
+    """Test successful retrieval of table metadata."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_table_metadata.return_value = {
+        'TableMetadata': {
+            'Name': 'test-table',
+            'CreateTime': '2023-01-01T00:00:00Z',
+            'LastAccessTime': '2023-01-02T00:00:00Z',
+            'TableType': 'EXTERNAL_TABLE',
+            'Columns': [{'Name': 'id', 'Type': 'int'}, {'Name': 'name', 'Type': 'string'}],
+        }
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_databases_and_tables(
+        ctx,
+        operation='get-table-metadata',
+        catalog_name='test-catalog',
+        database_name='test-db',
+        table_name='test-table',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert response.operation == 'get-table-metadata'
+    assert response.table_metadata['Name'] == 'test-table'
+    assert len(response.table_metadata['Columns']) == 2
+    mock_athena_client.get_table_metadata.assert_called_once_with(
+        CatalogName='test-catalog',
+        DatabaseName='test-db',
+        TableName='test-table',
+        WorkGroup='primary',
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_table_metadata_missing_parameters(handler):
+    """Test that get table metadata fails when required parameters are missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_databases_and_tables(
+            ctx,
+            operation='get-table-metadata',
+            catalog_name='test-catalog',
+            database_name='test-db',
+            table_name=None,
+        )
+
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_databases_and_tables(
+            ctx,
+            operation='get-table-metadata',
+            catalog_name='test-catalog',
+            database_name=None,
+            table_name='test-table',
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_databases_success(handler, mock_athena_client):
+    """Test successful listing of databases."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.list_databases.return_value = {
+        'DatabaseList': [
+            {'Name': 'db1', 'Description': 'Database 1'},
+            {'Name': 'db2', 'Description': 'Database 2'},
+        ],
+        'NextToken': 'next-token',
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_databases_and_tables(
+        ctx,
+        operation='list-databases',
+        catalog_name='test-catalog',
+        max_results=10,
+        next_token='token',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert response.operation == 'list-databases'
+    assert len(response.database_list) == 2
+    assert response.count == 2
+    assert response.next_token == 'next-token'
+    mock_athena_client.list_databases.assert_called_once_with(
+        CatalogName='test-catalog', MaxResults=10, NextToken='token', WorkGroup='primary'
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_table_metadata_success(handler, mock_athena_client):
+    """Test successful listing of table metadata."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.list_table_metadata.return_value = {
+        'TableMetadataList': [
+            {'Name': 'table1', 'TableType': 'EXTERNAL_TABLE'},
+            {'Name': 'table2', 'TableType': 'MANAGED_TABLE'},
+        ],
+        'NextToken': 'next-token',
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_databases_and_tables(
+        ctx,
+        operation='list-table-metadata',
+        catalog_name='test-catalog',
+        database_name='test-db',
+        expression='table*',
+        max_results=10,
+        next_token='token',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert response.operation == 'list-table-metadata'
+    assert len(response.table_metadata_list) == 2
+    assert response.count == 2
+    assert response.next_token == 'next-token'
+    mock_athena_client.list_table_metadata.assert_called_once_with(
+        CatalogName='test-catalog',
+        DatabaseName='test-db',
+        Expression='table*',
+        MaxResults=10,
+        NextToken='token',
+        WorkGroup='primary',
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_table_metadata_missing_parameters(handler):
+    """Test that list table metadata fails when database_name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_databases_and_tables(
+            ctx, operation='list-table-metadata', catalog_name='test-catalog', database_name=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_database_table_operation(handler):
+    """Test that running manage_aws_athena_databases_and_tables with an invalid operation results in an error."""
+    ctx = Mock()
+    response = await handler.manage_aws_athena_databases_and_tables(
+        ctx, operation='invalid-operation', catalog_name='test-catalog'
+    )
+
+    assert response.isError
+    assert 'Invalid operation' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_database_table_client_error_handling(handler, mock_athena_client):
+    """Test error handling when Athena client raises an exception."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_database.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'}},
+        'GetDatabase',
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_databases_and_tables(
+        ctx, operation='get-database', catalog_name='test-catalog', database_name='test-db'
+    )
+
+    assert response.isError
+    assert 'Error in manage_aws_athena_databases_and_tables' in response.content[0].text

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_query_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_query_handler.py
@@ -1,0 +1,651 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from awslabs.dataprocessing_mcp_server.handlers.athena.athena_query_handler import (
+    AthenaQueryHandler,
+)
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def mock_athena_client():
+    """Create a mock Athena client instance for testing."""
+    return Mock()
+
+
+@pytest.fixture
+def mock_aws_helper():
+    """Create a mock AwsHelper instance for testing."""
+    with patch(
+        'awslabs.dataprocessing_mcp_server.handlers.athena.athena_query_handler.AwsHelper'
+    ) as mock:
+        mock.create_boto3_client.return_value = Mock()
+        yield mock
+
+
+@pytest.fixture
+def handler(mock_aws_helper):
+    """Create a mock AthenaQueryHandler instance for testing."""
+    mcp = Mock()
+    return AthenaQueryHandler(mcp, allow_write=True)
+
+
+@pytest.fixture
+def read_only_handler(mock_aws_helper):
+    """Create a mock AthenaQueryHandler instance with read-only access for testing."""
+    mcp = Mock()
+    return AthenaQueryHandler(mcp, allow_write=False)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock context instance for testing."""
+    return Mock(spec=Context)
+
+
+# Query Execution Tests
+
+
+@pytest.mark.asyncio
+async def test_batch_get_query_execution_success(handler, mock_athena_client):
+    """Test successful batch retrieval of query executions."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.batch_get_query_execution.return_value = {
+        'QueryExecutions': [{'QueryExecutionId': 'query1'}, {'QueryExecutionId': 'query2'}],
+        'UnprocessedQueryExecutionIds': [],
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx, operation='batch-get-query-execution', query_execution_ids=['query1', 'query2']
+    )
+
+    assert not response.isError
+    assert len(response.query_executions) == 2
+    assert len(response.unprocessed_query_execution_ids) == 0
+    mock_athena_client.batch_get_query_execution.assert_called_once_with(
+        QueryExecutionIds=['query1', 'query2']
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_get_query_execution_missing_parameters(handler):
+    """Test that batch get query execution fails when query_execution_ids is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_queries(
+            ctx, operation='batch-get-query-execution', query_execution_ids=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_query_execution_success(handler, mock_athena_client):
+    """Test successful retrieval of a query execution."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_query_execution.return_value = {
+        'QueryExecution': {'QueryExecutionId': 'query1', 'Status': {'State': 'SUCCEEDED'}}
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx, operation='get-query-execution', query_execution_id='query1'
+    )
+
+    assert not response.isError
+    assert response.query_execution_id == 'query1'
+    assert response.query_execution['Status']['State'] == 'SUCCEEDED'
+    mock_athena_client.get_query_execution.assert_called_once_with(QueryExecutionId='query1')
+
+
+@pytest.mark.asyncio
+async def test_get_query_execution_missing_parameters(handler):
+    """Test that get query execution fails when query_execution_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_queries(
+            ctx, operation='get-query-execution', query_execution_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_query_results_success(handler, mock_athena_client):
+    """Test successful retrieval of query results."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_query_results.return_value = {
+        'ResultSet': {
+            'Rows': [{'Data': [{'VarCharValue': 'header1'}, {'VarCharValue': 'header2'}]}],
+            'ResultSetMetadata': {'ColumnInfo': []},
+        },
+        'NextToken': 'next-token',
+        'UpdateCount': 0,
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx,
+        operation='get-query-results',
+        query_execution_id='query1',
+        max_results=10,
+        next_token='token',
+        query_result_type='DATA_ROWS',
+    )
+
+    assert not response.isError
+    assert response.query_execution_id == 'query1'
+    assert response.next_token == 'next-token'
+    assert response.update_count == 0
+    mock_athena_client.get_query_results.assert_called_once_with(
+        QueryExecutionId='query1', MaxResults=10, NextToken='token', QueryResultType='DATA_ROWS'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_query_results_missing_parameters(handler):
+    """Test that get query results fails when query_execution_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_queries(
+            ctx, operation='get-query-results', query_execution_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_query_runtime_statistics_success(handler, mock_athena_client):
+    """Test successful retrieval of query runtime statistics."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_query_runtime_statistics.return_value = {
+        'QueryRuntimeStatistics': {
+            'Timeline': {'QueryQueueTime': 100, 'QueryPlanningTime': 200},
+            'Rows': {'InputRows': 1000, 'OutputRows': 500},
+        }
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx, operation='get-query-runtime-statistics', query_execution_id='query1'
+    )
+
+    assert not response.isError
+    assert response.query_execution_id == 'query1'
+    assert response.statistics['Timeline']['QueryQueueTime'] == 100
+    mock_athena_client.get_query_runtime_statistics.assert_called_once_with(
+        QueryExecutionId='query1'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_query_runtime_statistics_missing_parameters(handler):
+    """Test that get query runtime statistics fails when query_execution_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_queries(
+            ctx, operation='get-query-runtime-statistics', query_execution_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_query_executions_success(handler, mock_athena_client):
+    """Test successful listing of query executions."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.list_query_executions.return_value = {
+        'QueryExecutionIds': ['query1', 'query2', 'query3'],
+        'NextToken': 'next-token',
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx,
+        operation='list-query-executions',
+        max_results=10,
+        next_token='token',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert len(response.query_execution_ids) == 3
+    assert response.count == 3
+    assert response.next_token == 'next-token'
+    mock_athena_client.list_query_executions.assert_called_once_with(
+        MaxResults=10, NextToken='token', WorkGroup='primary'
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_query_execution_success(handler, mock_athena_client):
+    """Test successful start of a query execution."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.start_query_execution.return_value = {'QueryExecutionId': 'query1'}
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx,
+        operation='start-query-execution',
+        query_string='SELECT * FROM table',
+        client_request_token='token123',
+        query_execution_context={'Database': 'db1'},
+        result_configuration={'OutputLocation': 's3://bucket/path'},
+        work_group='primary',
+        execution_parameters=['param1', 'param2'],
+        result_reuse_configuration={'ResultReuseByAgeConfiguration': {'Enabled': True}},
+    )
+
+    assert not response.isError
+    assert response.query_execution_id == 'query1'
+    mock_athena_client.start_query_execution.assert_called_once_with(
+        QueryString='SELECT * FROM table',
+        ClientRequestToken='token123',
+        QueryExecutionContext={'Database': 'db1'},
+        ResultConfiguration={'OutputLocation': 's3://bucket/path'},
+        WorkGroup='primary',
+        ExecutionParameters=['param1', 'param2'],
+        ResultReuseConfiguration={'ResultReuseByAgeConfiguration': {'Enabled': True}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_query_execution_missing_parameters(handler):
+    """Test that start query execution fails when query_string is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_queries(
+            ctx, operation='start-query-execution', query_string=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_query_execution_without_write_permission_non_select(read_only_handler):
+    """Test that starting a non-select query execution fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_queries(
+        ctx, operation='start-query-execution', query_string='INSERT INTO table VALUES (1, 2, 3)'
+    )
+
+    assert response.isError
+    assert response.query_execution_id == ''
+
+
+@pytest.mark.asyncio
+async def test_start_query_execution_without_write_permission_select(
+    read_only_handler, mock_athena_client
+):
+    """Test that starting a select query execution succeeds when write access is disabled."""
+    read_only_handler.athena_client = mock_athena_client
+    mock_athena_client.start_query_execution.return_value = {'QueryExecutionId': 'query1'}
+
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_queries(
+        ctx, operation='start-query-execution', query_string='SELECT * FROM table'
+    )
+
+    assert not response.isError
+    assert response.query_execution_id == 'query1'
+
+
+@pytest.mark.asyncio
+async def test_start_query_execution_without_write_permission_ctas(read_only_handler):
+    """Test that starting a CTAS query execution fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_queries(
+        ctx, operation='start-query-execution', query_string='CREATE TABLE AS SELECT * FROM table'
+    )
+
+    assert response.isError
+    assert response.query_execution_id == ''
+
+
+@pytest.mark.asyncio
+async def test_stop_query_execution_success(handler, mock_athena_client):
+    """Test successful stop of a query execution."""
+    handler.athena_client = mock_athena_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx, operation='stop-query-execution', query_execution_id='query1'
+    )
+
+    assert not response.isError
+    assert response.query_execution_id == 'query1'
+    mock_athena_client.stop_query_execution.assert_called_once_with(QueryExecutionId='query1')
+
+
+@pytest.mark.asyncio
+async def test_stop_query_execution_missing_parameters(handler):
+    """Test that stop query execution fails when query_execution_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_queries(
+            ctx, operation='stop-query-execution', query_execution_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_query_operation(handler):
+    """Test that running manage_aws_athena_queries with an invalid operation results in an error."""
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(ctx, operation='invalid-operation')
+
+    assert response.isError
+    assert 'Invalid operation' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_query_client_error_handling(handler, mock_athena_client):
+    """Test error handling when Athena client raises an exception."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_query_execution.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'}},
+        'GetQueryExecution',
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_queries(
+        ctx, operation='get-query-execution', query_execution_id='query1'
+    )
+
+    assert response.isError
+    assert 'Error in manage_aws_athena_queries' in response.content[0].text
+
+
+# Named Query Tests
+
+
+@pytest.mark.asyncio
+async def test_batch_get_named_query_success(handler, mock_athena_client):
+    """Test successful batch retrieval of named queries."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.batch_get_named_query.return_value = {
+        'NamedQueries': [{'Name': 'query1'}, {'Name': 'query2'}],
+        'UnprocessedNamedQueryIds': [],
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx, operation='batch-get-named-query', named_query_ids=['id1', 'id2']
+    )
+
+    assert not response.isError
+    assert len(response.named_queries) == 2
+    assert len(response.unprocessed_named_query_ids) == 0
+    mock_athena_client.batch_get_named_query.assert_called_once_with(NamedQueryIds=['id1', 'id2'])
+
+
+@pytest.mark.asyncio
+async def test_batch_get_named_query_missing_parameters(handler):
+    """Test that batch get named query fails when named_query_ids is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_named_queries(
+            ctx, operation='batch-get-named-query', named_query_ids=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_named_query_success(handler, mock_athena_client):
+    """Test successful creation of a named query."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.create_named_query.return_value = {'NamedQueryId': 'id1'}
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx,
+        operation='create-named-query',
+        name='My Query',
+        description='Test query',
+        database='db1',
+        query_string='SELECT * FROM table',
+        client_request_token='token123',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert response.named_query_id == 'id1'
+    mock_athena_client.create_named_query.assert_called_once_with(
+        Name='My Query',
+        Description='Test query',
+        Database='db1',
+        QueryString='SELECT * FROM table',
+        ClientRequestToken='token123',
+        WorkGroup='primary',
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_named_query_missing_parameters(handler):
+    """Test that create named query fails when required parameters are missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_named_queries(
+            ctx, operation='create-named-query', name=None, query_string=None, database=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_named_query_without_write_permission(read_only_handler):
+    """Test that creating a named query fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_named_queries(
+        ctx,
+        operation='create-named-query',
+        name='My Query',
+        description='Test query',
+        database='db1',
+        query_string='SELECT * FROM table',
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_delete_named_query_success(handler, mock_athena_client):
+    """Test successful deletion of a named query."""
+    handler.athena_client = mock_athena_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx, operation='delete-named-query', named_query_id='id1'
+    )
+
+    assert not response.isError
+    assert response.named_query_id == 'id1'
+    mock_athena_client.delete_named_query.assert_called_once_with(NamedQueryId='id1')
+
+
+@pytest.mark.asyncio
+async def test_delete_named_query_missing_parameters(handler):
+    """Test that delete named query fails when named_query_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_named_queries(
+            ctx, operation='delete-named-query', named_query_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_named_query_without_write_permission(read_only_handler):
+    """Test that deleting a named query fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_named_queries(
+        ctx, operation='delete-named-query', named_query_id='id1'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_named_query_success(handler, mock_athena_client):
+    """Test successful retrieval of a named query."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_named_query.return_value = {
+        'NamedQuery': {
+            'Name': 'My Query',
+            'Description': 'Test query',
+            'Database': 'db1',
+            'QueryString': 'SELECT * FROM table',
+            'NamedQueryId': 'id1',
+        }
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx, operation='get-named-query', named_query_id='id1'
+    )
+
+    assert not response.isError
+    assert response.named_query_id == 'id1'
+    assert response.named_query['Name'] == 'My Query'
+    mock_athena_client.get_named_query.assert_called_once_with(NamedQueryId='id1')
+
+
+@pytest.mark.asyncio
+async def test_get_named_query_missing_parameters(handler):
+    """Test that get named query fails when named_query_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_named_queries(
+            ctx, operation='get-named-query', named_query_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_named_queries_success(handler, mock_athena_client):
+    """Test successful listing of named queries."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.list_named_queries.return_value = {
+        'NamedQueryIds': ['id1', 'id2', 'id3'],
+        'NextToken': 'next-token',
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx,
+        operation='list-named-queries',
+        max_results=10,
+        next_token='token',
+        work_group='primary',
+    )
+
+    assert not response.isError
+    assert len(response.named_query_ids) == 3
+    assert response.count == 3
+    assert response.next_token == 'next-token'
+    mock_athena_client.list_named_queries.assert_called_once_with(
+        MaxResults=10, NextToken='token', WorkGroup='primary'
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_named_query_success(handler, mock_athena_client):
+    """Test successful update of a named query."""
+    handler.athena_client = mock_athena_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx,
+        operation='update-named-query',
+        named_query_id='id1',
+        name='Updated Query',
+        description='Updated description',
+        database='new_db',
+        query_string='SELECT * FROM new_table',
+    )
+
+    assert not response.isError
+    assert response.named_query_id == 'id1'
+    mock_athena_client.update_named_query.assert_called_once_with(
+        NamedQueryId='id1',
+        Name='Updated Query',
+        Description='Updated description',
+        Database='new_db',
+        QueryString='SELECT * FROM new_table',
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_named_query_missing_parameters(handler):
+    """Test that update named query fails when named_query_id is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_named_queries(
+            ctx, operation='update-named-query', named_query_id=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_named_query_without_write_permission(read_only_handler):
+    """Test that updating a named query fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_named_queries(
+        ctx, operation='update-named-query', named_query_id='id1', name='Updated Query'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_invalid_named_query_operation(handler):
+    """Test that running manage_aws_athena_named_queries with an invalid operation results in an error."""
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(ctx, operation='invalid-operation')
+
+    assert response.isError
+    assert 'Invalid operation' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_named_query_client_error_handling(handler, mock_athena_client):
+    """Test error handling when Athena client raises an exception."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_named_query.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'}},
+        'GetNamedQuery',
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_named_queries(
+        ctx, operation='get-named-query', named_query_id='id1'
+    )
+
+    assert response.isError
+    assert 'Error in manage_aws_athena_named_queries' in response.content[0].text
+
+
+# Initialization Tests
+
+
+@pytest.mark.asyncio
+async def test_initialization_parameters(mock_aws_helper):
+    """Test initialization of parameters for AthenaQueryHandler object."""
+    mcp = Mock()
+    handler = AthenaQueryHandler(mcp, allow_write=True, allow_sensitive_data_access=True)
+
+    assert handler.allow_write
+    assert handler.allow_sensitive_data_access
+    assert handler.mcp == mcp
+
+
+@pytest.mark.asyncio
+async def test_initialization_registers_tools(mock_aws_helper):
+    """Test that initialization registers the tools with the MCP server."""
+    mcp = Mock()
+    AthenaQueryHandler(mcp)
+
+    mcp.tool.assert_any_call(name='manage_aws_athena_query_executions')
+    mcp.tool.assert_any_call(name='manage_aws_athena_named_queries')

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_workgroup_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_workgroup_handler.py
@@ -1,0 +1,389 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from awslabs.dataprocessing_mcp_server.handlers.athena.athena_workgroup_handler import (
+    AthenaWorkGroupHandler,
+)
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def mock_athena_client():
+    """Create a mock Athena client instance for testing."""
+    return Mock()
+
+
+@pytest.fixture
+def mock_aws_helper():
+    """Create a mock AwsHelper instance for testing."""
+    with patch(
+        'awslabs.dataprocessing_mcp_server.handlers.athena.athena_workgroup_handler.AwsHelper'
+    ) as mock:
+        mock.create_boto3_client.return_value = Mock()
+        mock.prepare_resource_tags.return_value = {
+            'ManagedBy': 'MCP',
+            'ResourceType': 'AthenaWorkgroup',
+        }
+        mock.convert_tags_to_aws_format.return_value = [{'Key': 'ManagedBy', 'Value': 'MCP'}]
+        mock.get_resource_tags_athena_workgroup.return_value = [
+            {'Key': 'ManagedBy', 'Value': 'MCP'}
+        ]
+        mock.verify_resource_managed_by_mcp.return_value = True
+        yield mock
+
+
+@pytest.fixture
+def handler(mock_aws_helper):
+    """Create a mock AthenaWorkGroupHandler instance for testing."""
+    mcp = Mock()
+    return AthenaWorkGroupHandler(mcp, allow_write=True)
+
+
+@pytest.fixture
+def read_only_handler(mock_aws_helper):
+    """Create a mock AthenaWorkGroupHandler instance with read-only access for testing."""
+    mcp = Mock()
+    return AthenaWorkGroupHandler(mcp, allow_write=False)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock context instance for testing."""
+    return Mock(spec=Context)
+
+
+# WorkGroup Tests
+
+
+@pytest.mark.asyncio
+async def test_create_work_group_success(handler, mock_athena_client):
+    """Test successful creation of a workgroup."""
+    handler.athena_client = mock_athena_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx,
+        operation='create-work-group',
+        name='test-workgroup',
+        description='Test workgroup',
+        configuration={'ResultConfiguration': {'OutputLocation': 's3://bucket/path'}},
+        state='ENABLED',
+        tags={'Owner': 'TestTeam'},
+    )
+
+    assert not response.isError
+    assert response.work_group_name == 'test-workgroup'
+    assert response.operation == 'create-work-group'
+    mock_athena_client.create_work_group.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_work_group_missing_parameters(handler):
+    """Test that create workgroup fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_workgroups(ctx, operation='create-work-group', name=None)
+
+
+@pytest.mark.asyncio
+async def test_create_work_group_without_write_permission(read_only_handler):
+    """Test that creating a workgroup fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_workgroups(
+        ctx, operation='create-work-group', name='test-workgroup', description='Test workgroup'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+    assert response.work_group_name == ''
+
+
+@pytest.mark.asyncio
+async def test_delete_work_group_success(handler, mock_athena_client, mock_aws_helper):
+    """Test successful deletion of a workgroup."""
+    handler.athena_client = mock_athena_client
+    mock_aws_helper.verify_resource_managed_by_mcp.return_value = True
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx, operation='delete-work-group', name='test-workgroup', recursive_delete_option=True
+    )
+
+    assert not response.isError
+    assert response.work_group_name == 'test-workgroup'
+    assert response.operation == 'delete-work-group'
+    mock_athena_client.delete_work_group.assert_called_once_with(
+        WorkGroup='test-workgroup', RecursiveDeleteOption=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_work_group_missing_parameters(handler):
+    """Test that delete workgroup fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_workgroups(ctx, operation='delete-work-group', name=None)
+
+
+@pytest.mark.asyncio
+async def test_delete_work_group_without_write_permission(read_only_handler):
+    """Test that deleting a workgroup fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_workgroups(
+        ctx, operation='delete-work-group', name='test-workgroup'
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+    assert response.work_group_name == ''
+
+
+@pytest.mark.asyncio
+async def test_delete_work_group_not_mcp_managed(handler, mock_aws_helper):
+    """Test that deleting a non-MCP managed workgroup fails."""
+    # Simulate a workgroup without MCP managed tags
+    mock_aws_helper.get_resource_tags_athena_workgroup.return_value = [
+        {'Key': 'OtherTag', 'Value': 'OtherValue'}
+    ]
+    mock_aws_helper.verify_resource_managed_by_mcp.return_value = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx, operation='delete-work-group', name='test-workgroup'
+    )
+
+    assert response.isError
+    assert 'not managed by the MCP server' in response.content[0].text
+    assert response.work_group_name == 'test-workgroup'
+
+
+@pytest.mark.asyncio
+async def test_get_work_group_success(handler, mock_athena_client):
+    """Test successful retrieval of a workgroup."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_work_group.return_value = {
+        'WorkGroup': {
+            'Name': 'test-workgroup',
+            'State': 'ENABLED',
+            'Configuration': {'ResultConfiguration': {'OutputLocation': 's3://bucket/path'}},
+        }
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx, operation='get-work-group', name='test-workgroup'
+    )
+
+    assert not response.isError
+    assert response.work_group['Name'] == 'test-workgroup'
+    assert response.operation == 'get-work-group'
+    mock_athena_client.get_work_group.assert_called_once_with(WorkGroup='test-workgroup')
+
+
+@pytest.mark.asyncio
+async def test_get_work_group_missing_parameters(handler):
+    """Test that get workgroup fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_workgroups(ctx, operation='get-work-group', name=None)
+
+
+@pytest.mark.asyncio
+async def test_list_work_groups_success(handler, mock_athena_client):
+    """Test successful listing of workgroups."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.list_work_groups.return_value = {
+        'WorkGroups': [
+            {'Name': 'workgroup1', 'State': 'ENABLED'},
+            {'Name': 'workgroup2', 'State': 'DISABLED'},
+        ],
+        'NextToken': 'next-token',
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx, operation='list-work-groups', max_results=10, next_token='token'
+    )
+
+    assert not response.isError
+    assert len(response.work_groups) == 2
+    assert response.count == 2
+    assert response.next_token == 'next-token'
+    assert response.operation == 'list-work-groups'
+    mock_athena_client.list_work_groups.assert_called_once_with(MaxResults=10, NextToken='token')
+
+
+@pytest.mark.asyncio
+async def test_update_work_group_success(handler, mock_athena_client, mock_aws_helper):
+    """Test successful update of a workgroup."""
+    handler.athena_client = mock_athena_client
+    mock_aws_helper.verify_resource_managed_by_mcp.return_value = True
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx,
+        operation='update-work-group',
+        name='test-workgroup',
+        description='Updated description',
+        configuration={'ResultConfiguration': {'OutputLocation': 's3://new-bucket/path'}},
+        state='DISABLED',
+    )
+
+    assert not response.isError
+    assert response.work_group_name == 'test-workgroup'
+    assert response.operation == 'update-work-group'
+    mock_athena_client.update_work_group.assert_called_once_with(
+        WorkGroup='test-workgroup',
+        Description='Updated description',
+        ConfigurationUpdates={'ResultConfiguration': {'OutputLocation': 's3://new-bucket/path'}},
+        State='DISABLED',
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_work_group_missing_parameters(handler):
+    """Test that update workgroup fails when name is missing."""
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_athena_workgroups(ctx, operation='update-work-group', name=None)
+
+
+@pytest.mark.asyncio
+async def test_update_work_group_without_write_permission(read_only_handler):
+    """Test that updating a workgroup fails when write access is disabled."""
+    ctx = Mock()
+    response = await read_only_handler.manage_aws_athena_workgroups(
+        ctx,
+        operation='update-work-group',
+        name='test-workgroup',
+        description='Updated description',
+    )
+
+    assert response.isError
+    assert 'not allowed without write access' in response.content[0].text
+    assert response.work_group_name == ''
+
+
+@pytest.mark.asyncio
+async def test_update_work_group_not_mcp_managed(handler, mock_aws_helper):
+    """Test that updating a non-MCP managed workgroup fails."""
+    # Simulate a workgroup without MCP managed tags
+    mock_aws_helper.get_resource_tags_athena_workgroup.return_value = [
+        {'Key': 'OtherTag', 'Value': 'OtherValue'}
+    ]
+    mock_aws_helper.verify_resource_managed_by_mcp.return_value = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx,
+        operation='update-work-group',
+        name='test-workgroup',
+        description='Updated description',
+    )
+
+    assert response.isError
+    assert 'not managed by the MCP server' in response.content[0].text
+    assert response.work_group_name == 'test-workgroup'
+
+
+@pytest.mark.asyncio
+async def test_invalid_work_group_operation(handler):
+    """Test that running manage_aws_athena_workgroups with an invalid operation results in an error."""
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(ctx, operation='invalid-operation')
+
+    assert response.isError
+    assert 'Invalid operation' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_work_group_client_error_handling(handler, mock_athena_client):
+    """Test error handling when Athena client raises an exception."""
+    handler.athena_client = mock_athena_client
+    mock_athena_client.get_work_group.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'}},
+        'GetWorkGroup',
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx, operation='get-work-group', name='test-workgroup'
+    )
+
+    assert response.isError
+    assert 'Error in manage_aws_athena_workgroups' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_delete_work_group_empty_tags(handler, mock_aws_helper):
+    """Test that deleting a workgroup with empty tags fails."""
+    # Simulate a workgroup with empty tags
+    mock_aws_helper.get_resource_tags_athena_workgroup.return_value = []
+    mock_aws_helper.verify_resource_managed_by_mcp.return_value = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx, operation='delete-work-group', name='test-workgroup'
+    )
+
+    assert response.isError
+    assert 'not managed by the MCP server' in response.content[0].text
+    assert response.work_group_name == 'test-workgroup'
+
+
+@pytest.mark.asyncio
+async def test_update_work_group_empty_tags(handler, mock_aws_helper):
+    """Test that updating a workgroup with empty tags fails."""
+    # Simulate a workgroup with empty tags
+    mock_aws_helper.get_resource_tags_athena_workgroup.return_value = []
+    mock_aws_helper.verify_resource_managed_by_mcp.return_value = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_athena_workgroups(
+        ctx,
+        operation='update-work-group',
+        name='test-workgroup',
+        description='Updated description',
+    )
+
+    assert response.isError
+    assert 'not managed by the MCP server' in response.content[0].text
+    assert response.work_group_name == 'test-workgroup'
+
+
+# Initialization Tests
+
+
+@pytest.mark.asyncio
+async def test_initialization_parameters(mock_aws_helper):
+    """Test initialization of parameters for AthenaWorkGroupHandler object."""
+    mcp = Mock()
+    handler = AthenaWorkGroupHandler(mcp, allow_write=True, allow_sensitive_data_access=True)
+
+    assert handler.allow_write
+    assert handler.allow_sensitive_data_access
+    assert handler.mcp == mcp
+
+
+@pytest.mark.asyncio
+async def test_initialization_registers_tools(mock_aws_helper):
+    """Test that initialization registers the tools with the MCP server."""
+    mcp = Mock()
+    AthenaWorkGroupHandler(mcp)
+
+    mcp.tool.assert_called_once_with(name='manage_aws_athena_workgroups')

--- a/src/aws-dataprocessing-mcp-server/tests/models/test_athena_models.py
+++ b/src/aws-dataprocessing-mcp-server/tests/models/test_athena_models.py
@@ -1,0 +1,685 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
+    BatchGetNamedQueryResponse,
+    BatchGetQueryExecutionResponse,
+    CreateDataCatalogResponse,
+    CreateNamedQueryResponse,
+    CreateWorkGroupResponse,
+    DeleteDataCatalogResponse,
+    DeleteNamedQueryResponse,
+    DeleteWorkGroupResponse,
+    GetDatabaseResponse,
+    GetDataCatalogResponse,
+    GetNamedQueryResponse,
+    GetQueryExecutionResponse,
+    GetQueryResultsResponse,
+    GetQueryRuntimeStatisticsResponse,
+    GetTableMetadataResponse,
+    GetWorkGroupResponse,
+    ListDatabasesResponse,
+    ListDataCatalogsResponse,
+    ListNamedQueriesResponse,
+    ListQueryExecutionsResponse,
+    ListTableMetadataResponse,
+    ListWorkGroupsResponse,
+    StartQueryExecutionResponse,
+    StopQueryExecutionResponse,
+    UpdateDataCatalogResponse,
+    UpdateNamedQueryResponse,
+    UpdateWorkGroupResponse,
+)
+from mcp.types import TextContent
+
+
+# Test data
+sample_text_content = [TextContent(type='text', text='Test message')]
+sample_dict = {'key': 'value'}
+sample_list = [{'id': 1}, {'id': 2}]
+
+
+class TestQueryExecutionResponses:
+    """Test class for Athena query execution response models."""
+
+    def test_batch_get_query_execution_response(self):
+        """Test the BatchGetQueryExecutionResponse model."""
+        response = BatchGetQueryExecutionResponse(
+            isError=False,
+            content=sample_text_content,
+            query_executions=sample_list,
+            unprocessed_query_execution_ids=[],
+        )
+        assert response.isError is False
+        assert response.query_executions == sample_list
+        assert response.unprocessed_query_execution_ids == []
+        assert response.operation == 'batch-get-query-execution'
+
+    def test_get_query_execution_response(self):
+        """Test the GetQueryExecutionResponse model."""
+        response = GetQueryExecutionResponse(
+            isError=False,
+            content=sample_text_content,
+            query_execution_id='query-123',
+            query_execution=sample_dict,
+        )
+        assert response.isError is False
+        assert response.query_execution_id == 'query-123'
+        assert response.query_execution == sample_dict
+        assert response.operation == 'get-query-execution'
+
+    def test_get_query_results_response(self):
+        """Test the GetQueryResultsResponse model."""
+        response = GetQueryResultsResponse(
+            isError=False,
+            content=sample_text_content,
+            query_execution_id='query-123',
+            result_set=sample_dict,
+            next_token='next-page',
+            update_count=10,
+        )
+        assert response.isError is False
+        assert response.query_execution_id == 'query-123'
+        assert response.result_set == sample_dict
+        assert response.next_token == 'next-page'
+        assert response.update_count == 10
+        assert response.operation == 'get-query-results'
+
+    def test_get_query_runtime_statistics_response(self):
+        """Test the GetQueryRuntimeStatisticsResponse model."""
+        response = GetQueryRuntimeStatisticsResponse(
+            isError=False,
+            content=sample_text_content,
+            query_execution_id='query-123',
+            statistics=sample_dict,
+        )
+        assert response.isError is False
+        assert response.query_execution_id == 'query-123'
+        assert response.statistics == sample_dict
+        assert response.operation == 'get-query-runtime-statistics'
+
+    def test_list_query_executions_response(self):
+        """Test the ListQueryExecutionsResponse model."""
+        response = ListQueryExecutionsResponse(
+            isError=False,
+            content=sample_text_content,
+            query_execution_ids=['query-1', 'query-2'],
+            count=2,
+            next_token='next-page',
+        )
+        assert response.isError is False
+        assert response.query_execution_ids == ['query-1', 'query-2']
+        assert response.count == 2
+        assert response.next_token == 'next-page'
+        assert response.operation == 'list-query-executions'
+
+    def test_start_query_execution_response(self):
+        """Test the StartQueryExecutionResponse model."""
+        response = StartQueryExecutionResponse(
+            isError=False,
+            content=sample_text_content,
+            query_execution_id='query-123',
+        )
+        assert response.isError is False
+        assert response.query_execution_id == 'query-123'
+        assert response.operation == 'start-query-execution'
+
+    def test_stop_query_execution_response(self):
+        """Test the StopQueryExecutionResponse model."""
+        response = StopQueryExecutionResponse(
+            isError=False,
+            content=sample_text_content,
+            query_execution_id='query-123',
+        )
+        assert response.isError is False
+        assert response.query_execution_id == 'query-123'
+        assert response.operation == 'stop-query-execution'
+
+
+class TestNamedQueryResponses:
+    """Test class for Athena named query response models."""
+
+    def test_batch_get_named_query_response(self):
+        """Test the BatchGetNamedQueryResponse model."""
+        response = BatchGetNamedQueryResponse(
+            isError=False,
+            content=sample_text_content,
+            named_queries=sample_list,
+            unprocessed_named_query_ids=[],
+        )
+        assert response.isError is False
+        assert response.named_queries == sample_list
+        assert response.unprocessed_named_query_ids == []
+        assert response.operation == 'batch-get-named-query'
+
+    def test_create_named_query_response(self):
+        """Test the CreateNamedQueryResponse model."""
+        response = CreateNamedQueryResponse(
+            isError=False,
+            content=sample_text_content,
+            named_query_id='query-123',
+        )
+        assert response.isError is False
+        assert response.named_query_id == 'query-123'
+        assert response.operation == 'create-named-query'
+
+    def test_delete_named_query_response(self):
+        """Test the DeleteNamedQueryResponse model."""
+        response = DeleteNamedQueryResponse(
+            isError=False,
+            content=sample_text_content,
+            named_query_id='query-123',
+        )
+        assert response.isError is False
+        assert response.named_query_id == 'query-123'
+        assert response.operation == 'delete-named-query'
+
+    def test_get_named_query_response(self):
+        """Test the GetNamedQueryResponse model."""
+        response = GetNamedQueryResponse(
+            isError=False,
+            content=sample_text_content,
+            named_query_id='query-123',
+            named_query=sample_dict,
+        )
+        assert response.isError is False
+        assert response.named_query_id == 'query-123'
+        assert response.named_query == sample_dict
+        assert response.operation == 'get-named-query'
+
+    def test_list_named_queries_response(self):
+        """Test the ListNamedQueriesResponse model."""
+        response = ListNamedQueriesResponse(
+            isError=False,
+            content=sample_text_content,
+            named_query_ids=['query-1', 'query-2'],
+            count=2,
+            next_token='next-page',
+        )
+        assert response.isError is False
+        assert response.named_query_ids == ['query-1', 'query-2']
+        assert response.count == 2
+        assert response.next_token == 'next-page'
+        assert response.operation == 'list-named-queries'
+
+    def test_update_named_query_response(self):
+        """Test the UpdateNamedQueryResponse model."""
+        response = UpdateNamedQueryResponse(
+            isError=False,
+            content=sample_text_content,
+            named_query_id='query-123',
+        )
+        assert response.isError is False
+        assert response.named_query_id == 'query-123'
+        assert response.operation == 'update-named-query'
+
+
+def test_error_responses():
+    """Test error cases for various response types."""
+    error_content = [TextContent(type='text', text='Error occurred')]
+
+    # Test query execution error response
+    query_error = StartQueryExecutionResponse(
+        isError=True, content=error_content, query_execution_id='query-123'
+    )
+    assert query_error.isError is True
+    assert query_error.content == error_content
+    assert query_error.query_execution_id == 'query-123'
+
+    # Test named query error response
+    named_query_error = CreateNamedQueryResponse(
+        isError=True, content=error_content, named_query_id='query-123'
+    )
+    assert named_query_error.isError is True
+    assert named_query_error.content == error_content
+    assert named_query_error.named_query_id == 'query-123'
+
+
+def test_optional_fields():
+    """Test responses with optional fields."""
+    # Test response with optional next_token
+    results_response = GetQueryResultsResponse(
+        isError=False,
+        content=sample_text_content,
+        query_execution_id='query-123',
+        result_set=sample_dict,
+        next_token=None,
+        update_count=None,
+    )
+    assert results_response.next_token is None
+    assert results_response.update_count is None
+
+    # Test response with optional next_token in list response
+    list_response = ListQueryExecutionsResponse(
+        isError=False,
+        content=sample_text_content,
+        query_execution_ids=['query-1', 'query-2'],
+        count=2,
+        next_token=None,
+    )
+    assert list_response.next_token is None
+
+    # Test response with optional next_token in named queries list response
+    named_list_response = ListNamedQueriesResponse(
+        isError=False,
+        content=sample_text_content,
+        named_query_ids=['query-1', 'query-2'],
+        count=2,
+        next_token=None,
+    )
+    assert named_list_response.next_token is None
+
+
+def test_complex_data_structures():
+    """Test responses with more complex data structures."""
+    # Complex query execution
+    complex_execution = {
+        'QueryExecutionId': 'query-123',
+        'Query': 'SELECT * FROM table',
+        'StatementType': 'DML',
+        'ResultConfiguration': {'OutputLocation': 's3://bucket/path'},
+        'QueryExecutionContext': {'Database': 'test_db'},
+        'Status': {
+            'State': 'SUCCEEDED',
+            'SubmissionDateTime': '2023-01-01T00:00:00.000Z',
+            'CompletionDateTime': '2023-01-01T00:01:00.000Z',
+        },
+        'Statistics': {
+            'EngineExecutionTimeInMillis': 5000,
+            'DataScannedInBytes': 1024,
+            'TotalExecutionTimeInMillis': 6000,
+        },
+        'WorkGroup': 'primary',
+    }
+
+    # Complex result set
+    complex_result_set = {
+        'ResultSetMetadata': {
+            'ColumnInfo': [
+                {'Name': 'col1', 'Type': 'varchar'},
+                {'Name': 'col2', 'Type': 'integer'},
+            ]
+        },
+        'Rows': [
+            {'Data': [{'VarCharValue': 'header1'}, {'VarCharValue': 'header2'}]},
+            {'Data': [{'VarCharValue': 'value1'}, {'VarCharValue': '42'}]},
+        ],
+    }
+
+    # Complex statistics
+    complex_statistics = {
+        'EngineExecutionTimeInMillis': 5000,
+        'DataScannedInBytes': 1024,
+        'TotalExecutionTimeInMillis': 6000,
+        'QueryQueueTimeInMillis': 100,
+        'ServiceProcessingTimeInMillis': 50,
+        'QueryPlanningTimeInMillis': 200,
+        'QueryStages': [
+            {
+                'StageId': 0,
+                'State': 'SUCCEEDED',
+                'OutputBytes': 1024,
+                'OutputRows': 10,
+                'InputBytes': 2048,
+                'InputRows': 20,
+                'ExecutionTime': 5000,
+            }
+        ],
+    }
+
+    # Test with complex query execution
+    execution_response = GetQueryExecutionResponse(
+        isError=False,
+        content=sample_text_content,
+        query_execution_id='query-123',
+        query_execution=complex_execution,
+    )
+    assert execution_response.query_execution['Status']['State'] == 'SUCCEEDED'
+    assert execution_response.query_execution['Statistics']['DataScannedInBytes'] == 1024
+
+    # Test with complex result set
+    results_response = GetQueryResultsResponse(
+        isError=False,
+        content=sample_text_content,
+        query_execution_id='query-123',
+        result_set=complex_result_set,
+    )
+    assert len(results_response.result_set['Rows']) == 2
+    assert results_response.result_set['ResultSetMetadata']['ColumnInfo'][0]['Name'] == 'col1'
+
+    # Test with complex statistics
+    statistics_response = GetQueryRuntimeStatisticsResponse(
+        isError=False,
+        content=sample_text_content,
+        query_execution_id='query-123',
+        statistics=complex_statistics,
+    )
+    assert statistics_response.statistics['DataScannedInBytes'] == 1024
+    assert statistics_response.statistics['QueryStages'][0]['OutputRows'] == 10
+
+
+class TestDataCatalogResponses:
+    """Test class for Athena data catalog response models."""
+
+    def test_create_data_catalog_response(self):
+        """Test the CreateDataCatalogResponse model."""
+        response = CreateDataCatalogResponse(
+            isError=False,
+            content=sample_text_content,
+            name='test-catalog',
+        )
+        assert response.isError is False
+        assert response.name == 'test-catalog'
+        assert response.operation == 'create'
+
+    def test_delete_data_catalog_response(self):
+        """Test the DeleteDataCatalogResponse model."""
+        response = DeleteDataCatalogResponse(
+            isError=False,
+            content=sample_text_content,
+            name='test-catalog',
+        )
+        assert response.isError is False
+        assert response.name == 'test-catalog'
+        assert response.operation == 'delete'
+
+    def test_get_data_catalog_response(self):
+        """Test the GetDataCatalogResponse model."""
+        catalog_details = {
+            'Name': 'test-catalog',
+            'Type': 'LAMBDA',
+            'Description': 'Test catalog description',
+            'Parameters': {'function': 'lambda-function-name'},
+            'Status': 'ACTIVE',
+            'ConnectionType': 'DIRECT',
+        }
+        response = GetDataCatalogResponse(
+            isError=False,
+            content=sample_text_content,
+            data_catalog=catalog_details,
+        )
+        assert response.isError is False
+        assert response.data_catalog == catalog_details
+        assert response.data_catalog['Name'] == 'test-catalog'
+        assert response.operation == 'get'
+
+    def test_list_data_catalogs_response(self):
+        """Test the ListDataCatalogsResponse model."""
+        catalogs = [
+            {
+                'CatalogName': 'catalog1',
+                'Type': 'LAMBDA',
+                'Status': 'ACTIVE',
+                'ConnectionType': 'DIRECT',
+            },
+            {
+                'CatalogName': 'catalog2',
+                'Type': 'GLUE',
+                'Status': 'ACTIVE',
+                'ConnectionType': 'DIRECT',
+            },
+        ]
+        response = ListDataCatalogsResponse(
+            isError=False,
+            content=sample_text_content,
+            data_catalogs=catalogs,
+            count=2,
+            next_token='next-page',
+        )
+        assert response.isError is False
+        assert response.data_catalogs == catalogs
+        assert response.count == 2
+        assert response.next_token == 'next-page'
+        assert response.operation == 'list'
+
+    def test_update_data_catalog_response(self):
+        """Test the UpdateDataCatalogResponse model."""
+        response = UpdateDataCatalogResponse(
+            isError=False,
+            content=sample_text_content,
+            name='test-catalog',
+        )
+        assert response.isError is False
+        assert response.name == 'test-catalog'
+        assert response.operation == 'update'
+
+    def test_get_database_response(self):
+        """Test the GetDatabaseResponse model."""
+        database_details = {
+            'Name': 'test-database',
+            'Description': 'Test database description',
+            'Parameters': {'created_by': 'test-user'},
+        }
+        response = GetDatabaseResponse(
+            isError=False,
+            content=sample_text_content,
+            database=database_details,
+        )
+        assert response.isError is False
+        assert response.database == database_details
+        assert response.database['Name'] == 'test-database'
+        assert response.operation == 'get'
+
+    def test_get_table_metadata_response(self):
+        """Test the GetTableMetadataResponse model."""
+        table_metadata = {
+            'Name': 'test-table',
+            'CreateTime': '2023-01-01T00:00:00.000Z',
+            'LastAccessTime': '2023-01-02T00:00:00.000Z',
+            'TableType': 'EXTERNAL_TABLE',
+            'Columns': [
+                {'Name': 'id', 'Type': 'int'},
+                {'Name': 'name', 'Type': 'string'},
+            ],
+            'PartitionKeys': [{'Name': 'date', 'Type': 'string'}],
+            'Parameters': {'EXTERNAL': 'TRUE'},
+        }
+        response = GetTableMetadataResponse(
+            isError=False,
+            content=sample_text_content,
+            table_metadata=table_metadata,
+        )
+        assert response.isError is False
+        assert response.table_metadata == table_metadata
+        assert response.table_metadata['Name'] == 'test-table'
+        assert len(response.table_metadata['Columns']) == 2
+        assert response.operation == 'get'
+
+    def test_list_databases_response(self):
+        """Test the ListDatabasesResponse model."""
+        databases = [
+            {
+                'Name': 'database1',
+                'Description': 'First test database',
+                'Parameters': {'created_by': 'user1'},
+            },
+            {
+                'Name': 'database2',
+                'Description': 'Second test database',
+                'Parameters': {'created_by': 'user2'},
+            },
+        ]
+        response = ListDatabasesResponse(
+            isError=False,
+            content=sample_text_content,
+            database_list=databases,
+            count=2,
+            next_token='next-page',
+        )
+        assert response.isError is False
+        assert response.database_list == databases
+        assert response.count == 2
+        assert response.next_token == 'next-page'
+        assert response.operation == 'list'
+
+    def test_list_table_metadata_response(self):
+        """Test the ListTableMetadataResponse model."""
+        tables = [
+            {
+                'Name': 'table1',
+                'CreateTime': '2023-01-01T00:00:00.000Z',
+                'TableType': 'EXTERNAL_TABLE',
+                'Columns': [{'Name': 'id', 'Type': 'int'}],
+            },
+            {
+                'Name': 'table2',
+                'CreateTime': '2023-01-02T00:00:00.000Z',
+                'TableType': 'MANAGED_TABLE',
+                'Columns': [{'Name': 'name', 'Type': 'string'}],
+            },
+        ]
+        response = ListTableMetadataResponse(
+            isError=False,
+            content=sample_text_content,
+            table_metadata_list=tables,
+            count=2,
+            next_token='next-page',
+        )
+        assert response.isError is False
+        assert response.table_metadata_list == tables
+        assert response.count == 2
+        assert response.next_token == 'next-page'
+        assert response.operation == 'list'
+
+
+class TestWorkGroupResponses:
+    """Test class for Athena work group response models."""
+
+    def test_create_work_group_response(self):
+        """Test the CreateWorkGroupResponse model."""
+        response = CreateWorkGroupResponse(
+            isError=False,
+            content=sample_text_content,
+            work_group_name='test-workgroup',
+        )
+        assert response.isError is False
+        assert response.work_group_name == 'test-workgroup'
+        assert response.operation == 'create'
+
+    def test_delete_work_group_response(self):
+        """Test the DeleteWorkGroupResponse model."""
+        response = DeleteWorkGroupResponse(
+            isError=False,
+            content=sample_text_content,
+            work_group_name='test-workgroup',
+        )
+        assert response.isError is False
+        assert response.work_group_name == 'test-workgroup'
+        assert response.operation == 'delete'
+
+    def test_get_work_group_response(self):
+        """Test the GetWorkGroupResponse model."""
+        work_group_details = {
+            'Name': 'test-workgroup',
+            'State': 'ENABLED',
+            'Configuration': {
+                'ResultConfiguration': {'OutputLocation': 's3://bucket/path'},
+                'EnforceWorkGroupConfiguration': True,
+                'PublishCloudWatchMetricsEnabled': True,
+                'BytesScannedCutoffPerQuery': 10000000,
+                'RequesterPaysEnabled': False,
+            },
+            'Description': 'Test work group',
+            'CreationTime': '2023-01-01T00:00:00.000Z',
+        }
+        response = GetWorkGroupResponse(
+            isError=False,
+            content=sample_text_content,
+            work_group=work_group_details,
+        )
+        assert response.isError is False
+        assert response.work_group == work_group_details
+        assert response.work_group['Name'] == 'test-workgroup'
+        assert response.operation == 'get'
+
+    def test_list_work_groups_response(self):
+        """Test the ListWorkGroupsResponse model."""
+        work_groups = [
+            {
+                'Name': 'workgroup1',
+                'State': 'ENABLED',
+                'Description': 'First test work group',
+            },
+            {
+                'Name': 'workgroup2',
+                'State': 'DISABLED',
+                'Description': 'Second test work group',
+            },
+        ]
+        response = ListWorkGroupsResponse(
+            isError=False,
+            content=sample_text_content,
+            work_groups=work_groups,
+            count=2,
+            next_token='next-page',
+        )
+        assert response.isError is False
+        assert response.work_groups == work_groups
+        assert response.count == 2
+        assert response.next_token == 'next-page'
+        assert response.operation == 'list'
+
+    def test_update_work_group_response(self):
+        """Test the UpdateWorkGroupResponse model."""
+        response = UpdateWorkGroupResponse(
+            isError=False,
+            content=sample_text_content,
+            work_group_name='test-workgroup',
+        )
+        assert response.isError is False
+        assert response.work_group_name == 'test-workgroup'
+        assert response.operation == 'update'
+
+
+def test_data_catalog_error_responses():
+    """Test error cases for data catalog response types."""
+    error_content = [TextContent(type='text', text='Error occurred')]
+
+    # Test data catalog error response
+    catalog_error = CreateDataCatalogResponse(
+        isError=True, content=error_content, name='test-catalog'
+    )
+    assert catalog_error.isError is True
+    assert catalog_error.content == error_content
+    assert catalog_error.name == 'test-catalog'
+
+    # Test database error response
+    database_error = GetDatabaseResponse(
+        isError=True, content=error_content, database={'Name': 'test-database'}
+    )
+    assert database_error.isError is True
+    assert database_error.content == error_content
+    assert database_error.database['Name'] == 'test-database'
+
+
+def test_work_group_error_responses():
+    """Test error cases for work group response types."""
+    error_content = [TextContent(type='text', text='Error occurred')]
+
+    # Test work group error response
+    work_group_error = CreateWorkGroupResponse(
+        isError=True, content=error_content, work_group_name='test-workgroup'
+    )
+    assert work_group_error.isError is True
+    assert work_group_error.content == error_content
+    assert work_group_error.work_group_name == 'test-workgroup'
+
+    # Test get work group error response
+    get_work_group_error = GetWorkGroupResponse(
+        isError=True, content=error_content, work_group={'Name': 'test-workgroup'}
+    )
+    assert get_work_group_error.isError is True
+    assert get_work_group_error.content == error_content
+    assert get_work_group_error.work_group['Name'] == 'test-workgroup'


### PR DESCRIPTION
## Summary

### Changes
* Add AWS Athena Query and Named Query related tools
* Add AWS Athena Workgroup and Catalog related tools
* Update ReadMe to provide information about the new tools added
* Add 2 new functions in AWS Helper for Athena Tag management
* Add Test coverage using unit test cases for all the new code introduced

### User experience

> Before this change: 
* No AWS Athena query and named query capabilities in the dataprocessing-mcp-server 
* No AWS Athena workgroup and catalog related capabilities in the dataprocessing-mcp-server 

> After this change: 
* Users can access AWS Athena tools in the dataprocessing-mcp-server providing support for wide variety of use cases 
* Data Discovery - Easily explore data catalogs, tables, and schemas using Athena Catalog APIs
* Data Query - Users can use LLM to create new queries on schema, run and store them in athena 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): 
N

**RFC issue number**:
https://github.com/awslabs/mcp/issues/614
Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
