### PR TITLE
feat(aws-dataprocessing-mcp-server): Add MCP tools for AWS Glue Crawler

### DIFF
--- a/src/aws-dataprocessing-mcp-server/README.md
+++ b/src/aws-dataprocessing-mcp-server/README.md
@@ -10,6 +10,8 @@ Integrating the DataProcessing MCP server into AI code assistants transforms dat
 ### AWS Glue Integration
 
 * Data Catalog Management: Enables users to explore, create, and manage databases, tables, and partitions through natural language requests, automatically translating them into appropriate AWS Glue Data Catalog operations.
+* Crawler Management: Enables intelligent data discovery through automated crawler configuration, scheduling, and metadata extraction from various data sources.
+
 
 
 ## Prerequisites
@@ -36,9 +38,11 @@ For read operations, the following permissions are required:
         "glue:GetDatabase*",
         "glue:GetTable*",
         "glue:GetPartition*",
+        "glue:GetCrawler*",
         "glue:GetConnection*",
         "glue:GetDatabases",
         "glue:GetTables",
+        "glue:ListCrawlers",
         "glue:SearchTables",
         "cloudwatch:GetMetricData",
         "logs:DescribeLogGroups",
@@ -234,12 +238,14 @@ Specifies the AWS region where Glue,EMR clusters or Athena are managed, which wi
 | manage_aws_glue_partitions | Manage AWS Glue Data Catalog partitions | create-partition, delete-partition, get-partition, list-partitions, update-partition | --allow-write flag for create/delete/update operations, database and table must exist, appropriate AWS permissions |
 | manage_aws_glue_catalog | Manage AWS Glue Data Catalog | create-catalog, delete-catalog, get-catalog, list-catalogs, import-catalog-to-glue | --allow-write flag for create/delete/import operations, appropriate AWS permissions |
 
+
 ### Athena Query Handler Tools
 
 | Tool Name | Description | Key Operations | Requirements |
 |-----------|-------------|----------------|--------------|
 | manage_aws_athena_query_executions | Execute and manage AWS Athena SQL queries | batch-get-query-execution, get-query-execution, get-query-results, get-query-runtime-statistics, list-query-executions, start-query-execution, stop-query-execution | --allow-write flag for start/stop operations, appropriate AWS permissions |
 | manage_aws_athena_named_queries | Manage saved SQL queries in AWS Athena | batch-get-named-query, create-named-query, delete-named-query, get-named-query, list-named-queries, update-named-query | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
+
 
 ### Athena Data Catalog Handler Tools
 
@@ -253,6 +259,15 @@ Specifies the AWS region where Glue,EMR clusters or Athena are managed, which wi
 | Tool Name | Description | Key Operations | Requirements |
 |-----------|-------------|----------------|--------------|
 | manage_aws_athena_workgroups | Manage AWS Athena workgroups | create-work-group, delete-work-group, get-work-group, list-work-groups, update-work-group | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
+
+
+### Glue Crawler Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_glue_crawlers | Manage AWS Glue crawlers to discover and catalog data sources | create-crawler, delete-crawler, get-crawler, get-crawlers, start-crawler, stop-crawler, batch-get-crawlers, list-crawlers, update-crawler | --allow-write flag for create/delete/start/stop/update operations, appropriate AWS permissions |
+| manage_aws_glue_classifiers | Manage AWS Glue classifiers to determine data formats and schemas | create-classifier, delete-classifier, get-classifier, get-classifiers, update-classifier | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
+| manage_aws_glue_crawler_management | Manage AWS Glue crawler schedules and monitor performance metrics | get-crawler-metrics, start-crawler-schedule, stop-crawler-schedule, update-crawler-schedule | --allow-write flag for schedule operations, appropriate AWS permissions |
 
 
 ## Version

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/crawler_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/crawler_handler.py
@@ -1,0 +1,1038 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CrawlerHandler for Data Processing MCP Server."""
+
+from awslabs.aws_dataprocessing_mcp_server.models.glue_models import (
+    BatchGetCrawlersResponse,
+    CreateClassifierResponse,
+    CreateCrawlerResponse,
+    DeleteClassifierResponse,
+    DeleteCrawlerResponse,
+    GetClassifierResponse,
+    GetClassifiersResponse,
+    GetCrawlerMetricsResponse,
+    GetCrawlerResponse,
+    GetCrawlersResponse,
+    ListCrawlersResponse,
+    StartCrawlerResponse,
+    StartCrawlerScheduleResponse,
+    StopCrawlerResponse,
+    StopCrawlerScheduleResponse,
+    UpdateClassifierResponse,
+    UpdateCrawlerResponse,
+    UpdateCrawlerScheduleResponse,
+)
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field
+from typing import Any, Dict, List, Optional, Union
+
+
+class CrawlerHandler:
+    """Handler for Amazon Glue Crawler operations."""
+
+    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+        """Initialize the Glue Crawler handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.glue_client = AwsHelper.create_boto3_client('glue')
+
+        # Register tools
+        self.mcp.tool(name='manage_aws_glue_crawlers')(self.manage_aws_glue_crawlers)
+        self.mcp.tool(name='manage_aws_glue_classifiers')(self.manage_aws_glue_classifiers)
+        self.mcp.tool(name='manage_aws_glue_crawler_management')(
+            self.manage_aws_glue_crawler_management
+        )
+
+    async def manage_aws_glue_crawlers(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-crawler, delete-crawler, get-crawler, get-crawlers, start-crawler, stop-crawler, batch-get-crawlers, list-crawlers, update-crawler. Choose "get-crawler", "get-crawlers", "batch-get-crawlers", or "list-crawlers" for read-only operations when write access is disabled.',
+        ),
+        crawler_name: Optional[str] = Field(
+            None,
+            description='Name of the crawler (required for all operations except get-crawlers, batch-get-crawlers, and list-crawlers).',
+        ),
+        crawler_definition: Optional[Dict[str, Any]] = Field(
+            None,
+            description='Crawler definition for create-crawler and update-crawler operations.',
+        ),
+        crawler_names: Optional[List[str]] = Field(
+            None,
+            description='List of crawler names for batch-get-crawlers operation.',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for get-crawlers and list-crawlers operations.',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for get-crawlers and list-crawlers operations.',
+        ),
+        tags: Optional[Dict[str, str]] = Field(
+            None,
+            description='Tags to filter crawlers by for list-crawlers operation.',
+        ),
+    ) -> Union[
+        CreateCrawlerResponse,
+        DeleteCrawlerResponse,
+        GetCrawlerResponse,
+        GetCrawlersResponse,
+        StartCrawlerResponse,
+        StopCrawlerResponse,
+        BatchGetCrawlersResponse,
+        ListCrawlersResponse,
+        UpdateCrawlerResponse,
+    ]:
+        """Manage AWS Glue crawlers to discover and catalog data sources.
+
+        This tool provides comprehensive operations for AWS Glue crawlers, which automatically discover and catalog
+        data from various sources like S3, JDBC databases, DynamoDB, and more. Crawlers examine your data sources,
+        determine schemas, and register metadata in the AWS Glue Data Catalog.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create, delete, start, stop, and update operations
+        - Appropriate AWS permissions for Glue crawler operations
+
+        ## Operations
+        - **create-crawler**: Create a new crawler with specified targets, role, and configuration
+        - **delete-crawler**: Remove an existing crawler from AWS Glue
+        - **get-crawler**: Retrieve detailed information about a specific crawler
+        - **get-crawlers**: List all crawlers with pagination
+        - **batch-get-crawlers**: Retrieve multiple specific crawlers in a single call
+        - **list-crawlers**: List all crawlers with tag-based filtering
+        - **start-crawler**: Initiate a crawler run immediately
+        - **stop-crawler**: Halt a currently running crawler
+        - **update-crawler**: Modify an existing crawler's configuration
+
+        ## Example
+        ```python
+        # Create a new S3 crawler
+        {
+            'operation': 'create-crawler',
+            'crawler_name': 'my-s3-data-crawler',
+            'crawler_definition': {
+                'Role': 'arn:aws:iam::123456789012:role/GlueServiceRole',
+                'Targets': {'S3Targets': [{'Path': 's3://my-bucket/data/'}]},
+                'DatabaseName': 'my_catalog_db',
+                'Description': 'Crawler for S3 data files',
+                'Schedule': 'cron(0 0 * * ? *)',
+                'TablePrefix': 'raw_',
+            },
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            crawler_name: Name of the crawler
+            crawler_definition: Crawler definition for create-crawler and update-crawler operations
+            crawler_names: List of crawler names for batch-get-crawlers operation
+            max_results: Maximum number of results to return for get-crawlers and list-crawlers operations
+            next_token: Pagination token for get-crawlers and list-crawlers operations
+            tags: Tags to filter crawlers by for list-crawlers operation
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in [
+                'get-crawler',
+                'get-crawlers',
+                'batch-get-crawlers',
+                'list-crawlers',
+            ]:
+                error_message = f'Operation {operation} is not allowed without write access'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == 'create-crawler':
+                    return CreateCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='create-crawler',
+                    )
+                elif operation == 'delete-crawler':
+                    return DeleteCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='delete-crawler',
+                    )
+                elif operation == 'start-crawler':
+                    return StartCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='start-crawler',
+                    )
+                elif operation == 'stop-crawler':
+                    return StopCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='top-crawler',
+                    )
+                elif operation == 'update-crawler':
+                    return UpdateCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='update-crawler',
+                    )
+                else:
+                    return GetCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='get-crawler',
+                    )
+
+            if operation == 'create-crawler':
+                if crawler_name is None or crawler_definition is None:
+                    raise ValueError(
+                        'crawler_name and crawler_definition are required for create-crawler operation'
+                    )
+
+                # Create the crawler with required and optional parameters
+                create_params = {'Name': crawler_name}
+
+                # Add required parameters
+                if 'Role' in crawler_definition:
+                    create_params['Role'] = crawler_definition.pop('Role')
+                else:
+                    raise ValueError('Role is required for create-crawler operation')
+
+                if 'Targets' in crawler_definition:
+                    create_params['Targets'] = crawler_definition.pop('Targets')
+                else:
+                    raise ValueError('Targets is required for create-crawler operation')
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags('GlueCrawler')
+                if 'Tags' in crawler_definition:
+                    crawler_definition['Tags'].update(resource_tags)
+                else:
+                    crawler_definition['Tags'] = resource_tags
+
+                # Add optional parameters
+                for param in [
+                    'DatabaseName',
+                    'Description',
+                    'Schedule',
+                    'Classifiers',
+                    'TablePrefix',
+                    'SchemaChangePolicy',
+                    'RecrawlPolicy',
+                    'LineageConfiguration',
+                    'LakeFormationConfiguration',
+                    'Configuration',
+                    'CrawlerSecurityConfiguration',
+                    'Tags',
+                ]:
+                    if param in crawler_definition:
+                        create_params[param] = crawler_definition.pop(param)
+
+                # Add any remaining parameters
+                create_params.update(crawler_definition)
+
+                # Create the crawler
+                self.glue_client.create_crawler(**create_params)
+
+                return CreateCrawlerResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully created Glue crawler {crawler_name} with MCP management tags',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='create-crawler',
+                )
+
+            elif operation == 'delete-crawler':
+                if crawler_name is None:
+                    raise ValueError('crawler_name is required for delete-crawler operation')
+
+                # Verify that the crawler is managed by MCP before deleting
+                # Construct the ARN for the crawler
+                region = AwsHelper.get_aws_region() or 'us-east-1'
+                account_id = AwsHelper.get_aws_account_id()
+                crawler_arn = f'arn:aws:glue:{region}:{account_id}:crawler/{crawler_name}'
+
+                # Get crawler parameters
+                try:
+                    response = self.glue_client.get_crawler(Name=crawler_name)
+                    crawler = response.get('Crawler', {})
+                    parameters = crawler.get('Parameters', {})
+                except ClientError:
+                    parameters = {}
+
+                # Check if the crawler is managed by MCP
+                if not AwsHelper.is_resource_mcp_managed(
+                    self.glue_client, crawler_arn, parameters
+                ):
+                    error_message = f'Cannot delete crawler {crawler_name} - it is not managed by the MCP server (missing required tags)'
+                    log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                    return DeleteCrawlerResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name=crawler_name,
+                        operation='delete-crawler',
+                    )
+
+                # Delete the crawler with required parameters
+                self.glue_client.delete_crawler(Name=crawler_name)
+
+                return DeleteCrawlerResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully deleted MCP-managed Glue crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='delete-crawler',
+                )
+
+            elif operation == 'get-crawler':
+                if crawler_name is None:
+                    raise ValueError('crawler_name is required for get-crawler operation')
+
+                # Get the crawler with required parameters
+                response = self.glue_client.get_crawler(Name=crawler_name)
+
+                return GetCrawlerResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    crawler_details=response.get('Crawler', {}),
+                    operation='get-crawler',
+                )
+
+            elif operation == 'get-crawlers':
+                # Prepare parameters for get_crawlers (all optional)
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+
+                # Get crawlers
+                response = self.glue_client.get_crawlers(**params)
+
+                crawlers = response.get('Crawlers', [])
+                return GetCrawlersResponse(
+                    isError=False,
+                    content=[TextContent(type='text', text='Successfully retrieved crawlers')],
+                    crawlers=crawlers,
+                    count=len(crawlers),
+                    next_token=response.get('NextToken'),
+                    operation='get-crawlers',
+                )
+
+            elif operation == 'start-crawler':
+                if crawler_name is None:
+                    raise ValueError('crawler_name is required for start-crawler operation')
+
+                # Start crawler with required parameters
+                self.glue_client.start_crawler(Name=crawler_name)
+
+                return StartCrawlerResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully started crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='start-crawler',
+                )
+
+            elif operation == 'stop-crawler':
+                if crawler_name is None:
+                    raise ValueError('crawler_name is required for stop-crawler operation')
+
+                # Stop crawler with required parameters
+                self.glue_client.stop_crawler(Name=crawler_name)
+
+                return StopCrawlerResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully stopped crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='stop-crawler',
+                )
+
+            elif operation == 'batch-get-crawlers':
+                if crawler_names is None or not crawler_names:
+                    raise ValueError('crawler_names is required for batch-get-crawlers operation')
+
+                # Batch get crawlers with required parameters
+                response = self.glue_client.batch_get_crawlers(CrawlerNames=crawler_names)
+
+                crawlers = response.get('Crawlers', [])
+                crawlers_not_found = response.get('CrawlersNotFound', [])
+                return BatchGetCrawlersResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved {len(crawlers)} crawlers',
+                        )
+                    ],
+                    crawlers=crawlers,
+                    crawlers_not_found=crawlers_not_found,
+                    operation='batch-get-crawlers',
+                )
+
+            elif operation == 'list-crawlers':
+                # Prepare parameters for list_crawlers (all optional)
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+                if tags is not None:
+                    params['Tags'] = tags
+
+                # List crawlers
+                response = self.glue_client.list_crawlers(**params)
+
+                crawlers = response.get('CrawlerNames', [])
+                return ListCrawlersResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text='Successfully listed crawlers',
+                        )
+                    ],
+                    crawlers=crawlers,
+                    count=len(crawlers),
+                    next_token=response.get('NextToken'),
+                    operation='list-crawlers',
+                )
+
+            elif operation == 'update-crawler':
+                if crawler_name is None or crawler_definition is None:
+                    raise ValueError(
+                        'crawler_name and crawler_definition are required for update-crawler operation'
+                    )
+
+                # Update the crawler with required and optional parameters
+                update_params = {'Name': crawler_name}
+
+                # Add optional parameters
+                for param in [
+                    'Role',
+                    'DatabaseName',
+                    'Description',
+                    'Targets',
+                    'Schedule',
+                    'Classifiers',
+                    'TablePrefix',
+                    'SchemaChangePolicy',
+                    'RecrawlPolicy',
+                    'LineageConfiguration',
+                    'LakeFormationConfiguration',
+                    'Configuration',
+                    'CrawlerSecurityConfiguration',
+                ]:
+                    if param in crawler_definition:
+                        update_params[param] = crawler_definition.pop(param)
+
+                # Add any remaining parameters
+                update_params.update(crawler_definition)
+
+                # Update the crawler
+                self.glue_client.update_crawler(**update_params)
+
+                return UpdateCrawlerResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully updated crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='update-crawler',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: create-crawler, delete-crawler, get-crawler, get-crawlers, start-crawler, stop-crawler, batch-get-crawlers, list-crawlers, update-crawler'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetCrawlerResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    crawler_name=crawler_name or '',
+                    crawler_details={},
+                    operation='get-crawler',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_glue_crawlers: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetCrawlerResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                crawler_name=crawler_name or '',
+                crawler_details={},
+                operation='get-crawler',
+            )
+
+    async def manage_aws_glue_classifiers(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-classifier, delete-classifier, get-classifier, get-classifiers, update-classifier. Choose "get-classifier" or "get-classifiers" for read-only operations when write access is disabled.',
+        ),
+        classifier_name: Optional[str] = Field(
+            None,
+            description='Name of the classifier (required for delete-classifier and get-classifier operations).',
+        ),
+        classifier_definition: Optional[Dict[str, Any]] = Field(
+            None,
+            description='Classifier definition for create-classifier and update-classifier operations. Must include one of GrokClassifier, XMLClassifier, JsonClassifier, or CsvClassifier.',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for get-classifiers operation.',
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='Pagination token for get-classifiers operation.',
+        ),
+    ) -> Union[
+        CreateClassifierResponse,
+        DeleteClassifierResponse,
+        GetClassifierResponse,
+        GetClassifiersResponse,
+        UpdateClassifierResponse,
+    ]:
+        r"""Manage AWS Glue classifiers to determine data formats and schemas.
+
+        This tool provides operations for AWS Glue classifiers, which help determine the schema of your data.
+        Classifiers analyze data samples to infer formats and structures, enabling accurate schema creation
+        when crawlers process your data sources.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create, delete, and update operations
+        - Appropriate AWS permissions for Glue classifier operations
+
+        ## Operations
+        - **create-classifier**: Create a new custom classifier (CSV, JSON, XML, or GROK)
+        - **delete-classifier**: Remove an existing classifier
+        - **get-classifier**: Retrieve detailed information about a specific classifier
+        - **get-classifiers**: List all available classifiers
+        - **update-classifier**: Modify an existing classifier's configuration
+
+        ## Example
+        ```python
+        # Create a CSV classifier
+        {
+            'operation': 'create-classifier',
+            'classifier_definition': {
+                'CsvClassifier': {
+                    'Name': 'my-csv-classifier',
+                    'Delimiter': ',',
+                    'QuoteSymbol': '"',
+                    'ContainsHeader': 'PRESENT',
+                    'Header': ['id', 'name', 'date', 'value'],
+                    'AllowSingleColumn': false,
+                }
+            },
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            classifier_name: Name of the classifier
+            classifier_definition: Classifier definition for create-classifier and update-classifier operations
+            max_results: Maximum number of results to return for get-classifiers operation
+            next_token: Pagination token for get-classifiers operation
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in [
+                'get-classifier',
+                'get-classifiers',
+            ]:
+                error_message = f'Operation {operation} is not allowed without write access'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == 'create-classifier':
+                    return CreateClassifierResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        classifier_name='',
+                        operation='create-classifier',
+                    )
+                elif operation == 'delete-classifier':
+                    return DeleteClassifierResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        classifier_name='',
+                        operation='delete-classifier',
+                    )
+                elif operation == 'update-classifier':
+                    return UpdateClassifierResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        classifier_name='',
+                        operation='update-classifier',
+                    )
+                else:
+                    return GetClassifierResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        classifier_name='',
+                        operation='get-classifier',
+                    )
+
+            if operation == 'create-classifier':
+                if classifier_definition is None:
+                    raise ValueError(
+                        'classifier_definition is required for create-classifier operation'
+                    )
+
+                # Create the classifier with required parameters
+                # Classifier definition must include one of: GrokClassifier, XMLClassifier, JsonClassifier, or CsvClassifier
+                if not any(
+                    key in classifier_definition
+                    for key in [
+                        'GrokClassifier',
+                        'XMLClassifier',
+                        'JsonClassifier',
+                        'CsvClassifier',
+                    ]
+                ):
+                    raise ValueError(
+                        'classifier_definition must include one of: GrokClassifier, XMLClassifier, JsonClassifier, or CsvClassifier'
+                    )
+
+                response = self.glue_client.create_classifier(**classifier_definition)
+
+                # Extract classifier name from definition based on classifier type
+                extracted_name = ''
+                if 'GrokClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['GrokClassifier']['Name']
+                elif 'XMLClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['XMLClassifier']['Name']
+                elif 'JsonClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['JsonClassifier']['Name']
+                elif 'CsvClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['CsvClassifier']['Name']
+
+                return CreateClassifierResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully created classifier {extracted_name}',
+                        )
+                    ],
+                    classifier_name=extracted_name,
+                    operation='create-classifier',
+                )
+
+            elif operation == 'delete-classifier':
+                if classifier_name is None:
+                    raise ValueError('classifier_name is required for delete-classifier operation')
+
+                # Delete the classifier with required parameters
+                self.glue_client.delete_classifier(Name=classifier_name)
+
+                return DeleteClassifierResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully deleted classifier {classifier_name}',
+                        )
+                    ],
+                    classifier_name=classifier_name,
+                    operation='delete-classifier',
+                )
+
+            elif operation == 'get-classifier':
+                if classifier_name is None:
+                    raise ValueError('classifier_name is required for get-classifier operation')
+
+                # Get the classifier with required parameters
+                response = self.glue_client.get_classifier(Name=classifier_name)
+
+                return GetClassifierResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully retrieved classifier {classifier_name}',
+                        )
+                    ],
+                    classifier_name=classifier_name,
+                    classifier_details=response.get('Classifier', {}),
+                    operation='get-classifier',
+                )
+
+            elif operation == 'get-classifiers':
+                # Prepare parameters for get_classifiers (all optional)
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+                if next_token is not None:
+                    params['NextToken'] = next_token
+
+                # Get classifiers
+                response = self.glue_client.get_classifiers(**params)
+
+                classifiers = response.get('Classifiers', [])
+                return GetClassifiersResponse(
+                    isError=False,
+                    content=[TextContent(type='text', text='Successfully retrieved classifiers')],
+                    classifiers=classifiers,
+                    count=len(classifiers),
+                    next_token=response.get('NextToken'),
+                    operation='get-classifiers',
+                )
+
+            elif operation == 'update-classifier':
+                if classifier_definition is None:
+                    raise ValueError(
+                        'classifier_definition is required for update-classifier operation'
+                    )
+
+                # Update the classifier with required parameters
+                # Classifier definition must include one of: GrokClassifier, XMLClassifier, JsonClassifier, or CsvClassifier
+                if not any(
+                    key in classifier_definition
+                    for key in [
+                        'GrokClassifier',
+                        'XMLClassifier',
+                        'JsonClassifier',
+                        'CsvClassifier',
+                    ]
+                ):
+                    raise ValueError(
+                        'classifier_definition must include one of: GrokClassifier, XMLClassifier, JsonClassifier, or CsvClassifier'
+                    )
+
+                self.glue_client.update_classifier(**classifier_definition)
+
+                # Extract classifier name from definition based on classifier type
+                extracted_name = ''
+                if 'GrokClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['GrokClassifier']['Name']
+                elif 'XMLClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['XMLClassifier']['Name']
+                elif 'JsonClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['JsonClassifier']['Name']
+                elif 'CsvClassifier' in classifier_definition:
+                    extracted_name = classifier_definition['CsvClassifier']['Name']
+
+                return UpdateClassifierResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully updated classifier {extracted_name}',
+                        )
+                    ],
+                    classifier_name=extracted_name,
+                    operation='update-classifier',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: create-classifier, delete-classifier, get-classifier, get-classifiers, update-classifier'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetClassifierResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    classifier_name=classifier_name or '',
+                    classifier_details={},
+                    operation='get-classifier',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_glue_classifiers: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetClassifierResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                classifier_name=classifier_name or '',
+                classifier_details={},
+                operation='get',
+            )
+
+    async def manage_aws_glue_crawler_management(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: get-crawler-metrics, start-crawler-schedule, stop-crawler-schedule, update-crawler-schedule. Choose "get-crawler-metrics" for read-only operations when write access is disabled.',
+        ),
+        crawler_name: Optional[str] = Field(
+            None,
+            description='Name of the crawler (required for start-crawler-schedule, stop-crawler-schedule, and update-crawler-schedule operations).',
+        ),
+        crawler_name_list: Optional[List[str]] = Field(
+            None,
+            description='List of crawler names for get-crawler-metrics operation (optional).',
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description='Maximum number of results to return for get-crawler-metrics operation (optional).',
+        ),
+        schedule: Optional[str] = Field(
+            None,
+            description='Cron expression for the crawler schedule (required for update-crawler-schedule operation).',
+        ),
+    ) -> Union[
+        GetCrawlerMetricsResponse,
+        StartCrawlerScheduleResponse,
+        StopCrawlerScheduleResponse,
+        UpdateCrawlerScheduleResponse,
+    ]:
+        """Manage AWS Glue crawler schedules and monitor performance metrics.
+
+        This tool provides operations for controlling crawler schedules and retrieving performance metrics.
+        Use it to automate crawler runs on a schedule and monitor crawler efficiency and status.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for schedule management operations
+        - Appropriate AWS permissions for Glue crawler operations
+
+        ## Operations
+        - **get-crawler-metrics**: Retrieve performance statistics about crawlers
+        - **start-crawler-schedule**: Activate a crawler's schedule
+        - **stop-crawler-schedule**: Deactivate a crawler's schedule
+        - **update-crawler-schedule**: Modify a crawler's schedule with a new cron expression
+
+        ## Example
+        ```python
+        # Update a crawler's schedule to run daily at 2:30 AM UTC
+        {
+            'operation': 'update-crawler-schedule',
+            'crawler_name': 'my-s3-data-crawler',
+            'schedule': 'cron(30 2 * * ? *)',
+        }
+
+        # Get metrics for specific crawlers
+        {
+            'operation': 'get-crawler-metrics',
+            'crawler_name_list': ['my-s3-data-crawler', 'my-jdbc-crawler'],
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            crawler_name: Name of the crawler for schedule operations
+            crawler_name_list: List of crawler names for get-crawler-metrics operation
+            max_results: Maximum number of results to return for get-crawler-metrics operation
+            schedule: Cron expression for the crawler schedule (required for update-crawler-schedule operation)
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in ['get-crawler-metrics']:
+                error_message = f'Operation {operation} is not allowed without write access'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == 'start-crawler-schedule':
+                    return StartCrawlerScheduleResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='start-crawler-schedule',
+                    )
+                elif operation == 'stop-crawler-schedule':
+                    return StopCrawlerScheduleResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='stop-crawler-schedule',
+                    )
+                elif operation == 'update-crawler-schedule':
+                    return UpdateCrawlerScheduleResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='update-crawler-schedule',
+                    )
+                else:
+                    return GetCrawlerMetricsResponse(
+                        isError=True,
+                        content=[TextContent(type='text', text=error_message)],
+                        crawler_name='',
+                        operation='get-crawler-metrics',
+                    )
+
+            if operation == 'get-crawler-metrics':
+                # Prepare parameters for get_crawler_metrics (all optional)
+                params: Dict[str, Any] = {}
+                if crawler_name_list is not None:
+                    params['CrawlerNameList'] = crawler_name_list
+                if max_results is not None:
+                    params['MaxResults'] = max_results
+
+                # Get crawler metrics
+                response = self.glue_client.get_crawler_metrics(**params)
+
+                crawler_metrics = response.get('CrawlerMetricsList', [])
+                return GetCrawlerMetricsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text='Successfully retrieved crawler metrics',
+                        )
+                    ],
+                    crawler_metrics=crawler_metrics,
+                    count=len(crawler_metrics),
+                    next_token=response.get('NextToken'),
+                    operation='get-crawler-metrics',
+                )
+
+            elif operation == 'start-crawler-schedule':
+                if crawler_name is None:
+                    raise ValueError(
+                        'crawler_name is required for start-crawler-schedule operation'
+                    )
+
+                # Start crawler schedule with required parameters
+                self.glue_client.start_crawler_schedule(CrawlerName=crawler_name)
+
+                return StartCrawlerScheduleResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully started schedule for crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='start-crawler-schedule',
+                )
+
+            elif operation == 'stop-crawler-schedule':
+                if crawler_name is None:
+                    raise ValueError(
+                        'crawler_name is required for stop-crawler-schedule operation'
+                    )
+
+                # Stop crawler schedule with required parameters
+                self.glue_client.stop_crawler_schedule(CrawlerName=crawler_name)
+
+                return StopCrawlerScheduleResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully stopped schedule for crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='stop-crawler-schedule',
+                )
+
+            elif operation == 'update-crawler-schedule':
+                if crawler_name is None or schedule is None:
+                    raise ValueError(
+                        'crawler_name and schedule are required for update-crawler-schedule operation'
+                    )
+
+                # Update crawler schedule with required parameters
+                self.glue_client.update_crawler_schedule(
+                    CrawlerName=crawler_name, Schedule=schedule
+                )
+
+                return UpdateCrawlerScheduleResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type='text',
+                            text=f'Successfully updated schedule for crawler {crawler_name}',
+                        )
+                    ],
+                    crawler_name=crawler_name,
+                    operation='update-crawler-schedule',
+                )
+
+            else:
+                error_message = f'Invalid operation: {operation}. Must be one of: get-crawler-metrics, start-crawler-schedule, stop-crawler-schedule, update-crawler-schedule'
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetCrawlerMetricsResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_message)],
+                    crawler_metrics=[],
+                    count=0,
+                    next_token=None,
+                    operation='get-crawler-metrics',
+                )
+
+        except ValueError as e:
+            log_with_request_id(ctx, LogLevel.ERROR, f'Parameter validation error: {str(e)}')
+            raise
+        except Exception as e:
+            error_message = f'Error in manage_aws_glue_crawler_management: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetCrawlerMetricsResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_message)],
+                crawler_metrics=[],
+                count=0,
+                next_token=None,
+                operation='get-crawler-metrics',
+            )

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/glue_models.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/glue_models.py
@@ -1,0 +1,156 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from mcp.types import CallToolResult
+from pydantic import Field
+from typing import Any, Dict, List, Optional
+
+
+class CreateCrawlerResponse(CallToolResult):
+    """Response model for create crawler operation."""
+
+    crawler_name: str = Field(..., description='Name of the created crawler')
+    operation: str = Field(default='create', description='Operation performed')
+
+
+class DeleteCrawlerResponse(CallToolResult):
+    """Response model for delete crawler operation."""
+
+    crawler_name: str = Field(..., description='Name of the deleted crawler')
+    operation: str = Field(default='delete', description='Operation performed')
+
+
+class GetCrawlerResponse(CallToolResult):
+    """Response model for get crawler operation."""
+
+    crawler_name: str = Field(..., description='Name of the crawler')
+    crawler_details: Dict[str, Any] = Field(..., description='Complete crawler definition')
+    operation: str = Field(default='get', description='Operation performed')
+
+
+class GetCrawlersResponse(CallToolResult):
+    """Response model for get crawlers operation."""
+
+    crawlers: List[Dict[str, Any]] = Field(..., description='List of crawlers')
+    count: int = Field(..., description='Number of crawlers found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class StartCrawlerResponse(CallToolResult):
+    """Response model for start crawler operation."""
+
+    crawler_name: str = Field(..., description='Name of the crawler')
+    operation: str = Field(default='start', description='Operation performed')
+
+
+class StopCrawlerResponse(CallToolResult):
+    """Response model for stop crawler operation."""
+
+    crawler_name: str = Field(..., description='Name of the crawler')
+    operation: str = Field(default='stop', description='Operation performed')
+
+
+class GetCrawlerMetricsResponse(CallToolResult):
+    """Response model for get crawler metrics operation."""
+
+    crawler_metrics: List[Dict[str, Any]] = Field(..., description='List of crawler metrics')
+    count: int = Field(..., description='Number of crawler metrics found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='get_metrics', description='Operation performed')
+
+
+class StartCrawlerScheduleResponse(CallToolResult):
+    """Response model for start crawler schedule operation."""
+
+    crawler_name: str = Field(..., description='Name of the crawler')
+    operation: str = Field(default='start_schedule', description='Operation performed')
+
+
+class StopCrawlerScheduleResponse(CallToolResult):
+    """Response model for stop crawler schedule operation."""
+
+    crawler_name: str = Field(..., description='Name of the crawler')
+    operation: str = Field(default='stop_schedule', description='Operation performed')
+
+
+class BatchGetCrawlersResponse(CallToolResult):
+    """Response model for batch get crawlers operation."""
+
+    crawlers: List[Any] = Field(..., description='List of crawlers')
+    crawlers_not_found: List[str] = Field(..., description='List of crawler names not found')
+    operation: str = Field(default='batch_get', description='Operation performed')
+
+
+class ListCrawlersResponse(CallToolResult):
+    """Response model for list crawlers operation."""
+
+    crawlers: List[Any] = Field(..., description='List of crawlers')
+    count: int = Field(..., description='Number of crawlers found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class UpdateCrawlerResponse(CallToolResult):
+    """Response model for update crawler operation."""
+
+    crawler_name: str = Field(..., description='Name of the updated crawler')
+    operation: str = Field(default='update', description='Operation performed')
+
+
+class UpdateCrawlerScheduleResponse(CallToolResult):
+    """Response model for update crawler schedule operation."""
+
+    crawler_name: str = Field(..., description='Name of the crawler')
+    operation: str = Field(default='update_schedule', description='Operation performed')
+
+
+# Response models for Classifiers
+class CreateClassifierResponse(CallToolResult):
+    """Response model for create classifier operation."""
+
+    classifier_name: str = Field(..., description='Name of the created classifier')
+    operation: str = Field(default='create', description='Operation performed')
+
+
+class DeleteClassifierResponse(CallToolResult):
+    """Response model for delete classifier operation."""
+
+    classifier_name: str = Field(..., description='Name of the deleted classifier')
+    operation: str = Field(default='delete', description='Operation performed')
+
+
+class GetClassifierResponse(CallToolResult):
+    """Response model for get classifier operation."""
+
+    classifier_name: str = Field(..., description='Name of the classifier')
+    classifier_details: Dict[str, Any] = Field(..., description='Complete classifier definition')
+    operation: str = Field(default='get', description='Operation performed')
+
+
+class GetClassifiersResponse(CallToolResult):
+    """Response model for get classifiers operation."""
+
+    classifiers: List[Dict[str, Any]] = Field(..., description='List of classifiers')
+    count: int = Field(..., description='Number of classifiers found')
+    next_token: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class UpdateClassifierResponse(CallToolResult):
+    """Response model for update classifier operation."""
+
+    classifier_name: str = Field(..., description='Name of the updated classifier')
+    operation: str = Field(default='update', description='Operation performed')

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/server.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/server.py
@@ -33,6 +33,9 @@ from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_query_handler 
 from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_workgroup_handler import (
     AthenaWorkGroupHandler,
 )
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler import (
+    CrawlerHandler,
+)
 from awslabs.aws_dataprocessing_mcp_server.handlers.glue.data_catalog_handler import (
     GlueDataCatalogHandler,
 )
@@ -97,6 +100,18 @@ It enables you to create, manage, and monitor data processing workflows.
 ### Athena Workgroup and Data Catalog
 1. Create a workgroup: `manage_aws_athena_workgroups(operation='create-work-group', work_group_name='my-workgroup', configuration={...})`
 2. Manage data catalogs: `manage_aws_athena_data_catalogs(operation='create-data-catalog', name='my-catalog', type='GLUE', parameters={...})`
+
+### Glue Crawlers and Classifiers
+1. Create a crawler: `manage_aws_glue_crawlers(operation='create-crawler', crawler_name='my-crawler', crawler_definition={...})`
+2. Start a crawler: `manage_aws_glue_crawlers(operation='start-crawler', crawler_name='my-crawler')`
+3. Get crawler details: `manage_aws_glue_crawlers(operation='get-crawler', crawler_name='my-crawler')`
+4. Create a classifier: `manage_aws_glue_classifiers(operation='create-classifier', classifier_definition={...})`
+5. Get classifier details: `manage_aws_glue_classifiers(operation='get-classifier', classifier_name='my-classifier')`
+6. Update a classifier: `manage_aws_glue_classifiers(operation='update-classifier', classifier_definition={...})`
+7. Delete a classifier: `manage_aws_glue_classifiers(operation='delete-classifier', classifier_name='my-classifier')`
+8. List all classifiers: `manage_aws_glue_classifiers(operation='get-classifiers')`
+9. Manage crawler schedules: `manage_aws_glue_crawler_management(operation='update-crawler-schedule', crawler_name='my-crawler', schedule='cron(0 0 * * ? *)')`
+10. Get crawler metrics: `manage_aws_glue_crawler_management(operation='get-crawler-metrics', crawler_name_list=['my-crawler'])`
 
 """
 
@@ -179,6 +194,11 @@ def main():
         allow_sensitive_data_access=allow_sensitive_data_access,
     )
     AthenaWorkGroupHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    CrawlerHandler(
         mcp,
         allow_write=allow_write,
         allow_sensitive_data_access=allow_sensitive_data_access,

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/glue/test_crawler_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/glue/test_crawler_handler.py
@@ -1,5 +1,5 @@
 import pytest
-from awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler import CrawlerHandler
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler import CrawlerHandler
 from botocore.exceptions import ClientError
 from unittest.mock import Mock, patch
 
@@ -24,7 +24,7 @@ def mock_context():
 def handler(mock_mcp):
     """Create a CrawlerHandler instance with write access for testing."""
     with patch(
-        'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
     ) as mock_aws_helper:
         mock_aws_helper.create_boto3_client.return_value = Mock()
         handler = CrawlerHandler(mock_mcp, allow_write=True)
@@ -35,7 +35,7 @@ def handler(mock_mcp):
 def no_write_handler(mock_mcp):
     """Create a CrawlerHandler instance without write access for testing."""
     with patch(
-        'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
     ) as mock_aws_helper:
         mock_aws_helper.create_boto3_client.return_value = Mock()
         handler = CrawlerHandler(mock_mcp, allow_write=False)
@@ -49,7 +49,7 @@ class TestCrawlerHandler:
     async def test_init(self, mock_mcp):
         """Test initialization of CrawlerHandler."""
         with patch(
-            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+            'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
         ) as mock_aws_helper:
             mock_aws_helper.create_boto3_client.return_value = Mock()
 
@@ -78,7 +78,7 @@ class TestCrawlerHandler:
 
         # Mock AwsHelper methods
         with patch(
-            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+            'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
         ) as mock_aws_helper:
             mock_aws_helper.prepare_resource_tags.return_value = {
                 'ManagedBy': 'DataprocessingMcpServer'
@@ -157,7 +157,7 @@ class TestCrawlerHandler:
 
         # Mock AwsHelper methods
         with patch(
-            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+            'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
         ) as mock_aws_helper:
             mock_aws_helper.get_aws_region.return_value = 'us-east-1'
             mock_aws_helper.get_aws_account_id.return_value = '123456789012'
@@ -182,7 +182,7 @@ class TestCrawlerHandler:
 
         # Mock AwsHelper methods
         with patch(
-            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+            'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
         ) as mock_aws_helper:
             mock_aws_helper.get_aws_region.return_value = 'us-east-1'
             mock_aws_helper.get_aws_account_id.return_value = '123456789012'
@@ -559,7 +559,7 @@ class TestCrawlerHandler:
 
         # Mock AwsHelper methods
         with patch(
-            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+            'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
         ) as mock_aws_helper:
             mock_aws_helper.get_aws_region.return_value = 'us-east-1'
             mock_aws_helper.get_aws_account_id.return_value = '123456789012'
@@ -1030,7 +1030,7 @@ class TestCrawlerHandler:
 
         # Mock AwsHelper methods
         with patch(
-            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+            'awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
         ) as mock_aws_helper:
             mock_aws_helper.get_aws_region.return_value = 'us-east-1'
             mock_aws_helper.get_aws_account_id.return_value = '123456789012'

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/glue/test_crawler_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/glue/test_crawler_handler.py
@@ -1,0 +1,1256 @@
+import pytest
+from awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler import CrawlerHandler
+from botocore.exceptions import ClientError
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def mock_mcp():
+    """Create a mock MCP server instance for testing."""
+    mcp = Mock()
+    mcp.tool = Mock(return_value=lambda x: x)
+    return mcp
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock context for testing."""
+    context = Mock()
+    context.request_id = 'test-request-id'
+    return context
+
+
+@pytest.fixture
+def handler(mock_mcp):
+    """Create a CrawlerHandler instance with write access for testing."""
+    with patch(
+        'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+    ) as mock_aws_helper:
+        mock_aws_helper.create_boto3_client.return_value = Mock()
+        handler = CrawlerHandler(mock_mcp, allow_write=True)
+        return handler
+
+
+@pytest.fixture
+def no_write_handler(mock_mcp):
+    """Create a CrawlerHandler instance without write access for testing."""
+    with patch(
+        'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+    ) as mock_aws_helper:
+        mock_aws_helper.create_boto3_client.return_value = Mock()
+        handler = CrawlerHandler(mock_mcp, allow_write=False)
+        return handler
+
+
+class TestCrawlerHandler:
+    """Test class for CrawlerHandler functionality."""
+
+    @pytest.mark.asyncio
+    async def test_init(self, mock_mcp):
+        """Test initialization of CrawlerHandler."""
+        with patch(
+            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        ) as mock_aws_helper:
+            mock_aws_helper.create_boto3_client.return_value = Mock()
+
+            handler = CrawlerHandler(mock_mcp, allow_write=True, allow_sensitive_data_access=True)
+
+            assert handler.mcp == mock_mcp
+            assert handler.allow_write is True
+            assert handler.allow_sensitive_data_access is True
+            mock_aws_helper.create_boto3_client.assert_called_once_with('glue')
+
+            assert mock_mcp.tool.call_count == 3
+
+            call_args_list = mock_mcp.tool.call_args_list
+
+            tool_names = [call_args[1]['name'] for call_args in call_args_list]
+
+            assert 'manage_aws_glue_crawlers' in tool_names
+            assert 'manage_aws_glue_classifiers' in tool_names
+            assert 'manage_aws_glue_crawler_management' in tool_names
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_create_success(self, handler, mock_context):
+        """Test successful creation of a Glue crawler."""
+        # Setup
+        handler.glue_client.create_crawler.return_value = {}
+
+        # Mock AwsHelper methods
+        with patch(
+            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        ) as mock_aws_helper:
+            mock_aws_helper.prepare_resource_tags.return_value = {
+                'ManagedBy': 'DataprocessingMcpServer'
+            }
+
+            # Test
+            result = await handler.manage_aws_glue_crawlers(
+                mock_context,
+                operation='create-crawler',
+                crawler_name='test-crawler',
+                crawler_definition={
+                    'Role': 'test-role',
+                    'Targets': {'S3Targets': [{'Path': 's3://test-bucket/'}]},
+                    'DatabaseName': 'test-db',
+                    'Description': 'Test crawler',
+                    'Schedule': 'cron(0 0 * * ? *)',
+                    'TablePrefix': 'test_',
+                    'Tags': {'custom': 'tag'},
+                },
+            )
+
+            # Assertions
+            assert result.isError is False
+            assert result.crawler_name == 'test-crawler'
+            assert result.operation == 'create-crawler'
+            handler.glue_client.create_crawler.assert_called_once()
+            mock_aws_helper.prepare_resource_tags.assert_called_once_with('GlueCrawler')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_create_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that creating a crawler fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawlers(
+            mock_context,
+            operation='create-crawler',
+            crawler_name='test-crawler',
+            crawler_definition={
+                'Role': 'test-role',
+                'Targets': {'S3Targets': [{'Path': 's3://test-bucket/'}]},
+            },
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.create_crawler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_create_missing_role(self, handler, mock_context):
+        """Test that creating a crawler without a role raises ValueError."""
+        with pytest.raises(ValueError, match='Role is required'):
+            await handler.manage_aws_glue_crawlers(
+                mock_context,
+                operation='create-crawler',
+                crawler_name='test-crawler',
+                crawler_definition={'Targets': {'S3Targets': [{'Path': 's3://test-bucket/'}]}},
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_create_missing_targets(self, handler, mock_context):
+        """Test that creating a crawler without targets raises ValueError."""
+        with pytest.raises(ValueError, match='Targets is required'):
+            await handler.manage_aws_glue_crawlers(
+                mock_context,
+                operation='create-crawler',
+                crawler_name='test-crawler',
+                crawler_definition={'Role': 'test-role'},
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_delete_success(self, handler, mock_context):
+        """Test successful deletion of a Glue crawler."""
+        # Setup
+        handler.glue_client.get_crawler.return_value = {'Crawler': {'Parameters': {}}}
+        handler.glue_client.delete_crawler.return_value = {}
+
+        # Mock AwsHelper methods
+        with patch(
+            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        ) as mock_aws_helper:
+            mock_aws_helper.get_aws_region.return_value = 'us-east-1'
+            mock_aws_helper.get_aws_account_id.return_value = '123456789012'
+            mock_aws_helper.is_resource_mcp_managed.return_value = True
+
+            # Test
+            result = await handler.manage_aws_glue_crawlers(
+                mock_context, operation='delete-crawler', crawler_name='test-crawler'
+            )
+
+            # Assertions
+            assert result.isError is False
+            assert result.crawler_name == 'test-crawler'
+            assert result.operation == 'delete-crawler'
+            handler.glue_client.delete_crawler.assert_called_once_with(Name='test-crawler')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_delete_not_mcp_managed(self, handler, mock_context):
+        """Test deletion of a crawler not managed by MCP."""
+        # Setup
+        handler.glue_client.get_crawler.return_value = {'Crawler': {'Parameters': {}}}
+
+        # Mock AwsHelper methods
+        with patch(
+            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        ) as mock_aws_helper:
+            mock_aws_helper.get_aws_region.return_value = 'us-east-1'
+            mock_aws_helper.get_aws_account_id.return_value = '123456789012'
+            mock_aws_helper.is_resource_mcp_managed.return_value = False
+
+            # Test
+            result = await handler.manage_aws_glue_crawlers(
+                mock_context, operation='delete-crawler', crawler_name='test-crawler'
+            )
+
+            # Assertions
+            assert result.isError is True
+            assert 'not managed by the MCP server' in result.content[0].text
+            handler.glue_client.delete_crawler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_delete_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that deleting a crawler fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawlers(
+            mock_context, operation='delete-crawler', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.delete_crawler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_get_crawler_success(self, handler, mock_context):
+        """Test successful retrieval of a Glue crawler."""
+        # Setup
+        crawler_details = {
+            'Name': 'test-crawler',
+            'Role': 'test-role',
+            'Targets': {'S3Targets': [{'Path': 's3://test-bucket/'}]},
+            'DatabaseName': 'test-db',
+            'State': 'READY',
+        }
+        handler.glue_client.get_crawler.return_value = {'Crawler': crawler_details}
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='get-crawler', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.crawler_details == crawler_details
+        assert result.operation == 'get-crawler'
+        handler.glue_client.get_crawler.assert_called_once_with(Name='test-crawler')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_get_crawler_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that getting a crawler works without write access."""
+        # Setup
+        crawler_details = {
+            'Name': 'test-crawler',
+            'Role': 'test-role',
+            'Targets': {'S3Targets': [{'Path': 's3://test-bucket/'}]},
+            'DatabaseName': 'test-db',
+            'State': 'READY',
+        }
+        no_write_handler.glue_client.get_crawler.return_value = {'Crawler': crawler_details}
+
+        # Test
+        result = await no_write_handler.manage_aws_glue_crawlers(
+            mock_context, operation='get-crawler', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.crawler_details == crawler_details
+        assert result.operation == 'get-crawler'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_get_crawlers_success(self, handler, mock_context):
+        """Test successful retrieval of all Glue crawlers."""
+        # Setup
+        crawlers = [
+            {'Name': 'test-crawler-1', 'Role': 'test-role', 'State': 'READY'},
+            {'Name': 'test-crawler-2', 'Role': 'test-role', 'State': 'RUNNING'},
+        ]
+        handler.glue_client.get_crawlers.return_value = {
+            'Crawlers': crawlers,
+            'NextToken': 'next-token',
+        }
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='get-crawlers', max_results=10, next_token='token'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawlers == crawlers
+        assert result.count == 2
+        assert result.next_token == 'next-token'
+        assert result.operation == 'get-crawlers'
+        handler.glue_client.get_crawlers.assert_called_once_with(MaxResults=10, NextToken='token')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_start_crawler_success(self, handler, mock_context):
+        """Test successful start of a Glue crawler."""
+        # Setup
+        handler.glue_client.start_crawler.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='start-crawler', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.operation == 'start-crawler'
+        handler.glue_client.start_crawler.assert_called_once_with(Name='test-crawler')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_start_crawler_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that starting a crawler fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawlers(
+            mock_context, operation='start-crawler', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.start_crawler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_stop_crawler_success(self, handler, mock_context):
+        """Test successful stop of a Glue crawler."""
+        # Setup
+        handler.glue_client.stop_crawler.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='stop-crawler', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.operation == 'stop-crawler'
+        handler.glue_client.stop_crawler.assert_called_once_with(Name='test-crawler')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_stop_crawler_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that stopping a crawler fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawlers(
+            mock_context, operation='stop-crawler', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.stop_crawler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_batch_get_crawlers_success(
+        self, handler, mock_context
+    ):
+        """Test successful batch retrieval of Glue crawlers."""
+        # Setup
+        crawlers = [
+            {'Name': 'test-crawler-1', 'Role': 'test-role', 'State': 'READY'},
+            {'Name': 'test-crawler-2', 'Role': 'test-role', 'State': 'RUNNING'},
+        ]
+        handler.glue_client.batch_get_crawlers.return_value = {
+            'Crawlers': crawlers,
+            'CrawlersNotFound': ['test-crawler-3'],
+        }
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context,
+            operation='batch-get-crawlers',
+            crawler_names=['test-crawler-1', 'test-crawler-2', 'test-crawler-3'],
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawlers == crawlers
+        assert result.crawlers_not_found == ['test-crawler-3']
+        assert result.operation == 'batch-get-crawlers'
+        handler.glue_client.batch_get_crawlers.assert_called_once_with(
+            CrawlerNames=['test-crawler-1', 'test-crawler-2', 'test-crawler-3']
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_list_crawlers_success(self, handler, mock_context):
+        """Test successful listing of Glue crawlers."""
+        # Setup
+        handler.glue_client.list_crawlers.return_value = {
+            'CrawlerNames': ['test-crawler-1', 'test-crawler-2'],
+            'NextToken': 'next-token',
+        }
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context,
+            operation='list-crawlers',
+            max_results=10,
+            next_token='token',
+            tags={'tag1': 'value1'},
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawlers == ['test-crawler-1', 'test-crawler-2']
+        assert result.count == 2
+        assert result.next_token == 'next-token'
+        assert result.operation == 'list-crawlers'
+        handler.glue_client.list_crawlers.assert_called_once_with(
+            MaxResults=10, NextToken='token', Tags={'tag1': 'value1'}
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_update_crawler_success(self, handler, mock_context):
+        """Test successful update of a Glue crawler."""
+        # Setup
+        handler.glue_client.update_crawler.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context,
+            operation='update-crawler',
+            crawler_name='test-crawler',
+            crawler_definition={
+                'Role': 'updated-role',
+                'Targets': {'S3Targets': [{'Path': 's3://updated-bucket/'}]},
+                'DatabaseName': 'updated-db',
+                'Description': 'Updated crawler',
+                'Schedule': 'cron(0 12 * * ? *)',
+                'TablePrefix': 'updated_',
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.operation == 'update-crawler'
+        handler.glue_client.update_crawler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_update_crawler_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that updating a crawler fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawlers(
+            mock_context,
+            operation='update-crawler',
+            crawler_name='test-crawler',
+            crawler_definition={
+                'Role': 'updated-role',
+                'Targets': {'S3Targets': [{'Path': 's3://updated-bucket/'}]},
+            },
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.update_crawler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_invalid_operation(self, handler, mock_context):
+        """Test handling of invalid operation."""
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='invalid-operation', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_missing_crawler_name(self, handler, mock_context):
+        """Test that operations requiring crawler_name raise ValueError when it's missing."""
+        operations = ['get-crawler', 'start-crawler', 'stop-crawler', 'delete-crawler']
+
+        for operation in operations:
+            with pytest.raises(
+                ValueError, match=f'crawler_name is required for {operation} operation'
+            ):
+                await handler.manage_aws_glue_crawlers(
+                    mock_context, operation=operation, crawler_name=None
+                )
+
+        operations = ['create-crawler', 'update-crawler']
+
+        for operation in operations:
+            with pytest.raises(
+                ValueError,
+                match=f'crawler_name and crawler_definition are required for {operation} operation',
+            ):
+                await handler.manage_aws_glue_crawlers(
+                    mock_context, operation=operation, crawler_name=None
+                )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_missing_crawler_definition(
+        self, handler, mock_context
+    ):
+        """Test that operations requiring crawler_definition raise ValueError when it's missing."""
+        operations = ['create-crawler', 'update-crawler']
+
+        for operation in operations:
+            with pytest.raises(
+                ValueError,
+                match=f'crawler_name and crawler_definition are required for {operation} operation',
+            ):
+                await handler.manage_aws_glue_crawlers(
+                    mock_context,
+                    operation=operation,
+                    crawler_name='test-crawler',
+                    crawler_definition=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_missing_crawler_names(self, handler, mock_context):
+        """Test that batch-get-crawlers raises ValueError when crawler_names is missing."""
+        with pytest.raises(
+            ValueError, match='crawler_names is required for batch-get-crawlers operation'
+        ):
+            await handler.manage_aws_glue_crawlers(
+                mock_context, operation='batch-get-crawlers', crawler_names=None
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_error_handling(self, handler, mock_context):
+        """Test error handling when Glue API calls raise exceptions."""
+        # Setup
+        handler.glue_client.get_crawler.side_effect = Exception('Test error')
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='get-crawler', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is True
+        assert 'Test error' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_client_error(self, handler, mock_context):
+        """Test handling of ClientError."""
+        # Setup
+        error_response = {'Error': {'Code': 'ValidationException', 'Message': 'Invalid input'}}
+        handler.glue_client.get_crawler.side_effect = ClientError(error_response, 'GetCrawler')
+
+        # Test
+        result = await handler.manage_aws_glue_crawlers(
+            mock_context, operation='get-crawler', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is True
+        assert 'Error in manage_aws_glue_crawlers' in result.content[0].text
+        assert 'Invalid input' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_delete_client_error(self, handler, mock_context):
+        """Test handling of ClientError during crawler deletion."""
+        # Setup
+        error_response = {
+            'Error': {'Code': 'EntityNotFoundException', 'Message': 'Crawler not found'}
+        }
+        handler.glue_client.get_crawler.side_effect = ClientError(error_response, 'GetCrawler')
+
+        # Mock AwsHelper methods
+        with patch(
+            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        ) as mock_aws_helper:
+            mock_aws_helper.get_aws_region.return_value = 'us-east-1'
+            mock_aws_helper.get_aws_account_id.return_value = '123456789012'
+
+            # Test
+            result = await handler.manage_aws_glue_crawlers(
+                mock_context, operation='get-crawler', crawler_name='test-crawler'
+            )
+
+            # Assertions
+            assert result.isError is True
+            assert 'Error in manage_aws_glue_crawlers' in result.content[0].text
+            assert 'Crawler not found' in result.content[0].text
+
+    # Tests for manage_aws_glue_classifiers method
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_success(self, handler, mock_context):
+        """Test successful creation of a Glue classifier."""
+        # Setup
+        handler.glue_client.create_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='create-classifier',
+            classifier_definition={
+                'CsvClassifier': {
+                    'Name': 'test-csv-classifier',
+                    'Delimiter': ',',
+                    'QuoteSymbol': '"',
+                    'ContainsHeader': 'PRESENT',
+                    'Header': ['id', 'name', 'date', 'value'],
+                }
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-csv-classifier'
+        assert result.operation == 'create-classifier'
+        handler.glue_client.create_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that creating a classifier fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='create-classifier',
+            classifier_definition={
+                'CsvClassifier': {'Name': 'test-csv-classifier', 'Delimiter': ','}
+            },
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.create_classifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_missing_definition(
+        self, handler, mock_context
+    ):
+        """Test that creating a classifier without definition raises ValueError."""
+        with pytest.raises(ValueError, match='classifier_definition is required'):
+            await handler.manage_aws_glue_classifiers(
+                mock_context, operation='create-classifier', classifier_definition=None
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_invalid_definition(
+        self, handler, mock_context
+    ):
+        """Test that creating a classifier with invalid definition raises ValueError."""
+        with pytest.raises(ValueError, match='classifier_definition must include one of'):
+            await handler.manage_aws_glue_classifiers(
+                mock_context,
+                operation='create-classifier',
+                classifier_definition={'InvalidType': {}},
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_delete_success(self, handler, mock_context):
+        """Test successful deletion of a Glue classifier."""
+        # Setup
+        handler.glue_client.delete_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context, operation='delete-classifier', classifier_name='test-classifier'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-classifier'
+        assert result.operation == 'delete-classifier'
+        handler.glue_client.delete_classifier.assert_called_once_with(Name='test-classifier')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_delete_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that deleting a classifier fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_classifiers(
+            mock_context, operation='delete-classifier', classifier_name='test-classifier'
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.delete_classifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_get_classifier_success(self, handler, mock_context):
+        """Test successful retrieval of a Glue classifier."""
+        # Setup
+        classifier_details = {
+            'CsvClassifier': {'Name': 'test-classifier', 'Delimiter': ',', 'QuoteSymbol': '"'}
+        }
+        handler.glue_client.get_classifier.return_value = {'Classifier': classifier_details}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context, operation='get-classifier', classifier_name='test-classifier'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-classifier'
+        assert result.classifier_details == classifier_details
+        assert result.operation == 'get-classifier'
+        handler.glue_client.get_classifier.assert_called_once_with(Name='test-classifier')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_get_classifiers_success(
+        self, handler, mock_context
+    ):
+        """Test successful retrieval of all Glue classifiers."""
+        # Setup
+        classifiers = [
+            {'CsvClassifier': {'Name': 'test-classifier-1', 'Delimiter': ','}},
+            {'JsonClassifier': {'Name': 'test-classifier-2'}},
+        ]
+        handler.glue_client.get_classifiers.return_value = {
+            'Classifiers': classifiers,
+            'NextToken': 'next-token',
+        }
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context, operation='get-classifiers', max_results=10, next_token='token'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifiers == classifiers
+        assert result.count == 2
+        assert result.next_token == 'next-token'
+        assert result.operation == 'get-classifiers'
+        handler.glue_client.get_classifiers.assert_called_once_with(
+            MaxResults=10, NextToken='token'
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_update_success(self, handler, mock_context):
+        """Test successful update of a Glue classifier."""
+        # Setup
+        handler.glue_client.update_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='update-classifier',
+            classifier_definition={
+                'CsvClassifier': {
+                    'Name': 'test-csv-classifier',
+                    'Delimiter': '|',
+                    'QuoteSymbol': '"',
+                }
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-csv-classifier'
+        assert result.operation == 'update-classifier'
+        handler.glue_client.update_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_update_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that updating a classifier fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='update-classifier',
+            classifier_definition={
+                'CsvClassifier': {'Name': 'test-csv-classifier', 'Delimiter': '|'}
+            },
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.update_classifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_invalid_operation(self, handler, mock_context):
+        """Test handling of invalid operation."""
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context, operation='invalid-operation', classifier_name='test-classifier'
+        )
+
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_missing_classifier_name(
+        self, handler, mock_context
+    ):
+        """Test that operations requiring classifier_name raise ValueError when it's missing."""
+        operations = ['delete-classifier', 'get-classifier']
+
+        for operation in operations:
+            with pytest.raises(
+                ValueError, match=f'classifier_name is required for {operation} operation'
+            ):
+                await handler.manage_aws_glue_classifiers(
+                    mock_context, operation=operation, classifier_name=None
+                )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_error_handling(self, handler, mock_context):
+        """Test error handling when Glue API calls raise exceptions."""
+        # Setup
+        handler.glue_client.get_classifier.side_effect = Exception('Test error')
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context, operation='get-classifier', classifier_name='test-classifier'
+        )
+
+        # Assertions
+        assert result.isError is True
+        assert 'Test error' in result.content[0].text
+
+    # Tests for manage_aws_glue_crawler_management method
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_get_metrics_success(
+        self, handler, mock_context
+    ):
+        """Test successful retrieval of crawler metrics."""
+        # Setup
+        metrics = [
+            {
+                'CrawlerName': 'test-crawler-1',
+                'TimeLeftSeconds': 100,
+                'StillEstimating': False,
+                'LastRuntimeSeconds': 200,
+            },
+            {
+                'CrawlerName': 'test-crawler-2',
+                'TimeLeftSeconds': 0,
+                'StillEstimating': False,
+                'LastRuntimeSeconds': 150,
+            },
+        ]
+        handler.glue_client.get_crawler_metrics.return_value = {
+            'CrawlerMetricsList': metrics,
+            'NextToken': 'next-token',
+        }
+
+        # Test
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context,
+            operation='get-crawler-metrics',
+            crawler_name_list=['test-crawler-1', 'test-crawler-2'],
+            max_results=10,
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_metrics == metrics
+        assert result.count == 2
+        assert result.next_token == 'next-token'
+        assert result.operation == 'get-crawler-metrics'
+        handler.glue_client.get_crawler_metrics.assert_called_once_with(
+            CrawlerNameList=['test-crawler-1', 'test-crawler-2'], MaxResults=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_start_schedule_success(
+        self, handler, mock_context
+    ):
+        """Test successful start of a crawler schedule."""
+        # Setup
+        handler.glue_client.start_crawler_schedule.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context, operation='start-crawler-schedule', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.operation == 'start-crawler-schedule'
+        handler.glue_client.start_crawler_schedule.assert_called_once_with(
+            CrawlerName='test-crawler'
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_start_schedule_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that starting a crawler schedule fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawler_management(
+            mock_context, operation='start-crawler-schedule', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.start_crawler_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_stop_schedule_success(
+        self, handler, mock_context
+    ):
+        """Test successful stop of a crawler schedule."""
+        # Setup
+        handler.glue_client.stop_crawler_schedule.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context, operation='stop-crawler-schedule', crawler_name='test-crawler'
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.operation == 'stop-crawler-schedule'
+        handler.glue_client.stop_crawler_schedule.assert_called_once_with(
+            CrawlerName='test-crawler'
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_stop_schedule_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that stopping a crawler schedule fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawler_management(
+            mock_context, operation='stop-crawler-schedule', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.stop_crawler_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_update_schedule_success(
+        self, handler, mock_context
+    ):
+        """Test successful update of a crawler schedule."""
+        # Setup
+        handler.glue_client.update_crawler_schedule.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context,
+            operation='update-crawler-schedule',
+            crawler_name='test-crawler',
+            schedule='cron(0 12 * * ? *)',
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.crawler_name == 'test-crawler'
+        assert result.operation == 'update-crawler-schedule'
+        handler.glue_client.update_crawler_schedule.assert_called_once_with(
+            CrawlerName='test-crawler', Schedule='cron(0 12 * * ? *)'
+        )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_update_schedule_missing_schedule(
+        self, handler, mock_context
+    ):
+        """Test that updating a crawler schedule without schedule raises ValueError."""
+        with pytest.raises(ValueError, match='crawler_name and schedule are required'):
+            await handler.manage_aws_glue_crawler_management(
+                mock_context,
+                operation='update-crawler-schedule',
+                crawler_name='test-crawler',
+                schedule=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_invalid_operation(
+        self, handler, mock_context
+    ):
+        """Test handling of invalid operation."""
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context, operation='invalid-operation', crawler_name='test-crawler'
+        )
+
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_missing_crawler_name(
+        self, handler, mock_context
+    ):
+        """Test that operations requiring crawler_name raise ValueError when it's missing."""
+        operations = ['start-crawler-schedule', 'stop-crawler-schedule']
+
+        for operation in operations:
+            with pytest.raises(
+                ValueError, match=f'crawler_name is required for {operation} operation'
+            ):
+                await handler.manage_aws_glue_crawler_management(
+                    mock_context, operation=operation, crawler_name=None
+                )
+
+        operation = 'update-crawler-schedule'
+        with pytest.raises(
+            ValueError, match=f'crawler_name and schedule are required for {operation} operation'
+        ):
+            await handler.manage_aws_glue_crawler_management(
+                mock_context, operation=operation, crawler_name=None
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_error_handling(self, handler, mock_context):
+        """Test error handling when Glue API calls raise exceptions."""
+        # Setup
+        handler.glue_client.get_crawler_metrics.side_effect = Exception('Test error')
+
+        # Test
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context, operation='get-crawler-metrics'
+        )
+
+        # Assertions
+        assert result.isError is True
+        assert 'Test error' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_update_crawler_schedule_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that updating a crawler schedule fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawler_management(
+            mock_context,
+            operation='update-crawler-schedule',
+            crawler_name='test-crawler',
+            schedule='cron(0 12 * * ? *)',
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.update_crawler_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_delete_with_parameters(self, handler, mock_context):
+        """Test deletion of a crawler with parameters."""
+        # Setup
+        handler.glue_client.get_crawler.return_value = {
+            'Crawler': {'Parameters': {'key': 'value'}}
+        }
+        handler.glue_client.delete_crawler.return_value = {}
+
+        # Mock AwsHelper methods
+        with patch(
+            'awslabs.dataprocessing_mcp_server.handlers.glue.crawler_handler.AwsHelper'
+        ) as mock_aws_helper:
+            mock_aws_helper.get_aws_region.return_value = 'us-east-1'
+            mock_aws_helper.get_aws_account_id.return_value = '123456789012'
+            mock_aws_helper.is_resource_mcp_managed.return_value = True
+
+            # Test
+            result = await handler.manage_aws_glue_crawlers(
+                mock_context, operation='delete-crawler', crawler_name='test-crawler'
+            )
+
+            # Assertions
+            assert result.isError is False
+            assert result.crawler_name == 'test-crawler'
+            assert result.operation == 'delete-crawler'
+            handler.glue_client.delete_crawler.assert_called_once_with(Name='test-crawler')
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawlers_get_crawler_error(self, handler, mock_context):
+        """Test error handling for get-crawler operation."""
+        # Setup
+        handler.glue_client.get_crawler.side_effect = ValueError('Test error')
+
+        # Test
+        with pytest.raises(ValueError, match='Test error'):
+            await handler.manage_aws_glue_crawlers(
+                mock_context, operation='get-crawler', crawler_name='test-crawler'
+            )
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_grok_classifier(self, handler, mock_context):
+        """Test successful creation of a Grok classifier."""
+        # Setup
+        handler.glue_client.create_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='create-classifier',
+            classifier_definition={
+                'GrokClassifier': {
+                    'Name': 'test-grok-classifier',
+                    'Classification': 'apache-log',
+                    'GrokPattern': '%{COMMONAPACHELOG}',
+                }
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-grok-classifier'
+        assert result.operation == 'create-classifier'
+        handler.glue_client.create_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_xml_classifier(self, handler, mock_context):
+        """Test successful creation of an XML classifier."""
+        # Setup
+        handler.glue_client.create_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='create-classifier',
+            classifier_definition={
+                'XMLClassifier': {
+                    'Name': 'test-xml-classifier',
+                    'Classification': 'xml',
+                    'RowTag': 'item',
+                }
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-xml-classifier'
+        assert result.operation == 'create-classifier'
+        handler.glue_client.create_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_create_json_classifier(self, handler, mock_context):
+        """Test successful creation of a JSON classifier."""
+        # Setup
+        handler.glue_client.create_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='create-classifier',
+            classifier_definition={
+                'JsonClassifier': {'Name': 'test-json-classifier', 'JsonPath': '$.records[*]'}
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-json-classifier'
+        assert result.operation == 'create-classifier'
+        handler.glue_client.create_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_update_grok_classifier(self, handler, mock_context):
+        """Test successful update of a Grok classifier."""
+        # Setup
+        handler.glue_client.update_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='update-classifier',
+            classifier_definition={
+                'GrokClassifier': {
+                    'Name': 'test-grok-classifier',
+                    'Classification': 'apache-log',
+                    'GrokPattern': '%{COMBINEDAPACHELOG}',
+                }
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-grok-classifier'
+        assert result.operation == 'update-classifier'
+        handler.glue_client.update_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_update_xml_classifier(self, handler, mock_context):
+        """Test successful update of an XML classifier."""
+        # Setup
+        handler.glue_client.update_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='update-classifier',
+            classifier_definition={
+                'XMLClassifier': {
+                    'Name': 'test-xml-classifier',
+                    'Classification': 'xml',
+                    'RowTag': 'record',
+                }
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-xml-classifier'
+        assert result.operation == 'update-classifier'
+        handler.glue_client.update_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_update_json_classifier(self, handler, mock_context):
+        """Test successful update of a JSON classifier."""
+        # Setup
+        handler.glue_client.update_classifier.return_value = {}
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context,
+            operation='update-classifier',
+            classifier_definition={
+                'JsonClassifier': {'Name': 'test-json-classifier', 'JsonPath': '$.items[*]'}
+            },
+        )
+
+        # Assertions
+        assert result.isError is False
+        assert result.classifier_name == 'test-json-classifier'
+        assert result.operation == 'update-classifier'
+        handler.glue_client.update_classifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_classifiers_client_error(self, handler, mock_context):
+        """Test handling of ClientError in classifiers."""
+        # Setup
+        error_response = {'Error': {'Code': 'ValidationException', 'Message': 'Invalid input'}}
+        handler.glue_client.get_classifier.side_effect = ClientError(
+            error_response, 'GetClassifier'
+        )
+
+        # Test
+        result = await handler.manage_aws_glue_classifiers(
+            mock_context, operation='get-classifier', classifier_name='test-classifier'
+        )
+
+        # Assertions
+        assert result.isError is True
+        assert 'Error in manage_aws_glue_classifiers' in result.content[0].text
+        assert 'Invalid input' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_update_schedule_no_write_access(
+        self, no_write_handler, mock_context
+    ):
+        """Test that updating a crawler schedule fails when write access is disabled."""
+        result = await no_write_handler.manage_aws_glue_crawler_management(
+            mock_context,
+            operation='update-crawler-schedule',
+            crawler_name='test-crawler',
+            schedule='cron(0 12 * * ? *)',
+        )
+
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        no_write_handler.glue_client.update_crawler_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_crawler_management_client_error(self, handler, mock_context):
+        """Test handling of ClientError in crawler management."""
+        # Setup
+        error_response = {'Error': {'Code': 'ValidationException', 'Message': 'Invalid input'}}
+        handler.glue_client.get_crawler_metrics.side_effect = ClientError(
+            error_response, 'GetCrawlerMetrics'
+        )
+
+        # Test
+        result = await handler.manage_aws_glue_crawler_management(
+            mock_context, operation='get-crawler-metrics'
+        )
+
+        # Assertions
+        assert result.isError is True
+        assert 'Error in manage_aws_glue_crawler_management' in result.content[0].text
+        assert 'Invalid input' in result.content[0].text

--- a/src/aws-dataprocessing-mcp-server/tests/test_server.py
+++ b/src/aws-dataprocessing-mcp-server/tests/test_server.py
@@ -17,6 +17,11 @@
 import argparse
 import pytest
 import sys
+
+# Import the modules that will be mocked
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler import (
+    CrawlerHandler,
+)
 from awslabs.aws_dataprocessing_mcp_server.handlers.glue.data_catalog_handler import (
     GlueDataCatalogHandler,
 )
@@ -35,10 +40,45 @@ class MockContext:
     pass
 
 
+# Create a proper TextContent class for type checking
+class MockTextContent:
+    """Mock TextContent class for testing."""
+
+    def __init__(self, type='text', text=''):
+        """Initialize the MockTextContent class.
+
+        Args:
+            type (str, optional): The content type. Defaults to 'text'.
+            text (str, optional): The text content. Defaults to ''.
+        """
+        self.type = type
+        self.text = text
+
+
+# Create a proper CallToolResult class for type checking
+class MockCallToolResult:
+    """Mock CallToolResult class for testing."""
+
+    def __init__(self, isError=False, content=None, **kwargs):
+        """Initialize the MockCallToolResult class.
+
+        Args:
+            isError (bool, optional): Whether the result is an error. Defaults to False.
+            content (list, optional): The content of the result. Defaults to None.
+            **kwargs: Additional attributes to set on the result.
+        """
+        self.isError = isError
+        self.content = content or []
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+# Set up mocks before importing any modules that use them
 sys.modules['mcp.server.fastmcp'] = MagicMock()
 sys.modules['mcp.server.fastmcp'].Context = MockContext
 sys.modules['mcp.types'] = MagicMock()
-sys.modules['mcp.types'].TextContent = MagicMock()
+sys.modules['mcp.types'].TextContent = MockTextContent
+sys.modules['mcp.types'].CallToolResult = MockCallToolResult
 
 
 @pytest.mark.asyncio
@@ -133,19 +173,27 @@ async def test_command_line_args():
                 with patch(
                     'awslabs.aws_dataprocessing_mcp_server.server.GlueDataCatalogHandler'
                 ) as mock_glue_data_catalog_handler:
-                    # Call the main function
-                    main()
+                    with patch(
+                        'awslabs.dataprocessing_mcp_server.server.CrawlerHandler'
+                    ) as mock_crawler_handler:
+                        # Call the main function
+                        main()
 
-                    # Verify that parse_args was called
-                    mock_parse_args.assert_called_once()
+                        # Verify that parse_args was called
+                        mock_parse_args.assert_called_once()
 
-                    # Verify that the handlers were initialized with correct parameters
-                    mock_glue_data_catalog_handler.assert_called_once_with(
-                        mock_server, allow_write=True, allow_sensitive_data_access=False
-                    )
+                        # Verify that the handlers were initialized with correct parameters
+                        mock_glue_data_catalog_handler.assert_called_once_with(
+                            mock_server, allow_write=True, allow_sensitive_data_access=False
+                        )
+                        mock_crawler_handler.assert_called_once_with(
+                            mock_server,
+                            allow_write=True,
+                            allow_sensitive_data_access=False,
+                        )
 
-                    # Verify that run was called
-                    mock_server.run.assert_called_once()
+                        # Verify that run was called
+                        mock_server.run.assert_called_once()
 
     # Test with sensitive data access enabled
     with patch.object(argparse.ArgumentParser, 'parse_args') as mock_parse_args:
@@ -167,19 +215,28 @@ async def test_command_line_args():
                 with patch(
                     'awslabs.aws_dataprocessing_mcp_server.server.GlueDataCatalogHandler'
                 ) as mock_glue_data_catalog_handler:
-                    # Call the main function
-                    main()
+                    with patch(
+                        'awslabs.dataprocessing_mcp_server.server.CrawlerHandler'
+                    ) as mock_crawler_handler:
+                        # Call the main function
+                        main()
 
-                    # Verify that parse_args was called
-                    mock_parse_args.assert_called_once()
+                        # Verify that parse_args was called
+                        mock_parse_args.assert_called_once()
 
-                    # Verify that the handlers were initialized with correct parameters
-                    mock_glue_data_catalog_handler.assert_called_once_with(
-                        mock_server, allow_write=False, allow_sensitive_data_access=True
-                    )
+                        # Verify that the handlers were initialized with correct parameters
+                        mock_glue_data_catalog_handler.assert_called_once_with(
+                            mock_server, allow_write=False, allow_sensitive_data_access=True
+                        )
 
-                    # Verify that run was called
-                    mock_server.run.assert_called_once()
+                        mock_crawler_handler.assert_called_once_with(
+                            mock_server,
+                            allow_write=False,
+                            allow_sensitive_data_access=True,
+                        )
+
+                        # Verify that run was called
+                        mock_server.run.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -208,6 +265,33 @@ async def test_glue_data_catalog_handler_initialization():
         # Verify that expected tools are registered
         assert 'manage_aws_glue_databases' in tool_names
         assert 'manage_aws_glue_tables' in tool_names
+
+
+@pytest.mark.asyncio
+async def test_glue_data_crawler_handler_initialization():
+    """Test that the Glue Crawler handler is initialized correctly and registers tools."""
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Mock the AWS helper's create_boto3_client method to avoid boto3 client creation
+    with patch(
+        'awslabs.aws_dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client',
+        return_value=MagicMock(),
+    ):
+        # Initialize the Glue Data Catalog handler with the mock MCP server
+        CrawlerHandler(mock_mcp)
+
+        # Verify that the tools were registered
+        assert mock_mcp.tool.call_count > 0
+
+        # Get all call args
+        call_args_list = mock_mcp.tool.call_args_list
+
+        # Get all tool names that were registered
+        tool_names = [call_args[1]['name'] for call_args in call_args_list]
+
+        # Verify that expected tools are registered
+        assert 'manage_aws_glue_crawlers' in tool_names
 
 
 @pytest.mark.asyncio

--- a/src/aws-dataprocessing-mcp-server/tests/test_server.py
+++ b/src/aws-dataprocessing-mcp-server/tests/test_server.py
@@ -174,7 +174,7 @@ async def test_command_line_args():
                     'awslabs.aws_dataprocessing_mcp_server.server.GlueDataCatalogHandler'
                 ) as mock_glue_data_catalog_handler:
                     with patch(
-                        'awslabs.dataprocessing_mcp_server.server.CrawlerHandler'
+                        'awslabs.aws_dataprocessing_mcp_server.server.CrawlerHandler'
                     ) as mock_crawler_handler:
                         # Call the main function
                         main()
@@ -216,7 +216,7 @@ async def test_command_line_args():
                     'awslabs.aws_dataprocessing_mcp_server.server.GlueDataCatalogHandler'
                 ) as mock_glue_data_catalog_handler:
                     with patch(
-                        'awslabs.dataprocessing_mcp_server.server.CrawlerHandler'
+                        'awslabs.aws_dataprocessing_mcp_server.server.CrawlerHandler'
                     ) as mock_crawler_handler:
                         # Call the main function
                         main()

--- a/src/aws-dataprocessing-mcp-server/uv.lock
+++ b/src/aws-dataprocessing-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-dataprocessing-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

> Adds AWS Glue Crawler MCP tools to the dataprocessing-mcp-server. It introduces a new CrawlerHandler class that provides comprehensive operations for managing AWS Glue crawlers, classifiers, and crawler schedules through the Model Context Protocol (MCP).

The new tools enable:

- Create, manage, and monitor AWS Glue crawlers for automated data discovery
- Configure and customize data classifiers for accurate schema detection
- Schedule and monitor crawler operations for efficient metadata extraction

** CrawlerHandler Class ** 
The CrawlerHandler class is implemented in `src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/crawler_handler.py` and provides the following MCP tools:

1. manage_aws_glue_crawlers

 - Operations:
   - `create-crawler`: Create a new crawler with specified targets, role, and configuration
   - `delete-crawler`: Remove an existing crawler from AWS Glue
   - `get-crawler`: Retrieve detailed information about a specific crawler
   - `get-crawlers`: List all crawlers with pagination
   - `batch-get-crawlers`: Retrieve multiple specific crawlers in a single call
   - `list-crawlers`: List all crawlers with tag-based filtering
   - `start-crawler`: Initiate a crawler run immediately
   - `stop-crawler`: Halt a currently running crawler
   - `update-crawler`: Modify an existing crawler's configuration

2. manage_aws_glue_classifiers

 - Operations:
  - `create-classifier`: Create a new custom classifier (CSV, JSON, XML, or GROK)
  - `delete-classifier`: Remove an existing classifier
  - `get-classifier`: Retrieve detailed information about a specific classifier
  - `get-classifiers`: List all available classifiers
  - `update-classifier`: Modify an existing classifier's configuration


3. manage_aws_glue_crawler_management

- Operations:
  - `get-crawler-metrics: Retrieve performance statistics about crawlers
  - `start-crawler-schedule`: Activate a crawler's schedule
  - `stop-crawler-schedule`: Deactivate a crawler's schedule
  - `update-crawler-schedule`: Modify a crawler's schedule with a new cron expression

The handler follows the same security model as other handlers in the server, with read-only operations available by default and write operations requiring the --allow-write flag.



### User experience

#### Before this change
Before this change, users could manage AWS Glue Data Catalog resources (databases, tables, partitions) through the MCP server, but had no way to automate the data discovery and schema detection process using AWS Glue crawlers. Users had to manually create and manage crawlers through the AWS Console or CLI, then separately work with the resulting metadata in the Data Catalog.

#### After this change
With this change, users can now use natural language to:

 - Create and configure crawlers that automatically discover and catalog data from various sources (S3, JDBC, DynamoDB, etc.)
 - Define custom classifiers to accurately determine data formats and schemas
 - Schedule crawler runs for regular data discovery
 - Monitor crawler performance and status
 - Manage the complete data discovery and cataloging workflow within the same interface

This creates an end-to-end experience where users can discover data, catalog it, and then process it using the existing ETL job capabilities, all through natural language interactions with AI code assistants.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
