### PR TITLE
fix(aws-dataprocessing-mcp-server): apply next_token on list operation and add get-catalogs MCP tool

### DIFF
--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_database_manager.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_database_manager.py
@@ -335,6 +335,7 @@ class DataCatalogDatabaseManager:
 
             response = self.glue_client.get_databases(**kwargs)
             databases = response.get('DatabaseList', [])
+            next_token = response.get('NextToken', None)  # Capture the next token for paginatio
 
             log_with_request_id(
                 ctx, LogLevel.INFO, f'Successfully listed {len(databases)} databases'
@@ -358,6 +359,7 @@ class DataCatalogDatabaseManager:
                 count=len(databases),
                 catalog_id=catalog_id,
                 operation='list-databases',
+                next_token=next_token,
                 content=[TextContent(type='text', text=success_msg)],
             )
 

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_handler.py
@@ -30,6 +30,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.data_catalog_models import (
     GetCatalogResponse,
     GetConnectionResponse,
     GetPartitionResponse,
+    ImportCatalogResponse,
+    ListCatalogsResponse,
     ListConnectionsResponse,
     ListPartitionsResponse,
     PartitionSummary,
@@ -1248,4 +1250,141 @@ class DataCatalogManager:
                 description='',
                 create_time='',
                 update_time='',
+            )
+
+    async def import_catalog_to_glue(
+        self,
+        ctx: Context,
+        catalog_id: str,
+    ) -> ImportCatalogResponse:
+        """Import metadata from an external source into the AWS Glue Data Catalog.
+
+        Imports metadata from external sources such as Hive metastores, Apache Spark,
+        or other compatible metadata repositories into the AWS Glue Data Catalog.
+        This operation can be used to migrate metadata from on-premises systems to AWS.
+
+        Args:
+            ctx: MCP context containing request information
+            catalog_id: ID of the catalog to import into
+
+        Returns:
+            ImportCatalogResponse with the result of the operation
+        """
+        try:
+            # Prepare import parameters
+            import_params = {
+                'CatalogId': catalog_id,
+            }
+
+            # Start the import process
+            self.glue_client.import_catalog_to_glue(**import_params)
+
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Successfully initiated catalog import Athena Data Catalog {catalog_id} to Glue',
+            )
+
+            success_msg = f'Successfully initiated catalog import from Athena Data Catalog {catalog_id} to Glue'
+            return ImportCatalogResponse(
+                isError=False,
+                catalog_id=catalog_id,
+                operation='import-catalog-to-glue',
+                content=[TextContent(type='text', text=success_msg)],
+            )
+
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            error_message = f'Failed to import Athena data catalog {catalog_id} to Glue: {error_code} - {e.response["Error"]["Message"]}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+            return ImportCatalogResponse(
+                isError=True,
+                catalog_id=catalog_id,
+                operation='import-catalog-to-glue',
+                content=[TextContent(type='text', text=error_message)],
+            )
+
+    async def list_catalogs(
+        self,
+        ctx: Context,
+        max_results: Optional[int] = None,
+        next_token: Optional[str] = None,
+        parent_catalog_id: Optional[str] = None,
+    ) -> ListCatalogsResponse:
+        """List all catalogs in AWS Glue.
+
+        Retrieves a list of all catalogs with their basic properties. Supports
+        pagination through the next_token parameter.
+
+        Args:
+            ctx: MCP context containing request information
+            max_results: Optional maximum number of results to return
+            next_token: Optional pagination token for retrieving the next set of results
+            parent_catalog_id: Optional parent catalog which the catalog resides
+
+        Returns:
+            ListCatalogsResponse with the list of catalogs
+        """
+        try:
+            kwargs: Dict[str, Any] = {}
+            if max_results:
+                kwargs['MaxResults'] = max_results
+            if next_token:
+                kwargs['NextToken'] = next_token
+            if parent_catalog_id:
+                kwargs['ParentCatalogId'] = parent_catalog_id
+
+            response = self.glue_client.get_catalogs(**kwargs)
+            catalogs = response.get('CatalogList', [])
+            next_token_response = response.get('NextToken', None)
+
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Successfully listed {len(catalogs)} catalogs',
+            )
+
+            success_msg = f'Successfully listed {len(catalogs)} catalogs'
+            return ListCatalogsResponse(
+                isError=False,
+                catalogs=[
+                    {
+                        'catalog_id': catalog.get('CatalogId', ''),
+                        'name': catalog.get('Name', ''),
+                        'description': catalog.get('Description', ''),
+                        'parameters': catalog.get('Parameters', {}),
+                        'create_time': (
+                            catalog.get('CreateTime', '').isoformat()
+                            if catalog.get('CreateTime')
+                            else ''
+                        ),
+                        'update_time': (
+                            catalog.get('UpdateTime', '').isoformat()
+                            if catalog.get('UpdateTime')
+                            else ''
+                        ),
+                    }
+                    for catalog in catalogs
+                ],
+                count=len(catalogs),
+                next_token=next_token_response,
+                operation='get-catalogs',
+                content=[TextContent(type='text', text=success_msg)],
+            )
+
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            error_message = (
+                f'Failed to list catalogs: {error_code} - {e.response["Error"]["Message"]}'
+            )
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+            return ListCatalogsResponse(
+                isError=True,
+                catalogs=[],
+                count=0,
+                next_token=None,
+                operation='get-catalogs',
+                content=[TextContent(type='text', text=error_message)],
             )

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_table_manager.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_table_manager.py
@@ -395,6 +395,7 @@ class DataCatalogTableManager:
 
             response = self.glue_client.get_tables(**kwargs)
             tables = response.get('TableList', [])
+            next_token_response = response.get('NextToken', None)
 
             log_with_request_id(
                 ctx,
@@ -433,6 +434,7 @@ class DataCatalogTableManager:
                 ],
                 count=len(tables),
                 operation='list-tables',
+                next_token=next_token_response,
                 content=[TextContent(type='text', text=success_msg)],
             )
 

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
@@ -125,6 +125,13 @@ class GlueDataCatalogHandler:
             None,
             description='ID of the catalog (optional, defaults to account ID).',
         ),
+        max_results: Optional[int] = Field(
+            None, description='The maximum number of databases to return in one response.'
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description='A continuation token, if this is a continuation call.',
+        ),
     ) -> Union[
         CreateDatabaseResponse,
         DeleteDatabaseResponse,
@@ -162,6 +169,8 @@ class GlueDataCatalogHandler:
             location_uri: Location URI of the database
             parameters: Additional parameters for the database
             catalog_id: ID of the catalog (optional, defaults to account ID)
+            max_results: The maximum number of databases to return in one response.
+            next_token: A continuation string token, if this is a continuation call.
 
         Returns:
             Union of response types specific to the operation performed
@@ -243,7 +252,7 @@ class GlueDataCatalogHandler:
 
             elif operation == 'list-databases' or operation == 'list':
                 return await self.data_catalog_database_manager.list_databases(
-                    ctx=ctx, catalog_id=catalog_id
+                    ctx=ctx, catalog_id=catalog_id, next_token=next_token, max_results=max_results
                 )
 
             elif operation == 'update-database' or operation == 'update':
@@ -323,6 +332,9 @@ class GlueDataCatalogHandler:
             None,
             description='Maximum number of results to return for list and search-tables operations.',
         ),
+        next_token: Optional[str] = Field(
+            None, description='A continuation token, included if this is a continuation call.'
+        ),
     ) -> Union[
         CreateTableResponse,
         DeleteTableResponse,
@@ -364,6 +376,7 @@ class GlueDataCatalogHandler:
             table_input: Table definition
             search_text: Search text for search operation
             max_results: Maximum results to return
+            next_token: A continuation string token, if this is a continuation call
 
         Returns:
             Union of response types specific to the operation performed
@@ -487,6 +500,7 @@ class GlueDataCatalogHandler:
                     database_name=database_name,
                     max_results=max_results,
                     catalog_id=catalog_id,
+                    next_token=next_token,
                 )
 
             elif operation == 'update-table' or operation == 'update':
@@ -559,6 +573,12 @@ class GlueDataCatalogHandler:
             None,
             description='Catalog ID for the connection (optional, defaults to account ID).',
         ),
+        max_results: Optional[int] = Field(
+            None, description='The maximum number of connections to return in one response.'
+        ),
+        next_token: Optional[str] = Field(
+            None, description='A continuation token, if this is a continuation call.'
+        ),
     ) -> Union[
         CreateConnectionResponse,
         DeleteConnectionResponse,
@@ -596,6 +616,8 @@ class GlueDataCatalogHandler:
             connection_name: Name of the connection
             connection_input: Connection definition
             catalog_id: Catalog ID for the connection
+            max_results: Maximum results to return
+            next_token: A continuation string token, if this is a continuation call
 
         Returns:
             Union of response types specific to the operation performed
@@ -706,7 +728,7 @@ class GlueDataCatalogHandler:
 
             elif operation == 'list-connections' or operation == 'list':
                 return await self.data_catalog_manager.list_connections(
-                    ctx=ctx, catalog_id=catalog_id
+                    ctx=ctx, catalog_id=catalog_id, max_results=max_results, next_token=next_token
                 )
 
             elif operation == 'update-connection' or operation == 'update':
@@ -790,6 +812,10 @@ class GlueDataCatalogHandler:
             None,
             description='Maximum number of results to return for list-partitions operation.',
         ),
+        next_token: Optional[str] = Field(
+            None,
+            description='A continuation token, if this is not the first call to retrieve these partitions.',
+        ),
         expression: Optional[str] = Field(
             None,
             description='Filter expression for list-partitions operation.',
@@ -836,6 +862,7 @@ class GlueDataCatalogHandler:
             partition_values: Values that define the partition
             partition_input: Partition definition
             max_results: Maximum results to return
+            next_token: A continuation token, if this is not the first call to retrieve these partitions
             expression: Filter expression for list-partitions operation
             catalog_id: ID of the catalog (optional, defaults to account ID)
 
@@ -956,6 +983,7 @@ class GlueDataCatalogHandler:
                     max_results=max_results,
                     expression=expression,
                     catalog_id=catalog_id,
+                    next_token=next_token,
                 )
 
             elif operation == 'update-partition' or operation == 'update':
@@ -1019,9 +1047,15 @@ class GlueDataCatalogHandler:
             None,
             description='Catalog definition for create-catalog operations.',
         ),
-        import_source: Optional[str] = Field(
+        max_results: Optional[int] = Field(
+            None, description='The maximum number of catalogs to return in one response.'
+        ),
+        next_token: Optional[str] = Field(
+            None, description='A continuation token, if this is a continuation call.'
+        ),
+        parent_catalog_id: Optional[str] = Field(
             None,
-            description='Source for import operations (e.g., Hive metastore URI).',
+            description='The ID of the parent catalog in which the catalog resides. If none is provided, the AWS Account Number is used by default.',
         ),
     ) -> Union[
         CreateCatalogResponse,
@@ -1058,7 +1092,9 @@ class GlueDataCatalogHandler:
             operation: Operation to perform
             catalog_id: ID of the catalog
             catalog_input: Catalog definition
-            import_source: Source for import operations
+            max_results: The maximum number of catalogs to return in one response
+            next_token: A continuation token, if this is a continuation call.
+            parent_catalog_id: The ID of the parent catalog in which the catalog resides
 
         Returns:
             Union of response types specific to the operation performed
@@ -1087,34 +1123,30 @@ class GlueDataCatalogHandler:
         try:
             if not self.allow_write and operation not in [
                 'get-catalog',
-                'get',
                 'list-catalogs',
-                'list',
             ]:
                 error_message = f'Operation {operation} is not allowed without write access'
                 log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-                if operation == 'create-catalog' or operation == 'create':
+                if operation == 'create-catalog':
                     return CreateCatalogResponse(
                         isError=True,
                         content=[TextContent(type='text', text=error_message)],
                         catalog_id='',
                         operation='create-catalog',
                     )
-                elif operation == 'delete-catalog' or operation == 'delete':
+                elif operation == 'delete-catalog':
                     return DeleteCatalogResponse(
                         isError=True,
                         content=[TextContent(type='text', text=error_message)],
                         catalog_id='',
                         operation='delete-catalog',
                     )
-                elif operation == 'import-catalog-to-glue' or operation == 'import':
+                elif operation == 'import-catalog-to-glue':
                     return ImportCatalogResponse(
                         isError=True,
                         content=[TextContent(type='text', text=error_message)],
                         catalog_id='',
-                        import_status='',
-                        import_source='',
                         operation='import-catalog-to-glue',
                     )
                 else:
@@ -1130,7 +1162,7 @@ class GlueDataCatalogHandler:
                         operation='get-catalog',
                     )
 
-            if operation == 'create-catalog' or operation == 'create':
+            if operation == 'create-catalog':
                 if catalog_id is None or catalog_input is None:
                     raise ValueError(
                         'catalog_id and catalog_input are required for create-catalog operation'
@@ -1139,49 +1171,32 @@ class GlueDataCatalogHandler:
                     ctx=ctx, catalog_name=catalog_id, catalog_input=catalog_input
                 )
 
-            elif operation == 'delete-catalog' or operation == 'delete':
+            elif operation == 'delete-catalog':
                 if catalog_id is None:
                     raise ValueError('catalog_id is required for delete-catalog operation')
                 return await self.data_catalog_manager.delete_catalog(
                     ctx=ctx, catalog_id=catalog_id
                 )
 
-            elif operation == 'get-catalog' or operation == 'get':
+            elif operation == 'get-catalog':
                 if catalog_id is None:
                     raise ValueError('catalog_id is required for get-catalog operation')
                 return await self.data_catalog_manager.get_catalog(ctx=ctx, catalog_id=catalog_id)
 
-            elif operation == 'list-catalogs' or operation == 'list':
-                # This method might not be implemented yet
-                error_message = 'list-catalogs operation is not implemented yet'
-                log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                return GetCatalogResponse(
-                    isError=True,
-                    content=[TextContent(type='text', text=error_message)],
-                    catalog_id='',
-                    catalog_definition={},
-                    name='',
-                    description='',
-                    create_time='',
-                    update_time='',
-                    operation='get-catalog',
+            elif operation == 'list-catalogs':
+                return await self.data_catalog_manager.list_catalogs(
+                    ctx=ctx,
+                    max_results=max_results,
+                    next_token=next_token,
+                    parent_catalog_id=parent_catalog_id,
                 )
 
-            elif operation == 'import-catalog-to-glue' or operation == 'import':
-                if catalog_id is None or import_source is None:
-                    raise ValueError(
-                        'catalog_id and import_source are required for import-catalog-to-glue operation'
-                    )
-                # This method might not be implemented yet
-                error_message = 'import-catalog-to-glue operation is not implemented yet'
-                log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                return ImportCatalogResponse(
-                    isError=True,
-                    catalog_id='',
-                    content=[TextContent(type='text', text=error_message)],
-                    import_status='',
-                    import_source='',
-                    operation='import-catalog-to-glue',
+            elif operation == 'import-catalog-to-glue':
+                if catalog_id is None:
+                    raise ValueError('catalog_id is required for import-catalog-to-glue operation')
+                return await self.data_catalog_manager.import_catalog_to_glue(
+                    ctx=ctx,
+                    catalog_id=catalog_id,
                 )
             else:
                 error_message = f'Invalid operation: {operation}. Must be one of: create-catalog, delete-catalog, get-catalog, list-catalogs, import-catalog-to-glue'

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/data_catalog_models.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/data_catalog_models.py
@@ -136,6 +136,7 @@ class ListDatabasesResponse(CallToolResult):
     count: int = Field(..., description='Number of databases found')
     catalog_id: Optional[str] = Field(None, description='Catalog ID used for listing')
     operation: str = Field(default='list', description='Operation performed')
+    next_token: Optional[str] = Field(None, description='Token for the next page of results')
 
 
 class UpdateDatabaseResponse(CallToolResult):
@@ -373,8 +374,6 @@ class ImportCatalogResponse(CallToolResult):
     """Response model for import catalog operation."""
 
     catalog_id: str = Field(..., description='ID of the catalog being imported to')
-    import_status: str = Field(..., description='Status of the import operation')
-    import_source: str = Field(..., description='Source of the import operation')
     operation: str = Field(default='import', description='Operation performed')
 
 

--- a/src/aws-dataprocessing-mcp-server/uv.lock
+++ b/src/aws-dataprocessing-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-dataprocessing-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

- Apply next token to AWS Glue Catalog list operation
- Add `get-catalogs` operation to MCP tool
- Fix `import-catalog-to-glue` operation to take the correct parameters

### User experience

#### Before this change
- `list-catalogs` is not available to use in data processing MCP tool
- `import-catalog-to-glue` operation fail to function due to incorrect parameter is provided
- Not able to get next page for all list operation due to `next_token` not applied

#### After this change
- `list-catalogs` operation is available for AI assistant
- `import-catalog-to-glue` operation is available to function
- All list operation is able to flip pages result with `next_token` 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
