### PR TITLE
fix(aws-dataprocessing-mcp-server): Fixed MCP managed tagging issue in AWS Glue Data Catalog MCP tools

### DIFF
--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_database_manager.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_database_manager.py
@@ -96,9 +96,6 @@ class DataCatalogDatabaseManager:
                 for k, v in parameters.items():
                     database_input[k] = v
 
-            # Remove complex types for now as they're causing type errors
-            # We can add them back with proper handling if needed
-
             # Add MCP management tags
             resource_tags = AwsHelper.prepare_resource_tags('GlueDatabase')
 

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_handler.py
@@ -236,7 +236,7 @@ class DataCatalogManager:
         ctx: Context,
         connection_name: str,
         catalog_id: Optional[str] = None,
-        hide_password: bool = False,
+        hide_password: Optional[bool] = None,
         apply_override_for_compute_environment: Optional[str] = None,
     ) -> GetConnectionResponse:
         """Get details of a connection from the AWS Glue Data Catalog.
@@ -255,11 +255,11 @@ class DataCatalogManager:
             GetConnectionResponse with the connection details
         """
         try:
-            kwargs = {'Name': connection_name}
+            kwargs: Dict[str, Any] = {'Name': connection_name}
             if catalog_id:
                 kwargs['CatalogId'] = catalog_id
             if hide_password:
-                kwargs['HidePassword'] = str(hide_password).lower()
+                kwargs['HidePassword'] = hide_password
             if apply_override_for_compute_environment:
                 kwargs['ApplyOverrideForComputeEnvironment'] = (
                     apply_override_for_compute_environment
@@ -333,7 +333,7 @@ class DataCatalogManager:
         ctx: Context,
         catalog_id: Optional[str] = None,
         filter_dict: Optional[Dict[str, Any]] = None,
-        hide_password: bool = False,
+        hide_password: Optional[bool] = None,
         next_token: Optional[str] = None,
         max_results: Optional[int] = None,
     ) -> ListConnectionsResponse:
@@ -842,7 +842,7 @@ class DataCatalogManager:
             if catalog_id:
                 kwargs['CatalogId'] = catalog_id
             if max_results:
-                kwargs['MaxResults'] = str(max_results)
+                kwargs['MaxResults'] = max_results
             if expression:
                 kwargs['Expression'] = expression
             if segment:

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_table_manager.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_table_manager.py
@@ -106,7 +106,6 @@ class DataCatalogTableManager:
             kwargs = {
                 'DatabaseName': database_name,
                 'TableInput': table_input,
-                'Tags': resource_tags,
             }
 
             # Note: kwargs already defined above with Tags included
@@ -638,6 +637,7 @@ class DataCatalogTableManager:
 
             response = self.glue_client.search_tables(**kwargs)
             tables = response.get('TableList', [])
+            next_token_response = response.get('NextToken', None)
 
             log_with_request_id(ctx, LogLevel.INFO, f'Search found {len(tables)} tables')
 
@@ -672,6 +672,7 @@ class DataCatalogTableManager:
                 search_text=search_text or '',
                 count=len(tables),
                 operation='search-tables',
+                next_token=next_token_response,
                 content=[TextContent(type='text', text=success_msg)],
             )
 

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
@@ -575,7 +575,7 @@ class GlueDataCatalogHandler:
             None, description='A continuation token, if this is a continuation call.'
         ),
         hide_password: Optional[bool] = Field(
-            None,
+            True,
             description='Flag to retrieve the connection metadata without returning the password(for get-connection and list-connections operation).',
         ),
     ) -> Union[

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
@@ -574,6 +574,10 @@ class GlueDataCatalogHandler:
         next_token: Optional[str] = Field(
             None, description='A continuation token, if this is a continuation call.'
         ),
+        hide_password: Optional[bool] = Field(
+            None,
+            description='Flag to retrieve the connection metadata without returning the password(for get-connection and list-connections operation).',
+        ),
     ) -> Union[
         CreateConnectionResponse,
         DeleteConnectionResponse,
@@ -613,6 +617,7 @@ class GlueDataCatalogHandler:
             catalog_id: Catalog ID for the connection
             max_results: Maximum results to return
             next_token: A continuation string token, if this is a continuation call
+            hide_password: The boolean flag to control connection password in return value for get-connection and list-connections operation
 
         Returns:
             Union of response types specific to the operation performed
@@ -716,12 +721,19 @@ class GlueDataCatalogHandler:
                 if connection_name is None:
                     raise ValueError('connection_name is required for get operation')
                 return await self.data_catalog_manager.get_connection(
-                    ctx=ctx, connection_name=connection_name, catalog_id=catalog_id
+                    ctx=ctx,
+                    connection_name=connection_name,
+                    catalog_id=catalog_id,
+                    hide_password=hide_password,
                 )
 
             elif operation == 'list-connections':
                 return await self.data_catalog_manager.list_connections(
-                    ctx=ctx, catalog_id=catalog_id, max_results=max_results, next_token=next_token
+                    ctx=ctx,
+                    catalog_id=catalog_id,
+                    max_results=max_results,
+                    next_token=next_token,
+                    hide_password=hide_password,
                 )
 
             elif operation == 'update-connection':

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/data_catalog_models.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/models/data_catalog_models.py
@@ -207,6 +207,7 @@ class SearchTablesResponse(CallToolResult):
     search_text: str = Field(..., description='Search text used for matching')
     count: int = Field(..., description='Number of tables found')
     operation: str = Field(default='search', description='Operation performed')
+    next_token: Optional[str] = Field('', description='Token for pagination')
 
 
 # Connection Response Models

--- a/src/aws-dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_handler.py
@@ -263,7 +263,6 @@ class TestDataCatalogManager:
         connection_properties = {
             'JDBC_CONNECTION_URL': 'jdbc:mysql://localhost:3306/test',
             'USERNAME': 'test-user',
-            'PASSWORD': 'test-password',  # pragma: allowlist secret
         }
         creation_time = datetime(2023, 1, 1, 0, 0, 0)
         last_updated_time = datetime(2023, 1, 2, 0, 0, 0)
@@ -289,7 +288,7 @@ class TestDataCatalogManager:
 
         # Verify that the Glue client was called with the correct parameters
         mock_glue_client.get_connection.assert_called_once_with(
-            Name=connection_name, CatalogId=catalog_id, HidePassword='true'
+            Name=connection_name, CatalogId=catalog_id, HidePassword=True
         )
 
         # Verify the response
@@ -568,7 +567,7 @@ class TestDataCatalogManager:
         mock_glue_client.get_partitions.assert_called_once_with(
             DatabaseName=database_name,
             TableName=table_name,
-            MaxResults=str(max_results),
+            MaxResults=max_results,
             Expression=expression,
             CatalogId=catalog_id,
         )
@@ -1654,7 +1653,7 @@ class TestDataCatalogManager:
         mock_glue_client.get_connection.assert_called_once_with(
             Name=connection_name,
             CatalogId=catalog_id,
-            HidePassword='true',  # pragma: allowlist secret
+            HidePassword=True,
             ApplyOverrideForComputeEnvironment=apply_override_for_compute_environment,
         )
 
@@ -1886,7 +1885,7 @@ class TestDataCatalogManager:
         mock_glue_client.get_partitions.assert_called_once_with(
             DatabaseName=database_name,
             TableName=table_name,
-            MaxResults=str(max_results),
+            MaxResults=max_results,
             Expression=expression,
             CatalogId=catalog_id,
             Segment=segment,

--- a/src/aws-dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_table_manager.py
+++ b/src/aws-dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_table_manager.py
@@ -85,7 +85,7 @@ class TestDataCatalogTableManager:
         # Mock the AWS helper prepare_resource_tags method
         with patch(
             'awslabs.aws_dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags',
-            return_value={'mcp:managed': 'true'},
+            return_value={'ManagedBy': 'DataprocessingMCPServer'},
         ):
             # Call the method
             result = await manager.create_table(
@@ -109,10 +109,7 @@ class TestDataCatalogTableManager:
             assert call_args['CatalogId'] == catalog_id
 
             # Verify that the MCP tags were added to Parameters
-            assert call_args['TableInput']['Parameters']['mcp:managed'] == 'true'
-
-            # Verify that the tags were added
-            assert call_args['Tags'] == {'mcp:managed': 'true'}
+            assert call_args['TableInput']['Parameters']['ManagedBy'] == 'DataprocessingMCPServer'
 
             # Verify the response
             assert isinstance(result, CreateTableResponse)

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/glue/test_data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/glue/test_data_catalog_handler.py
@@ -656,7 +656,7 @@ class TestGlueDataCatalogHandler:
         # Verify that the method was called with the correct parameters
         # Use ANY for catalog_id to handle the FieldInfo object
         mock_catalog_manager.get_connection.assert_called_once_with(
-            ctx=mock_ctx, connection_name='test-connection', catalog_id=ANY
+            ctx=mock_ctx, connection_name='test-connection', catalog_id=ANY, hide_password=ANY
         )
 
         # Verify that the result is the expected response

--- a/src/aws-dataprocessing-mcp-server/uv.lock
+++ b/src/aws-dataprocessing-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-dataprocessing-mcp-server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

- Fixed MCP managed tagging issue in AWS Glue Data Catalog MCP tools
- Remove incorrect param in `create-table` call
- Enable hide-password by default for get/list connections operations

### User experience

#### Before this change
- `Create-table` fail due to unable to append mcp managed tag
- Password is displayed from Glue get/list connection reponse

#### After this change
- `create-table` is able to create resource and append the correct tag
- connection password is hidden from AWS Glue API response

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
