### PR TITLE
chore(dataprocessing-mcp-server): Add Service owners for Data Processing MCP server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@ NOTICE                                @awslabs/mcp-admins
 /src/core-mcp-server                    @PaulVincent707                  @awslabs/mcp-admins
 #/src/cost-analysis-mcp-server          @awslabs/mcp-maintainers         @awslabs/mcp-admins
 /src/cost-explorer-mcp-server           @Fedayizada                      @awslabs/mcp-admins
-/src/dataprocessing-mcp-server          @naikvaib @LiyuanLD @ckha2000 @raghav1397 @chappidim @rajendrag @yuxiaorun                      @awslabs/mcp-admins
+/src/aws-dataprocessing-mcp-server          @naikvaib @LiyuanLD @ckha2000 @raghav1397 @chappidim @rajendrag @yuxiaorun                      @awslabs/mcp-admins
 #/src/documentdb-mcp-server             @awslabs/mcp-maintainers         @awslabs/mcp-admin
 /src/dynamodb-mcp-server                @erbenmo                         @awslabs/mcp-admins
 /src/ecs-mcp-server                     @karanbokil @matthewgoodman13    @awslabs/mcp-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@ NOTICE                                @awslabs/mcp-admins
 /src/core-mcp-server                    @PaulVincent707                  @awslabs/mcp-admins
 #/src/cost-analysis-mcp-server          @awslabs/mcp-maintainers         @awslabs/mcp-admins
 /src/cost-explorer-mcp-server           @Fedayizada                      @awslabs/mcp-admins
-/src/dataprocessing-mcp-server          @naikvaib                        @awslabs/mcp-admins
+/src/dataprocessing-mcp-server          @naikvaib @LiyuanLD @ckha2000 @raghav1397 @chappidim @rajendrag @yuxiaorun                      @awslabs/mcp-admins
 #/src/documentdb-mcp-server             @awslabs/mcp-maintainers         @awslabs/mcp-admin
 /src/dynamodb-mcp-server                @erbenmo                         @awslabs/mcp-admins
 /src/ecs-mcp-server                     @karanbokil @matthewgoodman13    @awslabs/mcp-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@ NOTICE                                @awslabs/mcp-admins
 /src/core-mcp-server                    @PaulVincent707                  @awslabs/mcp-admins
 #/src/cost-analysis-mcp-server          @awslabs/mcp-maintainers         @awslabs/mcp-admins
 /src/cost-explorer-mcp-server           @Fedayizada                      @awslabs/mcp-admins
-/src/aws-dataprocessing-mcp-server          @naikvaib @LiyuanLD @ckha2000 @raghav1397 @chappidim @rajendrag @yuxiaorun                      @awslabs/mcp-admins
+/src/aws-dataprocessing-mcp-server          @naikvaib @LiyuanLD @ckha2000 @raghav1397 @chappidim @yuxiaorun                      @awslabs/mcp-admins
 #/src/documentdb-mcp-server             @awslabs/mcp-maintainers         @awslabs/mcp-admin
 /src/dynamodb-mcp-server                @erbenmo                         @awslabs/mcp-admins
 /src/ecs-mcp-server                     @karanbokil @matthewgoodman13    @awslabs/mcp-admins

--- a/src/aws-dataprocessing-mcp-server/README.md
+++ b/src/aws-dataprocessing-mcp-server/README.md
@@ -23,6 +23,14 @@ Integrating the DataProcessing MCP server into AI code assistants transforms dat
 * Step Execution: Orchestrates data processing workflows through EMR steps, allowing users to submit, monitor, and manage Hadoop, Spark, and other application jobs on running clusters.
 * Security Configuration: Manages EMR security settings including encryption, authentication, and authorization policies to ensure secure data processing environments.
 
+### Amazon Athena Integration
+
+* Query Execution: Enables users to execute, monitor, and manage SQL queries with comprehensive control over query lifecycle, including starting queries, retrieving results, monitoring performance statistics, and canceling running queries through natural language requests.
+* Named Query Management: Provides the ability to create, update, retrieve, and delete saved SQL queries, enabling users to build reusable query libraries with proper organization and team collaboration capabilities.
+* Data Catalog Operations: Manages Athena data catalogs with support for multiple catalog types (LAMBDA, GLUE, HIVE, FEDERATED), enabling users to create, configure, and maintain data source connections for cross-platform querying.
+* Database and Table Discovery: Facilitates data exploration through comprehensive database and table metadata retrieval, allowing users to discover available data sources, understand schema structures, and navigate data catalogs efficiently.
+* Workgroup Administration: Orchestrates query execution environments through workgroup management, providing cost control, access management, and query result configuration with support for different user groups and organizational policies.
+
 ## Prerequisites
 
 * [Install Python 3.10+](https://www.python.org/downloads/release/python-3100/)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Add Service owners for Data Processing MCP server
### Changes
1. Made changes in .github/codeowners to add more dataprocessing mcp owners

### User experience
> Before
Dataprocessing Code Owners needs to take approvals from away team, which added a lot of turnaround time
> After
Dataprocessing Code Owners would be able to accelerate pushes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
