### PR TITLE
docs(cost-analysis-mcp-server): Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Connect systems with messaging, workflows, and location services.
 
 Monitor, optimize, and manage your AWS infrastructure and costs.
 
-- **[Cost Analysis MCP Server](src/cost-analysis-mcp-server/)** - Pre-deployment cost estimation and optimization
+- **[Cost Analysis MCP Server (DEPRECATED)](src/cost-analysis-mcp-server/)** - Pre-deployment cost estimation and optimization
 - **[AWS Cost Explorer MCP Server](src/cost-explorer-mcp-server/)** - Detailed cost analysis and reporting
 - **[Amazon CloudWatch MCP Server](src/cloudwatch-mcp-server/)** - Metrics, Alarms, and Logs analysis and operational troubleshooting
 - **[Amazon CloudWatch Logs MCP Server (deprecated)](src/cloudwatch-logs-mcp-server/)** - Log analysis and operational troubleshooting
@@ -271,7 +271,7 @@ Interact with AWS HealthAI services.
 ##### Business Services
 
 - **[Amazon Location Service MCP Server](src/aws-location-mcp-server/)** - Location search, geocoding, and business hours
-- **[Cost Analysis MCP Server](src/cost-analysis-mcp-server/)** - Answer cost questions and provide estimates
+- **[Cost Analysis MCP Server (DEPRECATED)](src/cost-analysis-mcp-server/)** - Answer cost questions and provide estimates
 - **[AWS Cost Explorer MCP Server](src/cost-explorer-mcp-server/)** - Detailed cost analysis and spend reports
 
 #### 🤖 Autonomous Background Agents

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Connect systems with messaging, workflows, and location services.
 
 Monitor, optimize, and manage your AWS infrastructure and costs.
 
-- **[Cost Analysis MCP Server (DEPRECATED)](src/cost-analysis-mcp-server/)** - Pre-deployment cost estimation and optimization
+- **[Cost Analysis MCP Server (DEPRECATED)](src/cost-analysis-mcp-server/)** - Pre-deployment cost estimation and optimization: replaced by [AWS Pricing MCP Server](src/aws-pricing-mcp-server).
 - **[AWS Cost Explorer MCP Server](src/cost-explorer-mcp-server/)** - Detailed cost analysis and reporting
 - **[Amazon CloudWatch MCP Server](src/cloudwatch-mcp-server/)** - Metrics, Alarms, and Logs analysis and operational troubleshooting
 - **[Amazon CloudWatch Logs MCP Server (deprecated)](src/cloudwatch-logs-mcp-server/)** - Log analysis and operational troubleshooting

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,9 @@ The Bedrock Knowledge Base Retrieval MCP Server enables AI assistants to retriev
 
 [Learn more about the Bedrock Knowledge Base Retrieval MCP Server](servers/bedrock-kb-retrieval-mcp-server.md)
 
-### Cost Analysis MCP Server
+### Cost Analysis MCP Server (DEPRECATED)
+
+>DEPRECATED. Please use the AWS Pricing MCP Server instead.
 
 The Cost Analysis MCP Server enables AI assistants to analyze the cost of AWS services.
 

--- a/src/cost-analysis-mcp-server/README.md
+++ b/src/cost-analysis-mcp-server/README.md
@@ -1,6 +1,6 @@
-# Cost Analysis MCP Server
+# Cost Analysis MCP Server (DEPRECATED)
 
-MCP server for generating upfront AWS service cost estimates and providing cost insights
+MCP server for generating upfront AWS service cost estimates and providing cost insights. (DEPRECATED). Please use the AWS Pricing MCP Server for AWS service pricing related tools.
 
 **Important Note**: This server provides estimated pricing based on AWS pricing APIs and web pages. These estimates are for pre-deployment planning purposes and do not reflect the actual expenses of deployed cloud services.
 
@@ -35,6 +35,8 @@ MCP server for generating upfront AWS service cost estimates and providing cost 
    - Ensure your IAM role/user has permissions to access AWS Pricing API
 
 ## Installation
+
+(DEPRECATED). Please use the AWS Pricing MCP Server for AWS service pricing related tools.
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=awslabs.cost-analysis-mcp-server&config=eyJjb21tYW5kIjoidXZ4IGF3c2xhYnMuY29zdC1hbmFseXNpcy1tY3Atc2VydmVyQGxhdGVzdCIsImVudiI6eyJGQVNUTUNQX0xPR19MRVZFTCI6IkVSUk9SIiwiQVdTX1BST0ZJTEUiOiJ5b3VyLWF3cy1wcm9maWxlIn0sImRpc2FibGVkIjpmYWxzZSwiYXV0b0FwcHJvdmUiOltdfQ%3D%3D)
 

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -60,7 +60,7 @@ async def create_error_response(
 
 mcp = FastMCP(
     name='awslabs.cost-analysis-mcp-server',
-    instructions="""Use this server for analyzing AWS service costs, with a focus on serverless services.
+    instructions="""IMPORTANT: This server is deprecated. Please use the AWS Pricing MCP Server instead. Use this server for analyzing AWS service costs, with a focus on serverless services.
 
     REQUIRED WORKFLOW:
     Analyze costs of AWS services by following these steps in order:
@@ -114,7 +114,7 @@ logger.info(f'Using AWS profile {profile_name}')
 
 @mcp.tool(
     name='analyze_cdk_project',
-    description='Analyze a CDK project to identify AWS services used. This tool dynamically extracts service information from CDK constructs without relying on hardcoded service mappings.',
+    description='IMPORTANT: This tool is deprecated. Please use the analyze_cdk_project tool in the AWS Pricing MCP Server instead. Analyze a CDK project to identify AWS services used. This tool dynamically extracts service information from CDK constructs without relying on hardcoded service mappings.',
 )
 async def analyze_cdk_project_wrapper(
     ctx: Context,
@@ -149,7 +149,7 @@ async def analyze_cdk_project_wrapper(
 
 @mcp.tool(
     name='analyze_terraform_project',
-    description='Analyze a Terraform project to identify AWS services used. This tool dynamically extracts service information from Terraform resource declarations.',
+    description='IMPORTANT: This tool is deprecated. Please use the analyze_terraform_project tool in the AWS Pricing MCP Server instead. Analyze a Terraform project to identify AWS services used. This tool dynamically extracts service information from Terraform resource declarations.',
 )
 async def analyze_terraform_project_wrapper(
     ctx: Context,
@@ -184,7 +184,7 @@ async def analyze_terraform_project_wrapper(
 
 @mcp.tool(
     name='get_pricing_from_web',
-    description='Get pricing information from AWS pricing webpage. Service codes typically use lowercase with hyphens format (e.g., "opensearch-service" for both OpenSearch and OpenSearch Serverless, "api-gateway", "lambda"). Note that some services like OpenSearch Serverless are part of broader service codes (use "opensearch-service" not "opensearch-serverless"). Important: Web service codes differ from API service codes (e.g., use "opensearch-service" for web but "AmazonES" for API). When retrieving foundation model pricing, always use the latest models for comparison rather than specific named ones that may become outdated.',
+    description='IMPORTANT: This tool is deprecated. Please use the get_pricing tool in the AWS Pricing MCP Server instead. Get pricing information from AWS pricing webpage. Service codes typically use lowercase with hyphens format (e.g., "opensearch-service" for both OpenSearch and OpenSearch Serverless, "api-gateway", "lambda"). Note that some services like OpenSearch Serverless are part of broader service codes (use "opensearch-service" not "opensearch-serverless"). Important: Web service codes differ from API service codes (e.g., use "opensearch-service" for web but "AmazonES" for API). When retrieving foundation model pricing, always use the latest models for comparison rather than specific named ones that may become outdated.',
 )
 async def get_pricing_from_web(
     ctx: Context,
@@ -248,7 +248,7 @@ async def get_pricing_from_web(
 
 @mcp.tool(
     name='get_pricing_from_api',
-    description="""
+    description="""IMPORTANT: This tool is deprecated. Please use the get_pricing tool in the AWS Pricing MCP Server instead.
     Get detailed pricing information from AWS Price List API with optional filters.
 
     Service codes for API often differ from web URLs.
@@ -467,7 +467,7 @@ async def get_pricing_from_api(
 
 @mcp.tool(
     name='get_bedrock_patterns',
-    description='Get architecture patterns for Amazon Bedrock applications, including component relationships and cost considerations',
+    description='IMPORTANT: This tool is deprecated. Please use the get_bedrock_patterns tool in the AWS Pricing MCP Server instead. Get architecture patterns for Amazon Bedrock applications, including component relationships and cost considerations',
 )
 async def get_bedrock_patterns(ctx: Optional[Context] = None) -> str:
     """Get architecture patterns for Amazon Bedrock applications.
@@ -507,7 +507,7 @@ Focus on the most impactful recommendations first. Do not limit yourself to a sp
 
 @mcp.tool(
     name='generate_cost_report',
-    description="""Generate a detailed cost analysis report based on pricing data for one or more AWS services.
+    description="""IMPORTANT: This tool is deprecated. Please use the generate_cost_report tool in the AWS Pricing MCP Server instead. Generate a detailed cost analysis report based on pricing data for one or more AWS services.
 
 This tool requires AWS pricing data and provides options for adding detailed cost information.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

This change adds deprecation warnings throughout the cost-analysis-mcp-server to guide users toward the AWS Pricing MCP Server.

### User experience

**Before**: Users could discover and use the cost-analysis-mcp-server without any indication that it's deprecated or that there's a preferred alternative.

**After**: Users will see clear deprecation warnings at multiple touchpoints: server listings, server docs, MCP server and tool descriptions.

This provides a clear migration path and prevents new users from adopting deprecated functionality.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: #562 

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
