### PR TITLE
docs(cost-analysis-mcp-server): Add deprecation warnings (part 2)

### DIFF
--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -19,6 +19,7 @@ This server provides tools for analyzing AWS service costs across different user
 
 import os
 import sys
+import warnings
 from awslabs.cost_analysis_mcp_server import consts
 from awslabs.cost_analysis_mcp_server.cdk_analyzer import analyze_cdk_project
 from awslabs.cost_analysis_mcp_server.models import ErrorResponse, PricingFilters
@@ -741,6 +742,11 @@ async def generate_cost_report_wrapper(
 
 def main():
     """Run the MCP server with CLI argument support."""
+    warnings.simplefilter('error', DeprecationWarning)
+    warnings.warn(
+        message='This server is deprecated. Please use the `awslabs.aws-pricing-mcp-server` instead.',
+        category=DeprecationWarning,
+    )
     mcp.run()
 
 

--- a/src/cost-analysis-mcp-server/tests/test_server.py
+++ b/src/cost-analysis-mcp-server/tests/test_server.py
@@ -23,8 +23,19 @@ from awslabs.cost_analysis_mcp_server.server import (
     get_bedrock_patterns,
     get_pricing_from_api,
     get_pricing_from_web,
+    main,
 )
 from unittest.mock import MagicMock, patch
+
+
+class TestMain:
+    """Tests for main function."""
+
+    def test_main_deprecation_warning(self):
+        """Test that main() raises a DeprecationWarning."""
+
+    with pytest.raises(DeprecationWarning, match='This server is deprecated'):
+        main()
 
 
 class TestAnalyzeCdkProject:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Follow-up to #772.

Add deprecation warnings for the `cost-analysis-mcp-server`, indicating it should no longer be used in favor of the AWS Pricing MCP Server.

### User experience

See #772 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? Y

**RFC issue number**: #562 

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
