### PR TITLE
docs: clarify AWS CDK MCP Server usage and non-standalone nature

### DIFF
--- a/src/cdk-mcp-server/README.md
+++ b/src/cdk-mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP server for AWS Cloud Development Kit (CDK) best practices, infrastructure as code patterns, and security compliance with CDK Nag.
 
-> **Note**: The [AWS CDK MCP Server](https://github.com/awslabs/mcp/tree/main/src/cdk-mcp-server) is not a standalone server. It lacks a FastAPI ASGI application, a direct server entry point, a standalone server implementation, and its own uvicorn-compatible server structure. Instead, it is a Python package that provides CDK-related functionality and is designed to register endpoints within an MCP server environment.
+> **Note**: The AWS CDK MCP Server is not a standalone server. It lacks a FastAPI ASGI application, a direct server entry point, a standalone server implementation, and its own uvicorn-compatible server structure. Instead, it is a Python package that provides CDK-related functionality and is designed to register endpoints within an MCP server environment.
 >
 > This package must be integrated into a proper MCP server environment rather than being run directly as a server itself. The MCP server is not included in this repository and must be set up separately to use this module. This approach is typically intended for customized workflows or specific needs, such as adding cdk-nag integration to generated code.
 >


### PR DESCRIPTION

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

The current README wording is potentially misleading, particularly in its use of the term "server." This PR adds a clarifying note to the README explaining that AWS CDK MCP Server is not a standalone server, but a module meant to be integrated into an MCP server environment. It also describes its intended use cases and highlights easier, hassle-free alternatives such as using the Amazon Q Developer extension.

### Changes

No changes to the code, but clarifies the README to minimize misunderstanding and make it easier for users to understand the use case and capabilities of this repository.

### User experience

This update improves clarity in the README, helping users quickly understand that the AWS CDK MCP Server is not a standalone server. It sets accurate expectations about how to use this module, reducing confusion and guiding most users toward the recommended approach with the Amazon Q Developer extension for a simpler, hassle-free experience.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
