### PR TITLE
feat: Add --transport argument with SSE support for EKS MCP Server

### DIFF
--- a/src/eks-mcp-server/Dockerfile
+++ b/src/eks-mcp-server/Dockerfile
@@ -72,6 +72,13 @@ COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
 # Run as non-root
 USER app
 
+EXPOSE 8000
+
 # When running the container, add --db-path and a bind mount to the host's db file
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "docker-healthcheck.sh" ]
 ENTRYPOINT ["awslabs.eks-mcp-server"]
+
+# Example configurations:
+#ENTRYPOINT ["awslabs.eks-mcp-server", "--allow-sensitive-data-access"]
+#ENTRYPOINT ["awslabs.eks-mcp-server", "--transport", "sse"]
+#ENTRYPOINT ["awslabs.eks-mcp-server", "--transport", "sse", "--allow-write", "--allow-sensitive-data-access"]

--- a/src/eks-mcp-server/README.md
+++ b/src/eks-mcp-server/README.md
@@ -199,6 +199,28 @@ The `args` field in the MCP server definition specifies the command-line argumen
 }
 ```
 
+**Example with SSE Transport (for containerized or HTTP-based deployments):**
+```
+{
+  "mcpServers": {
+    "awslabs.eks-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "awslabs.eks-mcp-server@latest",
+        "--transport",
+        "sse",
+        "--allow-write",
+        "--allow-sensitive-data-access"
+      ],
+      "env": {
+        "AWS_PROFILE": "your-profile",
+        "AWS_REGION": "us-east-1"
+      }
+    }
+  }
+}
+```
+
 #### Command Format
 
 The command format differs between operating systems:
@@ -224,6 +246,16 @@ Enables access to sensitive data such as logs, events, and Kubernetes Secrets. T
 
 * Default: false (Access to sensitive data is restricted by default)
 * Example: Add `--allow-sensitive-data-access` to the `args` list in your MCP server definition.
+
+#### `--transport` (optional)
+
+Specifies the transport type for the MCP server communication protocol.
+
+* Valid values: "stdio", "sse" 
+* Default: "stdio" (Standard input/output transport)
+* Example: Add `--transport sse` to the `args` list to enable Server-Sent Events (SSE) transport for HTTP-based communication on port 8000.
+
+**Note**: When using SSE transport, the server will listen on host `0.0.0.0` and port `8000`. This is useful for containerized deployments or when you need HTTP-based communication instead of stdio.
 
 ### Environment variables
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Added SSE (Server-Sent Events) transport support to the EKS MCP Server as an alternative to the default stdio transport. This includes:

* New --transport CLI argument with stdio (default) and sse options
* Automatic host/port configuration (0.0.0.0:8000) for SSE mode
* Updated documentation and Docker examples

### User experience
* Before: Users could only run the MCP server with stdio transport, limiting deployment options for containerized environments.

* After: Users can choose between stdio and SSE transport modes:

```
# Default stdio transport (unchanged)
awslabs.eks-mcp-server --allow-write

# New SSE transport for HTTP communication  
awslabs.eks-mcp-server --transport sse --allow-write
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: [#637](https://github.com/awslabs/mcp/issues/637) (partially)

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
