### PR TITLE
fix: split platforms build into separate runners

### DIFF
--- a/.github/actions/build-and-push-container-image/action.yml
+++ b/.github/actions/build-and-push-container-image/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: 'The region to login'
     type: string
     required: false
+  platform:
+    description: 'The platform to build for (e.g., linux/amd64 or linux/arm64)'
+    type: string
+    required: true
 
 outputs:
   version:
@@ -114,7 +118,7 @@ runs:
       id: build
       uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
       with:
-        platforms: 'linux/amd64,linux/arm64' # add more platforms after testing completed
+        platforms: ${{ inputs.platform }}
         labels: ${{ steps.meta.outputs.labels }}
         tags: public.ecr.aws/${{ inputs.public-erc-registry-alias }}/${{ github.repository_owner }}/${{ inputs.image }}
         context: ./src/${{ inputs.image }}
@@ -135,30 +139,11 @@ runs:
     - name: Upload digest
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: digests-${{ inputs.image }}
+        name: digests-${{ inputs.image }}-${{ inputs.platform }}
         path: ${{ runner.temp }}/digests/${{ inputs.image }}/*
         if-no-files-found: error
         retention-days: 1
 
-    - name: Create manifest list and push
-      working-directory: ${{ runner.temp }}/digests/${{ inputs.image }}
-      env:
-        IMAGE: ${{ inputs.image }}
-        ALIAS: ${{ inputs.public-erc-registry-alias }}
-        OWNER: ${{ github.repository_owner }}
-      run: |
-        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf 'public.ecr.aws/'$ALIAS'/'$OWNER'/'$IMAGE'@sha256:%s ' *)
-      shell: bash
-    - name: Inspect image
-      env:
-        IMAGE: ${{ inputs.image }}
-        ALIAS: ${{ inputs.public-erc-registry-alias }}
-        OWNER: ${{ github.repository_owner }}
-        VERSION: ${{ steps.meta.outputs.version }}
-      run: |
-        docker buildx imagetools inspect public.ecr.aws/$ALIAS/$OWNER/$IMAGE:$VERSION
-      shell: bash
     - name: Get version
       id: get-version
       working-directory: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,10 +129,10 @@ jobs:
     if: github.repository == 'awslabs/mcp' && needs.create-metadata.outputs.pypi_packages != '[]' && needs.create-metadata.outputs.pypi_packages != ''
     needs: [update-packages, create-metadata]
     strategy:
-      fail-fast: false
-      max-parallel: 10
       matrix:
         package: ${{ fromJson(needs.create-metadata.outputs.pypi_packages) }}
+        platform: [linux/amd64, linux/arm64]
+      max-parallel: 10
     name: Build ${{ matrix.package }}
     environment: release
     permissions:
@@ -190,6 +190,7 @@ jobs:
           public-erc-role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
           public-erc-registry-alias: 'f3y8w4n0' # 'w3i4n7u1'
           public-erc-aws-region: ${{ env.AWS_REGION || 'us-east-1' }}
+          platform: ${{ matrix.platform }}
 
       - name: Display Image Version ${{ matrix.package }}
         id: display-image-version
@@ -198,6 +199,45 @@ jobs:
           echo "version: ${VERSION}"
         env:
           VERSION: ${{ steps.build-and-publish.outputs.version }}
+
+  create-manifest:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.create-metadata.outputs.pypi_packages) }}
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-${{ matrix.package }}-linux/amd64
+          path: ./digests/amd64
+      - name: Download arm64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-${{ matrix.package }}-linux/arm64
+          path: ./digests/arm64
+      - name: Create and push manifest
+        env:
+          IMAGE: ${{ matrix.package }}
+          ALIAS: 'f3y8w4n0' # 'w3i4n7u1'
+          OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ github.sha }}
+        run: |
+          AMD64_DIGEST=$(ls ./digests/amd64)
+          ARM64_DIGEST=$(ls ./digests/arm64)
+          docker buildx imagetools create \
+            -t public.ecr.aws/$ALIAS/$OWNER/$IMAGE:$VERSION \
+            public.ecr.aws/$ALIAS/$OWNER/$IMAGE@sha256:$AMD64_DIGEST \
+            public.ecr.aws/$ALIAS/$OWNER/$IMAGE@sha256:$ARM64_DIGEST
+      - name: Inspect image
+        env:
+          IMAGE: ${{ matrix.package }}
+          ALIAS: 'f3y8w4n0' # 'w3i4n7u1'
+          OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ github.sha }}
+        run: |
+          docker buildx imagetools inspect public.ecr.aws/$ALIAS/$OWNER/$IMAGE:$VERSION
 
   publish-npm:
     if: github.repository == 'awslabs/mcp' && needs.create-metadata.outputs.npm_packages != '[]' && needs.create-metadata.outputs.npm_packages != ''
@@ -249,7 +289,7 @@ jobs:
 
   create-release:
     if: github.repository == 'awslabs/mcp' && needs.update-packages.outputs.changes_made == 'true' && !failure() && !cancelled() && ( needs.publish-npm.result == 'success' || needs.publish-pypi.result == 'success')
-    needs: [update-packages, create-metadata, publish-pypi, publish-npm]
+    needs: [update-packages, create-metadata, create-manifest, publish-pypi, publish-npm]
     runs-on: ubuntu-latest
     # environment: release
     permissions:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Recent Release workflow failed when trying to build large aws-api-mcp-server on both platforms simultaneously. Trying to unblock it by splitting platform builds onto separate runners.

### Changes
1. build-and-push-container-image/action.yml now accepts 'platform' input
2. digests are per-platform now
3. manifest creation is extracted into the top level release.yml flow, after digests were built

### User experience
> Please share what the user experience looks like before and after this change
Expectation is that this should unblock release of aws-api-mcp-server to ECR 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [-] Changes have been tested
* [-] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: —

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
