### PR TITLE
chore(aws-dataprocessing-mcp-server): Update MCP server name and pypi library in readme

### DIFF
--- a/src/aws-dataprocessing-mcp-server/README.md
+++ b/src/aws-dataprocessing-mcp-server/README.md
@@ -143,12 +143,12 @@ This quickstart guide walks you through the steps to configure the Amazon Data P
 ```
 {
   "mcpServers": {
-    "aws.aws-dataprocessing-mcp-server": {
+    "aws.dp-mcp": {
       "autoApprove": [],
       "disabled": false,
       "command": "uvx",
       "args": [
-        "aws.aws-dataprocessing-mcp-server@latest",
+        "awslabs.aws-dataprocessing-mcp-server@latest",
         "--allow-write"
       ],
       "env": {
@@ -172,9 +172,9 @@ After a few minutes, you should see a green indicator if your MCP server definit
 ```
 {
   "mcpServers": {
-    "aws.aws-dataprocessing-mcp-server": {
+    "aws.dp-mcp": {
       "command": "uvx",
-      "args": ["aws.aws-dataprocessing-mcp-server@latest"],
+      "args": ["awslabs.aws-dataprocessing-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
@@ -198,10 +198,10 @@ The `args` field in the MCP server definition specifies the command-line argumen
 ```
 {
   "mcpServers": {
-    "awslabs.aws-dataprocessing-mcp-server": {
+    "aws.dp-mcp": {
       "command": "uvx",
       "args": [
-        "aws.aws-dataprocessing-mcp-server@latest",
+        "awslabs.aws-dataprocessing-mcp-server@latest",
         "--allow-write",
         "--allow-sensitive-data-access"
       ],
@@ -241,7 +241,13 @@ The `env` field in the MCP server definition allows you to configure environment
 ```
 {
   "mcpServers": {
-    "awslabs.aws-dataprocessing-mcp-server": {
+    "aws.dp-mcp": {
+      "command": "uvx",
+      "args": [
+        "awslabs.aws-dataprocessing-mcp-server@latest",
+        "--allow-write",
+        "--allow-sensitive-data-access"
+      ],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR",
         "AWS_PROFILE": "my-profile",


### PR DESCRIPTION


<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
1. Update READMe for dataprocessing mcp server to reduce mcp server name.
2. Add a fix on the pypi library

### Changes

Changes made in the readme file to provide more ease of use for customers who are using aws-dataprocessing-mcp-server

### User experience
> before
Users may need to update the mcp server name to reduce the tool name length

> after
with the reduction of the mcp server name, most tools would be compatible with 60 length limit

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:
https://github.com/awslabs/mcp/issues/614

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
