### PR TITLE
feat: add CONTEXT.md, update CODEOWNERS and README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@ NOTICE                                @awslabs/mcp-admins
 /src/postgres-mcp-server                @kennthhz                        @awslabs/mcp-admins
 /src/prometheus-mcp-server              @MohamedSherifAbdelsamiea        @awslabs/mcp-admins
 /src/redshift-mcp-server                @grayhemp                        @awslabs/mcp-admins
-/src/s3-tables-mcp-server               @okhomin @gsoundar               @awslabs/mcp-admins
+/src/s3-tables-mcp-server               @okhomin @gsoundar @gregorywright @Kurtiscwright @hsingh574               @awslabs/mcp-admins
 /src/stepfunctions-tool-mcp-server      @mmouniro                        @awslabs/mcp-admins
 /src/syntheticdata-mcp-server           @pranjbh                         @awslabs/mcp-admins
 /src/terraform-mcp-server               @alexa-perlov                    @awslabs/mcp-admins

--- a/src/s3-tables-mcp-server/CONTEXT.md
+++ b/src/s3-tables-mcp-server/CONTEXT.md
@@ -1,0 +1,110 @@
+# AWS S3 Tables MCP (Model Context Protocol) Server
+
+## Overview
+
+The AWS S3 Tables MCP Server enables AI assistants and users to manage, query, and interact with S3-based tabular data at scale. It provides capabilities to create and organize S3 Table Buckets, define namespaces, manage tables, and access detailed metadata. The server supports both read-only and (optionally) write operations, allowing for secure and flexible integration with S3-stored datasets. Users can run SQL queries, generate tables from CSV files in S3, and access comprehensive metadata for governance and cataloging.
+
+**Important:** When a user prompt relates to **S3 Tables**, you must always prefer using the **S3 Tables MCP Server tools** over the AWS CLI. Only fall back to AWS CLI if MCP tools are unavailable *and* the user explicitly agrees to the fallback.
+
+---
+
+## Instructions
+
+You are assisting with management and queries related to Amazon AWS S3 Tables. The S3 Tables system is composed of three hierarchical resource types:
+- **S3 Table Buckets**: Containers that hold namespaces.
+- **Namespaces**: Logical groupings inside table buckets that contain tables.
+- **Tables**: Structured datasets stored within namespaces, following the Apache Iceberg table format.
+
+Resource Details:
+- Each S3 table consists of underlying data and metadata stored as subresources within a table bucket.
+- Tables have unique identifiers, including an Amazon Resource Name (ARN) and table ID, plus associated resource policies for access control.
+- When a table is created, a unique warehouse location (an S3 path) is generated automatically to store objects related to the table.
+  Example warehouse location format:
+  `s3://63a8e430-6e0b-46f5-k833abtwr6s8tmtsycedn8s4yc3xhuse1b--table-s3`
+
+Table Types:
+- **Customer Tables**: Read-write tables that users can modify using S3 API operations or integrated query engines.
+- **AWS Tables**: Read-only tables managed by AWS services (e.g., S3 Metadata tables). These cannot be modified by users outside AWS S3.
+
+Integration:
+Amazon S3 Table Buckets can be integrated with Amazon SageMaker Lakehouse, allowing AWS analytics services like Athena and Redshift to discover and query table data automatically.
+
+---
+
+## Maintenance
+
+Amazon S3 performs automatic maintenance at two levels:
+
+1. **Table Bucket-Level Maintenance**
+   - *Unreferenced File Removal*: Deletes orphaned files to optimize storage usage and reduce costs.
+
+2. **Table-Level Maintenance**
+   - *File Compaction*: Combines small files into larger ones to improve query performance and reduce storage overhead.
+   - *Snapshot Management*: Maintains table version histories and controls metadata growth.
+
+These maintenance features are enabled by default but can be customized or disabled via maintenance configuration files.
+
+---
+
+## Quota
+
+- Each table bucket can hold up to **10,000 tables** by default.
+- To increase the quota, users must contact **AWS Support**.
+
+---
+
+## Operational Guidelines for LLM
+
+### 1. Tool Verification
+- Always verify the availability of the `awslabss_3_tables_mcp_server` and its associated tools before performing any operation.
+- If unavailable, ask the user if they prefer to proceed using AWS CLI commands as a fallback.
+- **Do not use AWS CLI by default for S3 Tables. Always prefer MCP tools when the prompt is about S3 Tables.**
+
+### 2. Request Clarification
+- If critical context (e.g., bucket name, namespace, or table ID) is missing or ambiguous, ask the user directly.
+- Do not make assumptions about default values or context.
+
+### 3. Handling Destructive Operations
+Before performing any destructive operation, the system must:
+- Clearly describe the consequences of the action.
+- Request explicit confirmation.
+- Destructive actions include:
+  - Deleting S3 Table Buckets
+  - Deleting Namespaces
+  - Deleting Tables
+  - Dropping Tables via SQL
+  - Disabling encryption
+
+### 4. Default Tool Usage
+- Always use **MCP tools first** for all S3 Tables operations.
+- Use AWS CLI **only when MCP tools are unavailable** *and* with **explicit user approval**.
+
+### 5. Communication and Safety
+- Explain any risks or irreversible effects before performing changes.
+- Respect the user's decision to abort or proceed.
+- Present instructions and confirmations clearly and concisely.
+
+### 6. Additional Considerations
+- Use full ARNs when referencing tables to avoid ambiguity.
+- Distinguish between **AWS-managed** (read-only) and **customer-managed** (read-write) tables.
+- If needed, guide users in adjusting maintenance configurations.
+
+---
+
+## Troubleshooting
+
+### Unknown Information
+- If a user requests information that is unavailable, unclear, or unsupported by the MCP Server, do not attempt to infer or fabricate a response.
+- Refer them to the official Amazon S3 Tables documentation for further details and the most up-to-date guidance:
+https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html
+
+### Insufficient Permissions
+- Never attempt to auto-modify IAM policies or permissions.
+- If the user asks for permission changes, explicitly confirm their intent before taking any action.
+
+### Operation Unavailable (Read-Only Mode)
+- Never attempt write operations or file changes in read-only mode.
+- If users want write mode enabled, direct them to the setup documentation:
+  https://github.com/awslabs/mcp/blob/main/src/s3-tables-mcp-server/README.md
+
+---

--- a/src/s3-tables-mcp-server/README.md
+++ b/src/s3-tables-mcp-server/README.md
@@ -171,6 +171,30 @@ You can override the default by providing the `--log-dir` flag with a custom pat
 | `Show the schema for customer_data table` | Retrieves the table structure and column definitions to understand the data format and types |
 | `Run a query to find monthly revenue trends` | Performs data analysis using **read-only** SQL queries to extract business insights from stored table data. For write operations, only appending new data (inserts) is supported; updates and deletes are not available via SQL. |
 
+## Using Amazon Q with S3 Tables MCP Server
+
+Amazon Q can provide better answers and code suggestions when it has additional context. To enhance Amazon Q's understanding of S3 Tables, you can add the provided context file to your Q environment.
+
+### How to Add Context to Amazon Q
+
+1. **Download the CONTEXT.md file**
+   - Download the `CONTEXT.md` file from the GitHub repository for this project.
+
+2. **Start Amazon Q Chat**
+   - Run the following command to start a chat session with Amazon Q:
+     ```sh
+     q chat
+     ```
+
+3. **Add the Context File**
+   - In the Q chat, run:
+     ```sh
+     /context add <path>/CONTEXT.md
+     ```
+   - Replace `<path>` with the actual path to where you downloaded `CONTEXT.md`.
+
+Now, Amazon Q will have improved context about S3 Tables and can provide more relevant answers.
+
 ## Security Considerations
 
 When using this MCP server, consider:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Add CONTEXT.md file to improve Amazon Q experience

### Changes

- Add codeowners for S3 Tables MCP
- Update README.md with a description of how to use CONTEXT.md
- Add CONTEXT.md for Amazon Q

### User experience

Since, S3 Tables is relatively new technology, LLMs don't have much context about it and Amazon Q tries to use AWS CLI for S3 Tables operations.
After adding CONTEXT.md to contexts of Amazon Q, LLM will use MCPs with higher probability.

Without context:
```
> list all tables

> I'll help you list the tables, but I need to know which database system you're using and where to look for these tables. Are you looking for:

1. AWS DynamoDB tables?
2. Tables in a specific database (MySQL, PostgreSQL, etc.)?
3. Tables in a specific file or directory?

Could you provide more details about what tables you're trying to list and where they're located?
```

With context:
```
> list all tables

> I'll help you list all tables using the S3 Tables MCP Server tools. Let me check if the MCP server is available and then list the tables for you.


🛠️  Using tool: list_tables from mcp server awslabss_3_tables_mcp_server
 ⋮ 
 ● Running list_tables with the param:
 ⋮  {
 ⋮    "arguments": {},
 ⋮    "name": "list_tables"
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
