### PR TITLE
chore(aws-api-mcp-server): change version back to 0.1.1

### DIFF
--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.2"
+version = "0.1.1"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "0.1.2"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Reverting package version to 0.1.1 since 0.1.2 has not yet been released to PyPi.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
