### PR TITLE
chore: use full action location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Build and Publish ${{ matrix.package }} Container
         id: build-and-publish
-        uses: ./.github/actions/build-and-push-container-image
+        uses: awslabs/mcp/.github/actions/build-and-push-container-image@9ae15a5007b0d2d13dd58a6660484c6962157566
         if: hashFiles(format('./src/{0}/Dockerfile', matrix.package))
         with:
           image: ${{ matrix.package }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

Reference reusable workflow

### Changes

Because of a sparse checkout, the local referenced actions were not available. Best practice is to pin, so referencing the action directly.

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
