### PR TITLE
chore(aws-api-mcp-server): support profile for customizations

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -88,6 +88,10 @@ def execute_awscli_customization(
     """Execute the given AWS CLI command."""
     args = split_cli_command(cli_command)[1:]
 
+    # Identify if a profile was passed in already and insert the defined one otherwise
+    if AWS_API_MCP_PROFILE_NAME and not any(elem == '--profile' for elem in args):
+        args.extend(['--profile', AWS_API_MCP_PROFILE_NAME])
+
     try:
         stdout_capture = StringIO()
         stderr_capture = StringIO()

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -218,8 +218,6 @@ async def call_aws(
         )
 
     try:
-        creds = get_local_credentials()
-
         if ir.command and ir.command.is_awscli_customization:
             response: AwsCliAliasResponse | AwsApiMcpServerErrorResponse = (
                 execute_awscli_customization(cli_command)
@@ -228,6 +226,7 @@ async def call_aws(
                 await ctx.error(response.detail)
             return response
 
+        creds = get_local_credentials()
         return interpret_command(
             cli_command=cli_command,
             credentials=creds,

--- a/src/aws-api-mcp-server/tests/test_server.py
+++ b/src/aws-api-mcp-server/tests/test_server.py
@@ -512,7 +512,6 @@ async def test_call_aws_awscli_customization_success(
     mock_translate_cli_to_ir.assert_called_once_with('aws configure list')
     mock_validate.assert_called_once_with(mock_ir)
     mock_execute_awscli_customization.assert_called_once_with('aws configure list')
-    mock_get_creds.assert_called_once()
 
 
 @patch('awslabs.aws_api_mcp_server.server.execute_awscli_customization')
@@ -555,7 +554,6 @@ async def test_call_aws_awscli_customization_error(
     mock_validate.assert_called_once_with(mock_ir)
     mock_execute_awscli_customization.assert_called_once_with('aws configure list')
     mock_ctx.error.assert_called_once_with(error_response.detail)
-    mock_get_creds.assert_called_once()
 
 
 @patch('awslabs.aws_api_mcp_server.core.kb.threading.Thread')


### PR DESCRIPTION

## Summary

The profile wasn't working for customizations because it was solely used for the interpretation of service-based operations into boto3 API calls. This prevented customizations like `s3 ls` to work for instance when only SSO-based credentials via profiles were used.

Fixes https://github.com/awslabs/mcp/issues/892

### Changes

This PR injects `AWS_API_MCP_PROFILE_NAME` when it is provided for AWS CLI customizations. AWS CLI customizations are not interpreted via the `boto3` interpretation pipeline because these are Python classes with deterministic API calls.  

### User experience

> Please share what the user experience looks like before and after this change

* Before

<img width="945" height="588" alt="Screenshot 2025-07-21 at 13 58 27" src="https://github.com/user-attachments/assets/95a6e9ea-0bbb-4060-9c37-ce90e23ab88c" />


* After

<img width="775" height="490" alt="Screenshot 2025-07-21 at 13 56 15" src="https://github.com/user-attachments/assets/4c48b85f-df74-41f8-969c-076690afcc94" />


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
