### PR TITLE
docs: clarify MCP server startup in installation guide

### DIFF
--- a/src/aws-api-mcp-server/README.md
+++ b/src/aws-api-mcp-server/README.md
@@ -33,7 +33,26 @@ Choose the installation method that best fits your workflow and get started with
 pip install awslabs.aws-api-mcp-server
 ```
 
-**Step 2: Configure your MCP client**
+**Step 2: Run the MCP Python server in a separate terminal**
+
+```bash
+python -m awslabs.aws_api_mcp_server.server
+```
+
+You can verify that the MCP server is running by executing:
+
+```bash
+ps aux | grep awslabs.aws_api_mcp_server.server
+```
+
+If the server is active, you'll see a Python process like:
+
+```bash
+python -m awslabs.aws_api_mcp_server.server
+```
+
+
+**Step 3: Configure your MCP client**
 Add the following configuration to your MCP client config file (e.g., for Amazon Q Developer CLI, edit `~/.aws/amazonq/mcp.json`):
 
 ```json


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

This PR updates the `README.md` for the `aws-api-mcp-server` to make the installation guide more user-friendly by adding clear instructions on how to start the MCP server.

### User experience

Before this change:
- There were no instructions for launching the server, causing confusion.
- New users, especially in environments like WSL or VS Code, might not realize that the server needs to run in a separate terminal.

After this change:
- Users are guided to explicitly run the server and understand that it must stay active in a separate terminal for clients to interact with it.
- This improves onboarding and reduces friction.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
