### PR TITLE
fix: remove version against constant value

### DIFF
--- a/src/s3-tables-mcp-server/tests/test_init.py
+++ b/src/s3-tables-mcp-server/tests/test_init.py
@@ -68,4 +68,3 @@ class TestInit:
 
         # Check that __version__ is defined
         assert hasattr(awslabs.s3_tables_mcp_server, '__version__')
-        assert awslabs.s3_tables_mcp_server.__version__ == '0.0.0'


### PR DESCRIPTION
## Summary

Remove test against version `0.0.0`.

### Changes

The `__version__` is bumped during release, so should be removed from being tested against a constant `0.0.0`.

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
