### PR TITLE
fix: avoid checking remote too fast and image save debugging

### DIFF
--- a/.github/actions/build-and-push-container-image/action.yml
+++ b/.github/actions/build-and-push-container-image/action.yml
@@ -175,8 +175,19 @@ runs:
         ALIAS: ${{ inputs.public-erc-registry-alias }}
         OWNER: ${{ github.repository_owner }}
         VERSION: ${{ steps.meta.outputs.version }}
+      continue-on-error: true #TODO: Remove when figure out image save issue.
       run: |
-        docker image save -o "${{ runner.temp }}/image.tar" public.ecr.aws/$ALIAS/$OWNER/$IMAGE:$VERSION
+        set +e  # Don't fail on cleanup errors
+
+        #TODO: Remove
+        # Ensure a file is there (so the upload step doesn't fail)
+        touch "${{ runner.temp }}/image.tar"
+
+        # List images to ensure the image exists
+        docker images
+
+        # Save the image to a tar file
+        docker image save -o "${{ runner.temp }}/image.tar" "public.ecr.aws/$ALIAS/$OWNER/$IMAGE:$VERSION" || echo "Failed to save image, continuing anyway"
       shell: bash
     - name: Upload image
       id: upload-image

--- a/.github/workflows/release-merge-tag.yml
+++ b/.github/workflows/release-merge-tag.yml
@@ -139,6 +139,9 @@ jobs:
           # Create signed tag with proper message
           git tag -a "$TAG" -m "Release $TAG" --sign
 
+          # Avoid checking too fast
+          sleep 5
+
           # Verify tag was created and is signed
           if ! git tag -v "$TAG" 2>/dev/null; then
             echo "::error::Failed to verify signed tag: $TAG" >&2


### PR DESCRIPTION
## Summary

* Merge automation failing due to checking remote too fast
* Saving image is not finding expected target.

### Changes

* Add a sleep
* Add debugging and failure prevention (will be removed after fixes)

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
