### PR TITLE
fix(aws-api-mcp-server): Make AWS_REGION optional

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
@@ -12,9 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import boto3
 import os
 import tempfile
 from pathlib import Path
+
+
+def get_region() -> str:
+    """Get the default region for executing cli commands."""
+    if aws_region := os.getenv('AWS_REGION'):
+        return aws_region
+
+    fallback_region = 'us-east-1'
+
+    if AWS_API_MCP_PROFILE_NAME:
+        return boto3.Session(profile_name=AWS_API_MCP_PROFILE_NAME).region_name or fallback_region
+
+    return boto3.Session().region_name or fallback_region
 
 
 def get_server_directory():
@@ -40,8 +54,8 @@ def get_env_bool(env_key: str, default: bool) -> bool:
 
 
 FASTMCP_LOG_LEVEL = os.getenv('FASTMCP_LOG_LEVEL', 'WARNING')
-DEFAULT_REGION = os.getenv('AWS_REGION')
+AWS_API_MCP_PROFILE_NAME = os.getenv('AWS_API_MCP_PROFILE_NAME')
+DEFAULT_REGION = get_region()
 READ_OPERATIONS_ONLY_MODE = get_env_bool(READ_ONLY_KEY, False)
 OPT_IN_TELEMETRY = get_env_bool(TELEMETRY_KEY, True)
 WORKING_DIRECTORY = os.getenv('AWS_API_MCP_WORKING_DIR', get_server_directory() / 'workdir')
-AWS_API_MCP_PROFILE_NAME = os.getenv('AWS_API_MCP_PROFILE_NAME')

--- a/src/aws-api-mcp-server/tests/common/test_config.py
+++ b/src/aws-api-mcp-server/tests/common/test_config.py
@@ -1,5 +1,5 @@
 import pytest
-from awslabs.aws_api_mcp_server.core.common.config import get_server_directory
+from awslabs.aws_api_mcp_server.core.common.config import get_region, get_server_directory
 from unittest.mock import MagicMock, patch
 
 
@@ -36,3 +36,56 @@ def test_get_server_directory_windows_macos(
     result = get_server_directory()
 
     assert f'{expected_tempdir}/aws-api-mcp' in str(result)
+
+
+@pytest.mark.parametrize(
+    'aws_region,profile_name,profile_region,default_region,expected_region',
+    [
+        (
+            'us-west-1',
+            'profile1',
+            'eu-west-1',
+            'ap-south-1',
+            'us-west-1',
+        ),  # AWS_REGION takes precedence
+        (None, 'profile1', 'eu-west-1', 'ap-south-1', 'eu-west-1'),  # Profile region used
+        (None, 'profile1', None, 'ap-south-1', 'us-east-1'),  # Profile has no region, fallback
+        (None, None, None, 'ap-south-1', 'ap-south-1'),  # Default session region used
+        (None, None, None, None, 'us-east-1'),  # All None, fallback used
+    ],
+)
+@patch('awslabs.aws_api_mcp_server.core.common.config.boto3.Session')
+@patch('awslabs.aws_api_mcp_server.core.common.config.os.getenv')
+def test_get_region_parametrized(
+    mock_getenv: MagicMock,
+    mock_session_class: MagicMock,
+    aws_region: str,
+    profile_name: str,
+    profile_region: str,
+    default_region: str,
+    expected_region: str,
+):
+    """Parametrized test for various combinations of region sources."""
+    mock_getenv.return_value = aws_region
+
+    profile_session = MagicMock()
+    profile_session.region_name = profile_region
+
+    default_session = MagicMock()
+    default_session.region_name = default_region
+
+    # Configure mock_session_class to return different sessions based on arguments
+    def session_side_effect(*args, **kwargs):
+        if 'profile_name' in kwargs:
+            return profile_session
+        return default_session
+
+    mock_session_class.side_effect = session_side_effect
+
+    with patch(
+        'awslabs.aws_api_mcp_server.core.common.config.AWS_API_MCP_PROFILE_NAME', profile_name
+    ):
+        result = get_region()
+
+    assert result == expected_region
+    mock_getenv.assert_called_once_with('AWS_REGION')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
