### PR TITLE
fix(aws-api-mcp-server): Remove local_files_only flag when initializing SentenceTransformer

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
@@ -59,10 +59,7 @@ class DenseRetriever:
             from sentence_transformers import SentenceTransformer
 
             models_dir = get_server_directory() / 'models' / self.model_name
-            local_files_only = models_dir.exists()
-            self._model = SentenceTransformer(
-                self.model_name, cache_folder=str(models_dir), local_files_only=local_files_only
-            )
+            self._model = SentenceTransformer(self.model_name, cache_folder=str(models_dir))
             self._model_ready = True
         return self._model
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Remove local_files_only flag when initializing SentenceTransformer. This fixes #918 

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
