### PR TITLE
feat: add resource type support. add server side resource operations list/r…

### DIFF
--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -25,7 +25,10 @@ from awslabs.mcp_lambda_handler.types import (
     JSONRPCError,
     JSONRPCRequest,
     JSONRPCResponse,
+    Resource,
+    ResourceContent,
     ServerInfo,
+    StaticResource,
     TextContent,
 )
 from contextvars import ContextVar
@@ -97,6 +100,7 @@ class MCPLambdaHandler:
         self.version = version
         self.tools: Dict[str, Dict] = {}
         self.tool_implementations: Dict[str, Callable] = {}
+        self.resources: Dict[str, Resource] = {}
 
         # Configure session storage
         if session_store is None:
@@ -269,6 +273,41 @@ class MCPLambdaHandler:
 
         return decorator
 
+    def add_resource(self, resource: Resource) -> None:
+        """Add a resource to the handler.
+
+        Args:
+            resource: Resource instance to add
+        """
+        self.resources[resource.uri] = resource
+
+    def resource(
+        self,
+        uri: str,
+        name: str,
+        description: Optional[str] = None,
+        mime_type: Optional[str] = None,
+    ):
+        """Decorator to register a function as a resource provider.
+
+        The decorated function should return the resource content as a string.
+        """
+
+        def decorator(func: Callable):
+            resource = StaticResource(
+                uri=uri,
+                name=name,
+                content='',  # Will be populated by function call
+                description=description,
+                mime_type=mime_type or 'text/plain',
+            )
+            # Store the function to call when resource is accessed
+            resource._content_func = func
+            self.resources[uri] = resource
+            return func
+
+        return decorator
+
     def _create_error_response(
         self,
         code: int,
@@ -420,7 +459,9 @@ class MCPLambdaHandler:
                 result = InitializeResult(
                     protocolVersion='2024-11-05',
                     serverInfo=ServerInfo(name=self.name, version=self.version),
-                    capabilities=Capabilities(tools={'list': True, 'call': True}),
+                    capabilities=Capabilities(
+                        tools={'list': True, 'call': True}, resources={'list': True, 'read': True}
+                    ),
                 )
                 return self._create_success_response(result.model_dump(), request.id, session_id)
 
@@ -479,6 +520,66 @@ class MCPLambdaHandler:
                     return self._create_error_response(
                         -32603,
                         f'Error executing tool: {str(e)}',
+                        request.id,
+                        error_content,
+                        session_id,
+                    )
+            # Handle resources/list request
+            if request.method == 'resources/list':
+                logger.info('Handling resources/list request')
+                resources_list = [resource.model_dump() for resource in self.resources.values()]
+                return self._create_success_response(
+                    {'resources': resources_list}, request.id, session_id
+                )
+
+            # Handle resources/read request
+            if request.method == 'resources/read':
+                if not request.params:
+                    return self._create_error_response(
+                        -32602,
+                        'Missing required parameter: uri',
+                        request.id,
+                        session_id=session_id,
+                    )
+                resource_uri = request.params.get('uri')
+                if not resource_uri:
+                    return self._create_error_response(
+                        -32602,
+                        'Missing required parameter: uri',
+                        request.id,
+                        session_id=session_id,
+                    )
+
+                if resource_uri not in self.resources:
+                    return self._create_error_response(
+                        -32601,
+                        f'Resource not found: {resource_uri}',
+                        request.id,
+                        session_id=session_id,
+                    )
+
+                try:
+                    resource = self.resources[resource_uri]
+
+                    # Handle content resources that requires function calls
+                    if hasattr(resource, '_content_func') and resource._content_func is not None:
+                        content = resource._content_func()
+                        resource_content = ResourceContent(
+                            uri=resource_uri, mimeType=resource.mimeType, text=str(content)
+                        )
+                    else:
+                        # Handle static resources (like FileResource)
+                        resource_content = resource.read_content()
+
+                    return self._create_success_response(
+                        {'contents': [resource_content.model_dump()]}, request.id, session_id
+                    )
+                except Exception as e:
+                    logger.error(f'Error reading resource {resource_uri}: {e}')
+                    error_content = [ErrorContent(text=str(e)).model_dump()]
+                    return self._create_error_response(
+                        -32603,
+                        f'Error reading resource: {str(e)}',
                         request.id,
                         error_content,
                         session_id,

--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/types.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/types.py
@@ -14,6 +14,7 @@
 
 """Type definitions for MCP protocol."""
 
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -69,9 +70,13 @@ class ServerInfo:
 @dataclass
 class Capabilities:
     tools: Dict[str, bool]
+    resources: Optional[Dict[str, bool]] = None
 
     def model_dump(self) -> Dict:
-        return {'tools': self.tools}
+        data = {'tools': self.tools}
+        if self.resources:
+            data['resources'] = self.resources
+        return data
 
 
 @dataclass
@@ -151,3 +156,126 @@ class ImageContent:
         import json
 
         return json.dumps(self.model_dump())
+
+
+@dataclass
+class ResourceContent:
+    uri: str
+    mimeType: Optional[str] = None
+    text: Optional[str] = None
+    blob: Optional[str] = None  # base64 encoded binary data
+
+    def model_dump(self) -> Dict:
+        data = {'uri': self.uri}
+        if self.mimeType:
+            data['mimeType'] = self.mimeType
+        if self.text is not None:
+            data['text'] = self.text
+        if self.blob is not None:
+            data['blob'] = self.blob
+        return data
+
+
+@dataclass
+class Resource:
+    uri: str
+    name: str
+    description: Optional[str] = None
+    mimeType: Optional[str] = None
+
+    def __post_init__(self):
+        """Initialize optional attributes for subclass compatibility."""
+        if not hasattr(self, '_content_func'):
+            self._content_func: Optional[Any] = None
+
+    def model_dump(self) -> Dict:
+        data = {'uri': self.uri, 'name': self.name}
+        if self.description:
+            data['description'] = self.description
+        if self.mimeType:
+            data['mimeType'] = self.mimeType
+        return data
+
+    def read_content(self) -> 'ResourceContent':
+        """Default implementation - should be overridden by subclasses."""
+        raise NotImplementedError('Subclasses must implement read_content method')
+
+
+class FileResource(Resource):
+    def __init__(
+        self,
+        uri: str,
+        path: str,
+        name: str,
+        description: Optional[str] = None,
+        mime_type: Optional[str] = None,
+    ):
+        """Initialize a FileResource.
+
+        Args:
+            uri: The URI identifier for this resource
+            path: The file system path to the resource file
+            name: The display name for this resource
+            description: Optional description of the resource
+            mime_type: Optional MIME type override (auto-detected if not provided)
+        """
+        super().__init__(uri, name, description, mime_type)
+        self.path = path
+
+    def read_content(self) -> ResourceContent:
+        if not os.path.exists(self.path):
+            raise FileNotFoundError(f'Resource file not found: {self.path}')
+
+        # Determine MIME type if not specified
+        mime_type = self.mimeType
+        if not mime_type:
+            if self.path.endswith('.json'):
+                mime_type = 'application/json'
+            elif self.path.endswith('.yaml') or self.path.endswith('.yml'):
+                mime_type = 'application/yaml'
+            elif self.path.endswith('.txt'):
+                mime_type = 'text/plain'
+            else:
+                mime_type = 'text/plain'
+
+        try:
+            # Try to read as text first
+            with open(self.path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            return ResourceContent(uri=self.uri, mimeType=mime_type, text=content)
+        except UnicodeDecodeError:
+            # If text reading fails, read as binary and base64 encode
+            import base64
+
+            with open(self.path, 'rb') as f:
+                content = f.read()
+            blob_data = base64.b64encode(content).decode('utf-8')
+            return ResourceContent(
+                uri=self.uri, mimeType=mime_type or 'application/octet-stream', blob=blob_data
+            )
+
+
+class StaticResource(Resource):
+    def __init__(
+        self,
+        uri: str,
+        name: str,
+        content: str,
+        description: Optional[str] = None,
+        mime_type: str = 'text/plain',
+    ):
+        """Initialize a StaticResource.
+
+        Args:
+            uri: The URI identifier for this resource
+            name: The display name for this resource
+            content: The static content to serve
+            description: Optional description of the resource
+            mime_type: MIME type of the content (defaults to 'text/plain')
+        """
+        super().__init__(uri, name, description, mime_type)
+        self.content = content
+        self._content_func: Optional[Any] = None  # For decorator support
+
+    def read_content(self) -> ResourceContent:
+        return ResourceContent(uri=self.uri, mimeType=self.mimeType, text=self.content)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

>  add resource type support. add server side resource operations list/read.

### User experience

> before this change, user is not able to create resource in lambda mcp servers using this framework. After this change, user will be able to create server resources. 

<img width="2547" height="785" alt="Screenshot 2025-07-28 at 11 56 05 PM" src="https://github.com/user-attachments/assets/d0b208e0-fe55-4e4a-9a20-c90029fc700b" />

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [n/a] Migration process documented
* [n/a] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
