### PR TITLE
fix(aws-api-mcp-server): Add profile support to boto3 operations

### DIFF
--- a/src/aws-api-mcp-server/CHANGELOG.md
+++ b/src/aws-api-mcp-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for `--profile` in boto3 operations. (#986)
+
 ## [0.2.0] - 2025-07-29
 
 ### Added

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/__init__.py
@@ -14,10 +14,9 @@
 
 """AWS-specific functionality for the AWS API MCP server."""
 
-from .driver import translate_cli_to_ir
+from .driver import translate_cli_to_ir, get_local_credentials
 from .regions import GLOBAL_SERVICE_REGIONS
 from .service import (
-    get_local_credentials,
     interpret_command,
     is_operation_read_only,
 )

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/command.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/command.py
@@ -26,6 +26,7 @@ class IRCommand:
     command_metadata: CommandMetadata
     parameters: dict[str, Any]
     region: str | None = None
+    profile: str | None = None
     client_side_filter: ParsedResult | None = None
     is_awscli_customization: bool = False
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -745,6 +745,7 @@ def _construct_command(
         command_metadata=command_metadata,
         parameters=parameters,
         region=region,
+        profile=getattr(global_args, 'profile', None),
         client_side_filter=client_side_filter,
         is_awscli_customization=is_awscli_customization,
     )

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -17,7 +17,6 @@ import sys
 from .core.aws.driver import translate_cli_to_ir
 from .core.aws.service import (
     execute_awscli_customization,
-    get_local_credentials,
     interpret_command,
     is_operation_read_only,
     request_consent,
@@ -238,10 +237,8 @@ async def call_aws(
                 await ctx.error(response.detail)
             return response
 
-        creds = get_local_credentials()
         return interpret_command(
             cli_command=cli_command,
-            credentials=creds,
             default_region=cast(str, DEFAULT_REGION),
             max_results=max_results,
         )

--- a/src/aws-api-mcp-server/tests/fixtures.py
+++ b/src/aws-api-mcp-server/tests/fixtures.py
@@ -3,6 +3,7 @@ import botocore.exceptions
 import contextlib
 import datetime
 from .history_handler import history
+from awslabs.aws_api_mcp_server.core.common.models import Credentials
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -216,9 +217,13 @@ def patch_boto3():
     def mock_can_paginate(self, operation_name):
         return False
 
-    with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
-        with patch('botocore.client.BaseClient.can_paginate', new=mock_can_paginate):
-            yield
+    with patch(
+        'awslabs.aws_api_mcp_server.core.aws.driver.get_local_credentials',
+        return_value=Credentials(**TEST_CREDENTIALS),
+    ):
+        with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
+            with patch('botocore.client.BaseClient.can_paginate', new=mock_can_paginate):
+                yield
 
 
 class DummyCtx:

--- a/src/aws-api-mcp-server/tests/parser/test_parser.py
+++ b/src/aws-api-mcp-server/tests/parser/test_parser.py
@@ -630,5 +630,10 @@ def test_valid_expand_user_home_directory():
 def test_invalid_expand_user_home_directory():
     """Test that tilde is not replaced."""
     result = parse(cli_command='aws s3 cp s3://my_file ~user_that_does_not_exist/temp/test.txt')
-    print(result)
     assert any(param.startswith('~') for param in result.parameters['--paths'])
+
+
+def test_profile():
+    """Test that the profile is correctly extracted."""
+    result = parse(cli_command='aws s3api list-buckets --profile test-profile')
+    assert result.profile == 'test-profile'

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "0.2.9223372036854775807"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Add support for `--profile` to boto operations. The `--profile` flag was just ignored before but we are already supporting thus for the cli customizations. This allows users to make requests like `List the s3 buckets for profile X`. This will take precedence over `AWS_API_MCP_PROFILE_NAME`.

### User experience

> Please share what the user experience looks like before and after this change

Users can request to run operations for certain profiles.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
