### PR TITLE
change min_length of communication body to 0

### DIFF
--- a/src/aws-support-mcp-server/README.md
+++ b/src/aws-support-mcp-server/README.md
@@ -38,7 +38,7 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
       "awslabs_support_mcp_server": {
          "command": "uvx",
          "args": [
-            "-m", "awslabs.aws-support-mcp-server@latest",
+            "awslabs.aws-support-mcp-server@latest",
             "--debug",
             "--log-file",
             "./logs/mcp_support_server.log"

--- a/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/models.py
+++ b/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/models.py
@@ -68,7 +68,7 @@ class Communication(BaseModel):
     """A communication in a support case."""
 
     body: str = Field(
-        ..., description='The text of the communication', min_length=1, max_length=8000
+        ..., description='The text of the communication', min_length=0, max_length=8000
     )
     case_id: Optional[str] = Field(None, description='The ID of the support case', alias='caseId')
     submitted_by: Optional[str] = Field(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Some communication body in support case is empty and then it caused validation error.

### Changes
Change body min_length to 0 in Communication model.

> Please provide a summary of what's being changed
```
class Communication(BaseModel):
    """A communication in a support case."""

    body: str = Field(
        ..., description='The text of the communication', min_length=0, max_length=8000
    )
```
### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
