### PR TITLE
replace title with name in cost explorer fastmcp init

### DIFF
--- a/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/server.py
+++ b/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/server.py
@@ -71,7 +71,7 @@ SERVER_INSTRUCTIONS = """
 """
 
 # Create FastMCP server with instructions
-app = FastMCP(title='Cost Explorer MCP Server', instructions=SERVER_INSTRUCTIONS)
+app = FastMCP(name='Cost Explorer MCP Server', instructions=SERVER_INSTRUCTIONS)
 
 # Register all tools with the app
 app.tool('get_today_date')(get_today_date)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
TypeError: FastMCP.__init__() got an unexpected keyword argument 'title'
title seems work with 1.11.0 but not with 1.12.3

### Changes

> Please provide a summary of what's being changed
just the argument change, from title to name

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
