### PR TITLE
feat: add @WIIASD as codeowner for aws-healthomics-mcp-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@ NOTICE                                                                    @awsla
 #/src/aws-bedrock-data-automation-mcp-server @awslabs/mcp-maintainers     @awslabs/mcp-admins
 /src/aws-diagram-mcp-server             @MichaelWalker-git                @awslabs/mcp-admins
 /src/aws-documentation-mcp-server       @Lavoiedavidw @JonLim             @awslabs/mcp-admins
-/src/aws-healthomics-mcp-server         @markjschreiber                   @awslabs/mcp-admins
+/src/aws-healthomics-mcp-server         @markjschreiber @WIIASD           @awslabs/mcp-admins
 #/src/aws-location-mcp-server           @awslabs/mcp-maintainers          @awslabs/mcp-admins
 /src/aws-msk-mcp-server                 @elmoctarebnou @dingyiheng        @awslabs/mcp-admins
 /src/aws-pricing-mcp-server             @nspring00 @aytech-in @s12v       @awslabs/mcp-admins


### PR DESCRIPTION
Add additional maintainer to the HealthOmics MCP server codeowners

<!-- markdownlint-disable MD041 MD043 -->
## Summary

Adds @WIIASD as a code owner for AWS HealthOmics MCP server

### Changes

added github ID to `.github/CODEOWNERS`

### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
