### PR TITLE
fix: make async model loading work on windows clients

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
@@ -19,6 +19,7 @@ from awscli.clidriver import __version__ as awscli_version
 from copy import deepcopy
 from loguru import logger
 from pathlib import Path
+from sentence_transformers import SentenceTransformer
 
 
 DEFAULT_TOP_K = 5
@@ -57,7 +58,6 @@ class DenseRetriever:
         """Return the sentence transformer model."""
         if self._model is None:
             logger.info('Loading embedding model...')
-            from sentence_transformers import SentenceTransformer
 
             models_dir = get_server_directory() / 'models' / self.model_name
             self._model = SentenceTransformer(self.model_name, cache_folder=str(models_dir))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Currently async model loading does not work on Windows with popular IDE agents (Cline/Cursor/etc). Seems like an issue with threads and asynchronous code during server initialization, prevents dynamic import of the sentence-transformers library. While the exact chain if events which are happening under the hood is unclear, moving declaration of import to the top level made it work. This shouldn't have huge impact on startup time since the heavy lifting of downloading/initializing actual model still happens asynchronously. 

### Test

See "Connected to stdio server" and "Found 2 tools and 0 prompts" are printed (which concludes initialization), but we still load the model on the background.

```
2025-08-06 12:31:11.044 [info] Handling DeleteClient action
2025-08-06 12:31:11.056 [info] Handling DeleteClient action
2025-08-06 12:32:42.602 [info] Handling CreateClient action
2025-08-06 12:32:42.602 [info] Starting new stdio process with command: python -m awslabs.aws_api_mcp_server.server
2025-08-06 12:32:58.080 [error] 2025-08-06 12:32:58.079 | INFO     | __main__:main:292 - CWD: C:\Users\ADMINI~1\AppData\Local\Temp\1\aws-api-mcp\workdir

2025-08-06 12:32:58.080 [error] 2025-08-06 12:32:58.079 | INFO     | __main__:main:299 - AWS_REGION: us-east-1
2025-08-06 12:32:58.080 | INFO     | awslabs.aws_api_mcp_server.core.kb:_load_model_in_background:59 - Starting background process to load embedding model

2025-08-06 12:32:58.081 [error] 2025-08-06 12:32:58.080 | INFO     | awslabs.aws_api_mcp_server.core.kb.dense_retriever:model:60 - Loading embedding model...

2025-08-06 12:32:58.088 [error] Using proactor: IocpProactor

2025-08-06 12:32:58.088 [error] Use pytorch device_name: cpu
Load pretrained SentenceTransformer: BAAI/bge-base-en-v1.5

2025-08-06 12:32:58.098 [error] Starting new HTTPS connection (1): huggingface.co:443

2025-08-06 12:32:58.101 [info] Successfully connected to stdio server
2025-08-06 12:32:58.102 [info] Storing stdio client
2025-08-06 12:32:58.104 [error] Received message: root=InitializedNotification(method='notifications/initialized', params=None, jsonrpc='2.0')

2025-08-06 12:32:58.104 [error] Received message: root=InitializedNotification(method='notifications/initialized', params=None, jsonrpc='2.0')

2025-08-06 12:32:58.117 [info] Connected to stdio server, fetching offerings
2025-08-06 12:32:58.119 [error] Received message: <mcp.shared.session.RequestResponder object at 0x00000151DD29E790>

2025-08-06 12:32:58.119 [error] Received message: <mcp.shared.session.RequestResponder object at 0x00000151DD29E790>

2025-08-06 12:32:58.120 [error] Processing request of type ListToolsRequest
Dispatching request of type ListToolsRequest

2025-08-06 12:32:58.120 [error] Processing request of type ListToolsRequest
Dispatching request of type ListToolsRequest

2025-08-06 12:32:58.121 [error] Response sent

2025-08-06 12:32:58.121 [error] Response sent

2025-08-06 12:32:58.131 [error] Received message: <mcp.shared.session.RequestResponder object at 0x00000151DD345DD0>

2025-08-06 12:32:58.131 [error] Received message: <mcp.shared.session.RequestResponder object at 0x00000151DD345DD0>

2025-08-06 12:32:58.132 [error] Processing request of type ListPromptsRequest
Dispatching request of type ListPromptsRequest

2025-08-06 12:32:58.132 [error] Processing request of type ListPromptsRequest
Dispatching request of type ListPromptsRequest

2025-08-06 12:32:58.133 [error] Response sent

2025-08-06 12:32:58.133 [error] Response sent

2025-08-06 12:32:58.133 [info] Found 2 tools and 0 prompts
2025-08-06 12:32:58.210 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/modules.json HTTP/1.1" 307 0

2025-08-06 12:32:58.210 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/modules.json HTTP/1.1" 307 0

2025-08-06 12:32:58.223 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/modules.json HTTP/1.1" 200 0

2025-08-06 12:32:58.224 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/modules.json HTTP/1.1" 200 0

2025-08-06 12:32:58.319 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/config_sentence_transformers.json HTTP/1.1" 307 0

2025-08-06 12:32:58.320 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/config_sentence_transformers.json HTTP/1.1" 307 0

2025-08-06 12:32:58.332 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config_sentence_transformers.json HTTP/1.1" 200 0

2025-08-06 12:32:58.332 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config_sentence_transformers.json HTTP/1.1" 200 0

2025-08-06 12:32:58.424 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/config_sentence_transformers.json HTTP/1.1" 307 0

2025-08-06 12:32:58.424 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/config_sentence_transformers.json HTTP/1.1" 307 0

2025-08-06 12:32:58.436 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config_sentence_transformers.json HTTP/1.1" 200 0

2025-08-06 12:32:58.436 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config_sentence_transformers.json HTTP/1.1" 200 0

2025-08-06 12:32:58.522 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/README.md HTTP/1.1" 307 0

2025-08-06 12:32:58.522 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/README.md HTTP/1.1" 307 0

2025-08-06 12:32:58.534 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/README.md HTTP/1.1" 200 0

2025-08-06 12:32:58.534 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/README.md HTTP/1.1" 200 0

2025-08-06 12:32:58.625 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/modules.json HTTP/1.1" 307 0

2025-08-06 12:32:58.625 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/modules.json HTTP/1.1" 307 0

2025-08-06 12:32:58.638 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/modules.json HTTP/1.1" 200 0

2025-08-06 12:32:58.638 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/modules.json HTTP/1.1" 200 0

2025-08-06 12:32:58.725 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/sentence_bert_config.json HTTP/1.1" 307 0

2025-08-06 12:32:58.725 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/sentence_bert_config.json HTTP/1.1" 307 0

2025-08-06 12:32:58.737 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/sentence_bert_config.json HTTP/1.1" 200 0

2025-08-06 12:32:58.737 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/sentence_bert_config.json HTTP/1.1" 200 0

2025-08-06 12:32:58.832 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/adapter_config.json HTTP/1.1" 404 0

2025-08-06 12:32:58.832 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/adapter_config.json HTTP/1.1" 404 0

2025-08-06 12:32:58.916 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/config.json HTTP/1.1" 307 0

2025-08-06 12:32:58.916 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/config.json HTTP/1.1" 307 0

2025-08-06 12:32:58.927 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config.json HTTP/1.1" 200 0

2025-08-06 12:32:58.928 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config.json HTTP/1.1" 200 0

2025-08-06 12:32:59.155 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/tokenizer_config.json HTTP/1.1" 307 0

2025-08-06 12:32:59.155 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/tokenizer_config.json HTTP/1.1" 307 0

2025-08-06 12:32:59.168 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/tokenizer_config.json HTTP/1.1" 200 0

2025-08-06 12:32:59.168 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/tokenizer_config.json HTTP/1.1" 200 0

2025-08-06 12:32:59.282 [error] https://huggingface.co:443 "GET /api/models/BAAI/bge-base-en-v1.5/tree/main/additional_chat_templates?recursive=False&expand=False HTTP/1.1" 404 64

2025-08-06 12:32:59.282 [error] https://huggingface.co:443 "GET /api/models/BAAI/bge-base-en-v1.5/tree/main/additional_chat_templates?recursive=False&expand=False HTTP/1.1" 404 64

2025-08-06 12:32:59.443 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/1_Pooling/config.json HTTP/1.1" 307 0

2025-08-06 12:32:59.443 [error] https://huggingface.co:443 "HEAD /BAAI/bge-base-en-v1.5/resolve/main/1_Pooling/config.json HTTP/1.1" 307 0

2025-08-06 12:32:59.454 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/1_Pooling%2Fconfig.json HTTP/1.1" 200 0

2025-08-06 12:32:59.454 [error] https://huggingface.co:443 "HEAD /api/resolve-cache/models/BAAI/bge-base-en-v1.5/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/1_Pooling%2Fconfig.json HTTP/1.1" 200 0

2025-08-06 12:32:59.551 [error] https://huggingface.co:443 "GET /api/models/BAAI/bge-base-en-v1.5 HTTP/1.1" 200 148812

2025-08-06 12:32:59.552 [error] https://huggingface.co:443 "GET /api/models/BAAI/bge-base-en-v1.5 HTTP/1.1" 200 148812

2025-08-06 12:32:59.577 [error] 2025-08-06 12:32:59.576 | INFO     | awslabs.aws_api_mcp_server.core.kb.dense_retriever:model:65 - Embedding model loaded!

2025-08-06 12:32:59.577 [error] 2025-08-06 12:32:59.576 | INFO     | awslabs.aws_api_mcp_server.core.kb.dense_retriever:model:65 - Embedding model loaded!

2025-08-06 12:33:13.383 [info] Handling CallTool action for tool 'suggest_aws_commands'
2025-08-06 12:33:13.384 [info] Calling tool 'suggest_aws_commands' with toolCallId: tool_ffabce44-7813-4fde-872b-938c081238b
2025-08-06 12:33:13.385 [error] Received message: <mcp.shared.session.RequestResponder object at 0x00000151DBBAF490>

2025-08-06 12:33:13.385 [error] Received message: <mcp.shared.session.RequestResponder object at 0x00000151DBBAF490>

2025-08-06 12:33:13.386 [error] Processing request of type CallToolRequest

2025-08-06 12:33:13.386 [error] Processing request of type CallToolRequest

2025-08-06 12:33:13.386 [error] Dispatching request of type CallToolRequest
2025-08-06 12:33:13.385 | INFO     | __main__:suggest_aws_commands:130 - Suggesting AWS commands for query: list my s3 buckets

2025-08-06 12:33:13.386 [error] Dispatching request of type CallToolRequest
2025-08-06 12:33:13.385 | INFO     | __main__:suggest_aws_commands:130 - Suggesting AWS commands for query: list my s3 buckets

2025-08-06 12:33:13.395 [error] 
Batches:   0%|          | 0/1 [00:00<?, ?it/s]
2025-08-06 12:33:13.395 [error] 
Batches:   0%|          | 0/1 [00:00<?, ?it/s]
2025-08-06 12:33:13.593 [error] 
Batches: 100%|##########| 1/1 [00:00<00:00,  5.00it/s]
2025-08-06 12:33:13.593 [error] 
Batches: 100%|##########| 1/1 [00:00<00:00,  5.00it/s]
2025-08-06 12:33:13.593 [error] 
Batches: 100%|##########| 1/1 [00:00<00:00,  5.00it/s]

2025-08-06 12:33:13.593 [error] 
Batches: 100%|##########| 1/1 [00:00<00:00,  5.00it/s]

2025-08-06 12:33:13.597 [error] Environment variable FAISS_OPT_LEVEL is not set, so let's pick the instruction set according to the current CPU

2025-08-06 12:33:13.597 [error] Environment variable FAISS_OPT_LEVEL is not set, so let's pick the instruction set according to the current CPU

2025-08-06 12:33:13.598 [error] Loading faiss with AVX512 support.

2025-08-06 12:33:13.599 [error] Loading faiss with AVX512 support.

2025-08-06 12:33:13.599 [error] Could not load library with AVX512 support due to:
ModuleNotFoundError("No module named 'faiss.swigfaiss_avx512'")
Loading faiss with AVX2 support.

2025-08-06 12:33:13.599 [error] Could not load library with AVX512 support due to:
ModuleNotFoundError("No module named 'faiss.swigfaiss_avx512'")
Loading faiss with AVX2 support.

2025-08-06 12:33:14.143 [error] Successfully loaded faiss with AVX2 support.

2025-08-06 12:33:14.143 [error] Successfully loaded faiss with AVX2 support.

2025-08-06 12:33:14.155 [error] Failed to load GPU Faiss: name 'GpuIndexIVFFlat' is not defined. Will not load constructor refs for GPU indexes. This is only an error if you're trying to use GPU Faiss.

2025-08-06 12:33:14.155 [error] Failed to load GPU Faiss: name 'GpuIndexIVFFlat' is not defined. Will not load constructor refs for GPU indexes. This is only an error if you're trying to use GPU Faiss.
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
