### PR TITLE
Refactor ElastiCache MCP server tools to include AWSConfig for credential management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,185 @@
+services:
+  # ecs_mcp_server:
+  #   build:
+  #     context: src/ecs-mcp-server
+  #     dockerfile: Dockerfile
+  #   image: ecs-mcp-server:latest
+  #   container_name: ecs-mcp-server
+  #   environment:
+  #     FASTMCP_LOG_LEVEL: ${FASTMCP_LOG_LEVEL:-INFO}
+  #     ALLOW_WRITE: ${ALLOW_WRITE:-false}
+  #     ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+  #   ports:
+  #     - 127.0.0.1:8000:8000
+  #   networks:
+  #     - mcp-servers-network
+
+  eks_mcp_server:
+    build:
+      context: src/eks-mcp-server
+      dockerfile: Dockerfile
+    image: eks-mcp-server:latest
+    container_name: eks-mcp-server
+    environment:
+      FASTMCP_LOG_LEVEL: ${FASTMCP_LOG_LEVEL:-INFO}
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9000:9000
+    networks:
+      - mcp-servers-network
+
+  terraform_mcp_server:
+    build:
+      context: src/terraform-mcp-server
+      dockerfile: Dockerfile
+    image: terraform-mcp-server:latest
+    container_name: terraform-mcp-server
+    environment:
+      FASTMCP_LOG_LEVEL: ${FASTMCP_LOG_LEVEL:-INFO}
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9100:9100
+    networks:
+      - mcp-servers-network
+
+  # lambda_mcp_server:
+  #   build:
+  #     context: src/lambda-tool-mcp-server
+  #     dockerfile: Dockerfile
+  #   image: lambda-mcp-server:latest
+  #   container_name: lambda-mcp-server
+  #   environment:
+  #     AWS_PROFILE: your-aws-profile
+  #     AWS_REGION: us-east-1
+  #     FUNCTION_PREFIX: your-function-prefix
+  #     FUNCTION_LIST: your-first-function, your-second-function
+  #     FUNCTION_TAG_KEY: your-tag-key
+  #     FUNCTION_TAG_VALUE: your-tag-value
+  #     FUNCTION_INPUT_SCHEMA_ARN_TAG_KEY: your-function-tag-for-input-schema
+  #     ALLOW_WRITE: ${ALLOW_WRITE:-false}
+  #     ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+  #   ports:
+  #     - 127.0.0.1:9200:9200
+  #   networks:
+  #     - mcp-servers-network
+
+  # dynamodb_mcp_server:
+  #   build:
+  #     context: src/dynamodb-mcp-server
+  #     dockerfile: Dockerfile
+  #   image: dynamodb-mcp-server:latest
+  #   container_name: dynamodb-mcp-server
+  #   environment:
+  #     DDB-MCP-READONLY: "true"
+  #     AWS_PROFILE: default
+  #     AWS_REGION: us-west-2
+  #     FASTMCP_LOG_LEVEL: ERROR
+  #     ALLOW_WRITE: ${ALLOW_WRITE:-false}
+  #     ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+  #   ports:
+  #     - 127.0.0.1:9300:9300
+  #   networks:
+  #     - mcp-servers-network
+
+  elasticache_mcp_server:
+    build:
+      context: src/elasticache-mcp-server
+      dockerfile: Dockerfile
+    image: elasticache-mcp-server:latest
+    container_name: elasticache-mcp-server
+    environment:
+      AWS_PROFILE: default
+      AWS_REGION: us-west-2
+      FASTMCP_LOG_LEVEL: ERROR
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9400:9400
+    networks:
+      - mcp-servers-network
+
+  aurora_mcp_server:
+    build:
+      context: src/aurora-dsql-mcp-server
+      dockerfile: Dockerfile
+    image: aurora-mcp-server:latest
+    container_name: aurora-mcp-server
+    environment:
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9500:9500
+    networks:
+      - mcp-servers-network
+
+  mysql_mcp_server:
+    build:
+      context: src/mysql-mcp-server
+      dockerfile: Dockerfile
+    image: mysql-mcp-server:latest
+    container_name: mysql-mcp-server
+    environment:
+      AWS_PROFILE: your-aws-profile
+      AWS_REGION: us-east-1
+      FASTMCP_LOG_LEVEL: ERROR
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9600:9600
+    networks:
+      - mcp-servers-network
+
+  postgres_mcp_server:
+    build:
+      context: src/postgres-mcp-server
+      dockerfile: Dockerfile
+    image: postgres-mcp-server:latest
+    container_name: postgres-mcp-server
+    environment:
+      AWS_PROFILE: your-aws-profile
+      AWS_REGION: us-east-1
+      FASTMCP_LOG_LEVEL: ERROR
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9700:9700
+    networks:
+      - mcp-servers-network
+
+  cloudwatch_mcp_server:
+    build:
+      context: src/cloudwatch-mcp-server
+      dockerfile: Dockerfile
+    image: cloudwatch-mcp-server:latest
+    container_name: cloudwatch-mcp-server
+    environment:
+      AWS_PROFILE: your-aws-profile
+      FASTMCP_LOG_LEVEL: ERROR
+      ALLOW_WRITE: ${ALLOW_WRITE:-false}
+      ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+    ports:
+      - 127.0.0.1:9800:9800
+    networks:
+      - mcp-servers-network
+
+  # aws_serverless_mcp:
+  #   build:
+  #     context: src/aws-serverless-mcp-server
+  #     dockerfile: Dockerfile
+  #   image: aws-serverless-mcp:latest
+  #   container_name: aws-serverless-mcp
+  #   environment:
+  #     AWS_PROFILE: your-aws-profile
+  #     AWS_REGION: us-east-1
+  #     ALLOW_WRITE: ${ALLOW_WRITE:-false}
+  #     ALLOW_SENSITIVE_DATA: ${ALLOW_SENSITIVE_DATA:-false}
+  #   ports:
+  #     - 127.0.0.1:9900:9900
+  #   networks:
+  #     - mcp-servers-network
+
+networks:
+  mcp-servers-network:
+    driver: bridge

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/common.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/common.py
@@ -15,6 +15,7 @@
 import datetime
 import json
 from typing import Dict, List, Set
+from pydantic import BaseModel, Field
 
 
 def remove_null_values(d: Dict):
@@ -49,3 +50,10 @@ def clean_up_pattern(pattern_result: List[Dict[str, str]]):
         entry.pop('@visualization', None)
         # limit to 1 sample
         entry['@logSamples'] = json.loads(entry.get('@logSamples', '[]'))[:1]
+
+
+class AWSConfig(BaseModel):
+    """AWS credentials and region for creating clients."""
+    aws_access_key_id: str = Field(..., description="AWS access key ID")
+    aws_secret_access_key: str = Field(..., description="AWS secret access key")
+    region_name: str = Field("us-east-1", description="AWS region to query. Defaults to us-east-1.")

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/common.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/common.py
@@ -16,6 +16,7 @@ import os
 from functools import wraps
 from typing import Any, Callable, Dict, List, Literal, Optional
 from typing_extensions import TypedDict
+from pydantic import BaseModel, Field
 
 
 def handle_exceptions(func: Callable) -> Callable:
@@ -332,3 +333,10 @@ class UpdateTableInput(TypedDict, total=False):
     StreamSpecification: StreamSpecification
     TableClass: Literal['STANDARD', 'STANDARD_INFREQUENT_ACCESS']
     WarmThroughput: WarmThroughput
+
+
+class AWSConfig(BaseModel):
+    """AWS credentials and region for creating clients."""
+    aws_access_key_id: str = Field(..., description="AWS access key ID")
+    aws_secret_access_key: str = Field(..., description="AWS secret access key")
+    region_name: str = Field("us-west-2", description="The aws region to run the tool")

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/create.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/create.py
@@ -14,7 +14,7 @@
 
 """Create cache cluster tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -99,7 +99,7 @@ class CreateCacheClusterRequest(BaseModel):
 
 @mcp.tool(name='create-cache-cluster')
 @handle_exceptions
-async def create_cache_cluster(request: CreateCacheClusterRequest) -> Dict:
+async def create_cache_cluster(request: CreateCacheClusterRequest, aws_config: AWSConfig) -> Dict:
     """Create an Amazon ElastiCache cache cluster."""
     # Check if readonly mode is enabled
     if Context.readonly_mode():
@@ -108,7 +108,7 @@ async def create_cache_cluster(request: CreateCacheClusterRequest) -> Dict:
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Convert request model to dictionary, only including non-None values
     create_request: Dict[str, Any] = {

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/delete.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/delete.py
@@ -14,7 +14,7 @@
 
 """Delete cache cluster tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -24,6 +24,7 @@ from typing import Optional
 @mcp.tool(name='delete-cache-cluster')
 @handle_exceptions
 async def delete_cache_cluster(
+    aws_config: AWSConfig,
     cache_cluster_id: str,
     final_snapshot_identifier: Optional[str] = None,
 ) -> dict:
@@ -33,6 +34,10 @@ async def delete_cache_cluster(
     snapshot of the cluster before deletion.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         cache_cluster_id (str): The ID of the cache cluster to delete.
         final_snapshot_identifier (Optional[str]): The user-supplied name of a final
             cache cluster snapshot. This is the unique name that identifies the
@@ -49,7 +54,7 @@ async def delete_cache_cluster(
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build delete request
     delete_request = {

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/describe.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/describe.py
@@ -14,7 +14,7 @@
 
 """Describe cache clusters tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 @mcp.tool(name='describe-cache-clusters')
 @handle_exceptions
 async def describe_cache_clusters(
+    aws_config: AWSConfig,
     cache_cluster_id: Optional[str] = None,
     max_records: Optional[int] = None,
     marker: Optional[str] = None,
@@ -36,6 +37,10 @@ async def describe_cache_clusters(
     about up to MaxRecords cache clusters is returned.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         cache_cluster_id (Optional[str]): The identifier for the cache cluster to describe.
             If not provided, information about all cache clusters is returned.
         max_records (Optional[int]): The maximum number of records to include in the response.
@@ -56,7 +61,7 @@ async def describe_cache_clusters(
         - Marker: Pagination marker for next set of results
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build describe request
     describe_request = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/modify.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/modify.py
@@ -14,7 +14,7 @@
 
 """Modify cache cluster tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -89,7 +89,7 @@ class ModifyCacheClusterRequest(BaseModel):
 
 @mcp.tool(name='modify-cache-cluster')
 @handle_exceptions
-async def modify_cache_cluster(request: ModifyCacheClusterRequest) -> Dict:
+async def modify_cache_cluster(request: ModifyCacheClusterRequest, aws_config: AWSConfig) -> Dict:
     """Modify an existing Amazon ElastiCache cache cluster."""
     # Check if readonly mode is enabled
     if Context.readonly_mode():
@@ -98,7 +98,7 @@ async def modify_cache_cluster(request: ModifyCacheClusterRequest) -> Dict:
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Convert request model to dictionary, only including non-None values
     modify_request: Dict[str, Any] = {'CacheClusterId': request.cache_cluster_id}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/ce/get_cost_and_usage.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/ce/get_cost_and_usage.py
@@ -14,7 +14,7 @@
 
 """Get cost and usage data for ElastiCache resources."""
 
-from ...common.connection import CostExplorerConnectionManager
+from ...common.connection import CostExplorerConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from pydantic import BaseModel, ConfigDict, Field
@@ -36,7 +36,7 @@ class GetCostAndUsageRequest(BaseModel):
 
 @mcp.tool(name='get-cost-and-usage')
 @handle_exceptions
-async def get_cost_and_usage(request: GetCostAndUsageRequest) -> Dict[str, Any]:
+async def get_cost_and_usage(request: GetCostAndUsageRequest, aws_config: AWSConfig) -> Dict[str, Any]:
     """Get cost and usage data for ElastiCache resources.
 
     This tool retrieves cost and usage data for ElastiCache resources with customizable
@@ -49,12 +49,16 @@ async def get_cost_and_usage(request: GetCostAndUsageRequest) -> Dict[str, Any]:
         request: The GetCostAndUsageRequest object containing:
             - time_period: Time period in YYYY-MM-DD/YYYY-MM-DD format
             - granularity: Data granularity (DAILY, MONTHLY, or HOURLY)
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
 
     Returns:
         Dict containing the cost and usage data.
     """
     # Get Cost Explorer client
-    ce_client = CostExplorerConnectionManager.get_connection()
+    ce_client = CostExplorerConnectionManager.get_connection(aws_config)
 
     # Split time period into start and end dates
     start_date, end_date = request.time_period.split('/')

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cw/get_metric_statistics.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cw/get_metric_statistics.py
@@ -14,7 +14,7 @@
 
 """Tool for getting CloudWatch metric statistics."""
 
-from ...common.connection import CloudWatchConnectionManager
+from ...common.connection import CloudWatchConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from datetime import datetime
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 @mcp.tool(name='get-metric-statistics')
 @handle_exceptions
 async def get_metric_statistics(
+    aws_config: AWSConfig,
     metric_name: str,
     start_time: str,
     end_time: str,
@@ -36,6 +37,10 @@ async def get_metric_statistics(
     """Get CloudWatch metric statistics.
 
     Args:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         metric_name: The name of the metric
         start_time: The start time in ISO 8601 format
         end_time: The end time in ISO 8601 format
@@ -48,7 +53,7 @@ async def get_metric_statistics(
     Returns:
         Dict containing metric statistics
     """
-    client = CloudWatchConnectionManager.get_connection()
+    client = CloudWatchConnectionManager.get_connection(aws_config)
 
     # Convert ISO 8601 strings to datetime objects
     start = datetime.fromisoformat(start_time.replace('Z', '+00:00'))

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/create_log_group.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/create_log_group.py
@@ -14,7 +14,7 @@
 
 """Tool for creating a CloudWatch Logs log group."""
 
-from ...common.connection import CloudWatchLogsConnectionManager
+from ...common.connection import CloudWatchLogsConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -24,6 +24,7 @@ from typing import Any, Dict, Optional
 @mcp.tool(name='create-log-group')
 @handle_exceptions
 async def create_log_group(
+    aws_config: AWSConfig,
     log_group_name: str,
     kms_key_id: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
@@ -32,6 +33,10 @@ async def create_log_group(
     """Create a new CloudWatch Logs log group.
 
     Args:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         log_group_name: The name of the log group to create
         kms_key_id: The Amazon Resource Name (ARN) of the KMS key to use for encryption
         tags: The key-value pairs to use for the tags
@@ -48,7 +53,7 @@ async def create_log_group(
             'You have configured this tool in readonly mode. To make this change you will have to update your configuration.'
         )
 
-    client = CloudWatchLogsConnectionManager.get_connection()
+    client = CloudWatchLogsConnectionManager.get_connection(aws_config)
 
     # Build request parameters
     params: Dict[str, Any] = {

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_groups.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_groups.py
@@ -14,7 +14,7 @@
 
 """Tool for describing CloudWatch Logs log groups."""
 
-from ...common.connection import CloudWatchLogsConnectionManager
+from ...common.connection import CloudWatchLogsConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Any, Dict, List, Optional
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional
 @mcp.tool(name='describe-log-groups')
 @handle_exceptions
 async def describe_log_groups(
+    aws_config: AWSConfig,
     account_identifiers: Optional[List[str]] = None,
     log_group_name_prefix: Optional[str] = None,
     log_group_name_pattern: Optional[str] = None,
@@ -36,6 +37,10 @@ async def describe_log_groups(
     """Describe CloudWatch Logs log groups.
 
     Args:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         account_identifiers: List of account IDs to filter log groups
         log_group_name_prefix: Prefix to filter log groups by name
         log_group_name_pattern: Pattern to match log group names
@@ -49,7 +54,7 @@ async def describe_log_groups(
     Returns:
         Dict containing log groups information or error details
     """
-    client = CloudWatchLogsConnectionManager.get_connection()
+    client = CloudWatchLogsConnectionManager.get_connection(aws_config)
 
     # Build request parameters
     params: Dict[str, Any] = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_streams.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_streams.py
@@ -14,7 +14,7 @@
 
 """Tool for describing CloudWatch Logs log streams."""
 
-from ...common.connection import CloudWatchLogsConnectionManager
+from ...common.connection import CloudWatchLogsConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Any, Dict, Optional
@@ -23,6 +23,7 @@ from typing import Any, Dict, Optional
 @mcp.tool(name='describe-log-streams')
 @handle_exceptions
 async def describe_log_streams(
+    aws_config: AWSConfig,
     log_group_name: Optional[str] = None,
     log_group_identifier: Optional[str] = None,
     log_stream_name_prefix: Optional[str] = None,
@@ -47,7 +48,7 @@ async def describe_log_streams(
     Returns:
         Dict containing information about the log streams or error details.
     """
-    client = CloudWatchLogsConnectionManager.get_connection()
+    client = CloudWatchLogsConnectionManager.get_connection(aws_config)
 
     # Build request parameters
     params: Dict[str, Any] = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/filter_log_events.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/filter_log_events.py
@@ -14,7 +14,7 @@
 
 """Tool for filtering log events from CloudWatch Logs."""
 
-from ...common.connection import CloudWatchLogsConnectionManager
+from ...common.connection import CloudWatchLogsConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from datetime import datetime
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 @mcp.tool(name='filter-log-events')
 @handle_exceptions
 async def filter_log_events(
+    aws_config: AWSConfig,
     log_group_name: Optional[str] = None,
     log_group_identifier: Optional[str] = None,
     log_stream_names: Optional[List[str]] = None,
@@ -40,6 +41,10 @@ async def filter_log_events(
     """Filter log events from CloudWatch Logs.
 
     Args:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         log_group_name: The name of the log group
         log_group_identifier: The unique identifier of the log group
         log_stream_names: Optional list of log stream names to search
@@ -59,7 +64,7 @@ async def filter_log_events(
         - searchedLogStreams: List of log streams that were searched
         - nextToken: Token for getting the next set of events
     """
-    client = CloudWatchLogsConnectionManager.get_connection()
+    client = CloudWatchLogsConnectionManager.get_connection(aws_config)
 
     # Build request parameters
     params: Dict[str, Any] = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/get_log_events.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/get_log_events.py
@@ -14,7 +14,7 @@
 
 """Tool for retrieving log events from CloudWatch Logs."""
 
-from ...common.connection import CloudWatchLogsConnectionManager
+from ...common.connection import CloudWatchLogsConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from datetime import datetime
@@ -24,6 +24,7 @@ from typing import Any, Dict, Optional
 @mcp.tool(name='get-log-events')
 @handle_exceptions
 async def get_log_events(
+    aws_config: AWSConfig,
     log_stream_name: str,
     log_group_name: Optional[str] = None,
     log_group_identifier: Optional[str] = None,
@@ -37,6 +38,7 @@ async def get_log_events(
     """Get log events from CloudWatch Logs.
 
     Args:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
         log_group_name: The name of the log group
         log_group_identifier: The unique identifier of the log group
         log_stream_name: The name of the log stream
@@ -53,7 +55,7 @@ async def get_log_events(
         - nextForwardToken: Token for getting the next set of events
         - nextBackwardToken: Token for getting the previous set of events
     """
-    client = CloudWatchLogsConnectionManager.get_connection()
+    client = CloudWatchLogsConnectionManager.get_connection(aws_config)
 
     # Build request parameters
     params: Dict[str, Any] = {

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/firehose/list_delivery_streams.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/firehose/list_delivery_streams.py
@@ -14,7 +14,7 @@
 
 """Tool for listing Kinesis Firehose delivery streams."""
 
-from ...common.connection import FirehoseConnectionManager
+from ...common.connection import FirehoseConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Any, Dict
@@ -23,6 +23,7 @@ from typing import Any, Dict
 @mcp.tool(name='list-delivery-streams')
 @handle_exceptions
 async def list_delivery_streams(
+    aws_config: AWSConfig,
     limit: Any = None,
     delivery_stream_type: Any = None,
     exclusive_start_delivery_stream_name: Any = None,
@@ -30,6 +31,10 @@ async def list_delivery_streams(
     """List your delivery streams.
 
     Args:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         limit: The maximum number of delivery streams to list
         delivery_stream_type: The delivery stream type. This can be one of the following values:
             DirectPut - Provider data is sent directly to the Firehose stream
@@ -39,7 +44,7 @@ async def list_delivery_streams(
     Returns:
         Dict containing the list of delivery streams and whether there are more streams available
     """
-    client = FirehoseConnectionManager.get_connection()
+    client = FirehoseConnectionManager.get_connection(aws_config)
 
     # Build request parameters
     params: Dict[str, Any] = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/batch_apply_update_action.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/batch_apply_update_action.py
@@ -14,7 +14,7 @@
 
 """Batch apply update action tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -24,6 +24,7 @@ from typing import Dict, List, Optional
 @mcp.tool(name='batch-apply-update-action')
 @handle_exceptions
 async def batch_apply_update_action(
+    aws_config: AWSConfig,
     service_update_name: str,
     replication_group_ids: Optional[List[str]] = None,
     cache_cluster_ids: Optional[List[str]] = None,
@@ -31,6 +32,10 @@ async def batch_apply_update_action(
     """Apply service update to multiple ElastiCache resources.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         service_update_name (str): The unique ID of the service update to apply.
         replication_group_ids (Optional[List[str]]): List of replication group IDs to update.
             Either this or cache_cluster_ids must be provided.
@@ -47,7 +52,7 @@ async def batch_apply_update_action(
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build request
     request: Dict[str, str | List[str]] = {'ServiceUpdateName': service_update_name}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/batch_stop_update_action.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/batch_stop_update_action.py
@@ -14,7 +14,7 @@
 
 """Batch stop update action tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -24,6 +24,7 @@ from typing import Dict, List, Optional
 @mcp.tool(name='batch-stop-update-action')
 @handle_exceptions
 async def batch_stop_update_action(
+    aws_config: AWSConfig,
     service_update_name: str,
     replication_group_ids: Optional[List[str]] = None,
     cache_cluster_ids: Optional[List[str]] = None,
@@ -31,6 +32,10 @@ async def batch_stop_update_action(
     """Stop service update for multiple ElastiCache resources.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         service_update_name (str): The unique ID of the service update to stop.
         replication_group_ids (Optional[List[str]]): List of replication group IDs to stop update.
             Either this or cache_cluster_ids must be provided.
@@ -47,7 +52,7 @@ async def batch_stop_update_action(
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build request
     request: Dict[str, str | List[str]] = {'ServiceUpdateName': service_update_name}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_cache_engine_versions.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_cache_engine_versions.py
@@ -14,7 +14,7 @@
 
 """Describe cache engine versions tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 @mcp.tool(name='describe-cache-engine-versions')
 @handle_exceptions
 async def describe_cache_engine_versions(
+    aws_config: AWSConfig,
     engine: Optional[str] = None,
     engine_version: Optional[str] = None,
     cache_parameter_group_family: Optional[str] = None,
@@ -33,6 +34,10 @@ async def describe_cache_engine_versions(
     """Returns a list of the available cache engines and their versions.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         engine (Optional[str]): The cache engine to return. Valid values: memcached | redis | valkey
         engine_version (Optional[str]): The cache engine version to return.
             Example: memcached 1.4.14, redis 6.x, valkey 8.0
@@ -55,7 +60,7 @@ async def describe_cache_engine_versions(
         - Marker: Pagination marker for next set of results
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build describe request
     describe_request = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_engine_default_parameters.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_engine_default_parameters.py
@@ -14,7 +14,7 @@
 
 """Describe engine default parameters tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 @mcp.tool(name='describe-engine-default-parameters')
 @handle_exceptions
 async def describe_engine_default_parameters(
+    aws_config: AWSConfig,
     cache_parameter_group_family: str,
     max_records: Optional[int] = None,
     marker: Optional[str] = None,
@@ -30,6 +31,10 @@ async def describe_engine_default_parameters(
     """Returns the default engine and system parameter information for the specified cache engine family.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         cache_parameter_group_family (str): The name of the cache parameter group family.
             Valid values are: memcached1.4 | memcached1.5 | memcached1.6 | redis2.6 | redis2.8 |
             redis3.2 | redis4.0 | redis5.0 | redis6.x | redis7.x | valkey7.x | valkey8.x
@@ -48,7 +53,7 @@ async def describe_engine_default_parameters(
         - Marker: Pagination marker for next set of results
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build describe request
     describe_request = {'CacheParameterGroupFamily': cache_parameter_group_family}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_events.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_events.py
@@ -14,7 +14,7 @@
 
 """Describe events tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from datetime import datetime
@@ -24,6 +24,7 @@ from typing import Dict, Optional
 @mcp.tool(name='describe-events')
 @handle_exceptions
 async def describe_events(
+    aws_config: AWSConfig,
     source_type: Optional[str] = None,
     source_identifier: Optional[str] = None,
     start_time: Optional[datetime] = None,
@@ -35,6 +36,10 @@ async def describe_events(
     """Returns events related to clusters, cache security groups, and parameter groups.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         source_type (Optional[str]): The event source to retrieve events for. If not specified, all
             events are returned. Valid values: cache-cluster | cache-parameter-group |
             cache-security-group | cache-subnet-group | replication-group | user | user-group
@@ -60,7 +65,7 @@ async def describe_events(
         - Marker: Pagination marker for next set of results
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build describe request
     describe_request = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_service_updates.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_service_updates.py
@@ -14,7 +14,7 @@
 
 """Describe service updates tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, List, Optional
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional
 @mcp.tool(name='describe-service-updates')
 @handle_exceptions
 async def describe_service_updates(
+    aws_config: AWSConfig,
     service_update_name: Optional[str] = None,
     service_update_status: Optional[List[str]] = None,
     starting_token: Optional[str] = None,
@@ -32,6 +33,10 @@ async def describe_service_updates(
     """Returns details of the service updates.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         service_update_name (Optional[str]): The unique ID of the service update to describe.
         service_update_status (Optional[List[str]]): List of status values to filter by.
             Valid values: available | cancelled | expired | complete
@@ -49,7 +54,7 @@ async def describe_service_updates(
         - NextToken: Token for next set of results
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build describe request
     describe_request = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/complete_migration.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/complete_migration.py
@@ -14,7 +14,7 @@
 
 """Complete migration tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -61,7 +61,7 @@ def prepare_request_dict(request: CompleteMigrationRequest) -> Dict[str, Any]:
 
 @mcp.tool(name='complete-migration')
 @handle_exceptions
-async def complete_migration(request: CompleteMigrationRequest) -> Dict:
+async def complete_migration(request: CompleteMigrationRequest, aws_config: AWSConfig) -> Dict:
     """Complete migration to an Amazon ElastiCache replication group.
 
     This tool completes the migration of data from a Redis instance to an ElastiCache replication group.
@@ -73,6 +73,10 @@ async def complete_migration(request: CompleteMigrationRequest) -> Dict:
             - force: (Optional) Forces the migration to stop without ensuring that data is in sync.
               It is recommended to use this option only to abort the migration and not recommended
               when application wants to continue migration to ElastiCache.
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
 
     Returns:
         Dict containing information about the migration completion result.
@@ -84,7 +88,7 @@ async def complete_migration(request: CompleteMigrationRequest) -> Dict:
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Prepare request dictionary
     complete_request = prepare_request_dict(request)

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/create.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/create.py
@@ -14,7 +14,7 @@
 
 """Create replication group tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -284,7 +284,7 @@ def prepare_request_dict(request: CreateReplicationGroupRequest) -> Dict[str, An
 
 @mcp.tool(name='create-replication-group')
 @handle_exceptions
-async def create_replication_group(request: CreateReplicationGroupRequest) -> Dict:
+async def create_replication_group(request: CreateReplicationGroupRequest, aws_config: AWSConfig) -> Dict:
     """Create an Amazon ElastiCache replication group.
 
     This tool creates a new replication group with specified configuration including:
@@ -297,6 +297,10 @@ async def create_replication_group(request: CreateReplicationGroupRequest) -> Di
 
     Args:
         request: The CreateReplicationGroupRequest object containing all parameters
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
 
     Returns:
         Dict containing information about the created replication group.
@@ -308,7 +312,7 @@ async def create_replication_group(request: CreateReplicationGroupRequest) -> Di
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Prepare request dictionary
     create_request = prepare_request_dict(request)

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/delete.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/delete.py
@@ -14,7 +14,7 @@
 
 """Delete replication group tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -24,6 +24,7 @@ from typing import Dict, Optional
 @mcp.tool(name='delete-replication-group')
 @handle_exceptions
 async def delete_replication_group(
+    aws_config: AWSConfig,
     replication_group_id: str,
     retain_primary_cluster: Optional[bool] = None,
     final_snapshot_name: Optional[str] = None,
@@ -34,6 +35,10 @@ async def delete_replication_group(
     as a standalone cache cluster or create a final snapshot before deletion.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         replication_group_id (str): The identifier of the replication group to delete.
         retain_primary_cluster (Optional[bool]): If True, retains the primary cluster as a standalone
             cache cluster. If False, deletes all clusters in the replication group.
@@ -50,7 +55,7 @@ async def delete_replication_group(
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build delete request
     delete_request = {

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/describe.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/describe.py
@@ -14,7 +14,7 @@
 
 """Describe replication groups tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 @mcp.tool(name='describe-replication-groups')
 @handle_exceptions
 async def describe_replication_groups(
+    aws_config: AWSConfig,
     replication_group_id: Optional[str] = None,
     max_records: Optional[int] = None,
     marker: Optional[str] = None,
@@ -34,6 +35,10 @@ async def describe_replication_groups(
     about up to MaxRecords replication groups is returned.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         replication_group_id (Optional[str]): The identifier for the replication group to describe.
             If not provided, information about all replication groups is returned.
         max_records (Optional[int]): The maximum number of records to include in the response.
@@ -50,7 +55,7 @@ async def describe_replication_groups(
         - Marker: Pagination marker for next set of results
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build describe request
     describe_request = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/modify.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/modify.py
@@ -15,7 +15,7 @@
 """Modify replication group tool for ElastiCache MCP server."""
 
 import json
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Union
 @mcp.tool(name='modify-replication-group-shard-configuration')
 @handle_exceptions
 async def modify_replication_group_shard_configuration(
+    aws_config: AWSConfig,
     replication_group_id: str,
     node_group_count: int,
     apply_immediately: Optional[bool] = None,
@@ -39,6 +40,10 @@ async def modify_replication_group_shard_configuration(
     - Specifying preferred availability zones for replicas
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         replication_group_id (str): The identifier of the replication group to modify.
         node_group_count (int): The number of node groups (shards) in the replication group.
         apply_immediately (Optional[bool]): Whether to apply changes immediately or during maintenance window.
@@ -61,7 +66,7 @@ async def modify_replication_group_shard_configuration(
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build modify request
     modify_request = {
@@ -201,7 +206,7 @@ def prepare_modify_request_dict(request: ModifyReplicationGroupRequest) -> Dict[
 
 @mcp.tool(name='modify-replication-group')
 @handle_exceptions
-async def modify_replication_group(request: ModifyReplicationGroupRequest) -> Dict:
+async def modify_replication_group(request: ModifyReplicationGroupRequest, aws_config: AWSConfig) -> Dict:
     """Modify an existing Amazon ElastiCache replication group.
 
     This tool modifies the settings of an existing replication group including:
@@ -215,6 +220,10 @@ async def modify_replication_group(request: ModifyReplicationGroupRequest) -> Di
 
     Args:
         request: The ModifyReplicationGroupRequest object containing all parameters
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
 
     Returns:
         Dict containing information about the modified replication group.
@@ -226,7 +235,7 @@ async def modify_replication_group(request: ModifyReplicationGroupRequest) -> Di
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Prepare request dictionary
     modify_request = prepare_modify_request_dict(request)

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/start_migration.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/start_migration.py
@@ -14,7 +14,7 @@
 
 """Start migration tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -118,7 +118,7 @@ def prepare_request_dict(request: StartMigrationRequest) -> Dict[str, Any]:
 
 @mcp.tool(name='start-migration')
 @handle_exceptions
-async def start_migration(request: StartMigrationRequest) -> Dict:
+async def start_migration(request: StartMigrationRequest, aws_config: AWSConfig) -> Dict:
     """Start migration to an Amazon ElastiCache replication group.
 
     This tool starts migration from a Redis instance to an ElastiCache replication group.
@@ -130,6 +130,10 @@ async def start_migration(request: StartMigrationRequest) -> Dict:
             - replication_group_id: The ID of the replication group to which data should be migrated
             - customer_node_endpoint_list: List of endpoints from which data should be migrated.
               For Valkey or Redis OSS (cluster mode disabled), the list should have only one element.
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
 
     Returns:
         Dict containing information about the migration start result.
@@ -141,7 +145,7 @@ async def start_migration(request: StartMigrationRequest) -> Dict:
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Prepare request dictionary
     start_request = prepare_request_dict(request)

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/test_migration.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/test_migration.py
@@ -14,7 +14,7 @@
 
 """Test migration tool for ElastiCache MCP server."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from pydantic import BaseModel, ConfigDict, Field
@@ -112,7 +112,7 @@ def prepare_request_dict(request: MigrationTestRequest) -> Dict[str, Any]:
 
 @mcp.tool(name='test-migration')
 @handle_exceptions
-async def test_migration(request: MigrationTestRequest) -> Dict:
+async def test_migration(request: MigrationTestRequest, aws_config: AWSConfig) -> Dict:
     """Test migration to an Amazon ElastiCache replication group.
 
     This tool tests migration from a Redis instance to an ElastiCache replication group.
@@ -124,12 +124,16 @@ async def test_migration(request: MigrationTestRequest) -> Dict:
             - replication_group_id: The ID of the replication group to which data is to be migrated
             - customer_node_endpoint_list: List of endpoints from which data should be migrated.
               List should have only one element with Address and Port fields.
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
 
     Returns:
         Dict containing information about the migration test result.
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Prepare request dictionary
     test_request = prepare_request_dict(request)

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/create.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/create.py
@@ -14,7 +14,7 @@
 
 """Create serverless cache operations."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from ...context import Context
@@ -24,7 +24,10 @@ from typing import Dict
 
 @mcp.tool(name='create-serverless-cache')
 @handle_exceptions
-async def create_serverless_cache(request: CreateServerlessCacheRequest) -> Dict:
+async def create_serverless_cache(
+    request: CreateServerlessCacheRequest,
+    aws_config: AWSConfig,
+) -> Dict:
     """Create a new Amazon ElastiCache serverless cache.
 
     This tool creates a new serverless cache with specified configuration including:
@@ -36,40 +39,46 @@ async def create_serverless_cache(request: CreateServerlessCacheRequest) -> Dict
     - Optional tags
 
     Parameters:
-        serverless_cache_name (str): Name of the serverless cache.
-        engine (str): Cache engine type.
-        description (Optional[str]): Description for the cache.
-        kms_key_id (Optional[str]): KMS key ID for encryption.
-        major_engine_version (Optional[str]): Major engine version.
-        snapshot_arns_to_restore (Optional[List[str]]): List of snapshot ARNs to restore from.
-        subnet_ids (Optional[List[str]]): List of subnet IDs for VPC configuration.
-        tags (Optional[Union[str, List[Dict[str, Optional[str]]], Dict[str, Optional[str]]]]): Tags to apply to the cache.
-            Tag requirements:
-            - Key: (string) Required. The key for the tag. Must not be empty.
-            - Value: (string) Optional. The tag's value. May be null.
+        request (CreateServerlessCacheRequest): Request object containing all parameters.
+            serverless_cache_name (str): Name of the serverless cache to create.
+            engine (str): Cache engine type.
+            description (Optional[str]): Description for the cache.
+            kms_key_id (Optional[str]): KMS key ID for encryption.
+            major_engine_version (Optional[str]): Major engine version.
+            snapshot_arns_to_restore (Optional[List[str]]): List of snapshot ARNs to restore from.
+            subnet_ids (Optional[List[str]]): List of subnet IDs for VPC configuration.
+            tags (Optional[Union[str, List[Dict[str, Optional[str]]], Dict[str, Optional[str]]]]): Tags to apply to the cache.
+                Tag requirements:
+                - Key: (string) Required. The key for the tag. Must not be empty.
+                - Value: (string) Optional. The tag's value. May be null.
 
-            Supports three formats:
-            1. Shorthand syntax: "Key=value,Key2=value2" or "Key=,Key2=" for null values
-            2. Dictionary: {"key": "value", "key2": null}
-            3. JSON array: [{"Key": "string", "Value": "string"}, {"Key": "string2", "Value": null}]
+                Supports three formats:
+                1. Shorthand syntax: "Key=value,Key2=value2" or "Key=,Key2=" for null values
+                2. Dictionary: {"key": "value", "key2": null}
+                3. JSON array: [{"Key": "string", "Value": "string"}, {"Key": "string2", "Value": null}]
 
-            Can be None if no tags are needed.
-        security_group_ids (Optional[List[str]]): List of security group IDs.
-        cache_usage_limits (Optional[CacheUsageLimits]): Usage limits for the cache. Structure:
-            {
-                "DataStorage": {
-                    "Maximum": int,  # Maximum storage in GB
-                    "Minimum": int,  # Minimum storage in GB
-                    "Unit": "GB"     # Storage unit (currently only GB is supported)
-                },
-                "ECPUPerSecond": {
-                    "Maximum": int,  # Maximum ECPU per second
-                    "Minimum": int   # Minimum ECPU per second
+                Can be None if no tags are needed.
+            security_group_ids (Optional[List[str]]): List of security group IDs.
+            cache_usage_limits (Optional[CacheUsageLimits]): Usage limits for the cache. Structure:
+                {
+                    "DataStorage": {
+                        "Maximum": int,  # Maximum storage in GB
+                        "Minimum": int,  # Minimum storage in GB
+                        "Unit": "GB"     # Storage unit (currently only GB is supported)
+                    },
+                    "ECPUPerSecond": {
+                        "Maximum": int,  # Maximum ECPU per second
+                        "Minimum": int   # Minimum ECPU per second
+                    }
                 }
-            }
-        user_group_id (Optional[str]): ID of the user group to associate with the cache.
-        snapshot_retention_limit (Optional[int]): Number of days for which ElastiCache retains automatic snapshots.
-        daily_snapshot_time (Optional[str]): Time range (in UTC) when daily snapshots are taken (e.g., '04:00-05:00').
+            user_group_id (Optional[str]): ID of the user group to associate with the cache.
+            snapshot_retention_limit (Optional[int]): Number of days for which ElastiCache retains automatic snapshots.
+            daily_snapshot_time (Optional[str]): Time range (in UTC) when daily snapshots are taken (e.g., '04:00-05:00').
+        aws_config (AWSConfig):
+            Pydantic model with:
+                - aws_access_key_id: str
+                - aws_secret_access_key: str
+                - region_name: str
 
     Returns:
         Dict containing information about the created serverless cache.
@@ -97,7 +106,7 @@ async def create_serverless_cache(request: CreateServerlessCacheRequest) -> Dict
         )
 
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Build AWS API request
     create_request = {}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/delete.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/delete.py
@@ -14,7 +14,7 @@
 
 """Delete serverless cache operations."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 @mcp.tool(name='delete-serverless-cache')
 @handle_exceptions
 async def delete_serverless_cache(
+    aws_config: AWSConfig,
     serverless_cache_name: str,
     final_snapshot_name: Optional[str] = None,
 ) -> Dict:
@@ -32,6 +33,10 @@ async def delete_serverless_cache(
     The cache must exist and be in a deletable state.
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         serverless_cache_name (str): Name of the serverless cache to delete.
         final_snapshot_name (Optional[str]): Name of the final snapshot to create before deletion.
 
@@ -39,7 +44,7 @@ async def delete_serverless_cache(
         Dict containing the deletion response or error information.
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     delete_request = {'ServerlessCacheName': serverless_cache_name}
     if final_snapshot_name:

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/describe.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/describe.py
@@ -14,7 +14,7 @@
 
 """Describe serverless cache operations."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 @mcp.tool(name='describe-serverless-caches')
 @handle_exceptions
 async def describe_serverless_caches(
+    aws_config: AWSConfig,
     serverless_cache_name: Optional[str] = None,
     max_items: Optional[int] = None,
     starting_token: Optional[str] = None,
@@ -38,6 +39,10 @@ async def describe_serverless_caches(
     - Cache connections
 
     Parameters:
+        aws_config (AWSConfig): Pydantic model with AWS credentials and region.
+            aws_access_key_id (str): AWS access key ID.
+            aws_secret_access_key (str): AWS secret access key.
+            region_name (str): AWS region, e.g. 'us-east-1'.
         serverless_cache_name (Optional[str]): Name of the serverless cache to describe. If not provided, describes all caches.
         max_items (Optional[int]): Maximum number of results to return.
         starting_token (Optional[str]): Token to start the list from a specific page.
@@ -47,7 +52,7 @@ async def describe_serverless_caches(
         Dict containing information about the serverless cache(s).
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     if serverless_cache_name:
         # Get specific cache details

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/modify.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/modify.py
@@ -14,7 +14,7 @@
 
 """Modify serverless cache operations."""
 
-from ...common.connection import ElastiCacheConnectionManager
+from ...common.connection import ElastiCacheConnectionManager, AWSConfig
 from ...common.decorators import handle_exceptions
 from ...common.server import mcp
 from .models import ModifyServerlessCacheRequest
@@ -23,7 +23,10 @@ from typing import Dict
 
 @mcp.tool(name='modify-serverless-cache')
 @handle_exceptions
-async def modify_serverless_cache(request: ModifyServerlessCacheRequest) -> Dict:
+async def modify_serverless_cache(
+    request: ModifyServerlessCacheRequest,
+    aws_config: AWSConfig,
+) -> Dict:
     """Modify an Amazon ElastiCache serverless cache.
 
     This tool modifies the configuration of an existing serverless cache including:
@@ -35,26 +38,32 @@ async def modify_serverless_cache(request: ModifyServerlessCacheRequest) -> Dict
     - User groups
 
     Parameters:
-        serverless_cache_name (str): Name of the serverless cache to modify.
-        apply_immediately (Optional[bool]): Whether to apply changes immediately or during maintenance window.
-        description (Optional[str]): New description for the cache.
-        major_engine_version (Optional[str]): New major engine version.
-        snapshot_retention_limit (Optional[int]): Number of days for which ElastiCache retains automatic snapshots.
-        daily_snapshot_time (Optional[str]): Time range (in UTC) when daily snapshots are taken (e.g., '04:00-05:00').
-        cache_usage_limits (Optional[CacheUsageLimits]): New usage limits for the cache. Structure:
-            {
-                "DataStorage": {
-                    "Maximum": int,  # Maximum storage in GB
-                    "Minimum": int,  # Minimum storage in GB
-                    "Unit": "GB"     # Storage unit (currently only GB is supported)
-                },
-                "ECPUPerSecond": {
-                    "Maximum": int,  # Maximum ECPU per second
-                    "Minimum": int   # Minimum ECPU per second
+        request (ModifyServerlessCacheRequest): Request object containing modification parameters.
+            serverless_cache_name (str): Name of the serverless cache to modify.
+            apply_immediately (Optional[bool]): Whether to apply changes immediately or during maintenance window.
+            description (Optional[str]): New description for the cache.
+            major_engine_version (Optional[str]): New major engine version.
+            snapshot_retention_limit (Optional[int]): Number of days for which ElastiCache retains automatic snapshots.
+            daily_snapshot_time (Optional[str]): Time range (in UTC) when daily snapshots are taken (e.g., '04:00-05:00').
+            cache_usage_limits (Optional[CacheUsageLimits]): New usage limits for the cache. Structure:
+                {
+                    "DataStorage": {
+                        "Maximum": int,  # Maximum storage in GB
+                        "Minimum": int,  # Minimum storage in GB
+                        "Unit": "GB"     # Storage unit (currently only GB is supported)
+                    },
+                    "ECPUPerSecond": {
+                        "Maximum": int,  # Maximum ECPU per second
+                        "Minimum": int   # Minimum ECPU per second
+                    }
                 }
-            }
-        security_group_ids (Optional[List[str]]): List of security group IDs.
-        user_group_id (Optional[str]): ID of the user group to associate with the cache.
+            security_group_ids (Optional[List[str]]): List of security group IDs.
+            user_group_id (Optional[str]): ID of the user group to associate with the cache.
+        aws_config (AWSConfig):
+            Pydantic model with:
+                - aws_access_key_id: str
+                - aws_secret_access_key: str
+                - region_name: str
 
     Returns:
         Dict containing information about the modified serverless cache.
@@ -76,7 +85,7 @@ async def modify_serverless_cache(request: ModifyServerlessCacheRequest) -> Dict
         Dict containing information about the modified serverless cache.
     """
     # Get ElastiCache client
-    elasticache_client = ElastiCacheConnectionManager.get_connection()
+    elasticache_client = ElastiCacheConnectionManager.get_connection(aws_config)
 
     # Convert request to dict and remove None values
     modify_request = {k: v for k, v in request.model_dump().items() if v is not None}


### PR DESCRIPTION
- Updated test_migration.py to accept AWSConfig as a parameter for ElastiCache connection.
- Modified connect.py to utilize AWSConfig for EC2 and ElastiCache connections.
- Enhanced create.py to include AWSConfig in the create_serverless_cache function.
- Adjusted delete.py to accept AWSConfig for ElastiCache client initialization.
- Updated describe.py to use AWSConfig for describing serverless caches.
- Refactored modify.py to include AWSConfig for modifying serverless caches.
- Revised server.py to implement AWSConfig for Lambda function invocations and AWS client creation.
- Added a new docker-compose.yml file to define services for various MCP servers.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
