### PR TITLE
fix(aws-pricing-mcp-server): Improve get_pricing error response

### DIFF
--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -463,14 +463,19 @@ async def get_pricing(
         return await create_error_response(
             ctx=ctx,
             error_type='empty_results',
-            message=f'The service "{service_code}" did not return any pricing data. AWS service codes typically follow patterns like "AmazonS3", "AmazonEC2", "AmazonES", etc. Please check the exact service code and try again.',
+            message=f'No results found for given filters [{filters}], service: "{service_code}", region "{region}"',
             service_code=service_code,
             region=region,
+            suggestion='Try these approaches: (1) Verify that the service code is valid. Use get_service_codes() to get valid service codes. (2) Validate region and filter values using get_pricing_attribute_values(). (3) Test with fewer filters to isolate the issue.',
             examples={
-                'OpenSearch': 'AmazonES',
-                'Lambda': 'AWSLambda',
-                'DynamoDB': 'AmazonDynamoDB',
-                'Bedrock': 'AmazonBedrock',
+                'Example service codes': [
+                    'AmazonEC2',
+                    'AmazonS3',
+                    'AmazonES',
+                    'AWSLambda',
+                    'AmazonDynamoDB',
+                ],
+                'Example regions': ['us-east-1', 'eu-west-1', 'ap-south-1'],
             },
         )
 

--- a/src/aws-pricing-mcp-server/tests/test_server.py
+++ b/src/aws-pricing-mcp-server/tests/test_server.py
@@ -306,10 +306,22 @@ class TestGetPricing:
         assert result['status'] == 'error'
         assert result['error_type'] == 'empty_results'
         assert 'InvalidService' in result['message']
+        assert 'No results found for given filters' in result['message']
         assert result['service_code'] == 'InvalidService'
         assert result['region'] == 'us-west-2'
         assert 'examples' in result
-        assert 'AmazonES' in result['examples']['OpenSearch']
+        assert 'Example service codes' in result['examples']
+        assert 'Example regions' in result['examples']
+        assert 'suggestion' in result
+        assert (
+            'Verify that the service code is valid. Use get_service_codes() to get valid service codes'
+            in result['suggestion']
+        )
+        assert (
+            'Validate region and filter values using get_pricing_attribute_values()'
+            in result['suggestion']
+        )
+        assert 'Test with fewer filters' in result['suggestion']
         mock_context.error.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #968 

## Summary

Improve the `get_pricing` tool error response when an empty response is received.

### Changes

> Please provide a summary of what's being changed

Add suggestions to verify service code, to check region and filter values, and to test with fewer filters.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
