### PR TITLE
fix(aws-api-mcp-server): Remove environment variable GITHUB_REPOSITORY

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/scripts/download_latest_embeddings.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/scripts/download_latest_embeddings.py
@@ -15,7 +15,6 @@
 #!/usr/bin/env python3
 
 import json
-import os
 import re
 import shutil
 import subprocess
@@ -48,9 +47,6 @@ def run_command(command: list[str]) -> subprocess.CompletedProcess:
 def get_latest_artifact() -> Optional[dict]:
     """Get the latest dist-aws-api-mcp-server artifact from GitHub."""
     try:
-        repo = os.environ.get('GITHUB_REPOSITORY', 'awslabs/mcp')
-        owner = repo.split('/')[0]
-
         cmd = [
             'gh',
             'api',
@@ -59,7 +55,7 @@ def get_latest_artifact() -> Optional[dict]:
             'Accept: application/vnd.github+json',
             '-H',
             'X-GitHub-Api-Version: 2022-11-28',
-            f'/repos/{owner}/mcp/actions/artifacts?name=dist-aws-api-mcp-server&per_page=100',
+            '/repos/awslabs/mcp/actions/artifacts?name=dist-aws-api-mcp-server&per_page=100',
         ]
 
         result = run_command(cmd)

--- a/src/aws-api-mcp-server/tests/kb/test_download_latest_embeddings.py
+++ b/src/aws-api-mcp-server/tests/kb/test_download_latest_embeddings.py
@@ -1,5 +1,4 @@
 import json
-import os
 import pytest
 import subprocess
 import sys
@@ -83,8 +82,7 @@ def test_get_latest_artifact_success(mock_run_command):
     )
     mock_run_command.return_value = mock_result
 
-    with patch.dict(os.environ, {'GITHUB_REPOSITORY': 'awslabs/mcp'}):
-        artifact = get_latest_artifact()
+    artifact = get_latest_artifact()
 
     assert artifact is not None
     assert artifact['id'] == 123
@@ -108,8 +106,7 @@ def test_get_latest_artifact_no_main_branch(mock_run_command):
     )
     mock_run_command.return_value = mock_result
 
-    with patch.dict(os.environ, {'GITHUB_REPOSITORY': 'awslabs/mcp'}):
-        artifact = get_latest_artifact()
+    artifact = get_latest_artifact()
 
     assert artifact is None
 
@@ -121,8 +118,7 @@ def test_get_latest_artifact_no_artifacts(mock_run_command):
     mock_result.stdout = json.dumps({'artifacts': []})
     mock_run_command.return_value = mock_result
 
-    with patch.dict(os.environ, {'GITHUB_REPOSITORY': 'awslabs/mcp'}):
-        artifact = get_latest_artifact()
+    artifact = get_latest_artifact()
 
     assert artifact is None
 
@@ -134,8 +130,7 @@ def test_get_latest_artifact_command_failure(mock_run_command):
         returncode=1, cmd=['gh', 'api'], output='', stderr='API error'
     )
 
-    with patch.dict(os.environ, {'GITHUB_REPOSITORY': 'awslabs/mcp'}):
-        artifact = get_latest_artifact()
+    artifact = get_latest_artifact()
 
     assert artifact is None
 
@@ -147,8 +142,7 @@ def test_get_latest_artifact_invalid_json(mock_run_command):
     mock_result.stdout = 'invalid json'
     mock_run_command.return_value = mock_result
 
-    with patch.dict(os.environ, {'GITHUB_REPOSITORY': 'awslabs/mcp'}):
-        artifact = get_latest_artifact()
+    artifact = get_latest_artifact()
 
     assert artifact is None
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Remove environment variable `GITHUB_REPOSITORY`, this was only used for testing before we released under awslabs. Currently this can be abused to download embeddings from a different repository.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
