### PR TITLE
fix(sns-sqs-server): handle list type for AttributeNames

### DIFF
--- a/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/generator.py
+++ b/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/generator.py
@@ -148,6 +148,7 @@ class AWSToolGenerator:
             'boolean': bool,
             'integer': int,
             'map': dict[Any, Any],
+            'list': list[Any],
         }
         try:
             input_parameters = self.__get_operation_input_parameters(operation)


### PR DESCRIPTION
Fixes #978

## Summary

Fix tool generator

### Changes

The `AWSToolGenerator` in the `amazon-sns-sqs-mcp-server` did not correctly handle parameters of type `list`. It would default to `str`, causing a validation error when calling tools that expect a list of strings, such as `get_queue_attributes` with the `AttributeNames` parameter.

This change adds `list` to the `type_conversion` dictionary in the `AWSToolGenerator`, ensuring that list parameters are correctly typed in the generated tool schema.

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
