### PR TITLE
feat(redshift): add ability to run queries as superuser

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -74,6 +74,7 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 
 - `AWS_REGION`: AWS region to use (default: `us-east-1`)
 - `AWS_PROFILE`: AWS profile to use (optional, uses default if not specified)
+- `REDSHIFT_DB_USER`: Default database user for query execution (optional, uses IAM user if not specified)
 - `FASTMCP_LOG_LEVEL`: Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
 - `LOG_FILE`: Path to log file (optional, logs to stdout if not specified)
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -536,6 +536,10 @@ async def execute_query_tool(
     sql: str = Field(
         ..., description='The SQL statement to execute. Should be a single SQL statement.'
     ),
+    use_superuser: bool = Field(
+        False,
+        description="Execute as cluster superuser instead of current user. When True, uses the cluster's master username for provisioned clusters.",
+    ),
 ) -> QueryResult:
     """Execute a SQL query against a Redshift cluster or serverless workgroup.
 
@@ -594,7 +598,9 @@ async def execute_query_tool(
     """
     try:
         logger.info(f'Executing query on cluster {cluster_identifier} in database {database_name}')
-        query_result_data = await execute_query(cluster_identifier, database_name, sql)
+        query_result_data = await execute_query(
+            cluster_identifier, database_name, sql, use_superuser
+        )
 
         # Convert to QueryResult model
         query_result = QueryResult(**query_result_data)


### PR DESCRIPTION
## Summary

Adds `use_superuser` parameter and `REDSHIFT_DB_USER` environment variable support to execute functions, enabling flexible user context for queries including access to system tables restricted to superusers.

## Changes

- **New Parameter**: `use_superuser: bool = False` in `execute_query()` and `execute_statement()`
- **New Environment Variable**: `REDSHIFT_DB_USER` to specify database user
- **User Selection Logic**: `use_superuser=True` → `REDSHIFT_DB_USER` env var → default IAM user
- **Superuser Access**: Uses cluster's `master_username` for provisioned clusters when `use_superuser=True`
- **Documentation**: Complete docstring updates

## Use Case: System Table Access

Primary use case is troubleshooting via system tables requiring elevated privileges:
- `stv_*` tables - Cluster monitoring and active queries
- `svv_*` views - Performance analysis 
- `pg_user`, `pg_group` - User/group management
- `pg_stat_*` - Database statistics

## Implementation

- **Provisioned**: Uses `master_username` from cluster info when `use_superuser=True`
- **Serverless**: No change (no master username concept)
- **Fallback**: Gracefully falls back to regular user if superuser unavailable
- **Read-only**: Maintains existing transaction safety

## Testing

✅ All 48 tests pass, 94% coverage maintained  
✅ Backward compatible, no breaking changes

## Example

```python
# Regular user access
execute_query(cluster, db, "SELECT * FROM my_table")

# Superuser for system tables  
execute_query(cluster, db, "SELECT * FROM stv_inflight", use_superuser=True)
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).