### PR TITLE
feat(bedrock-kb-retrieval-mcp-server): Add metadata of retrieveAPI response to QueryKnowledgeBases tool

### DIFF
--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
@@ -106,6 +106,7 @@ async def query_knowledge_base(
                     'content': result['content'],
                     'location': result.get('location', ''),
                     'score': result.get('score', ''),
+                    'metadata': result.get('metadata', {}),
                 }
             )
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -168,6 +168,7 @@ async def query_knowledge_bases_tool(
     - content: The text content of the document
     - location: The source location of the document
     - score: The relevance score of the document
+    - metadata: The metadata of the document
 
 
     ## Interpretation Best Practices


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary
I added `metadata` of retrieve API response to QueryKnowledgeBases tool since I'd like to use knowledge base metadata.

### Changes
- Modified `QueryKnowledgeBases` tool in `retrieval.py` to include metadata from Bedrock Knowledge Base retrieval results
- Added `'metadata': result.get('metadata', {})` to the document structure
- Added description of `metadata` to the `server.py`

### User experience
Users can refer to knowledge base metadata alongside content, location, and score information.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) : No

**RFC issue number**: None

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
