### PR TITLE
build(deps): add commitizen for versioning

### DIFF
--- a/src/ecs-mcp-server/pyproject.toml
+++ b/src/ecs-mcp-server/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "black>=23.3.0",
+    "commitizen>=4.2.2",
     "isort>=5.12.0",
     "mypy>=1.3.0",
     "pytest>=7.3.1",
@@ -88,3 +89,13 @@ markers = [
 [tool.coverage.run]
 concurrency = ["gevent"]
 omit = ["tests/*"]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.0.0"
+tag_format = "v$version"
+version_files = [
+    "pyproject.toml:version",
+    "awslabs/ecs_mcp_server/__init__.py:__version__"
+]
+update_changelog_on_bump = true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Added commitizen dependency to help with versioning.

### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

• [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
• [x] I have performed a self-review of this change
• [x] Changes have been tested
• [x] Changes are documented

Is this a breaking change? (Y/N) N

RFC issue number: N/A

Checklist:

• [ ] Migration process documented
• [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).