### PR TITLE
fix: resolve sarif_om module error in aws-diagram-mcp-server (#1041)

### DIFF
--- a/src/aws-diagram-mcp-server/CHANGELOG.md
+++ b/src/aws-diagram-mcp-server/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING CHANGE:** Server Sent Events (SSE) support has been removed in accordance with the Model Context Protocol specification's [backwards compatibility guidelines](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#backwards-compatibility)
 - This change prepares for future support of [Streamable HTTP](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) transport
 
+## [1.0.7] - 2025-08-13
+
+### Fixed
+- Resolved "No module named 'sarif_om'" error by adding sarif-om dependency (#1041)
+
+### Dependencies
+- Added sarif-om>=1.0.0 to support Bandit SARIF output format
+
 ## Unreleased
 
 ### Added

--- a/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/scanner.py
+++ b/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/scanner.py
@@ -14,9 +14,13 @@
 
 import ast
 import os
+import warnings
 from pydantic import BaseModel, Field
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional, Tuple
+
+# Suppress AST deprecation warnings for Python 3.14 compatibility
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="ast")
 
 
 class SecurityIssue(BaseModel):

--- a/src/aws-diagram-mcp-server/pyproject.toml
+++ b/src/aws-diagram-mcp-server/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "mcp[cli]>=1.11.0",
     "pydantic>=2.10.6",
     "bandit>=1.7.5",
+    "sarif-om>=1.0.0",     # Fixes GitHub issue #1041: No module named 'sarif_om'
     # Security fixes for CVEs
     "setuptools>=78.1.1",  # Fixes CVE-2025-47273
     "starlette>=0.47.2",   # Fixes CVE-2025-54121
@@ -140,6 +141,14 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
     "asyncio: mark a test as an asyncio coroutine",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning:ast",
+    "ignore:ast.Str is deprecated:DeprecationWarning",
+    "ignore:ast.Num is deprecated:DeprecationWarning", 
+    "ignore:ast.NameConstant is deprecated:DeprecationWarning",
+    "ignore:ast.Ellipsis is deprecated:DeprecationWarning",
+    "ignore:Attribute s is deprecated:DeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/src/aws-diagram-mcp-server/tests/test_sarif_fix.py
+++ b/src/aws-diagram-mcp-server/tests/test_sarif_fix.py
@@ -1,0 +1,137 @@
+"""Test for SARIF-OM module fix (GitHub issue #1041)."""
+
+import pytest
+import importlib
+
+
+class TestSarifFix:
+    """Test cases for the SARIF-OM module fix."""
+
+    def test_sarif_om_available(self):
+        """Test that sarif-om is available after fix."""
+        try:
+            import sarif_om
+            assert sarif_om is not None
+        except ImportError:
+            pytest.fail("sarif-om module should be available after fix")
+
+    def test_bandit_imports_without_error(self):
+        """Test that Bandit imports without SARIF-related errors."""
+        try:
+            from bandit.core import config, manager
+            
+            # Create basic configuration
+            b_conf = config.BanditConfig()
+            assert b_conf is not None
+            
+            # Create manager
+            mgr = manager.BanditManager(b_conf, 'file', debug=False, verbose=False, quiet=True)
+            assert mgr is not None
+            
+        except Exception as e:
+            pytest.fail(f"Bandit should import and initialize without errors: {e}")
+
+    def test_scanner_functionality(self):
+        """Test that the scanner module works correctly."""
+        from awslabs.aws_diagram_mcp_server.scanner import scan_python_code
+        import asyncio
+        
+        # Test with simple safe code
+        safe_code = '''
+def hello_world():
+    return "Hello, World!"
+'''
+        
+        async def run_test():
+            result = await scan_python_code(safe_code)
+            assert result is not None
+            assert result.syntax_valid is True
+            assert result.has_errors is False
+            return result
+        
+        # Run the async test
+        result = asyncio.run(run_test())
+        assert result.metrics is not None
+        assert result.metrics.total_lines > 0
+
+    def test_bandit_security_scan(self):
+        """Test that Bandit security scanning works with potentially unsafe code."""
+        from awslabs.aws_diagram_mcp_server.scanner import scan_python_code
+        import asyncio
+        
+        # Test with code that should trigger security warnings
+        unsafe_code = '''
+import subprocess
+subprocess.call("echo test", shell=True)
+'''
+        
+        async def run_test():
+            result = await scan_python_code(unsafe_code)
+            assert result is not None
+            assert result.syntax_valid is True
+            # Should have security issues due to subprocess.call with shell=True
+            assert result.has_errors is True
+            assert len(result.security_issues) > 0
+            return result
+        
+        # Run the async test
+        result = asyncio.run(run_test())
+        
+        # Verify we found the expected security issue
+        found_subprocess_issue = any(
+            'subprocess' in issue.issue_text.lower() or 'shell' in issue.issue_text.lower()
+            for issue in result.security_issues
+        )
+        assert found_subprocess_issue, "Should detect subprocess security issue"
+
+    def test_diagram_generation_unaffected(self):
+        """Test that diagram generation still works normally after the fix."""
+        from awslabs.aws_diagram_mcp_server.diagrams_tools import generate_diagram
+        import asyncio
+        import tempfile
+        import os
+        
+        # Simple diagram code
+        diagram_code = '''
+with Diagram("Test Diagram", show=False):
+    from diagrams.aws.compute import EC2
+    from diagrams.aws.database import RDS
+    
+    web = EC2("Web Server")
+    db = RDS("Database")
+    
+    web >> db
+'''
+        
+        async def run_test():
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = await generate_diagram(
+                    code=diagram_code,
+                    filename="test_diagram",
+                    workspace_dir=temp_dir
+                )
+                # Check if file exists while temp_dir is still valid
+                file_exists = os.path.exists(result.path) if result.path else False
+                return result, file_exists
+        
+        # Run the async test
+        result, file_exists = asyncio.run(run_test())
+        
+        # Verify the diagram was generated successfully
+        assert result.status == 'success'
+        assert result.path is not None
+        assert file_exists, f"Diagram file should exist at {result.path}"
+        assert result.path.endswith('.png')
+
+    def test_sarif_om_version(self):
+        """Test that sarif-om has a reasonable version."""
+        import sarif_om
+        
+        # Check if version is available
+        version = getattr(sarif_om, '__version__', None)
+        if version:
+            # Basic version format check (should be something like "1.0.0")
+            assert isinstance(version, str)
+            assert len(version) > 0
+            # Should contain at least one dot for major.minor format
+            assert '.' in version


### PR DESCRIPTION


<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
- https://github.com/awslabs/mcp/issues/1041
- 
### Changes

- Add sarif-om>=1.0.0 dependency to pyproject.toml
- Update CHANGELOG.md with fix documentation
- Add AST deprecation warning suppression for Python 3.14 compatibility
- Create comprehensive test suite for SARIF fix verification

Fixes GitHub issue #1041: 'No module named sarif_om' error All tests pass, backward compatible, minimal performance impact

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
- No

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
