### PR TITLE
Fix docker health check permissions

### DIFF
--- a/src/aws-diagram-mcp-server/Dockerfile
+++ b/src/aws-diagram-mcp-server/Dockerfile
@@ -85,7 +85,7 @@ RUN apk update && \
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
 
 # Get healthcheck script
-COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
+COPY --chmod=0755 ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
 
 # Run as non-root
 USER app

--- a/src/aws-documentation-mcp-server/Dockerfile
+++ b/src/aws-documentation-mcp-server/Dockerfile
@@ -78,7 +78,7 @@ RUN apk update && \
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
 
 # Get healthcheck script
-COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
+COPY --chmod=0755 ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
 
 # Run as non-root
 USER app

--- a/src/core-mcp-server/Dockerfile
+++ b/src/core-mcp-server/Dockerfile
@@ -78,7 +78,7 @@ RUN apk update && \
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
 
 # Get healthcheck script
-COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
+COPY --chmod=0755 ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
 
 # Run as non-root
 USER app

--- a/src/terraform-mcp-server/Dockerfile
+++ b/src/terraform-mcp-server/Dockerfile
@@ -78,7 +78,7 @@ RUN out=$(mktemp) && \
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
 
 # Get healthcheck script
-COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
+COPY --chmod=0755 ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
 
 # Run as non-root
 USER app


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes failing docker health checks on a number of images.

## Summary

When I start VS Code with the core, docs, diagram, and terraform MCP servers enabled, I end up with a large number of containers failing health checks:

```
$ docker ps
CONTAINER ID   IMAGE                            COMMAND                  CREATED         STATUS                     PORTS     NAMES
752147dc6026   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             quirky_turing
1109d3e149e3   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             amazing_benz
d23f6bb0f85b   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             sleepy_nightingale
da6d546b6f7a   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             trusting_cray
38a4931843ec   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             funny_mccarthy
47ce165821df   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             modest_villani
9872086c9b1a   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             sad_bassi
8eed3dc6170e   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             quirky_maxwell
988374e7b9a4   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             tender_mestorf
4b7934c29469   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             nervous_goldstine
9960542f3a39   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             tender_proskuriakova
8255b7e50108   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             zen_carver
3aa98ee040eb   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             frosty_fermat
669ec57d2f35   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             epic_ramanujan
3bc359f794d8   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             funny_austin
109f02625d77   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             busy_euclid
e27ed80ca7bb   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             peaceful_grothendieck
19377806acf9   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             nifty_payne
eca833f4b53c   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             bold_kalam
3d8a5d249605   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             happy_bouman
88453454abbf   awslabs/aws-diagram-mcp-server   "awslabs.aws-diagram…"   5 minutes ago   Up 5 minutes (unhealthy)             gallant_williamson
f40500fc9f95   awslabs/core-mcp-server          "awslabs.core-mcp-se…"   5 minutes ago   Up 5 minutes (unhealthy)             lucid_banach
```

If I exec the health check for the container I find that the user id running the container cannot execute the health check script because the permissions are wrong.  However running as root works fine:
```
$ docker exec -ti 752147dc6026 docker-healthcheck.sh
/bin/sh: can't open '/usr/local/bin/docker-healthcheck.sh': Permission denied
$ docker exec -ti --user root 752147dc6026 docker-healthcheck.sh
aws-diagram-mcp-server is running
```

### Changes

This change ensures that the health check is created with explicit world-exec permissions.

### User experience

Docker-based MCP servers now work and I don't get "Since the search tools are timing out, I'll analyze the code directly and use my knowledge of AWS services to ..."

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented - this doesn't seem necessary, since it's just fixing existing functionality.

Is this a breaking change? (Y/N) n

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
