### PR TITLE
docs: mcp-proxy links to wrong project

### DIFF
--- a/src/aws-knowledge-mcp-server/README.md
+++ b/src/aws-knowledge-mcp-server/README.md
@@ -63,7 +63,7 @@ You can configure the Knowledge server for use with any MCP client that supports
 }
 ```
 
-If the client you use does not support HTTP transport for MCP or if it encounters issues during setup, we recommend to use either the [mcp-remote](https://github.com/geelen/mcp-remote) or [mcp-proxy](https://github.com/TBXark/mcp-proxy) utility to proxy from stdio to HTTP transport. Clients that fall in this category may include Kiro, Cline, Q CLI and Claude Desktop. Find below configuration examples for both utilities.
+If the client you use does not support HTTP transport for MCP or if it encounters issues during setup, we recommend to use either the [mcp-remote](https://github.com/geelen/mcp-remote) or [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) utility to proxy from stdio to HTTP transport. Clients that fall in this category may include Kiro, Cline, Q CLI and Claude Desktop. Find below configuration examples for both utilities.
 
 **mcp-remote**
 


### PR DESCRIPTION
## Summary

### Changes

We need the python package https://pypi.org/project/mcp-proxy/,  not the other tool that aggregates and serves multiple MCP resource servers through a single HTTP server.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
