### PR TITLE
fix(aws-api-mcp-server): use region from profile specified in cli command

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/driver.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/driver.py
@@ -79,7 +79,6 @@ def translate_cli_to_ir(cli_command: str) -> IRTranslation:
 
 def interpret_command(
     cli_command: str,
-    default_region: str,
     max_results: int | None = None,
 ) -> InterpretedProgram:
     """Interpret the CLI command.
@@ -95,7 +94,7 @@ def interpret_command(
     if translation.command is None:
         return InterpretedProgram(translation=translation)
 
-    region = translation.command.region or default_region
+    region = translation.command.region
     if (
         translation.command.command_metadata.service_sdk_name in GLOBAL_SERVICE_REGIONS
         and region != GLOBAL_SERVICE_REGIONS[translation.command.command_metadata.service_sdk_name]

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -131,13 +131,11 @@ def execute_awscli_customization(
 
 def interpret_command(
     cli_command: str,
-    default_region: str,
     max_results: int | None = None,
 ) -> ProgramInterpretationResponse:
     """Interpret the given CLI command and return an interpretation response."""
     interpreted_program = _interpret_command(
         cli_command,
-        default_region=default_region,
         max_results=max_results,
     )
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/command.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/command.py
@@ -25,7 +25,7 @@ class IRCommand:
 
     command_metadata: CommandMetadata
     parameters: dict[str, Any]
-    region: str | None = None
+    region: str
     profile: str | None = None
     client_side_filter: ParsedResult | None = None
     is_awscli_customization: bool = False

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
@@ -18,15 +18,15 @@ import tempfile
 from pathlib import Path
 
 
-def get_region() -> str:
-    """Get the default region for executing cli commands."""
-    if aws_region := os.getenv('AWS_REGION'):
-        return aws_region
+def get_region(profile_name: str | None = None) -> str:
+    """Get the region depending on configuration."""
+    if AWS_REGION:
+        return AWS_REGION
 
     fallback_region = 'us-east-1'
 
-    if AWS_API_MCP_PROFILE_NAME:
-        return boto3.Session(profile_name=AWS_API_MCP_PROFILE_NAME).region_name or fallback_region
+    if profile_name:
+        return boto3.Session(profile_name=profile_name).region_name or fallback_region
 
     return boto3.Session().region_name or fallback_region
 
@@ -56,7 +56,8 @@ def get_env_bool(env_key: str, default: bool) -> bool:
 
 FASTMCP_LOG_LEVEL = os.getenv('FASTMCP_LOG_LEVEL', 'WARNING')
 AWS_API_MCP_PROFILE_NAME = os.getenv('AWS_API_MCP_PROFILE_NAME')
-DEFAULT_REGION = get_region()
+AWS_REGION = os.getenv('AWS_REGION')
+DEFAULT_REGION = get_region(AWS_API_MCP_PROFILE_NAME)
 READ_OPERATIONS_ONLY_MODE = get_env_bool(READ_ONLY_KEY, False)
 OPT_IN_TELEMETRY = get_env_bool(TELEMETRY_KEY, True)
 WORKING_DIRECTORY = os.getenv('AWS_API_MCP_WORKING_DIR', get_server_directory() / 'workdir')

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -32,6 +32,7 @@ from .core.common.config import (
     get_server_directory,
 )
 from .core.common.errors import AwsApiMcpError
+from .core.common.helpers import validate_aws_region
 from .core.common.models import (
     AwsApiMcpServerErrorResponse,
     AwsCliAliasResponse,
@@ -39,13 +40,12 @@ from .core.common.models import (
 )
 from .core.kb import knowledge_base
 from .core.metadata.read_only_operations_list import ReadOnlyOperations, get_read_only_operations
-from awslabs.aws_api_mcp_server.core.common.helpers import validate_aws_region
 from botocore.exceptions import NoCredentialsError
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import Field
-from typing import Annotated, Any, Optional, cast
+from typing import Annotated, Any, Optional
 
 
 logger.remove()
@@ -247,7 +247,6 @@ async def call_aws(
 
         return interpret_command(
             cli_command=cli_command,
-            default_region=cast(str, DEFAULT_REGION),
             max_results=max_results,
         )
     except NoCredentialsError:

--- a/src/aws-api-mcp-server/tests/aws/test_driver.py
+++ b/src/aws-api-mcp-server/tests/aws/test_driver.py
@@ -107,6 +107,7 @@ def test_get_local_credentials_raises_no_credentials_error(mock_session_class):
             IRTranslation(
                 command=IRCommand(
                     command_metadata=CommandMetadata('s3', None, 'ls'),
+                    region='us-east-1',
                     parameters={},
                     is_awscli_customization=True,
                 ),
@@ -118,6 +119,7 @@ def test_get_local_credentials_raises_no_credentials_error(mock_session_class):
             IRTranslation(
                 command=IRCommand(
                     command_metadata=CommandMetadata('s3', None, 'ls'),
+                    region='us-east-1',
                     parameters={},
                     is_awscli_customization=True,
                 ),
@@ -129,6 +131,7 @@ def test_get_local_credentials_raises_no_credentials_error(mock_session_class):
             IRTranslation(
                 command=IRCommand(
                     command_metadata=CommandMetadata('dynamodb', None, 'wait table-exists'),
+                    region='us-east-1',
                     parameters={'--table-name': 'MyTable'},
                     is_awscli_customization=True,
                 ),

--- a/src/aws-api-mcp-server/tests/common/test_config.py
+++ b/src/aws-api-mcp-server/tests/common/test_config.py
@@ -55,9 +55,7 @@ def test_get_server_directory_windows_macos(
     ],
 )
 @patch('awslabs.aws_api_mcp_server.core.common.config.boto3.Session')
-@patch('awslabs.aws_api_mcp_server.core.common.config.os.getenv')
 def test_get_region_parametrized(
-    mock_getenv: MagicMock,
     mock_session_class: MagicMock,
     aws_region: str,
     profile_name: str,
@@ -66,8 +64,6 @@ def test_get_region_parametrized(
     expected_region: str,
 ):
     """Parametrized test for various combinations of region sources."""
-    mock_getenv.return_value = aws_region
-
     profile_session = MagicMock()
     profile_session.region_name = profile_region
 
@@ -82,10 +78,7 @@ def test_get_region_parametrized(
 
     mock_session_class.side_effect = session_side_effect
 
-    with patch(
-        'awslabs.aws_api_mcp_server.core.common.config.AWS_API_MCP_PROFILE_NAME', profile_name
-    ):
-        result = get_region()
+    with patch('awslabs.aws_api_mcp_server.core.common.config.AWS_REGION', aws_region):
+        result = get_region(profile_name)
 
     assert result == expected_region
-    mock_getenv.assert_called_once_with('AWS_REGION')

--- a/src/aws-api-mcp-server/tests/parser/test_parser.py
+++ b/src/aws-api-mcp-server/tests/parser/test_parser.py
@@ -20,6 +20,7 @@ from awslabs.aws_api_mcp_server.core.common.errors import (
     UnknownFiltersError,
 )
 from awslabs.aws_api_mcp_server.core.parser.parser import parse
+from unittest.mock import patch
 
 
 @pytest.mark.parametrize(
@@ -633,7 +634,8 @@ def test_invalid_expand_user_home_directory():
     assert any(param.startswith('~') for param in result.parameters['--paths'])
 
 
-def test_profile():
+@patch('awslabs.aws_api_mcp_server.core.parser.parser.get_region', return_value='us-east-1')
+def test_profile(mock_get_region):
     """Test that the profile is correctly extracted."""
     result = parse(cli_command='aws s3api list-buckets --profile test-profile')
     assert result.profile == 'test-profile'

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "0.2.4"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Use the region from the profile if it is set

### User experience

> Please share what the user experience looks like before and after this change

Before:
- We would not fetch the region from the profile inside the command. We were relying on either the fallback region (`us-east-1`) or the region from the profile `AWS_API_MCP_PROFILE_NAME` set in the MCP server configuration

After:
- We correctly fetch regions from the profile specified in the command

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
