### PR TITLE
fix: Pin CPU device in SentenceTransformer

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
@@ -65,7 +65,7 @@ class DenseRetriever:
                 download_embedding_model(self.model_name)
             logger.debug('Embedding model is cached at {}', model_dir)
             self._model = SentenceTransformer(
-                model_name_or_path=str(model_dir), local_files_only=True
+                model_name_or_path=str(model_dir), local_files_only=True, device='cpu'
             )
             self._model_ready = True
             logger.info('Embedding model loaded!')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

When installing server using uvx on Mac, suggest_aws_command returns irrelevant results. This happens because CPU device is used on Ubuntu runner that generates embeddings, while MPS (Metal Performance Shaders) is preferred on OSX, when encoding query.

### Changes

Pins device to CPU when initializing SentenceTransformer.

### User experience

Should fix irrelevant results being returned on OSX.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
