### PR TITLE
fix(postgres-mcp-server)  Initialize psycopg connection in DBConnectionSingleton #1150 

### DIFF
--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/db_connection_singleton.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/db_connection_singleton.py
@@ -12,80 +12,118 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Database connection singleton for postgres MCP Server."""
+"""Database connection singleton for postgres MCP Server.
+
+This singleton can initialize one of two connection strategies based on the
+arguments provided to `initialize`:
+
+- RDS Data API (`RDSDataAPIConnection`) when `resource_arn` is provided
+- Direct psycopg pooled connection (`PsycopgPoolConnection`) when
+  `resource_arn` is None and `host`/`port` are provided
+"""
 
 import asyncio
 from awslabs.postgres_mcp_server.connection.rds_api_connection import RDSDataAPIConnection
+from awslabs.postgres_mcp_server.connection.psycopg_pool_connection import PsycopgPoolConnection
 from loguru import logger
 
 
 class DBConnectionSingleton:
-    """Manages a single RDS Data API connection instance across the application."""
+    """Manages a single database connection instance across the application."""
 
     _instance = None
 
     def __init__(
         self,
-        resource_arn: str,
         secret_arn: str,
         database: str,
         region: str,
         readonly: bool = True,
         is_test: bool = False,
+        resource_arn: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
     ):
-        """Initialize a new DB connection singleton for RDS Data API.
+        """Initialize a new DB connection singleton.
 
         Args:
-            resource_arn: The ARN of the RDS cluster
             secret_arn: The ARN of the secret containing credentials
             database: The name of the database to connect to
-            region: The AWS region where the RDS instance is located
+            region: The AWS region for RDS/Secrets Manager
             readonly: Whether the connection should be read-only (default: True)
             is_test: Whether this is a test connection (default: False)
+            resource_arn: The ARN of the RDS cluster (use RDS Data API if provided)
+            host: Database hostname (required if resource_arn is None)
+            port: Database port (required if resource_arn is None)
         """
-        if not all([resource_arn, secret_arn, database, region]):
-            raise ValueError(
-                'Missing required connection parameters for RDS Data API. '
-                'Please provide resource_arn, secret_arn, database, and region.'
-            )
+        if resource_arn:
+            # RDS Data API path
+            if not all([resource_arn, secret_arn, database, region]):
+                raise ValueError(
+                    'Missing required connection parameters for RDS Data API. '
+                    'Please provide resource_arn, secret_arn, database, and region.'
+                )
 
-        self._db_connection = RDSDataAPIConnection(
-            cluster_arn=resource_arn,
-            secret_arn=secret_arn,
-            database=database,
-            region=region,
-            readonly=readonly,
-            is_test=is_test,
-        )
-
-    @classmethod
-    def initialize(
-        cls,
-        resource_arn: str,
-        secret_arn: str,
-        database: str,
-        region: str,
-        readonly: bool = True,
-        is_test: bool = False,
-    ):
-        """Initialize the singleton instance if it doesn't exist.
-
-        Args:
-            resource_arn: The ARN of the RDS cluster
-            secret_arn: The ARN of the secret containing credentials
-            database: The name of the database to connect to
-            region: The AWS region where the RDS instance is located
-            readonly: Whether the connection should be read-only (default: True)
-            is_test: Whether this is a test connection (default: False)
-        """
-        if cls._instance is None:
-            cls._instance = cls(
-                resource_arn=resource_arn,
+            self._db_connection = RDSDataAPIConnection(
+                cluster_arn=resource_arn,
                 secret_arn=secret_arn,
                 database=database,
                 region=region,
                 readonly=readonly,
                 is_test=is_test,
+            )
+        else:
+            # Direct psycopg connection path
+            if not all([host, port, secret_arn, database, region]):
+                raise ValueError(
+                    'Missing required connection parameters for direct PostgreSQL connection. '
+                    'Please provide host, port, secret_arn, database, and region.'
+                )
+
+            self._db_connection = PsycopgPoolConnection(
+                host=host,  # type: ignore[arg-type]
+                port=port,  # type: ignore[arg-type]
+                database=database,
+                readonly=readonly,
+                secret_arn=secret_arn,
+                region=region,
+                is_test=is_test,
+            )
+
+    @classmethod
+    def initialize(
+        cls,
+        resource_arn: str | None,
+        secret_arn: str,
+        database: str,
+        region: str,
+        readonly: bool = True,
+        is_test: bool = False,
+        host: str | None = None,
+        port: int | None = None,
+    ):
+        """Initialize the singleton instance if it doesn't exist.
+
+        Args:
+            resource_arn: The ARN of the RDS cluster (if provided, uses RDS Data API)
+            secret_arn: The ARN of the secret containing credentials
+            database: The name of the database to connect to
+            region: The AWS region where the RDS instance/Secrets Manager is located
+            readonly: Whether the connection should be read-only (default: True)
+            is_test: Whether this is a test connection (default: False)
+            host: Database hostname (required if resource_arn is None)
+            port: Database port (required if resource_arn is None)
+        """
+        if cls._instance is None:
+            cls._instance = cls(
+                secret_arn=secret_arn,
+                database=database,
+                region=region,
+                readonly=readonly,
+                is_test=is_test,
+                resource_arn=resource_arn,
+                host=host,
+                port=port,
             )
 
     @classmethod


### PR DESCRIPTION
## Summary

Add full support for psycopg Postgres direct connection.

### Changes

- Add conditional init in DBConnectionSingleton for RDS Data API or psycopg
- Update server to initialize singleton for both connection modes and remove direct pool instantiation

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
