### PR TITLE
chore: update tool names

### DIFF
--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -192,7 +192,6 @@ Cost Explorer:
 - ce:GetUsageForecast
 - ce:GetTags
 - ce:GetCostCategories
-- ce:
 
 Cost Optimization Hub:
 - cost-optimization-hub:GetRecommendation
@@ -301,7 +300,7 @@ The server currently supports the following AWS services
    - get_auto_scaling_group_recommendations
    - get_ebs_volume_recommendations
    - get_ec2_instance_recommendations
-   - getvecs_service_recommendations
+   - get_ecs_service_recommendations
    - get_rds_database_recommendations
    - get_lambda_function_recommendations
    - get_idle_recommendations

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -82,15 +82,15 @@ Available components:
 TOOLS:
 - cost-explorer: Historical cost and usage data with flexible filtering
 - compute-optimizer: Performance optimization recommendations to identify under provisioned AWS compute resources like EC2, Lambda, ASG, RDS, ECS
-- cost-optimization-hub: Cost optimization recommendations across AWS services
-- storage-lens-run-query: Query S3 Storage Lens metrics data using Athena SQL
+- cost-optimization: Cost optimization recommendations across AWS services
+- storage-lens: Query S3 Storage Lens metrics data using Athena SQL
 - athena-cur: Query Cost and Usage Report data through Athena
 - pricing: Access AWS service pricing information
 - budget: Retrieve AWS budget information
 - cost-anomaly: Identify cost anomalies in AWS accounts
 - cost-comparison: Compare costs between time periods
 - free-tier-usage: Monitor AWS Free Tier usage
-- get-recommendation-details: Get enhanced cost optimization recommendations
+- rec-details: Get enhanced cost optimization recommendations
 - ri-performance: Analyze Reserved Instance coverage and utilization
 - sp-performance: Analyze Savings Plans coverage and utilization
 - session-sql: Execute SQL queries on the session database
@@ -101,20 +101,20 @@ PROMPTS:
 
 For financial analysis:
 1. Start with a high-level view of costs using cost-explorer with SERVICE dimension
-2. Look for cost optimization opportunities with compute-optimizer or cost-optimization-hub
-3. For S3-specific optimizations, use storage-lens-run-query
+2. Look for cost optimization opportunities with compute-optimizer or cost-optimization
+3. For S3-specific optimizations, use storage-lens
 4. For budget monitoring, use the budget tool
 5. For anomaly detection, use the cost-anomaly tool
 
 For optimization recommendations:
-1. Use cost-optimization-hub to get recommendations for cost optimization across services. This includes including Idle resources, Rightsizing for savings, RI/SP.
-2. Use get-recommendation-details for enhanced recommendation analysis for specific cost optimization recommendations.
+1. Use cost-optimization to get recommendations for cost optimization across services. This includes including Idle resources, Rightsizing for savings, RI/SP.
+2. Use rec-details for enhanced recommendation analysis for specific cost optimization recommendations.
 3. Use compute-optimizer to get performance optimization recommendations for compute resources such as EC2, ECS, EBS, Lambda, RDS, ASG.
 4. Use ri-performance and sp-performance to analyze purchase programs
 
 For multi-account environments:
 - Include the LINKED_ACCOUNT dimension in cost_explorer queries
-- Specify accountIds parameter for compute_optimizer and cost_optimization_hub tools
+- Specify accountIds parameter for compute-optimizer and cost-optimization tools
 """,
 )
 
@@ -154,14 +154,14 @@ async def setup():
     tools = [
         'cost-explorer',
         'compute-optimizer',
-        'cost-optimization-hub',
-        'storage-lens-run-query',
+        'cost-optimization',
+        'storage-lens',
         'pricing',
         'budget',
         'cost-anomaly',
         'cost-comparison',
         'free-tier-usage',
-        'get-recommendation-details',
+        'rec-details',
         'ri-performance',
         'sp-performance',
         'session-sql',

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_tools.py
@@ -45,7 +45,7 @@ cost_optimization_hub_server = FastMCP(
 
 
 @cost_optimization_hub_server.tool(
-    name='cost-optimization-hub',
+    name='cost-optimization',
     description="""Retrieves cost optimization recommendations from AWS Cost Optimization Hub.
 
 IMPORTANT USAGE GUIDELINES:

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/recommendation_details_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/recommendation_details_tools.py
@@ -49,7 +49,7 @@ recommendation_details_server = FastMCP(
 
 
 @recommendation_details_server.tool(
-    name='recommendation-details',
+    name='rec-details',
     description="""Get detailed cost optimization recommendation with integrated data from multiple AWS services.
 
 This tool combines data from:

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/storage_lens_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/storage_lens_tools.py
@@ -665,7 +665,7 @@ class StorageLensQueryTool:
 
 
 @storage_lens_server.tool(
-    name='storage-lens-run-query',
+    name='storage-lens',
     description="""Query S3 Storage Lens metrics data using Athena SQL.
 
 IMPORTANT USAGE GUIDELINES:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Updated tool names to be shorter so certain clients (Cursor, Q CLI, etc.) will have access to the tools that were originally greater than the required length. The tools we identified that had errors are storage-lens-run-query, cost-optimization-hub, and recommendation-details. Now they have been renamed to storage-lens, cost-optimization, and rec-details.

### Changes

Here are the files that have the changes:
**README.md
awslabs/billing_cost_management_mcp_server/server.py
awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_tools.py
awslabs/billing_cost_management_mcp_server/tools/recommendation_details_tools.py
awslabs/billing_cost_management_mcp_server/tools/storage_lens_tools.py**

There were no code changes and strictly changes with the tool names.

### User experience

Users that are using certain clients and having the tool not loaded because of the name, will now have access to the tools.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
