### PR TITLE
fix: resolve windows cp1252 encoding issue

### DIFF
--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/server.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/server.py
@@ -718,7 +718,7 @@ def main():
 
     # Display read-only mode status
     if args.readonly:
-        print('\n⚠️ READ-ONLY MODE ACTIVE ⚠️')
+        print('\n[WARNING] READ-ONLY MODE ACTIVE [WARNING]')
         print('The server will not perform any create, update, or delete operations.')
 
     mcp.run()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #1147 
## Summary
This PR fixes a UnicodeEncodeError that causes ccapi-mcp-server to crash on Windows when using the `--readonly` flag. The issue occurs because Windows console uses cp1252 encoding which cannot handle Unicode emoji characters.

### Changes
Replaced Unicode emoji characters (⚠️) with ASCII text equivalent in the read-only mode warning message. Changed `⚠️ READ-ONLY MODE ACTIVE ⚠️` to `[WARNING] READ-ONLY MODE ACTIVE [WARNING]` to prevent UnicodeEncodeError on Windows systems using cp1252 encoding.

### User experience
**Before**: ccapi-mcp-server crashes immediately on Windows when started with `--readonly` flag, preventing any MCP functionality from working.

**After**: Server starts successfully on Windows with `--readonly` flag and displays a clear ASCII warning message, allowing users to use the server in read-only mode without crashes.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
