### PR TITLE
fix(eks-mcp-server): support previous parameter for get_pod_logs tool

### DIFF
--- a/src/eks-mcp-server/README.md
+++ b/src/eks-mcp-server/README.md
@@ -383,7 +383,7 @@ Features:
 
 Parameters:
 
-* cluster_name, pod_name, namespace, container_name (optional), since_seconds (optional), tail_lines (optional), limit_bytes (optional)
+* cluster_name, pod_name, namespace, container_name (optional), since_seconds (optional), tail_lines (optional), limit_bytes (optional), previous (optional)
 
 #### `get_k8s_events`
 

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_apis.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_apis.py
@@ -418,6 +418,7 @@ class K8sApis:
         since_seconds: Optional[int] = None,
         tail_lines: Optional[int] = None,
         limit_bytes: Optional[int] = None,
+        previous: Optional[bool] = None,
     ) -> str:
         """Get logs from a pod.
 
@@ -428,6 +429,7 @@ class K8sApis:
             since_seconds: Only return logs newer than this many seconds (optional)
             tail_lines: Number of lines to return from the end of the logs (optional)
             limit_bytes: Maximum number of bytes to return (optional)
+            previous: Return previous terminated container logs (optional)
 
         Returns:
             Pod logs as a string
@@ -448,6 +450,8 @@ class K8sApis:
                 params['tail_lines'] = tail_lines
             if limit_bytes:
                 params['limit_bytes'] = limit_bytes
+            if previous:
+                params['previous'] = previous
 
             # Call the read_namespaced_pod_log method
             logs_response = core_v1_api.read_namespaced_pod_log(

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
@@ -878,6 +878,10 @@ class K8sHandler:
             10240,
             description='Maximum number of bytes to return. Default: 10KB (10240 bytes). Prevents retrieving extremely large log files.',
         ),
+        previous: bool = Field(
+            False,
+            description='Return previous terminated container logs. Default: false. Useful to get logs for pods that are restarting.',
+        ),
     ) -> PodLogsResponse:
         """Get logs from a pod in a Kubernetes cluster.
 
@@ -905,6 +909,7 @@ class K8sHandler:
             since_seconds: Only return logs newer than this many seconds (optional)
             tail_lines: Number of lines to return from the end of the logs (defaults to 100)
             limit_bytes: Maximum number of bytes to return (defaults to 10KB)
+            previous: Return previous terminated container logs (defaults to false)
 
         Returns:
             PodLogsResponse with pod logs
@@ -934,6 +939,7 @@ class K8sHandler:
                 since_seconds=since_seconds,
                 tail_lines=tail_lines,
                 limit_bytes=limit_bytes,
+                previous=previous,
             )
 
             # Split logs into lines

--- a/src/eks-mcp-server/tests/test_k8s_apis.py
+++ b/src/eks-mcp-server/tests/test_k8s_apis.py
@@ -540,6 +540,7 @@ class TestK8sApisOperations:
                 since_seconds=60,
                 tail_lines=100,
                 limit_bytes=1024,
+                previous=True,
             )
 
             # Verify the result
@@ -556,6 +557,7 @@ class TestK8sApisOperations:
                 since_seconds=60,
                 tail_lines=100,
                 limit_bytes=1024,
+                previous=True,
             )
 
     def test_get_pod_logs_minimal(self, k8s_apis):

--- a/src/eks-mcp-server/tests/test_k8s_handler.py
+++ b/src/eks-mcp-server/tests/test_k8s_handler.py
@@ -1253,6 +1253,7 @@ metadata:
                 since_seconds=60,
                 tail_lines=100,
                 limit_bytes=1024,
+                previous=True,
             )
 
             # Verify that get_client was called
@@ -1266,6 +1267,7 @@ metadata:
                 since_seconds=60,
                 tail_lines=100,
                 limit_bytes=1024,
+                previous=True,
             )
 
             # Verify the result
@@ -1304,6 +1306,7 @@ metadata:
                 since_seconds=None,
                 tail_lines=100,  # Default value
                 limit_bytes=10240,  # Default value
+                previous=False, # Default value
             )
 
             # Verify that get_client was called

--- a/src/eks-mcp-server/uv.lock
+++ b/src/eks-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-eks-mcp-server"
-version = "0.1.8"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Adds `previous` parameter to the `get_pods_logs` tool of the EKS MCP server.

Currently if the tool is used on a pod that has restarted the logs that caused the restart and not visible through the tool. This is problematic for troubleshooting situations like a CrashLoopBackOff, where based on timing of the replacement the previous logs may not be available without this flag.

The `previous` parameter flows through to the Kubernetes API call.

### User experience

Existing behavior defaults to existing, `previous` flag can be set to trigger new behavior.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
