### PR TITLE
feat(redshift-mcp-server): set application name, minor config updates

### DIFF
--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -14,12 +14,12 @@
 
 """Redshift MCP Server constants."""
 
-# Defaults
+# System
+CLIENT_CONNECT_TIMEOUT = 60
+CLIENT_READ_TIMEOUT = 600
+CLIENT_RETRIES = {'max_attempts': 5, 'mode': 'adaptive'}
+CLIENT_USER_AGENT_NAME = 'awslabs/mcp/redshift-mcp-server'
 DEFAULT_LOG_LEVEL = 'WARNING'
-
-# Timeouts (seconds), etc
-CLIENT_TIMEOUT = 60
-DATA_CLIENT_TIMEOUT = 60
 QUERY_TIMEOUT = 3600
 QUERY_POLL_INTERVAL = 2
 

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -815,6 +815,7 @@ class TestExecuteQueryTool:
         mock_data_client.describe_statement.return_value = {
             'Status': 'FINISHED',
             'SubStatements': [
+                {'Id': 'set-app-name'},  # SET application_name
                 {'Id': 'sub-query-0'},  # BEGIN READ ONLY
                 {'Id': 'query-123'},  # Our actual SQL query
                 {'Id': 'sub-query-2'},  # END


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Implements https://github.com/awslabs/mcp/issues/1180.

## Summary

Implementing the request to be able to track the MCP issued activity in the Redshift logs.

### Changes

- Added application_name setting to identify MCP server queries
- Updated query execution to handle additional SET statement
- Fixed tests for adding application_name statement
- (little extra) Refactored client timeout constants for clarity

### User experience

Users will be able to track the MCP sessions via the application_name column in stl_connection_log and sys_connection_log system tables in Redshift clusters.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [N/A] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: 1180

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
