### PR TITLE
feat(aws-api-mcp): add support for custom defined consent and deny list operations

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -33,6 +33,7 @@ from ..metadata.read_only_operations_list import (
     ReadOnlyOperations,
 )
 from ..parser.lexer import split_cli_command
+from ..security.policy import PolicyDecision, security_policy
 from .driver import interpret_command as _interpret_command
 from awslabs.aws_api_mcp_server.core.common.command import IRCommand
 from awslabs.aws_api_mcp_server.core.common.helpers import operation_timer
@@ -83,6 +84,49 @@ def is_operation_read_only(ir: IRTranslation, read_only_operations: ReadOnlyOper
     service_name = ir.command_metadata.service_sdk_name
     operation_name = ir.command_metadata.operation_sdk_name
     return read_only_operations.has(service=service_name, operation=operation_name)
+
+
+async def check_elicitation_support(ctx: Context) -> bool:
+    """Check if elicitation is supported."""
+    try:
+        return hasattr(ctx, 'elicit')
+    except Exception:
+        return False
+
+
+def check_security_policy(
+    cli_command: str, ir: IRTranslation, read_only_operations: ReadOnlyOperations, ctx: Context
+) -> PolicyDecision:
+    """Check security policy for the given command and return decision."""
+
+    def is_read_only_func(service: str, operation: str) -> bool:
+        return read_only_operations.has(service=service, operation=operation)
+
+    # Check if client supports elicitation
+    supports_elicitation = hasattr(ctx, 'elicit')
+
+    # First check if this matches a customization
+    customization_decision = security_policy.check_customization(
+        cli_command, is_read_only_func, supports_elicitation
+    )
+    if customization_decision is not None:
+        return customization_decision
+
+    # If no customization matches, check individual operation
+    if (
+        not ir.command_metadata
+        or not getattr(ir.command_metadata, 'service_sdk_name', None)
+        or not getattr(ir.command_metadata, 'operation_sdk_name', None)
+    ):
+        return PolicyDecision.ELICIT if supports_elicitation else PolicyDecision.DENY
+
+    service_name = ir.command_metadata.service_sdk_name
+    operation_name = ir.command_metadata.operation_sdk_name
+    is_read_only = is_operation_read_only(ir, read_only_operations)
+
+    return security_policy.get_decision(
+        service_name, operation_name, is_read_only, supports_elicitation
+    )
 
 
 def validate(ir: IRTranslation) -> ProgramValidationResponse:

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .policy import SecurityPolicy, PolicyDecision, security_policy
+
+__all__ = [
+    'SecurityPolicy',
+    'PolicyDecision',
+    'security_policy',
+]

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
@@ -1,0 +1,383 @@
+{
+  "customizations": {
+    "cloudformation deploy": {
+      "api_calls": [
+        "aws s3api head-object",
+        "aws s3 cp",
+        "aws cloudformation execute-change-set",
+        "aws cloudformation create-change-set",
+        "aws cloudformation wait change-set-create-complete"
+      ]
+    },
+    "cloudformation package": {
+      "api_calls": [
+        "aws s3 cp"
+      ]
+    },
+    "cloudtrail create-subscription": {
+      "api_calls": [
+        "aws s3api get-object",
+        "aws s3api head-bucket",
+        "aws s3api create-bucket",
+        "aws s3api put-bucket-policy",
+        "aws s3api delete-bucket",
+        "aws sns list-topics",
+        "aws sns create-topic",
+        "aws sns get-topic-attributes",
+        "aws sns set-topic-attributes",
+        "aws sns delete-topic",
+        "aws cloudtrail create-trail",
+        "aws cloudtrail update-trail",
+        "aws cloudtrail describe-trails",
+        "aws cloudtrail start-logging"
+      ]
+    },
+    "cloudtrail update-subscription": {
+      "api_calls": [
+        "aws s3api get-object",
+        "aws s3api head-bucket",
+        "aws s3api create-bucket",
+        "aws s3api put-bucket-policy",
+        "aws s3api delete-bucket",
+        "aws sns list-topics",
+        "aws sns create-topic",
+        "aws sns get-topic-attributes",
+        "aws sns set-topic-attributes",
+        "aws sns delete-topic",
+        "aws cloudtrail create-trail",
+        "aws cloudtrail update-trail",
+        "aws cloudtrail describe-trails",
+        "aws cloudtrail start-logging"
+      ]
+    },
+    "cloudtrail validate-logs": {
+      "api_calls": [
+        "aws cloudtrail describe-trails",
+        "aws organizations describe-organization",
+        "aws s3api list-objects",
+        "aws s3api get-object",
+        "aws cloudtrail list-public-keys",
+        "aws s3api get-bucket-location"
+      ]
+    },
+    "codeartifact login": {
+      "api_calls": [
+        "aws codeartifact get-repository-endpoint",
+        "aws codeartifact get-authorization-token"
+      ]
+    },
+    "configservice get-status": {
+      "api_calls": [
+        "aws configservice describe-configuration-recorder-status"
+      ]
+    },
+    "configservice subscribe": {
+      "api_calls": [
+        "aws s3api create-bucket",
+        "aws sns create-topic",
+        "aws configservice put-configuration-recorder",
+        "aws configservice put-delivery-channel",
+        "aws configservice start-configuration-recorder",
+        "aws configservice describe-configuration-recorders",
+        "aws configservice describe-delivery-channels"
+      ]
+    },
+    "datapipeline create-default-roles": {
+      "api_calls": [
+        "aws iam get-role",
+        "aws iam create-role",
+        "aws iam attach-role-policy",
+        "aws iam get-policy-version",
+        "aws iam get-policy"
+      ]
+    },
+    "datapipeline list-runs": {
+      "api_calls": [
+        "aws datapipeline query-objects",
+        "aws datapipeline describe-objects"
+      ]
+    },
+    "deploy deregister": {
+      "api_calls": [
+        "aws iam delete-user-policy",
+        "aws iam delete-access-key",
+        "aws iam delete-user",
+        "aws deploy get-on-premises-instance",
+        "aws deploy remove-tags-from-on-premises-instances",
+        "aws deploy deregister-on-premises-instance"
+      ]
+    },
+    "deploy install": {
+      "api_calls": [
+        "aws s3api get-object"
+      ]
+    },
+    "deploy push": {
+      "api_calls": [
+        "aws deploy register-application-revision",
+        "aws s3api put-object",
+        "aws s3api create-multipart-upload",
+        "aws s3api upload-part",
+        "aws s3api complete-multipart-upload",
+        "aws s3api abort-multipart-upload"
+      ]
+    },
+    "deploy register": {
+      "api_calls": [
+        "aws deploy register-on-premises-instance",
+        "aws deploy add-tags-to-on-premises-instances",
+        "aws iam create-user",
+        "aws iam create-access-key",
+        "aws iam put-user-policy"
+      ]
+    },
+    "dlm create-default-role": {
+      "api_calls": [
+        "aws iam get-role",
+        "aws iam get-policy",
+        "aws iam create-role",
+        "aws iam attach-role-policy"
+      ]
+    },
+    "ecr get-login": {
+      "api_calls": [
+        "aws ecr get-authorization-token"
+      ]
+    },
+    "ecr get-login-password": {
+      "api_calls": [
+        "aws ecr get-authorization-token"
+      ]
+    },
+    "ecr-public get-login-password": {
+      "api_calls": [
+        "aws ecr-public get-authorization-token"
+      ]
+    },
+    "ecs deploy": {
+      "api_calls": [
+        "aws ecs describe-services",
+        "aws ecs register-task-definition",
+        "aws deploy get-application",
+        "aws deploy get-deployment-group",
+        "aws deploy create-deployment",
+        "aws deploy wait deployment-successful"
+      ]
+    },
+    "eks get-token": {
+      "api_calls": [
+        "aws sts assume-role",
+        "aws sts get-caller-identity",
+        "aws sts presign-url",
+        "aws sts get-caller-identity"
+      ]
+    },
+    "eks update-kubeconfig": {
+      "api_calls": [
+        "aws sts assume-role",
+        "aws eks describe-cluster"
+      ]
+    },
+    "emr add-instance-groups": {
+      "api_calls": [
+        "aws emr add-instance-groups"
+      ]
+    },
+    "emr add-steps": {
+      "api_calls": [
+        "aws emr add-job-flow-steps"
+      ]
+    },
+    "emr create-cluster": {
+      "api_calls": [
+        "aws emr run-job-flow"
+      ]
+    },
+    "emr create-default-roles": {
+      "api_calls": [
+        "aws ec2 describe-regions",
+        "aws iam get-instance-profile",
+        "aws iam create-instance-profile",
+        "aws iam add-role-to-instance-profile",
+        "aws iam attach-role-policy",
+        "aws iam create-role",
+        "aws iam get-policy",
+        "aws iam get-policy-version"
+      ]
+    },
+    "emr create-hbase-backup": {
+      "api_calls": [
+        "aws emr add-job-flow-steps"
+      ]
+    },
+    "emr describe-cluster": {
+      "api_calls": [
+        "aws emr describe-cluster",
+        "aws emr list-instance-fleets",
+        "aws emr list-instance-groups",
+        "aws emr list-bootstrap-actions"
+      ]
+    },
+    "emr disable-hbase-backups": {
+      "api_calls": [
+        "aws emr add-job-flow-steps"
+      ]
+    },
+    "emr get": {
+      "api_calls": [
+        "aws emr describe-cluster"
+      ]
+    },
+    "emr install-applications": {
+      "api_calls": [
+        "aws emr add-job-flow-steps"
+      ]
+    },
+    "emr modify-cluster-attributes": {
+      "api_calls": [
+        "aws emr set-visible-to-all-users",
+        "aws emr set-termination-protection",
+        "aws emr set-keep-job-flow-alive-when-no-steps",
+        "aws emr set-unhealthy-node-replacement"
+      ]
+    },
+    "emr put": {
+      "api_calls": [
+        "aws emr describe-cluster"
+      ]
+    },
+    "emr restore-from-hbase-backup": {
+      "api_calls": [
+        "aws emr add-job-flow-steps"
+      ]
+    },
+    "emr schedule-hbase-backup": {
+      "api_calls": [
+        "aws emr add-job-flow-steps"
+      ]
+    },
+    "emr socks": {
+      "api_calls": [
+        "aws emr describe-cluster"
+      ]
+    },
+    "emr ssh": {
+      "api_calls": [
+        "aws emr describe-cluster",
+        "aws emr wait"
+      ]
+    },
+    "emr terminate-cluster": {
+      "api_calls": [
+        "aws emr terminate-job-flows"
+      ]
+    },
+    "emr-containers update-role-trust-policy": {
+      "api_calls": [
+        "aws eks describe-cluster",
+        "aws iam get-role",
+        "aws iam update-assume-role-policy"
+      ]
+    },
+    "gamelist get-game-session-log": {
+      "api_calls": [
+        "aws gamelift get-game-session-log-url"
+      ]
+    },
+    "gamelist upload-build": {
+      "api_calls": [
+        "aws gamelift create-build",
+        "aws gamelift request-upload-credentials",
+        "aws s3 cp"
+      ]
+    },
+    "logs start-live-tail": {
+      "api_calls": [
+        "aws logs start-live-tail"
+      ]
+    },
+    "opsworks register": {
+      "api_calls": [
+        "aws opsworks describe-stacks",
+        "aws opsworks describe-stack-provisioning-parameters",
+        "aws ec2 describe-instances",
+        "aws opsworks describe-instances",
+        "aws iam create-group",
+        "aws iam create-user",
+        "aws iam add-user-to-group",
+        "aws iam attach-user-policy",
+        "aws iam put-user-policy",
+        "aws iam create-access-key"
+      ]
+    },
+    "rds generate-db-auth-token": {
+      "api_calls": [
+        "aws rds generate-db-auth-token"
+      ]
+    },
+    "s3 cp": {
+      "api_calls": [
+        "aws s3api copy-object",
+        "aws s3api upload-part-copy",
+        "aws s3api put-object",
+        "aws s3api upload-part",
+        "aws s3api head-object",
+        "aws s3api get-object"
+      ]
+    },
+    "s3 ls": {
+      "api_calls": [
+        "aws s3api list-buckets",
+        "aws s3api list-objects-v2"
+      ]
+    },
+    "s3 mb": {
+      "api_calls": [
+        "aws s3api create-bucket"
+      ]
+    },
+    "s3 mv": {
+      "api_calls": [
+        "aws s3api copy-object",
+        "aws s3api upload-part-copy",
+        "aws s3api delete-object"
+      ]
+    },
+    "s3 presign": {
+      "api_calls": [
+        "aws s3 presign"
+      ]
+    },
+    "s3 rb": {
+      "api_calls": [
+        "aws s3api delete-bucket"
+      ]
+    },
+    "s3 rm": {
+      "api_calls": [
+        "aws s3api delete-object"
+      ]
+    },
+    "s3 sync": {
+      "api_calls": [
+        "aws s3api copy-object",
+        "aws s3api upload-part-copy",
+        "aws s3api put-object",
+        "aws s3api upload-part",
+        "aws s3api head-object",
+        "aws s3api get-object"
+      ]
+    },
+    "s3 website": {
+      "api_calls": [
+        "aws s3api put-bucket-website"
+      ]
+    },
+    "servicecatalog generate": {
+      "api_calls": [
+        "aws s3 cp",
+        "aws servicecatalog create-product"
+      ]
+    }
+  }
+}

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/mcp-security-policy.json
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/mcp-security-policy.json
@@ -1,0 +1,4 @@
+{
+  "denylist": [],
+  "elicitList": []
+}

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/policy.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/policy.py
@@ -1,0 +1,193 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+from enum import Enum
+from loguru import logger
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+
+class PolicyDecision(Enum):
+    """Class to list the policy decisions."""
+
+    DENY = 'deny'
+    ELICIT = 'elicit'
+    ALLOW = 'allow'
+
+
+class SecurityPolicy:
+    """Class to determine if the command is in he security policy or not."""
+
+    def __init__(self):
+        """Initialize the policy lists."""
+        self.denylist: Set[str] = set()
+        self.elicit_list: Set[str] = set()
+        self.customizations: Dict[str, List[str]] = {}
+        self._load_policy()
+
+    def _load_policy(self):
+        """Load security policy from local security directory."""
+        security_dir = Path(__file__).parent
+        policy_path = security_dir / 'mcp-security-policy.json'
+        customization_path = security_dir / 'aws_api_customization.json'
+
+        if not policy_path.exists():
+            logger.info('No security policy file found at {}, using default behavior', policy_path)
+        else:
+            try:
+                with open(policy_path, 'r') as f:
+                    policy_data = json.load(f)
+
+                # Load denylist
+                if 'denylist' in policy_data:
+                    self.denylist = set(policy_data['denylist'])
+                    logger.info('Loaded {} commands in denylist', len(self.denylist))
+
+                # Load elicit list (consent list)
+                if 'elicitList' in policy_data:
+                    self.elicit_list = set(policy_data['elicitList'])
+                    logger.info('Loaded {} commands in elicit list', len(self.elicit_list))
+
+            except Exception as e:
+                logger.error('Failed to load security policy from {}: {}', policy_path, e)
+
+        # Load customizations from separate file
+        if customization_path.exists():
+            try:
+                with open(customization_path, 'r') as f:
+                    customization_data = json.load(f)
+
+                if 'customizations' in customization_data:
+                    self.customizations = {}
+                    for cmd, config in customization_data['customizations'].items():
+                        if 'api_calls' in config:
+                            self.customizations[cmd] = config['api_calls']
+                    logger.info('Loaded {} customizations', len(self.customizations))
+
+            except Exception as e:
+                logger.error('Failed to load customizations from {}: {}', customization_path, e)
+
+    def get_decision(
+        self, service: str, operation: str, is_read_only: bool, supports_elicitation: bool
+    ) -> PolicyDecision:
+        """Get policy decision for a service/operation combination.
+
+        Priority: deny > elicit > default behavior
+        """
+        operation_kebab = operation.replace('_', '-')
+        operation_kebab = re.sub('([A-Z])', r'-\1', operation_kebab).lower().lstrip('-')
+
+        api_call = f'aws {service} {operation_kebab}'
+
+        # s3 service maps to s3api in CLI for some operations
+        if service == 's3':
+            # For s3 service, also check s3api variant
+            api_call_s3api = f'aws s3api {operation_kebab}'
+
+            # Check denylist first
+            if api_call in self.denylist or api_call_s3api in self.denylist:
+                return PolicyDecision.DENY
+
+            # Check elicit list
+            if api_call in self.elicit_list or api_call_s3api in self.elicit_list:
+                if not supports_elicitation:
+                    return PolicyDecision.DENY
+                return PolicyDecision.ELICIT
+        else:
+            # Check denylist first
+            if api_call in self.denylist:
+                return PolicyDecision.DENY
+
+            # Check elicit list
+            if api_call in self.elicit_list:
+                # If client doesn't support elicitation, treat the elicit list as deny
+                if not supports_elicitation:
+                    return PolicyDecision.DENY
+                return PolicyDecision.ELICIT
+
+        # Default behavior: read-only allowed, mutations elicited
+        if is_read_only:
+            return PolicyDecision.ALLOW
+        else:
+            if not supports_elicitation:
+                return PolicyDecision.DENY
+            return PolicyDecision.ELICIT
+
+    def check_customization(
+        self, cli_command: str, is_read_only_func, supports_elicitation: bool
+    ) -> Optional[PolicyDecision]:
+        """Check if command matches a customization and return the highest priority decision.
+
+        Returns None if no customization matches.
+        """
+        # Extract base command (e.g., "s3 ls" from "aws s3 ls bucket-name")
+        parts = cli_command.strip().split()
+        if len(parts) < 3 or parts[0] != 'aws':
+            return None
+
+        base_cmd = f'{parts[1]} {parts[2]}'
+
+        if base_cmd not in self.customizations:
+            return None
+
+        api_calls = self.customizations[base_cmd]
+        decisions = []
+
+        # Check the parent command itself
+        parent_api_call = f'aws {base_cmd}'
+        if parent_api_call in self.denylist:
+            return PolicyDecision.DENY
+        elif parent_api_call in self.elicit_list:
+            if not supports_elicitation:
+                return PolicyDecision.DENY
+            decisions.append(PolicyDecision.ELICIT)
+
+        # Check all underlying API calls
+        for api_call in api_calls:
+            # Parse service and operation from api_call
+            api_parts = api_call.strip().split()
+            if len(api_parts) < 3 or api_parts[0] != 'aws':
+                continue
+
+            service = api_parts[1]
+            operation = api_parts[2].replace('-', '_')
+
+            # Check against denylist/elicitlist first
+            if api_call in self.denylist:
+                return PolicyDecision.DENY
+            elif api_call in self.elicit_list:
+                if not supports_elicitation:
+                    return PolicyDecision.DENY
+                decisions.append(PolicyDecision.ELICIT)
+            else:
+                # Check default behavior based on read-only status
+                is_read_only = is_read_only_func(service, operation)
+                decision = self.get_decision(
+                    service, operation, is_read_only, supports_elicitation
+                )
+                decisions.append(decision)
+
+        # Return highest priority decision: DENY > ELICIT > ALLOW
+
+        if PolicyDecision.DENY in decisions:
+            return PolicyDecision.DENY
+        elif PolicyDecision.ELICIT in decisions:
+            return PolicyDecision.ELICIT
+        else:
+            return PolicyDecision.ALLOW
+
+
+security_policy = SecurityPolicy()

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -17,9 +17,9 @@ import sys
 from .core.agent_scripts.manager import AGENT_SCRIPTS_MANAGER
 from .core.aws.driver import translate_cli_to_ir
 from .core.aws.service import (
+    check_security_policy,
     execute_awscli_customization,
     interpret_command,
-    is_operation_read_only,
     request_consent,
     validate,
 )
@@ -45,6 +45,7 @@ from .core.common.models import (
 )
 from .core.kb import knowledge_base
 from .core.metadata.read_only_operations_list import ReadOnlyOperations, get_read_only_operations
+from .core.security.policy import PolicyDecision
 from botocore.exceptions import NoCredentialsError
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
@@ -230,7 +231,17 @@ async def call_aws(
         )
 
     try:
-        if READ_OPERATIONS_INDEX is None or not is_operation_read_only(ir, READ_OPERATIONS_INDEX):
+        # Check security policy
+        if READ_OPERATIONS_INDEX is not None:
+            policy_decision = check_security_policy(cli_command, ir, READ_OPERATIONS_INDEX, ctx)
+
+            if policy_decision == PolicyDecision.DENY:
+                error_message = 'Execution of this operation is denied by security policy.'
+                await ctx.error(error_message)
+                return AwsApiMcpServerErrorResponse(detail=error_message)
+            elif policy_decision == PolicyDecision.ELICIT:
+                await request_consent(cli_command, ctx)
+        else:
             if READ_OPERATIONS_ONLY_MODE:
                 error_message = (
                     'Execution of this operation is not allowed because read only mode is enabled. '
@@ -355,8 +366,12 @@ def main():
         logger.error(error_message)
         raise RuntimeError(error_message)
 
-    if READ_OPERATIONS_ONLY_MODE or REQUIRE_MUTATION_CONSENT:
+    # Always load read operations index for security policy checking
+    try:
         READ_OPERATIONS_INDEX = get_read_only_operations()
+    except Exception as e:
+        logger.warning('Failed to load read operations index: {}', e)
+        READ_OPERATIONS_INDEX = None
 
     server.run(transport=TRANSPORT)
 

--- a/src/aws-api-mcp-server/tests/test_security_policy.py
+++ b/src/aws-api-mcp-server/tests/test_security_policy.py
@@ -1,0 +1,183 @@
+from awslabs.aws_api_mcp_server.core.aws.service import check_security_policy
+from awslabs.aws_api_mcp_server.core.common.models import IRTranslation
+from awslabs.aws_api_mcp_server.core.metadata.read_only_operations_list import ReadOnlyOperations
+from awslabs.aws_api_mcp_server.core.security.policy import PolicyDecision, SecurityPolicy
+from pathlib import Path
+from unittest.mock import Mock, mock_open, patch
+
+
+# Core SecurityPolicy Tests
+def test_security_policy_file_loading_success():
+    """Test successful policy loading from files."""
+    mock_policy_data = (
+        '{"denylist": ["aws iam delete-user"], "elicitList": ["aws s3api put-object"]}'
+    )
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch('builtins.open', mock_open(read_data=mock_policy_data)):
+            policy = SecurityPolicy()
+
+            assert 'aws iam delete-user' in policy.denylist
+            assert 'aws s3api put-object' in policy.elicit_list
+
+
+def test_security_policy_customization_file_loading():
+    """Test successful customization loading from separate file."""
+    mock_policy_data = '{"denylist": [], "elicitList": []}'
+    mock_customization_data = (
+        '{"customizations": {"s3 ls": {"api_calls": ["aws s3api list-buckets"]}}}'
+    )
+
+    def mock_open_side_effect(file_path, *args, **kwargs):
+        if 'mcp-security-policy.json' in str(file_path):
+            return mock_open(read_data=mock_policy_data)()
+        elif 'aws_api_customization.json' in str(file_path):
+            return mock_open(read_data=mock_customization_data)()
+        return mock_open()()
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch('builtins.open', side_effect=mock_open_side_effect):
+            policy = SecurityPolicy()
+
+            assert 's3 ls' in policy.customizations
+            assert policy.customizations['s3 ls'] == ['aws s3api list-buckets']
+
+
+def test_security_policy_deny_takes_priority():
+    """Test that denylist takes priority over elicitList."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+        policy.denylist = {'aws s3api list-buckets'}
+        policy.elicit_list = {'aws s3api list-buckets'}
+
+        decision = policy.get_decision('s3api', 'list_buckets', True, True)
+        assert decision == PolicyDecision.DENY
+
+
+def test_security_policy_elicit_fallback_to_deny():
+    """Test elicitation fallback to deny when client doesn't support it."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+        policy.elicit_list = {'aws s3api put-object'}
+
+        decision = policy.get_decision('s3api', 'put_object', False, False)
+        assert decision == PolicyDecision.DENY
+
+
+def test_security_policy_default_read_only_allowed():
+    """Test default behavior for read-only operations."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+
+        decision = policy.get_decision('s3api', 'list_buckets', True, True)
+        assert decision == PolicyDecision.ALLOW
+
+
+def test_security_policy_default_mutation_elicited():
+    """Test default behavior for mutation operations."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+
+        decision = policy.get_decision('s3api', 'put_object', False, True)
+        assert decision == PolicyDecision.ELICIT
+
+
+# Customization Tests
+def test_security_policy_customization_parent_deny():
+    """Test customization when parent command is in denylist."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+        policy.denylist = {'aws s3 ls'}
+        policy.customizations = {'s3 ls': ['aws s3api list-buckets']}
+
+        def mock_is_read_only(service, operation):
+            return service == 's3api' and operation == 'list_buckets'
+
+        decision = policy.check_customization('aws s3 ls my-bucket', mock_is_read_only, True)
+        assert decision == PolicyDecision.DENY
+
+
+def test_security_policy_customization_child_deny():
+    """Test customization when child API call is in denylist."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+        policy.denylist = {'aws s3api list-buckets'}
+        policy.customizations = {'s3 ls': ['aws s3api list-buckets', 'aws s3api list-objects-v2']}
+
+        def mock_is_read_only(service, operation):
+            return service == 's3api' and operation in ['list_buckets', 'list_objects_v2']
+
+        decision = policy.check_customization('aws s3 ls my-bucket', mock_is_read_only, True)
+        assert decision == PolicyDecision.DENY
+
+
+def test_security_policy_customization_mixed_decisions_deny_wins():
+    """Test customization with mixed decisions - deny should win."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+        policy.denylist = {'aws s3api list-buckets'}
+        policy.elicit_list = {'aws s3api list-objects-v2'}
+        policy.customizations = {'s3 ls': ['aws s3api list-buckets', 'aws s3api list-objects-v2']}
+
+        def mock_is_read_only(service, operation):
+            return service == 's3api' and operation in ['list_buckets', 'list_objects_v2']
+
+        decision = policy.check_customization('aws s3 ls my-bucket', mock_is_read_only, True)
+        assert decision == PolicyDecision.DENY
+
+
+def test_security_policy_customization_all_allowed():
+    """Test customization when all child API calls are allowed."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy()
+        policy.customizations = {'s3 ls': ['aws s3api list-buckets', 'aws s3api list-objects-v2']}
+
+        def mock_is_read_only(service, operation):
+            return service == 's3api' and operation in ['list_buckets', 'list_objects_v2']
+
+        decision = policy.check_customization('aws s3 ls my-bucket', mock_is_read_only, True)
+        assert decision == PolicyDecision.ALLOW
+
+
+# Integration Tests
+@patch('awslabs.aws_api_mcp_server.core.aws.service.security_policy')
+def test_check_security_policy_customization_deny(mock_security_policy):
+    """Test security policy integration when customization returns deny."""
+    mock_security_policy.check_customization.return_value = PolicyDecision.DENY
+
+    mock_ctx = Mock()
+    mock_ctx.elicit = Mock()
+
+    mock_read_only_ops = Mock(spec=ReadOnlyOperations)
+    mock_ir = Mock(spec=IRTranslation)
+    mock_ir.command_metadata = Mock()
+    mock_ir.command_metadata.service_sdk_name = 's3api'
+    mock_ir.command_metadata.operation_sdk_name = 'list_buckets'
+
+    decision = check_security_policy('aws s3 ls', mock_ir, mock_read_only_ops, mock_ctx)
+
+    assert decision == PolicyDecision.DENY
+    mock_security_policy.check_customization.assert_called_once()
+
+
+@patch('awslabs.aws_api_mcp_server.core.aws.service.security_policy')
+def test_check_security_policy_no_customization(mock_security_policy):
+    """Test security policy integration when no customization matches."""
+    mock_security_policy.check_customization.return_value = None
+    mock_security_policy.get_decision.return_value = PolicyDecision.ALLOW
+
+    mock_ctx = Mock()
+    mock_ctx.elicit = Mock()
+
+    mock_read_only_ops = Mock(spec=ReadOnlyOperations)
+    mock_ir = Mock(spec=IRTranslation)
+    mock_ir.command_metadata = Mock()
+    mock_ir.command_metadata.service_sdk_name = 's3api'
+    mock_ir.command_metadata.operation_sdk_name = 'list_buckets'
+
+    decision = check_security_policy(
+        'aws s3api list-buckets', mock_ir, mock_read_only_ops, mock_ctx
+    )
+
+    assert decision == PolicyDecision.ALLOW
+    mock_security_policy.get_decision.assert_called_once()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
This commit adds support for customer-defined security policies with elicitation and denylisting capabilities for AWS CLI operations.
### Changes

> Please provide a summary of what's being changed
- Added SecurityPolicy class to manage denylist, elicit list, and API customizations
- Supports JSON configuration files for flexible policy management
- Implements priority-based decision making: DENY > ELICIT > ALLOW
- Handles API customizations that map to multiple underlying API calls (for example aws s3 ls)
- If elicitation is not supported, the operations are denylisted

> Testing
- Unit tests
- Added commands to the denylist, elicit list, started local sever and tested locally with my account
### User experience

> Please share what the user experience looks like before and after this change
- The user can add API commands into the JSON to enforce deny/eliciting operations

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented -> will do it as a followup after another change

Is this a breaking change? (Y/N) - N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
