### PR TITLE
feat(HealthOmics): workflow capability enhancements

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_execution.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_execution.py
@@ -205,6 +205,13 @@ async def start_run(
         await ctx.error(error_message)
         raise ValueError(error_message)
 
+    # Validate that cache_behavior requires cache_id
+    if cache_behavior and not cache_id:
+        error_message = 'cache_behavior requires cache_id to be provided'
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
     # Ensure output URI ends with a slash
     try:
         output_uri = ensure_s3_uri_ends_with_slash(output_uri)

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_execution.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_execution.py
@@ -628,7 +628,7 @@ async def get_run_task(
         task_id: ID of the task
 
     Returns:
-        Dictionary containing task details
+        Dictionary containing task details including imageDetails when available
     """
     client = get_omics_client()
 
@@ -655,7 +655,15 @@ async def get_run_task(
         if 'logStream' in response:
             result['logStream'] = response['logStream']
 
+        if 'imageDetails' in response:
+            result['imageDetails'] = response['imageDetails']
+
         return result
+    except botocore.exceptions.ClientError as e:
+        error_message = f'AWS error getting task {task_id} for run {run_id}: {str(e)}'
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise
     except botocore.exceptions.BotoCoreError as e:
         error_message = f'AWS error getting task {task_id} for run {run_id}: {str(e)}'
         logger.error(error_message)

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_management.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_management.py
@@ -117,6 +117,14 @@ async def create_workflow(
         None,
         description='Optional parameter template for the workflow',
     ),
+    container_registry_map: Optional[Dict[str, Any]] = Field(
+        None,
+        description='Optional container registry map with registryMappings array containing upstreamRegistryUrl and ecrRepositoryPrefix pairs',
+    ),
+    container_registry_map_uri: Optional[str] = Field(
+        None,
+        description='Optional S3 URI pointing to a JSON file containing container registry mappings. Cannot be used together with container_registry_map',
+    ),
 ) -> Dict[str, Any]:
     """Create a new HealthOmics workflow.
 
@@ -126,10 +134,21 @@ async def create_workflow(
         definition_zip_base64: Base64-encoded workflow definition ZIP file
         description: Optional description of the workflow
         parameter_template: Optional parameter template for the workflow
+        container_registry_map: Optional container registry map with registryMappings array containing upstreamRegistryUrl and ecrRepositoryPrefix pairs
+        container_registry_map_uri: Optional S3 URI pointing to a JSON file containing container registry mappings. Cannot be used together with container_registry_map
 
     Returns:
         Dictionary containing the created workflow information
     """
+    # Validate that both container registry parameters are not provided together
+    if container_registry_map is not None and container_registry_map_uri is not None:
+        error_message = (
+            'Cannot specify both container_registry_map and container_registry_map_uri parameters'
+        )
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
     # Validate base64 input first, before creating client
     try:
         definition_zip = decode_from_base64(definition_zip_base64)
@@ -151,6 +170,12 @@ async def create_workflow(
 
     if parameter_template:
         params['parameterTemplate'] = parameter_template
+
+    if container_registry_map:
+        params['containerRegistryMap'] = container_registry_map
+
+    if container_registry_map_uri:
+        params['containerRegistryMapUri'] = container_registry_map_uri
 
     try:
         response = client.create_workflow(**params)
@@ -229,6 +254,9 @@ async def get_workflow(
         if 'definition' in response:
             result['definition'] = response['definition']
 
+        if 'containerRegistryMap' in response:
+            result['containerRegistryMap'] = response['containerRegistryMap']
+
         return result
     except botocore.exceptions.BotoCoreError as e:
         error_message = f'AWS error getting workflow {workflow_id}: {str(e)}'
@@ -273,6 +301,14 @@ async def create_workflow_version(
         description='Storage capacity in GB (required for STATIC)',
         ge=1,
     ),
+    container_registry_map: Optional[Dict[str, Any]] = Field(
+        None,
+        description='Optional container registry map with registryMappings array containing upstreamRegistryUrl and ecrRepositoryPrefix pairs',
+    ),
+    container_registry_map_uri: Optional[str] = Field(
+        None,
+        description='Optional S3 URI pointing to a JSON file containing container registry mappings. Cannot be used together with container_registry_map',
+    ),
 ) -> Dict[str, Any]:
     """Create a new version of an existing workflow.
 
@@ -285,10 +321,21 @@ async def create_workflow_version(
         parameter_template: Optional parameter template for the workflow
         storage_type: Storage type (STATIC or DYNAMIC)
         storage_capacity: Storage capacity in GB (required for STATIC)
+        container_registry_map: Optional container registry map with registryMappings array containing upstreamRegistryUrl and ecrRepositoryPrefix pairs
+        container_registry_map_uri: Optional S3 URI pointing to a JSON file containing container registry mappings. Cannot be used together with container_registry_map
 
     Returns:
         Dictionary containing the created workflow version information
     """
+    # Validate that both container registry parameters are not provided together
+    if container_registry_map is not None and container_registry_map_uri is not None:
+        error_message = (
+            'Cannot specify both container_registry_map and container_registry_map_uri parameters'
+        )
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
     # Validate inputs first, before creating client
     try:
         definition_zip = decode_from_base64(definition_zip_base64)
@@ -323,6 +370,12 @@ async def create_workflow_version(
 
     if storage_type == 'STATIC':
         params['storageCapacity'] = storage_capacity
+
+    if container_registry_map:
+        params['containerRegistryMap'] = container_registry_map
+
+    if container_registry_map_uri:
+        params['containerRegistryMapUri'] = container_registry_map_uri
 
     try:
         response = client.create_workflow_version(**params)

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmi
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "boto3>=1.40.17",
+    "boto3>=1.40.23",
     "loguru>=0.7.0",
     "mcp[cli]>=1.11.0",
     "pydantic>=2.10.6",

--- a/src/aws-healthomics-mcp-server/tests/test_workflow_execution.py
+++ b/src/aws-healthomics-mcp-server/tests/test_workflow_execution.py
@@ -1459,6 +1459,31 @@ async def test_start_run_invalid_cache_behavior():
 
 
 @pytest.mark.asyncio
+async def test_start_run_cache_behavior_without_cache_id():
+    """Test start_run with cache_behavior but no cache_id."""
+    mock_ctx = AsyncMock()
+
+    with pytest.raises(ValueError, match='cache_behavior requires cache_id to be provided'):
+        await start_run(
+            ctx=mock_ctx,
+            workflow_id='wfl-12345',
+            role_arn='arn:aws:iam::123456789012:role/HealthOmicsRole',
+            name='test-run',
+            output_uri='s3://bucket/output/',
+            parameters={'param1': 'value1'},
+            workflow_version_name=None,
+            storage_type='DYNAMIC',
+            storage_capacity=None,
+            cache_id=None,  # No cache_id provided
+            cache_behavior='CACHE_ALWAYS',  # But cache_behavior is provided
+        )
+
+    # Verify error was reported to context
+    mock_ctx.error.assert_called_once()
+    assert 'cache_behavior requires cache_id to be provided' in mock_ctx.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
 async def test_start_run_invalid_s3_uri():
     """Test start_run with invalid S3 URI."""
     mock_ctx = AsyncMock()

--- a/src/aws-healthomics-mcp-server/tests/test_workflow_execution.py
+++ b/src/aws-healthomics-mcp-server/tests/test_workflow_execution.py
@@ -18,6 +18,7 @@ import botocore.exceptions
 import pytest
 from awslabs.aws_healthomics_mcp_server.tools.workflow_execution import (
     get_run,
+    get_run_task,
     list_run_tasks,
     list_runs,
     start_run,
@@ -1699,3 +1700,231 @@ async def test_list_run_tasks_unexpected_error():
     # Verify error was reported to context
     mock_ctx.error.assert_called_once()
     assert 'Unexpected error listing tasks for run' in mock_ctx.error.call_args[0][0]
+
+
+# Tests for get_run_task function
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_success():
+    """Test successful retrieval of task details."""
+    # Mock response data with all possible fields
+    start_time = datetime.now(timezone.utc)
+    stop_time = datetime.now(timezone.utc)
+
+    mock_response = {
+        'taskId': 'task-12345',
+        'status': 'COMPLETED',
+        'name': 'test-task',
+        'cpus': 4,
+        'memory': 8192,
+        'startTime': start_time,
+        'stopTime': stop_time,
+        'statusMessage': 'Task completed successfully',
+        'logStream': 'log-stream-name',
+        'imageDetails': {
+            'imageUri': '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest',
+            'imageDigest': 'sha256:abcdef123456...',
+        },
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.return_value = mock_response
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify client was called correctly
+    mock_client.get_run_task.assert_called_once_with(id='run-12345', taskId='task-12345')
+
+    # Verify result contains all expected fields
+    assert result['taskId'] == 'task-12345'
+    assert result['status'] == 'COMPLETED'
+    assert result['name'] == 'test-task'
+    assert result['cpus'] == 4
+    assert result['memory'] == 8192
+    assert result['startTime'] == start_time.isoformat()
+    assert result['stopTime'] == stop_time.isoformat()
+    assert result['statusMessage'] == 'Task completed successfully'
+    assert result['logStream'] == 'log-stream-name'
+    assert result['imageDetails'] == {
+        'imageUri': '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest',
+        'imageDigest': 'sha256:abcdef123456...',
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_minimal_response():
+    """Test task retrieval with minimal response fields."""
+    # Mock response with minimal required fields
+    mock_response = {
+        'taskId': 'task-12345',
+        'status': 'RUNNING',
+        'name': 'test-task',
+        'cpus': 2,
+        'memory': 4096,
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.return_value = mock_response
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify required fields
+    assert result['taskId'] == 'task-12345'
+    assert result['status'] == 'RUNNING'
+    assert result['name'] == 'test-task'
+    assert result['cpus'] == 2
+    assert result['memory'] == 4096
+
+    # Verify optional fields are not present
+    assert 'startTime' not in result
+    assert 'stopTime' not in result
+    assert 'statusMessage' not in result
+    assert 'logStream' not in result
+    assert 'imageDetails' not in result
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_with_image_details():
+    """Test task retrieval specifically focusing on imageDetails field."""
+    # Mock response with imageDetails
+    mock_response = {
+        'taskId': 'task-12345',
+        'status': 'COMPLETED',
+        'name': 'test-task',
+        'cpus': 4,
+        'memory': 8192,
+        'imageDetails': {
+            'imageUri': 'public.ecr.aws/biocontainers/samtools:1.15.1--h1170115_0',
+            'imageDigest': 'sha256:1234567890abcdef...',
+            'registryId': '123456789012',
+            'repositoryName': 'biocontainers/samtools',
+        },
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.return_value = mock_response
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify imageDetails is properly returned
+    assert 'imageDetails' in result
+    assert (
+        result['imageDetails']['imageUri']
+        == 'public.ecr.aws/biocontainers/samtools:1.15.1--h1170115_0'
+    )
+    assert result['imageDetails']['imageDigest'] == 'sha256:1234567890abcdef...'
+    assert result['imageDetails']['registryId'] == '123456789012'
+    assert result['imageDetails']['repositoryName'] == 'biocontainers/samtools'
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_failed_status():
+    """Test task retrieval with failed status."""
+    # Mock response for failed task
+    mock_response = {
+        'taskId': 'task-12345',
+        'status': 'FAILED',
+        'name': 'test-task',
+        'cpus': 4,
+        'memory': 8192,
+        'statusMessage': 'Task failed due to resource constraints',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.return_value = mock_response
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify failure information
+    assert result['status'] == 'FAILED'
+    assert result['statusMessage'] == 'Task failed due to resource constraints'
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_boto_error():
+    """Test handling of BotoCoreError."""
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.side_effect = botocore.exceptions.BotoCoreError()
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        with pytest.raises(botocore.exceptions.BotoCoreError):
+            await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify error was reported to context
+    mock_ctx.error.assert_called_once()
+    assert 'AWS error getting task task-12345 for run run-12345' in mock_ctx.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_client_error():
+    """Test handling of ClientError."""
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.side_effect = botocore.exceptions.ClientError(
+        {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Task not found'}}, 'GetRunTask'
+    )
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        with pytest.raises(botocore.exceptions.ClientError):
+            await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify error was reported to context
+    mock_ctx.error.assert_called_once()
+    assert 'AWS error getting task task-12345 for run run-12345' in mock_ctx.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_get_run_task_unexpected_error():
+    """Test handling of unexpected errors."""
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_run_task.side_effect = Exception('Unexpected error')
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        with pytest.raises(Exception, match='Unexpected error'):
+            await get_run_task(mock_ctx, run_id='run-12345', task_id='task-12345')
+
+    # Verify error was reported to context
+    mock_ctx.error.assert_called_once()
+    assert (
+        'Unexpected error getting task task-12345 for run run-12345'
+        in mock_ctx.error.call_args[0][0]
+    )

--- a/src/aws-healthomics-mcp-server/tests/test_workflow_management.py
+++ b/src/aws-healthomics-mcp-server/tests/test_workflow_management.py
@@ -430,6 +430,97 @@ async def test_get_workflow_with_status_message():
 
 
 @pytest.mark.asyncio
+async def test_get_workflow_with_container_registry_map():
+    """Test workflow retrieval with container registry map."""
+    # Mock response with container registry map
+    creation_time = datetime.now(timezone.utc)
+    container_registry_map = {
+        'registryMappings': [
+            {'upstreamRegistryUrl': 'registry-1.docker.io', 'ecrRepositoryPrefix': 'docker-hub'},
+            {'upstreamRegistryUrl': 'quay.io', 'ecrRepositoryPrefix': 'quay'},
+        ]
+    }
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'name': 'test-workflow',
+        'status': 'ACTIVE',
+        'type': 'WDL',
+        'description': 'Test workflow with container registry map',
+        'parameterTemplate': {'param1': {'type': 'string'}},
+        'containerRegistryMap': container_registry_map,
+        'creationTime': creation_time,
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_workflow.return_value = mock_response
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await get_workflow(ctx=mock_ctx, workflow_id='wfl-12345', export_definition=False)
+
+    # Verify container registry map is included
+    assert result['containerRegistryMap'] == container_registry_map
+    assert (
+        result['containerRegistryMap']['registryMappings'][0]['upstreamRegistryUrl']
+        == 'registry-1.docker.io'
+    )
+    assert (
+        result['containerRegistryMap']['registryMappings'][0]['ecrRepositoryPrefix']
+        == 'docker-hub'
+    )
+    assert (
+        result['containerRegistryMap']['registryMappings'][1]['upstreamRegistryUrl'] == 'quay.io'
+    )
+    assert result['containerRegistryMap']['registryMappings'][1]['ecrRepositoryPrefix'] == 'quay'
+
+    # Verify other fields are present
+    assert result['id'] == 'wfl-12345'
+    assert result['status'] == 'ACTIVE'
+    assert result['description'] == 'Test workflow with container registry map'
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_without_container_registry_map():
+    """Test workflow retrieval without container registry map."""
+    # Mock response without container registry map
+    creation_time = datetime.now(timezone.utc)
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'name': 'test-workflow',
+        'status': 'ACTIVE',
+        'type': 'WDL',
+        'description': 'Test workflow without container registry map',
+        'parameterTemplate': {'param1': {'type': 'string'}},
+        'creationTime': creation_time,
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_workflow.return_value = mock_response
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await get_workflow(ctx=mock_ctx, workflow_id='wfl-12345', export_definition=False)
+
+    # Verify container registry map is not present
+    assert 'containerRegistryMap' not in result
+
+    # Verify other fields are present
+    assert result['id'] == 'wfl-12345'
+    assert result['status'] == 'ACTIVE'
+    assert result['description'] == 'Test workflow without container registry map'
+
+
+@pytest.mark.asyncio
 async def test_list_workflow_versions_success(mock_omics_client, mock_context):
     """Test successful listing of workflow versions."""
     # Mock response from AWS
@@ -631,6 +722,8 @@ async def test_create_workflow_success():
             definition_zip_base64=definition_zip_base64,
             description='Test workflow description',
             parameter_template={'param1': {'type': 'string'}},
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify client was called correctly
@@ -678,6 +771,8 @@ async def test_create_workflow_minimal():
             definition_zip_base64=definition_zip_base64,
             description=None,
             parameter_template=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify client was called with only required parameters
@@ -706,6 +801,8 @@ async def test_create_workflow_invalid_base64():
             definition_zip_base64='invalid base64!',
             description=None,
             parameter_template=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify error was reported to context
@@ -737,6 +834,8 @@ async def test_create_workflow_boto_error():
             definition_zip_base64=definition_zip_base64,
             description=None,
             parameter_template=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify error was reported to context
@@ -768,11 +867,211 @@ async def test_create_workflow_unexpected_error():
             definition_zip_base64=definition_zip_base64,
             description=None,
             parameter_template=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify error was reported to context
     mock_ctx.error.assert_called_once()
     assert 'Unexpected error creating workflow' in mock_ctx.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_with_container_registry_map():
+    """Test workflow creation with container registry map."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+        'description': 'Test workflow with container registry map',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content').decode('utf-8')
+
+    # Container registry map - using correct AWS API structure
+    container_registry_map = {
+        'registryMappings': [
+            {'upstreamRegistryUrl': 'registry-1.docker.io', 'ecrRepositoryPrefix': 'docker-hub'},
+            {'upstreamRegistryUrl': 'quay.io', 'ecrRepositoryPrefix': 'quay'},
+        ]
+    }
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow(
+            mock_ctx,
+            name='test-workflow',
+            definition_zip_base64=definition_zip_base64,
+            description='Test workflow with container registry map',
+            parameter_template={'param1': {'type': 'string'}},
+            container_registry_map=container_registry_map,
+            container_registry_map_uri=None,
+        )
+
+    # Verify client was called correctly with container registry map
+    mock_client.create_workflow.assert_called_once_with(
+        name='test-workflow',
+        definitionZip=b'test workflow content',
+        description='Test workflow with container registry map',
+        parameterTemplate={'param1': {'type': 'string'}},
+        containerRegistryMap=container_registry_map,
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['arn'] == 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345'
+    assert result['status'] == 'ACTIVE'
+    assert result['name'] == 'test-workflow'
+    assert result['description'] == 'Test workflow with container registry map'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_without_container_registry_map():
+    """Test workflow creation without container registry map."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content').decode('utf-8')
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow(
+            mock_ctx,
+            name='test-workflow',
+            definition_zip_base64=definition_zip_base64,
+            description=None,
+            parameter_template=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
+        )
+
+    # Verify client was called without container registry map
+    mock_client.create_workflow.assert_called_once_with(
+        name='test-workflow',
+        definitionZip=b'test workflow content',
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['name'] == 'test-workflow'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_with_container_registry_map_uri():
+    """Test workflow creation with container registry map URI."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+        'description': 'Test workflow with container registry map URI',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content').decode('utf-8')
+
+    # S3 URI for container registry map
+    container_registry_map_uri = 's3://my-bucket/registry-mappings.json'
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow(
+            mock_ctx,
+            name='test-workflow',
+            definition_zip_base64=definition_zip_base64,
+            description='Test workflow with container registry map URI',
+            parameter_template={'param1': {'type': 'string'}},
+            container_registry_map=None,
+            container_registry_map_uri=container_registry_map_uri,
+        )
+
+    # Verify client was called correctly with container registry map URI
+    mock_client.create_workflow.assert_called_once_with(
+        name='test-workflow',
+        definitionZip=b'test workflow content',
+        description='Test workflow with container registry map URI',
+        parameterTemplate={'param1': {'type': 'string'}},
+        containerRegistryMapUri=container_registry_map_uri,
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['arn'] == 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345'
+    assert result['status'] == 'ACTIVE'
+    assert result['name'] == 'test-workflow'
+    assert result['description'] == 'Test workflow with container registry map URI'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_both_container_registry_params_error():
+    """Test workflow creation fails when both container registry parameters are provided."""
+    # Mock context
+    mock_ctx = AsyncMock()
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content').decode('utf-8')
+
+    # Container registry map
+    container_registry_map = {
+        'registryMappings': [
+            {'upstreamRegistryUrl': 'registry-1.docker.io', 'ecrRepositoryPrefix': 'docker-hub'}
+        ]
+    }
+
+    # S3 URI for container registry map
+    container_registry_map_uri = 's3://my-bucket/registry-mappings.json'
+
+    with pytest.raises(
+        ValueError,
+        match='Cannot specify both container_registry_map and container_registry_map_uri parameters',
+    ):
+        await create_workflow(
+            mock_ctx,
+            name='test-workflow',
+            definition_zip_base64=definition_zip_base64,
+            description=None,
+            parameter_template=None,
+            container_registry_map=container_registry_map,
+            container_registry_map_uri=container_registry_map_uri,
+        )
+
+    # Verify error was reported to context
+    mock_ctx.error.assert_called_once()
+    assert (
+        'Cannot specify both container_registry_map and container_registry_map_uri parameters'
+        in mock_ctx.error.call_args[0][0]
+    )
 
 
 @pytest.mark.asyncio
@@ -808,6 +1107,8 @@ async def test_create_workflow_version_success():
             parameter_template={'param1': {'type': 'string'}},
             storage_type='DYNAMIC',
             storage_capacity=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify client was called correctly
@@ -859,6 +1160,8 @@ async def test_create_workflow_version_with_static_storage():
             parameter_template=None,
             storage_type='STATIC',
             storage_capacity=1000,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify client was called with static storage parameters
@@ -890,6 +1193,8 @@ async def test_create_workflow_version_static_without_capacity():
             parameter_template=None,
             storage_type='STATIC',
             storage_capacity=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify error was reported to context
@@ -912,6 +1217,8 @@ async def test_create_workflow_version_invalid_base64():
             parameter_template=None,
             storage_type='DYNAMIC',
             storage_capacity=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify error was reported to context
@@ -946,8 +1253,287 @@ async def test_create_workflow_version_boto_error():
             parameter_template=None,
             storage_type='DYNAMIC',
             storage_capacity=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
         )
 
     # Verify error was reported to context
     mock_ctx.error.assert_called_once()
     assert 'AWS error creating workflow version' in mock_ctx.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_version_with_container_registry_map():
+    """Test workflow version creation with container registry map."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+        'versionName': 'v2.0',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow_version.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content v2').decode('utf-8')
+
+    # Container registry map - using correct AWS API structure
+    container_registry_map = {
+        'registryMappings': [
+            {'upstreamRegistryUrl': 'registry-1.docker.io', 'ecrRepositoryPrefix': 'docker-hub'},
+            {'upstreamRegistryUrl': 'quay.io', 'ecrRepositoryPrefix': 'quay'},
+        ]
+    }
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow_version(
+            mock_ctx,
+            workflow_id='wfl-12345',
+            version_name='v2.0',
+            definition_zip_base64=definition_zip_base64,
+            description='Version 2.0 with container registry map',
+            parameter_template={'param1': {'type': 'string'}},
+            storage_type='DYNAMIC',
+            storage_capacity=None,
+            container_registry_map=container_registry_map,
+            container_registry_map_uri=None,
+        )
+
+    # Verify client was called correctly with container registry map
+    mock_client.create_workflow_version.assert_called_once_with(
+        workflowId='wfl-12345',
+        versionName='v2.0',
+        definitionZip=b'test workflow content v2',
+        description='Version 2.0 with container registry map',
+        parameterTemplate={'param1': {'type': 'string'}},
+        storageType='DYNAMIC',
+        containerRegistryMap=container_registry_map,
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['versionName'] == 'v2.0'
+    assert result['status'] == 'ACTIVE'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_version_without_container_registry_map():
+    """Test workflow version creation without container registry map."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+        'versionName': 'v2.0',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow_version.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content v2').decode('utf-8')
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow_version(
+            mock_ctx,
+            workflow_id='wfl-12345',
+            version_name='v2.0',
+            definition_zip_base64=definition_zip_base64,
+            description='Version 2.0 without container registry map',
+            parameter_template={'param1': {'type': 'string'}},
+            storage_type='DYNAMIC',
+            storage_capacity=None,
+            container_registry_map=None,
+            container_registry_map_uri=None,
+        )
+
+    # Verify client was called without container registry map
+    mock_client.create_workflow_version.assert_called_once_with(
+        workflowId='wfl-12345',
+        versionName='v2.0',
+        definitionZip=b'test workflow content v2',
+        description='Version 2.0 without container registry map',
+        parameterTemplate={'param1': {'type': 'string'}},
+        storageType='DYNAMIC',
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['versionName'] == 'v2.0'
+    assert result['status'] == 'ACTIVE'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_version_with_static_storage_and_container_registry_map():
+    """Test workflow version creation with both static storage and container registry map."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+        'versionName': 'v2.0',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow_version.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content v2').decode('utf-8')
+
+    # Container registry map - using correct AWS API structure
+    container_registry_map = {
+        'registryMappings': [
+            {'upstreamRegistryUrl': 'registry-1.docker.io', 'ecrRepositoryPrefix': 'docker-hub'}
+        ]
+    }
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow_version(
+            mock_ctx,
+            workflow_id='wfl-12345',
+            version_name='v2.0',
+            definition_zip_base64=definition_zip_base64,
+            description='Version 2.0 with static storage and container registry map',
+            parameter_template=None,
+            storage_type='STATIC',
+            storage_capacity=2000,
+            container_registry_map=container_registry_map,
+            container_registry_map_uri=None,
+        )
+
+    # Verify client was called with both static storage and container registry map
+    mock_client.create_workflow_version.assert_called_once_with(
+        workflowId='wfl-12345',
+        versionName='v2.0',
+        definitionZip=b'test workflow content v2',
+        description='Version 2.0 with static storage and container registry map',
+        storageType='STATIC',
+        storageCapacity=2000,
+        containerRegistryMap=container_registry_map,
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['versionName'] == 'v2.0'
+    assert result['status'] == 'ACTIVE'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_version_with_container_registry_map_uri():
+    """Test workflow version creation with container registry map URI."""
+    # Mock response data
+    mock_response = {
+        'id': 'wfl-12345',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:workflow/wfl-12345',
+        'status': 'ACTIVE',
+        'name': 'test-workflow',
+        'versionName': 'v2.0',
+    }
+
+    # Mock context and client
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.create_workflow_version.return_value = mock_response
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content v2').decode('utf-8')
+
+    # S3 URI for container registry map
+    container_registry_map_uri = 's3://my-bucket/registry-mappings.json'
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await create_workflow_version(
+            mock_ctx,
+            workflow_id='wfl-12345',
+            version_name='v2.0',
+            definition_zip_base64=definition_zip_base64,
+            description='Version 2.0 with container registry map URI',
+            parameter_template={'param1': {'type': 'string'}},
+            storage_type='DYNAMIC',
+            storage_capacity=None,
+            container_registry_map=None,
+            container_registry_map_uri=container_registry_map_uri,
+        )
+
+    # Verify client was called correctly with container registry map URI
+    mock_client.create_workflow_version.assert_called_once_with(
+        workflowId='wfl-12345',
+        versionName='v2.0',
+        definitionZip=b'test workflow content v2',
+        description='Version 2.0 with container registry map URI',
+        parameterTemplate={'param1': {'type': 'string'}},
+        storageType='DYNAMIC',
+        containerRegistryMapUri=container_registry_map_uri,
+    )
+
+    # Verify result contains expected fields
+    assert result['id'] == 'wfl-12345'
+    assert result['versionName'] == 'v2.0'
+    assert result['status'] == 'ACTIVE'
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_version_both_container_registry_params_error():
+    """Test workflow version creation fails when both container registry parameters are provided."""
+    # Mock context
+    mock_ctx = AsyncMock()
+
+    # Create base64 encoded workflow definition
+    definition_zip_base64 = base64.b64encode(b'test workflow content v2').decode('utf-8')
+
+    # Container registry map
+    container_registry_map = {
+        'registryMappings': [
+            {'upstreamRegistryUrl': 'registry-1.docker.io', 'ecrRepositoryPrefix': 'docker-hub'}
+        ]
+    }
+
+    # S3 URI for container registry map
+    container_registry_map_uri = 's3://my-bucket/registry-mappings.json'
+
+    with pytest.raises(
+        ValueError,
+        match='Cannot specify both container_registry_map and container_registry_map_uri parameters',
+    ):
+        await create_workflow_version(
+            mock_ctx,
+            workflow_id='wfl-12345',
+            version_name='v2.0',
+            definition_zip_base64=definition_zip_base64,
+            description=None,
+            parameter_template=None,
+            storage_type='DYNAMIC',
+            storage_capacity=None,
+            container_registry_map=container_registry_map,
+            container_registry_map_uri=container_registry_map_uri,
+        )
+
+    # Verify error was reported to context
+    mock_ctx.error.assert_called_once()
+    assert (
+        'Cannot specify both container_registry_map and container_registry_map_uri parameters'
+        in mock_ctx.error.call_args[0][0]
+    )

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-healthomics-mcp-server"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -79,7 +79,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.40.17" },
+    { name = "boto3", specifier = ">=1.40.23" },
     { name = "coloredlogs", specifier = ">=15.0" },
     { name = "cwltool", extras = ["deps"], specifier = ">=3.1.0" },
     { name = "isodate", specifier = ">=0.6.0" },
@@ -126,30 +126,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.40.18"
+version = "1.40.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/35/a30dc21ca6582358e0ce963f38e85d42ea619f12e7be4101a834c21d749d/boto3-1.40.18.tar.gz", hash = "sha256:64301d39adecc154e3e595eaf0d4f28998ef0a5551f1d033aeac51a9e1a688e5", size = 111994, upload-time = "2025-08-26T19:21:38.61Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/24/bf634f3e5ff8dd5b4e38d838492fb14d3f6aa4b1a78ab8ca31b7054a9947/boto3-1.40.23.tar.gz", hash = "sha256:ca5e2f767a7b759b0bb5c7e5c665effa1512799e763823e68d04e7c10b1399d5", size = 111564, upload-time = "2025-09-03T19:27:57.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/b5/3fc1802eb24aef135c3ba69fff2a9bfcc6a7a8258fb396706b1a6a44de36/boto3-1.40.18-py3-none-any.whl", hash = "sha256:daa776ba1251a7458c9d6c7627873d0c2460c8e8272d35759065580e9193700a", size = 140076, upload-time = "2025-08-26T19:21:36.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/53/5fdaa30851c34e8a14113dfeef402d899aab2c3f111781ab1965ae3d2978/boto3-1.40.23-py3-none-any.whl", hash = "sha256:9826fb6abcdda2f016a939b81e94d1a9e1147ae897a523f366cf5a1558936356", size = 139323, upload-time = "2025-09-03T19:27:56.603Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.40.18"
+version = "1.40.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/91/2e745382793fa7d30810a7d5ca3e05f6817b6db07601ca5aaab12720caf9/botocore-1.40.18.tar.gz", hash = "sha256:afd69bdadd8c55cc89d69de0799829e555193a352d87867f746e19020271cc0f", size = 14375007, upload-time = "2025-08-26T19:21:24.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1b/3815d258e70e6eea26648b93ba6fe41d32f7646e600b48c97d7f89e0157c/botocore-1.40.23.tar.gz", hash = "sha256:de07cceaf9b142c183e165d303a0eee289c34d63f63e6b7a640406d6bacfb646", size = 14327014, upload-time = "2025-09-03T19:27:48.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/f5/bd57bf21fdcc4e500cc406ed2c296e626ddd160f0fee2a4932256e5d62d8/botocore-1.40.18-py3-none-any.whl", hash = "sha256:57025c46ca00cf8cec25de07a759521bfbfb3036a0f69b272654a354615dc45f", size = 14039935, upload-time = "2025-08-26T19:21:19.085Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/bffb1b0fec021a6f8eee941adca53d843a03fcdd69c23f2b0f8a58e4d033/botocore-1.40.23-py3-none-any.whl", hash = "sha256:487cced8f9346f7d1038e9158c56b6ecf6d839dd43e345bc730053c8cf321ed3", size = 13999485, upload-time = "2025-09-03T19:27:46.118Z" },
 ]
 
 [[package]]
@@ -505,7 +505,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

Adds support for creating workflows using the new container registry mapping features which will make it much easier to create and migrate workflows. Adds some checking for mutually exclusive parameters.

### Changes

You can now create a workflow with a container registry map in JSON or provide a S3 URI to a pre-made JSON file.

### User experience

If a workflow is created with a container registry map it removes the need for a user or agent to migrate public containers to private ECR and re-write the container URIs.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
