### PR TITLE
fix: core release requires disk space

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
     steps:
       # Clear up space for specific large projects
       - name: Clear Up Space (Aggressively) for Specific Projects
-        if: contains(fromJson('["aws-api-mcp-server"]'), matrix.changed-directory)
+        if: contains(fromJson('["aws-api-mcp-server","core-mcp-server"]'), matrix.changed-directory)
         uses: awslabs/mcp/.github/actions/clear-space-ubuntu-latest-agressively@25167c70e07d52455d651af931970d0ffdac75c5
       #TODO: remove local action checkout when working...
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Allows docker build due to <19Gb disk space for the core.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
