### PR TITLE
feat(dynamodb-mcp-server): Add MySQL integration to support DynamoDB Data Modeling and Migration planning

### DIFF
--- a/src/dynamodb-mcp-server/README.md
+++ b/src/dynamodb-mcp-server/README.md
@@ -2,12 +2,15 @@
 
 The official MCP Server for interacting with AWS DynamoDB
 
-This comprehensive server provides both operational DynamoDB management and expert design guidance, featuring 30+ operational tools for managing DynamoDB tables, items, indexes, backups, and more, expert data modeling guidance.
+This comprehensive server provides both operational DynamoDB management and expert design guidance, featuring 30+ operational tools for managing DynamoDB tables, items, indexes, backups, and more, expert data modeling guidance and also MySQL query capabilities for database analysis and migration planning.
 
 ## Available MCP Tools
 
 ### Design & Modeling
 - `dynamodb_data_modeling` - Retrieves the complete DynamoDB Data Modeling Expert prompt
+
+### MySQL Integration
+- `mysql_run_query` - Run SQL queries against MySQL databases for analysis and migration planning
 
 ### Table Operations
 - `create_table` - Creates a new DynamoDB table with optional secondary indexes
@@ -61,6 +64,22 @@ To use these tools, ensure you have proper AWS credentials configured with appro
 
 All tools support an optional `region_name` parameter to specify which AWS region to operate in. If not provided, it will use the AWS_REGION environment variable or default to 'us-west-2'.
 
+## MySQL Integration
+
+The DynamoDB MCP server includes MySQL integration to run mysql queries within DynamoDB MCP server. When configured, it adds a `mysql_run_query` tool for database analysis and migration planning.
+
+### MySQL Environment Variables
+
+Add these environment variables to DynamoDB MCP Server configuration to enable MySQL integration:
+
+- `MYSQL_CLUSTER_ARN`: RDS / Aurora MySQL cluster ARN
+- `MYSQL_SECRET_ARN`: AWS Secrets Manager secret ARN with database credentials
+- `MYSQL_DATABASE`: Database name to connect to
+- `MYSQL_AWS_REGION`: AWS region for MySQL cluster (default: "us-west-2")
+- `MYSQL_READONLY`: optional (default: "true")
+
+**Note**: MySQL integration tool is available only when these variables are set.
+
 ## Prerequisites
 
 1. Install `uv` from [Astral](https://docs.astral.sh/uv/getting-started/installation/) or the [GitHub README](https://github.com/astral-sh/uv#installation)
@@ -86,7 +105,12 @@ Add the MCP to your favorite agentic tools. (e.g. for Amazon Q Developer CLI MCP
         "DDB-MCP-READONLY": "true",
         "AWS_PROFILE": "default",
         "AWS_REGION": "us-west-2",
-        "FASTMCP_LOG_LEVEL": "ERROR"
+        "FASTMCP_LOG_LEVEL": "ERROR",
+        "MYSQL_CLUSTER_ARN": "[your data]",
+        "MYSQL_SECRET_ARN": "[your data]",
+        "MYSQL_DATABASE": "[your data]",
+        "MYSQL_AWS_REGION": "us-west-2",
+        "MYSQL_READONLY": "true"
       },
       "disabled": false,
       "autoApprove": []
@@ -116,7 +140,12 @@ For Windows users, the MCP server configuration format is slightly different:
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR",
         "AWS_PROFILE": "your-aws-profile",
-        "AWS_REGION": "us-east-1"
+        "AWS_REGION": "us-east-1",,
+        "MYSQL_CLUSTER_ARN": "[your data]",
+        "MYSQL_SECRET_ARN": "[your data]",
+        "MYSQL_DATABASE": "[your data]",
+        "MYSQL_AWS_REGION": "us-west-2",
+        "MYSQL_READONLY": "true"
       }
     }
   }

--- a/src/dynamodb-mcp-server/awslabs/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/__init__.py
@@ -14,3 +14,6 @@
 
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
+
+# Extend namespace to include installed packages
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "pydantic==2.11.7",
     "typing-extensions==4.14.1",
     "strands-agents>=1.5.0",
-    "dspy-ai>=2.6.27"
+    "dspy-ai>=2.6.27",
+    "awslabs-mysql-mcp-server>=1.0.5",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/dynamodb-mcp-server/tests/__init__.py
+++ b/src/dynamodb-mcp-server/tests/__init__.py
@@ -1,0 +1,8 @@
+"""Tests package - sets up import path for local modules."""
+import sys
+import os
+
+# Add the project root to Python path so tests can import local modules when running pytest
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/src/dynamodb-mcp-server/tests/conftest.py
+++ b/src/dynamodb-mcp-server/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for DynamoDB MCP Server tests."""
+import sys
+import os
+
+# Add the project root to Python path so tests can import local modules
+project_root = os.path.dirname(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/src/dynamodb-mcp-server/tests/conftest.py
+++ b/src/dynamodb-mcp-server/tests/conftest.py
@@ -1,8 +1,0 @@
-"""Test configuration for DynamoDB MCP Server tests."""
-import sys
-import os
-
-# Add the project root to Python path so tests can import local modules
-project_root = os.path.dirname(os.path.dirname(__file__))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)

--- a/src/dynamodb-mcp-server/tests/test_mysql_integration.py
+++ b/src/dynamodb-mcp-server/tests/test_mysql_integration.py
@@ -1,0 +1,44 @@
+import os
+import pytest
+import pytest_asyncio
+from awslabs.dynamodb_mcp_server.server import mysql_run_query
+
+
+class TestMySQLIntegration:
+    """Test MySQL integration functionality."""
+
+    @pytest.mark.asyncio
+    async def test_mysql_connection_and_query(self, monkeypatch):
+        """Test MySQL connection initialization and query execution."""
+        # Set environment variables using monkeypatch
+        monkeypatch.setenv('MYSQL_CLUSTER_ARN', 'arn:aws:rds:us-west-2:123456789012:cluster:test-cluster')
+        monkeypatch.setenv('MYSQL_SECRET_ARN', 'arn:aws:secretsmanager:us-west-2:123456789012:secret:test-secret')
+        monkeypatch.setenv('MYSQL_DATABASE', 'test_database')
+        monkeypatch.setenv('MYSQL_AWS_REGION', 'us-west-2')
+        monkeypatch.setenv('MYSQL_READONLY', 'true')
+        
+        # Mock the MySQL functions using monkeypatch
+        def mock_initialize(*args, **kwargs):
+            return True
+        
+        async def mock_query(*args, **kwargs):
+            return [{'id': 1, 'name': 'test'}]
+        
+        monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.DBConnectionSingleton.initialize', mock_initialize)
+        monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_query', mock_query)
+        
+        result = await mysql_run_query("SELECT * FROM users")
+        
+        assert result == [{'id': 1, 'name': 'test'}]
+
+    @pytest.mark.asyncio
+    async def test_mysql_missing_config(self, monkeypatch):
+        """Test MySQL query when configuration is missing."""
+        # Clear MySQL env vars using monkeypatch
+        monkeypatch.delenv('MYSQL_CLUSTER_ARN', raising=False)
+        monkeypatch.delenv('MYSQL_SECRET_ARN', raising=False)
+        monkeypatch.delenv('MYSQL_DATABASE', raising=False)
+        
+        result = await mysql_run_query("SELECT * FROM users")
+        assert 'error' in result[0]
+        assert 'MySQL configuration not properly configured' in result[0]['error']

--- a/src/dynamodb-mcp-server/tests/test_mysql_integration.py
+++ b/src/dynamodb-mcp-server/tests/test_mysql_integration.py
@@ -1,6 +1,4 @@
-import os
 import pytest
-import pytest_asyncio
 from awslabs.dynamodb_mcp_server.server import mysql_run_query
 
 
@@ -11,24 +9,30 @@ class TestMySQLIntegration:
     async def test_mysql_connection_and_query(self, monkeypatch):
         """Test MySQL connection initialization and query execution."""
         # Set environment variables using monkeypatch
-        monkeypatch.setenv('MYSQL_CLUSTER_ARN', 'arn:aws:rds:us-west-2:123456789012:cluster:test-cluster')
-        monkeypatch.setenv('MYSQL_SECRET_ARN', 'arn:aws:secretsmanager:us-west-2:123456789012:secret:test-secret')
+        monkeypatch.setenv(
+            'MYSQL_CLUSTER_ARN', 'arn:aws:rds:us-west-2:123456789012:cluster:test-cluster'
+        )
+        monkeypatch.setenv(
+            'MYSQL_SECRET_ARN', 'arn:aws:secretsmanager:us-west-2:123456789012:secret:test-secret'
+        )
         monkeypatch.setenv('MYSQL_DATABASE', 'test_database')
         monkeypatch.setenv('MYSQL_AWS_REGION', 'us-west-2')
         monkeypatch.setenv('MYSQL_READONLY', 'true')
-        
+
         # Mock the MySQL functions using monkeypatch
         def mock_initialize(*args, **kwargs):
             return True
-        
+
         async def mock_query(*args, **kwargs):
             return [{'id': 1, 'name': 'test'}]
-        
-        monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.DBConnectionSingleton.initialize', mock_initialize)
+
+        monkeypatch.setattr(
+            'awslabs.dynamodb_mcp_server.server.DBConnectionSingleton.initialize', mock_initialize
+        )
         monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_query', mock_query)
-        
-        result = await mysql_run_query("SELECT * FROM users")
-        
+
+        result = await mysql_run_query('SELECT * FROM users')
+
         assert result == [{'id': 1, 'name': 'test'}]
 
     @pytest.mark.asyncio
@@ -38,7 +42,7 @@ class TestMySQLIntegration:
         monkeypatch.delenv('MYSQL_CLUSTER_ARN', raising=False)
         monkeypatch.delenv('MYSQL_SECRET_ARN', raising=False)
         monkeypatch.delenv('MYSQL_DATABASE', raising=False)
-        
-        result = await mysql_run_query("SELECT * FROM users")
+
+        result = await mysql_run_query('SELECT * FROM users')
         assert 'error' in result[0]
-        assert 'MySQL configuration not properly configured' in result[0]['error']
+        assert 'MySQL integration requires these environment variables' in result[0]['error']

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -197,6 +197,7 @@ name = "awslabs-dynamodb-mcp-server"
 version = "1.0.9"
 source = { editable = "." }
 dependencies = [
+    { name = "awslabs-mysql-mcp-server" },
     { name = "boto3" },
     { name = "dspy-ai" },
     { name = "loguru" },
@@ -222,6 +223,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "awslabs-mysql-mcp-server", specifier = ">=1.0.5" },
     { name = "boto3", specifier = "==1.40.5" },
     { name = "dspy-ai", specifier = ">=2.6.27" },
     { name = "loguru", specifier = "==0.7.3" },
@@ -243,6 +245,22 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "ruff", specifier = ">=0.9.7" },
+]
+
+[[package]]
+name = "awslabs-mysql-mcp-server"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "loguru" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/af/60684a88d3da7bdc0e03ae2af26dbad32f209146d4a519c0ab08582ed511/awslabs_mysql_mcp_server-1.0.5.tar.gz", hash = "sha256:a168c3bc63d5f215603041a510716509ab9192d89d463f5d44f92b4d9788ee5b", size = 85049, upload-time = "2025-08-21T18:29:43.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/a8/01b3171433594d4e0649757207cc25d1c0a8340d6a5a25dc6758265fd69c/awslabs_mysql_mcp_server-1.0.5-py3-none-any.whl", hash = "sha256:bd23fa850137d15d1b1aecf60ae49e546b73999e54563cd69b10f5d8be01aa11", size = 15042, upload-time = "2025-08-21T18:29:42.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Implementation of MySQL integration into the DynamoDB MCP server, providing foundational query capabilities for database migration analysis. This establishes the framework for comprehensive MySQL database analysis tooling.

#### Key Changes:
• **Added MySQL Integration**: Direct import of mysql_mcp_server functionality into the DynamoDB MCP server
• **Tool**: mysql_run_query tool is added to DynamoDB server and connects to MySQL DB when MySQL environment variables are configured
• **Basic query execution**:  Execute SQL queries against RDS / Aurora MySQL clusters for migration analysis. Foundation for migration workflow analysis and database assessment

### User experience

#### Before this change:
Users needed separate MCP servers for MySQL and DynamoDB operations, requiring:
• Multiple MCP server configurations in their setup
• Separate authentication and connection management
• Manual coordination between MySQL analysis and DynamoDB design workflows

#### After this change:
Users get a unified experience with a single MCP server that provides:
• **Single Configuration**: One MCP server configuration handles both MySQL analysis and DynamoDB operations
• **Seamless Migration Workflow**: Direct access to MySQL data for informing DynamoDB design decisions within the same tool context
• **Extensible Foundation**: Framework ready for specialized migration analysis like schema assessment and access pattern analysis

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? No

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

