### PR TITLE
feat(redshift-mcp-server): Implement ExecuteStatement with sessions

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -418,7 +418,6 @@ Your AWS credentials need the following IAM permissions:
         "redshift-serverless:ListWorkgroups",
         "redshift-serverless:GetWorkgroup",
         "redshift-data:ExecuteStatement",
-        "redshift-data:BatchExecuteStatement",
         "redshift-data:DescribeStatement",
         "redshift-data:GetStatementResult"
       ],

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -21,7 +21,8 @@ CLIENT_RETRIES = {'max_attempts': 5, 'mode': 'adaptive'}
 CLIENT_USER_AGENT_NAME = 'awslabs/mcp/redshift-mcp-server'
 DEFAULT_LOG_LEVEL = 'WARNING'
 QUERY_TIMEOUT = 3600
-QUERY_POLL_INTERVAL = 2
+QUERY_POLL_INTERVAL = 1
+SESSION_KEEPALIVE = 600
 
 # Best practices
 
@@ -85,7 +86,7 @@ SELECT
     source_database,
     schema_option
 FROM pg_catalog.svv_all_schemas
-WHERE database_name = {}
+WHERE database_name = :database_name
 ORDER BY schema_name;
 """
 
@@ -98,7 +99,7 @@ SELECT
     table_type,
     remarks
 FROM pg_catalog.svv_all_tables
-WHERE database_name = {} AND schema_name = {}
+WHERE database_name = :database_name AND schema_name = :schema_name
 ORDER BY table_name;
 """
 
@@ -117,7 +118,7 @@ SELECT
     numeric_scale,
     remarks
 FROM pg_catalog.svv_all_columns
-WHERE database_name = {} AND schema_name = {} AND table_name = {}
+WHERE database_name = :database_name AND schema_name = :schema_name AND table_name = :table_name
 ORDER BY ordinal_position;
 """
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -18,6 +18,7 @@ import asyncio
 import boto3
 import os
 import regex
+import time
 from awslabs.redshift_mcp_server import __version__
 from awslabs.redshift_mcp_server.consts import (
     CLIENT_CONNECT_TIMEOUT,
@@ -26,6 +27,7 @@ from awslabs.redshift_mcp_server.consts import (
     CLIENT_USER_AGENT_NAME,
     QUERY_POLL_INTERVAL,
     QUERY_TIMEOUT,
+    SESSION_KEEPALIVE,
     SUSPICIOUS_QUERY_REGEXP,
     SVV_ALL_COLUMNS_QUERY,
     SVV_ALL_SCHEMAS_QUERY,
@@ -101,61 +103,124 @@ class RedshiftClientManager:
         return self._redshift_data_client
 
 
-def quote_literal_string(value: str | None) -> str:
-    """Quote a string value as a SQL literal.
+class RedshiftSessionManager:
+    """Manages Redshift Data API sessions for connection reuse."""
 
-    Args:
-        value: The string value to quote.
-    """
-    if value is None:
-        return 'NULL'
+    def __init__(self, session_keepalive: int, app_name: str):
+        """Initialize the session manager.
 
-    # TODO Reimplement a proper way.
-    # A lazy hack for SQL literal quoting.
-    return "'" + repr('"' + value)[2:]
+        Args:
+            session_keepalive: Session keepalive timeout in seconds.
+            app_name: Application name to set in sessions.
+        """
+        self._sessions = {}  # {cluster:database -> session_info}
+        self._session_keepalive = session_keepalive
+        self._app_name = app_name
+
+    async def session(
+        self, cluster_identifier: str, database_name: str, cluster_info: dict
+    ) -> str:
+        """Get or create a session for the given cluster and database.
+
+        Args:
+            cluster_identifier: The cluster identifier to get session for.
+            database_name: The database name to get session for.
+            cluster_info: Cluster information dictionary from discover_clusters.
+
+        Returns:
+            Session ID for use in ExecuteStatement calls.
+        """
+        # Check existing session
+        session_key = f'{cluster_identifier}:{database_name}'
+        if session_key in self._sessions:
+            session_info = self._sessions[session_key]
+            if not self._is_session_expired(session_info):
+                logger.debug(f'Reusing existing session: {session_info["session_id"]}')
+                return session_info['session_id']
+            else:
+                logger.debug(f'Session expired, removing: {session_info["session_id"]}')
+                del self._sessions[session_key]
+
+        # Create new session with application name
+        session_id = await self._create_session_with_app_name(
+            cluster_identifier, database_name, cluster_info
+        )
+
+        # Store session
+        self._sessions[session_key] = {'session_id': session_id, 'created_at': time.time()}
+
+        logger.info(f'Created new session: {session_id} for {cluster_identifier}:{database_name}')
+        return session_id
+
+    async def _create_session_with_app_name(
+        self, cluster_identifier: str, database_name: str, cluster_info: dict
+    ) -> str:
+        """Create a new session by executing SET application_name.
+
+        Args:
+            cluster_identifier: The cluster identifier.
+            database_name: The database name.
+            cluster_info: Cluster information dictionary.
+
+        Returns:
+            Session ID from the ExecuteStatement response.
+        """
+        # Set application name to create session
+        app_name_sql = f"SET application_name TO '{self._app_name}';"
+
+        # Execute statement to create session
+        statement_id = await _execute_statement(
+            cluster_info=cluster_info,
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            sql=app_name_sql,
+            session_keepalive=self._session_keepalive,
+        )
+
+        # Get session ID from the response
+        data_client = client_manager.redshift_data_client()
+        status_response = data_client.describe_statement(Id=statement_id)
+        session_id = status_response['SessionId']
+
+        logger.debug(f'Created session with application name: {session_id}')
+        return session_id
+
+    def _is_session_expired(self, session_info: dict) -> bool:
+        """Check if a session has expired based on keepalive timeout.
+
+        Args:
+            session_info: Session information dictionary.
+
+        Returns:
+            True if session is expired, False otherwise.
+        """
+        return (time.time() - session_info['created_at']) > self._session_keepalive
 
 
-def protect_sql(sql: str, allow_read_write: bool) -> list[str]:
-    """Protect SQL depending on if the read-write mode allowed.
+async def _execute_protected_statement(
+    cluster_identifier: str,
+    database_name: str,
+    sql: str,
+    parameters: list[dict] | None = None,
+    allow_read_write: bool = False,
+) -> tuple[dict, str]:
+    """Execute a SQL statement against a Redshift cluster in a protected fashion.
 
-    The SQL is wrapped in a transaction block with READ ONLY or READ WRITE mode
+    The SQL is protected by wrapping it in a transaction block with READ ONLY or READ WRITE mode
     based on allow_read_write flag. Transaction breaker protection is implemented
     to prevent unauthorized modifications.
 
-    The SQL takes the form:
-    BEGIN [READ ONLY|READ WRITE];
-    <sql>
-    END;
-
-    Args:
-        sql: The SQL statement to protect.
-        allow_read_write: Indicates if read-write mode should be activated.
-
-    Returns:
-        List of strings to execute by batch_execute_statement.
-    """
-    if allow_read_write:
-        return ['BEGIN READ WRITE;', sql, 'END;']
-    else:
-        # Check if SQL contains suspicious patterns trying to break the transaction context
-        if regex.compile(SUSPICIOUS_QUERY_REGEXP).search(sql):
-            logger.error(f'SQL contains suspicious pattern, execution rejected: {sql}')
-            raise Exception(f'SQL contains suspicious pattern, execution rejected: {sql}')
-
-        return ['BEGIN READ ONLY;', sql, 'END;']
-
-
-async def execute_statement(
-    cluster_identifier: str, database_name: str, sql: str, allow_read_write: bool = False
-) -> tuple[dict, str]:
-    """Execute a SQL statement against a Redshift cluster using the Data API.
-
-    This is a common function used by other functions in this module.
+    The SQL execution takes the form:
+    1. Get or create session (with SET application_name)
+    2. BEGIN [READ ONLY|READ WRITE];
+    3. <user sql>
+    4. END;
 
     Args:
         cluster_identifier: The cluster identifier to query.
         database_name: The database to execute the query against.
         sql: The SQL statement to execute.
+        parameters: Optional list of parameter dictionaries with 'name' and 'value' keys.
         allow_read_write: Indicates if read-write mode should be activated.
 
     Returns:
@@ -166,9 +231,7 @@ async def execute_statement(
     Raises:
         Exception: If cluster not found, query fails, or times out.
     """
-    data_client = client_manager.redshift_data_client()
-
-    # First, check if this is a provisioned cluster or serverless workgroup
+    # Get cluster info
     clusters = await discover_clusters()
     cluster_info = None
     for cluster in clusters:
@@ -181,57 +244,131 @@ async def execute_statement(
             f'Cluster {cluster_identifier} not found. Please use list_clusters to get valid cluster identifiers.'
         )
 
-    # Guard from executing read-write statements if not allowed
-    sqls = protect_sql(sql, allow_read_write)
-    # Add application name and version
-    sqls = [f"SET application_name TO '{CLIENT_USER_AGENT_NAME}/{__version__}';"] + sqls
+    # Get session (creates if needed, sets app name automatically)
+    session_id = await session_manager.session(cluster_identifier, database_name, cluster_info)
 
-    logger.debug(f'Protected and versioned SQL: {" ".join(sqls)}')
+    # Check for suspicious patterns in read-only mode
+    if not allow_read_write:
+        if regex.compile(SUSPICIOUS_QUERY_REGEXP).search(sql):
+            logger.error(f'SQL contains suspicious pattern, execution rejected: {sql}')
+            raise Exception(f'SQL contains suspicious pattern, execution rejected: {sql}')
 
-    # Execute the query using Data API
-    if cluster_info['type'] == 'provisioned':
-        logger.debug(f'Using ClusterIdentifier for provisioned cluster: {cluster_identifier}')
-        response = data_client.batch_execute_statement(
-            ClusterIdentifier=cluster_identifier, Database=database_name, Sqls=sqls
-        )
-    elif cluster_info['type'] == 'serverless':
-        logger.debug(f'Using WorkgroupName for serverless workgroup: {cluster_identifier}')
-        response = data_client.batch_execute_statement(
-            WorkgroupName=cluster_identifier, Database=database_name, Sqls=sqls
-        )
-    else:
-        raise Exception(f'Unknown cluster type: {cluster_info["type"]}')
+    # Execute BEGIN statement
+    begin_sql = 'BEGIN READ WRITE;' if allow_read_write else 'BEGIN READ ONLY;'
+    await _execute_statement(
+        cluster_info=cluster_info,
+        cluster_identifier=cluster_identifier,
+        database_name=database_name,
+        sql=begin_sql,
+        session_id=session_id,
+    )
 
-    query_id = response['Id']
-    logger.debug(f'Started query execution: {query_id}')
+    # Execute user SQL with parameters
+    user_query_id = await _execute_statement(
+        cluster_info=cluster_info,
+        cluster_identifier=cluster_identifier,
+        database_name=database_name,
+        sql=sql,
+        parameters=parameters,
+        session_id=session_id,
+    )
 
-    # Wait for query completion
+    # Execute END statement to close transaction
+    await _execute_statement(
+        cluster_info=cluster_info,
+        cluster_identifier=cluster_identifier,
+        database_name=database_name,
+        sql='END;',
+        session_id=session_id,
+    )
+
+    # Get results from user query
+    data_client = client_manager.redshift_data_client()
+    results_response = data_client.get_statement_result(Id=user_query_id)
+    return results_response, user_query_id
+
+
+async def _execute_statement(
+    cluster_info: dict,
+    cluster_identifier: str,
+    database_name: str,
+    sql: str,
+    parameters: list[dict] | None = None,
+    session_id: str | None = None,
+    session_keepalive: int | None = None,
+    query_poll_interval: float = QUERY_POLL_INTERVAL,
+    query_timeout: float = QUERY_TIMEOUT,
+) -> str:
+    """Execute a single statement with optional session support and parameters.
+
+    Args:
+        cluster_info: Cluster information dictionary.
+        cluster_identifier: The cluster identifier.
+        database_name: The database name.
+        sql: The SQL statement to execute.
+        parameters: Optional list of parameter dictionaries with 'name' and 'value' keys.
+        session_id: Optional session ID to use.
+        session_keepalive: Optional session keepalive seconds (only used when session_id is None).
+        query_poll_interval: Polling interval in seconds for checking query status.
+        query_timeout: Maximum time in seconds to wait for query completion.
+
+    Returns:
+        Statement ID from the ExecuteStatement response.
+    """
+    data_client = client_manager.redshift_data_client()
+
+    # Build request parameters
+    request_params: dict[str, str | int | list[dict]] = {'Sql': sql}
+
+    # Add database and cluster/workgroup identifier only if not using session
+    if not session_id:
+        request_params['Database'] = database_name
+        if cluster_info['type'] == 'provisioned':
+            request_params['ClusterIdentifier'] = cluster_identifier
+        elif cluster_info['type'] == 'serverless':
+            request_params['WorkgroupName'] = cluster_identifier
+        else:
+            raise Exception(f'Unknown cluster type: {cluster_info["type"]}')
+
+    # Add parameters if provided
+    if parameters:
+        request_params['Parameters'] = parameters
+
+    # Add session ID if provided, otherwise add session keepalive
+    if session_id:
+        request_params['SessionId'] = session_id
+    elif session_keepalive is not None:
+        request_params['SessionKeepAliveSeconds'] = session_keepalive
+
+    response = data_client.execute_statement(**request_params)
+    statement_id = response['Id']
+
+    logger.debug(
+        f'Executed statement: {statement_id}' + (f' in session {session_id}' if session_id else '')
+    )
+
+    # Wait for statement completion
     wait_time = 0
-    status_response = {}
-    while wait_time < QUERY_TIMEOUT:
-        status_response = data_client.describe_statement(Id=query_id)
+    while wait_time < query_timeout:
+        status_response = data_client.describe_statement(Id=statement_id)
         status = status_response['Status']
 
         if status == 'FINISHED':
-            logger.debug(f'Query execution completed: {query_id}')
+            logger.debug(f'Statement completed: {statement_id}')
             break
         elif status in ['FAILED', 'ABORTED']:
             error_msg = status_response.get('Error', 'Unknown error')
-            logger.error(f'Query execution failed: {error_msg}')
-            raise Exception(f'Query failed: {error_msg}')
+            logger.error(f'Statement failed: {error_msg}')
+            raise Exception(f'Statement failed: {error_msg}')
 
-        # Wait before polling again
-        await asyncio.sleep(QUERY_POLL_INTERVAL)
-        wait_time += QUERY_POLL_INTERVAL
+        await asyncio.sleep(query_poll_interval)
+        wait_time += query_poll_interval
 
-    if wait_time >= QUERY_TIMEOUT:
-        logger.error(f'Query execution timed out: {query_id}')
-        raise Exception(f'Query timed out after {QUERY_TIMEOUT} seconds')
+    if wait_time >= query_timeout:
+        logger.error(f'Statement timed out: {statement_id}')
+        raise Exception(f'Statement timed out after {wait_time} seconds')
 
-    # Get user query results
-    subquery2_id = status_response['SubStatements'][2]['Id']
-    results_response = data_client.get_statement_result(Id=subquery2_id)
-    return results_response, subquery2_id
+    return statement_id
 
 
 async def discover_clusters() -> list[dict]:
@@ -334,7 +471,7 @@ async def discover_databases(cluster_identifier: str, database_name: str = 'dev'
         logger.info(f'Discovering databases in cluster {cluster_identifier}')
 
         # Execute the query using the common function
-        results_response, _ = await execute_statement(
+        results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=database_name,
             sql=SVV_REDSHIFT_DATABASES_QUERY,
@@ -379,10 +516,11 @@ async def discover_schemas(cluster_identifier: str, schema_database_name: str) -
         )
 
         # Execute the query using the common function
-        results_response, _ = await execute_statement(
+        results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=schema_database_name,
-            sql=SVV_ALL_SCHEMAS_QUERY.format(quote_literal_string(schema_database_name)),
+            sql=SVV_ALL_SCHEMAS_QUERY,
+            parameters=[{'name': 'database_name', 'value': schema_database_name}],
         )
 
         schemas = []
@@ -432,12 +570,14 @@ async def discover_tables(
         )
 
         # Execute the query using the common function
-        results_response, _ = await execute_statement(
+        results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=table_database_name,
-            sql=SVV_ALL_TABLES_QUERY.format(
-                quote_literal_string(table_database_name), quote_literal_string(table_schema_name)
-            ),
+            sql=SVV_ALL_TABLES_QUERY,
+            parameters=[
+                {'name': 'database_name', 'value': table_database_name},
+                {'name': 'schema_name', 'value': table_schema_name},
+            ],
         )
 
         tables = []
@@ -490,14 +630,15 @@ async def discover_columns(
         )
 
         # Execute the query using the common function
-        results_response, _ = await execute_statement(
+        results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=column_database_name,
-            sql=SVV_ALL_COLUMNS_QUERY.format(
-                quote_literal_string(column_database_name),
-                quote_literal_string(column_schema_name),
-                quote_literal_string(column_table_name),
-            ),
+            sql=SVV_ALL_COLUMNS_QUERY,
+            parameters=[
+                {'name': 'database_name', 'value': column_database_name},
+                {'name': 'schema_name', 'value': column_schema_name},
+                {'name': 'table_name', 'value': column_table_name},
+            ],
         )
 
         columns = []
@@ -554,7 +695,7 @@ async def execute_query(cluster_identifier: str, database_name: str, sql: str) -
         start_time = time.time()
 
         # Execute the query using the common function
-        results_response, query_id = await execute_statement(
+        results_response, query_id = await _execute_protected_statement(
             cluster_identifier=cluster_identifier, database_name=database_name, sql=sql
         )
 
@@ -619,4 +760,9 @@ client_manager = RedshiftClientManager(
     ),
     aws_region=os.environ.get('AWS_REGION'),
     aws_profile=os.environ.get('AWS_PROFILE'),
+)
+
+# Global session manager instance
+session_manager = RedshiftSessionManager(
+    session_keepalive=SESSION_KEEPALIVE, app_name=f'{CLIENT_USER_AGENT_NAME}/{__version__}'
 )

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -219,7 +219,9 @@ async def list_databases_tool(
     """
     try:
         logger.info(f'Discovering databases on cluster: {cluster_identifier}')
-        databases_data = await discover_databases(cluster_identifier, database_name)
+        databases_data = await discover_databases(
+            cluster_identifier=cluster_identifier, database_name=database_name
+        )
 
         # Convert to RedshiftDatabase models
         databases = []
@@ -302,7 +304,9 @@ async def list_schemas_tool(
         logger.info(
             f'Discovering schemas in database {schema_database_name} on cluster {cluster_identifier}'
         )
-        schemas_data = await discover_schemas(cluster_identifier, schema_database_name)
+        schemas_data = await discover_schemas(
+            cluster_identifier=cluster_identifier, schema_database_name=schema_database_name
+        )
 
         # Convert to RedshiftSchema models
         schemas = []
@@ -394,7 +398,9 @@ async def list_tables_tool(
             f'Discovering tables in schema {table_schema_name} in database {table_database_name} on cluster {cluster_identifier}'
         )
         tables_data = await discover_tables(
-            cluster_identifier, table_database_name, table_schema_name
+            cluster_identifier=cluster_identifier,
+            table_database_name=table_database_name,
+            table_schema_name=table_schema_name,
         )
 
         # Convert to RedshiftTable models
@@ -500,7 +506,10 @@ async def list_columns_tool(
             f'Discovering columns in table {column_table_name} in schema {column_schema_name} in database {column_database_name} on cluster {cluster_identifier}'
         )
         columns_data = await discover_columns(
-            cluster_identifier, column_database_name, column_schema_name, column_table_name
+            cluster_identifier=cluster_identifier,
+            column_database_name=column_database_name,
+            column_schema_name=column_schema_name,
+            column_table_name=column_table_name,
         )
 
         # Convert to RedshiftColumn models
@@ -594,7 +603,9 @@ async def execute_query_tool(
     """
     try:
         logger.info(f'Executing query on cluster {cluster_identifier} in database {database_name}')
-        query_result_data = await execute_query(cluster_identifier, database_name, sql)
+        query_result_data = await execute_query(
+            cluster_identifier=cluster_identifier, database_name=database_name, sql=sql
+        )
 
         # Convert to QueryResult model
         query_result = QueryResult(**query_result_data)

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -15,10 +15,18 @@
 """Tests for the redshift module."""
 
 import pytest
+import time
 from awslabs.redshift_mcp_server.redshift import (
     RedshiftClientManager,
-    protect_sql,
-    quote_literal_string,
+    RedshiftSessionManager,
+    _execute_protected_statement,
+    _execute_statement,
+    discover_clusters,
+    discover_columns,
+    discover_databases,
+    discover_schemas,
+    discover_tables,
+    execute_query,
 )
 from botocore.config import Config
 
@@ -42,6 +50,35 @@ class TestRedshiftClientManagerRedshiftClient:
         mock_boto3_session.assert_called_once_with(profile_name=None, region_name=None)
         mock_boto3_session.return_value.client.assert_called_once_with('redshift', config=config)
 
+    def test_redshift_client_creation_error(self, mocker):
+        """Test Redshift client creation error handling."""
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.side_effect = Exception('AWS credentials error')
+
+        config = Config()
+        manager = RedshiftClientManager(config)
+
+        with pytest.raises(Exception, match='AWS credentials error'):
+            manager.redshift_client()
+
+    def test_client_caching(self, mocker):
+        """Test that clients are cached after first creation."""
+        mock_client = mocker.Mock()
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.return_value = mock_client
+
+        config = Config()
+        manager = RedshiftClientManager(config)
+
+        # First call should create client
+        client1 = manager.redshift_client()
+        # Second call should return cached client
+        client2 = manager.redshift_client()
+
+        assert client1 == client2 == mock_client
+        # Session should only be called once
+        mock_boto3_session.assert_called_once()
+
     def test_redshift_client_creation_with_profile_and_region(self, mocker):
         """Test Redshift client creation with AWS profile and region."""
         mock_session = mocker.Mock()
@@ -60,16 +97,6 @@ class TestRedshiftClientManagerRedshiftClient:
             profile_name='test-profile', region_name='us-west-2'
         )
         mock_session.client.assert_called_once_with('redshift', config=config)
-
-    def test_redshift_client_creation_error(self, mocker):
-        """Test error handling when session creation fails."""
-        mocker.patch('boto3.Session', side_effect=Exception('Session error'))
-
-        config = Config()
-        manager = RedshiftClientManager(config)
-
-        with pytest.raises(Exception, match='Session error'):
-            manager.redshift_client()
 
 
 class TestRedshiftClientManagerServerlessClient:
@@ -93,6 +120,17 @@ class TestRedshiftClientManagerServerlessClient:
             'redshift-serverless', config=config
         )
 
+    def test_redshift_serverless_client_creation_error(self, mocker):
+        """Test Redshift Serverless client creation error handling."""
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.side_effect = Exception('Serverless client error')
+
+        config = Config()
+        manager = RedshiftClientManager(config)
+
+        with pytest.raises(Exception, match='Serverless client error'):
+            manager.redshift_serverless_client()
+
     def test_redshift_serverless_client_creation_with_profile_and_region(self, mocker):
         """Test Redshift Serverless client creation with AWS profile and region."""
         mock_session = mocker.Mock()
@@ -112,15 +150,23 @@ class TestRedshiftClientManagerServerlessClient:
         )
         mock_session.client.assert_called_once_with('redshift-serverless', config=config)
 
-    def test_redshift_serverless_client_creation_error(self, mocker):
-        """Test error handling when session creation fails."""
-        mocker.patch('boto3.Session', side_effect=Exception('Session error'))
+    def test_redshift_serverless_client_caching(self, mocker):
+        """Test that redshift serverless client is cached after first creation."""
+        mock_client = mocker.Mock()
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.return_value = mock_client
 
         config = Config()
         manager = RedshiftClientManager(config)
 
-        with pytest.raises(Exception, match='Session error'):
-            manager.redshift_serverless_client()
+        # First call should create client
+        client1 = manager.redshift_serverless_client()
+        # Second call should return cached client
+        client2 = manager.redshift_serverless_client()
+
+        assert client1 == client2 == mock_client
+        # Session should only be called once
+        mock_boto3_session.assert_called_once()
 
 
 class TestRedshiftClientManagerDataClient:
@@ -144,6 +190,17 @@ class TestRedshiftClientManagerDataClient:
             'redshift-data', config=config
         )
 
+    def test_redshift_data_client_creation_error(self, mocker):
+        """Test Redshift Data client creation error handling."""
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.side_effect = Exception('Data client error')
+
+        config = Config()
+        manager = RedshiftClientManager(config)
+
+        with pytest.raises(Exception, match='Data client error'):
+            manager.redshift_data_client()
+
     def test_redshift_data_client_creation_with_profile_and_region(self, mocker):
         """Test Redshift Data API client creation with AWS profile and region."""
         mock_session = mocker.Mock()
@@ -163,77 +220,125 @@ class TestRedshiftClientManagerDataClient:
         )
         mock_session.client.assert_called_once_with('redshift-data', config=config)
 
-    def test_redshift_data_client_creation_error(self, mocker):
-        """Test error handling when session creation fails."""
-        mocker.patch('boto3.Session', side_effect=Exception('Session error'))
+    def test_redshift_data_client_caching(self, mocker):
+        """Test that redshift data client is cached after first creation."""
+        mock_client = mocker.Mock()
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.return_value = mock_client
 
         config = Config()
         manager = RedshiftClientManager(config)
 
-        with pytest.raises(Exception, match='Session error'):
-            manager.redshift_data_client()
+        # First call should create client
+        client1 = manager.redshift_data_client()
+        # Second call should return cached client
+        client2 = manager.redshift_data_client()
+
+        assert client1 == client2 == mock_client
+        # Session should only be called once
+        mock_boto3_session.assert_called_once()
 
 
-class TestQuoteLiteralString:
-    """Tests for the quote_literal_string function."""
+class TestExecuteProtectedStatement:
+    """Tests for _execute_protected_statement function."""
 
-    def test_quote_literal_string_none_value(self):
-        """Test quoting None value returns NULL."""
-        result = quote_literal_string(None)
-        assert result == 'NULL'
+    @pytest.mark.asyncio
+    async def test_execute_protected_statement_read_only(self, mocker):
+        """Test executing protected statement in read-only mode."""
+        # Mock discover_clusters
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
 
-    def test_quote_literal_string_simple_string(self):
-        """Test quoting a simple string."""
-        result = quote_literal_string('hello')
-        assert result == "'hello'"
+        # Mock session manager
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
 
-    def test_quote_literal_string_empty_string(self):
-        """Test quoting an empty string."""
-        result = quote_literal_string('')
-        assert result == "''"
+        # Mock _execute_statement
+        mock_execute_statement = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement'
+        )
+        mock_execute_statement.side_effect = ['begin-stmt-id', 'user-stmt-id', 'end-stmt-id']
 
-    def test_quote_literal_string_with_single_quote(self):
-        """Test quoting a string containing single quotes."""
-        result = quote_literal_string("it's")
-        assert result == "'it\\'s'"
+        # Mock data client
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {'Records': [], 'ColumnMetadata': []}
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
 
-    def test_quote_literal_string_with_double_quote(self):
-        """Test quoting a string containing double quotes."""
-        result = quote_literal_string('say "hello"')
-        assert result == '\'say "hello"\''
+        result = await _execute_protected_statement(
+            'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+        )
 
-    def test_quote_literal_string_numeric_string(self):
-        """Test quoting a numeric string."""
-        result = quote_literal_string('123')
-        assert result == "'123'"
+        # Verify session was created
+        mock_session_manager.session.assert_called_once()
 
-    def test_quote_literal_string_with_newline(self):
-        """Test quoting a string with newline characters."""
-        result = quote_literal_string('line1\nline2')
-        assert result == "'line1\\nline2'"
+        # Verify three statements were executed: BEGIN READ ONLY, user SQL, END
+        assert mock_execute_statement.call_count == 3
+        calls = mock_execute_statement.call_args_list
+        assert calls[0][1]['sql'] == 'BEGIN READ ONLY;'
+        assert calls[1][1]['sql'] == 'SELECT 1'
+        assert calls[2][1]['sql'] == 'END;'
 
-    def test_quote_literal_string_with_special_characters(self):
-        """Test quoting a string with various special characters."""
-        result = quote_literal_string('test\t\r\n\\')
-        assert result == "'test\\t\\r\\n\\\\'"
+        assert result[1] == 'user-stmt-id'
 
+    @pytest.mark.asyncio
+    async def test_execute_protected_statement_read_write(self, mocker):
+        """Test executing protected statement in read-write mode."""
+        # Mock discover_clusters
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
 
-class TestProtectSQL:
-    """Tests for the protect_sql function."""
+        # Mock session manager
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
 
-    def test_protect_sql_allow_read_write(self):
-        """Test protecting with read-write allowed."""
-        result = protect_sql(sql='DROP TABLE public.test', allow_read_write=True)
-        assert result == ['BEGIN READ WRITE;', 'DROP TABLE public.test', 'END;']
+        # Mock _execute_statement
+        mock_execute_statement = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement'
+        )
+        mock_execute_statement.side_effect = ['begin-stmt-id', 'user-stmt-id', 'end-stmt-id']
 
-    def test_protect_sql_read_only(self):
-        """Test protecting with read-only mode."""
-        result = protect_sql(sql='SELECT * FROM test', allow_read_write=False)
-        assert result == ['BEGIN READ ONLY;', 'SELECT * FROM test', 'END;']
+        # Mock data client
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {'Records': [], 'ColumnMetadata': []}
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
 
-    def test_protect_sql_read_only_transaction_breaker_error(self):
-        """Test protecting with transaction breaker error."""
-        for sql in (
+        await _execute_protected_statement(
+            'test-cluster', 'test-db', 'DROP TABLE test', allow_read_write=True
+        )
+
+        # Verify BEGIN READ WRITE was used
+        calls = mock_execute_statement.call_args_list
+        assert calls[0][1]['sql'] == 'BEGIN READ WRITE;'
+        assert calls[1][1]['sql'] == 'DROP TABLE test'
+        assert calls[2][1]['sql'] == 'END;'
+
+    @pytest.mark.asyncio
+    async def test_execute_protected_statement_transaction_breaker_error(self, mocker):
+        """Test transaction breaker protection in read-only mode."""
+        # Mock discover_clusters
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
+
+        # Mock session manager
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+
+        # Test suspicious SQL patterns that should be rejected
+        suspicious_sqls = [
             'END; SELECT 1',
             '  COMMIT\t\r\n; SELECT 1',
             ';;;abort -- slc \n; SELECT 1',
@@ -244,9 +349,742 @@ class TestProtectSQL:
             'ROLLBACK TRANSACTION;/* mlc /* /* mlc */ mlc */ */SELECT 1',
             ';; \t\r\n; rollback -- slc\n  /* mlc -- mlc \n */  work;-- slc \n SELECT 1',
             'SELECT 1; COMMIT;',
-        ):
+        ]
+
+        for sql in suspicious_sqls:
             with pytest.raises(
                 Exception,
                 match='SQL contains suspicious pattern, execution rejected',
             ):
-                protect_sql(sql=sql, allow_read_write=False)
+                await _execute_protected_statement(
+                    'test-cluster', 'test-db', sql, allow_read_write=False
+                )
+
+    @pytest.mark.asyncio
+    async def test_execute_protected_statement_cluster_not_found(self, mocker):
+        """Test error when cluster is not found."""
+        # Mock discover_clusters to return empty list
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = []
+
+        with pytest.raises(Exception, match='Cluster nonexistent-cluster not found'):
+            await _execute_protected_statement(
+                'nonexistent-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_protected_statement_cluster_not_in_list(self, mocker):
+        """Test error when cluster is not in the returned list."""
+        # Mock discover_clusters to return different clusters
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'other-cluster', 'type': 'provisioned'},
+            {'identifier': 'another-cluster', 'type': 'serverless'},
+        ]
+
+        with pytest.raises(Exception, match='Cluster target-cluster not found'):
+            await _execute_protected_statement(
+                'target-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+            )
+
+
+class TestExecuteStatement:
+    """Tests for _execute_statement function."""
+
+    @pytest.mark.asyncio
+    async def test_execute_statement_failed_status(self, mocker):
+        """Test _execute_statement with FAILED status."""
+        mock_client = mocker.Mock()
+        mock_client.execute_statement.return_value = {'Id': 'stmt-123'}
+        mock_client.describe_statement.return_value = {
+            'Status': 'FAILED',
+            'Error': 'SQL syntax error',
+        }
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_client,
+        )
+
+        cluster_info = {'type': 'provisioned'}
+        with pytest.raises(Exception, match='Statement failed: SQL syntax error'):
+            await _execute_statement(cluster_info, 'cluster', 'db', 'SELECT 1')
+
+    @pytest.mark.asyncio
+    async def test_execute_statement_timeout(self, mocker):
+        """Test _execute_statement timeout."""
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned'}
+        ]
+
+        mock_client = mocker.Mock()
+        mock_client.execute_statement.return_value = {'Id': 'stmt-123'}
+        mock_client.describe_statement.return_value = {'Status': 'RUNNING'}
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_client,
+        )
+
+        cluster_info = {'type': 'provisioned'}
+        # Use small timeout and poll interval to trigger timeout quickly
+        with pytest.raises(Exception, match='Statement timed out after'):
+            await _execute_statement(
+                cluster_info,
+                'test-cluster',
+                'db',
+                'SELECT 1',
+                query_timeout=0.1,
+                query_poll_interval=0.05,
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_statement_unknown_cluster_type(self, mocker):
+        """Test _execute_statement with unknown cluster type."""
+        # Mock discover_clusters to return cluster with unknown type
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'unknown-type'}
+        ]
+
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_data_client = mocker.Mock()
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        cluster_info = {'type': 'unknown-type', 'identifier': 'test-cluster'}
+
+        # This should trigger the unknown cluster type error (lines 324, 331)
+        with pytest.raises(Exception, match='Unknown cluster type: unknown-type'):
+            await _execute_statement(cluster_info, 'test-cluster', 'dev', 'SELECT 1')
+
+    @pytest.mark.asyncio
+    async def test_execute_statement_with_parameters(self, mocker):
+        """Test _execute_statement with parameters to cover line 335."""
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned'}
+        ]
+
+        mock_client = mocker.Mock()
+        mock_client.execute_statement.return_value = {'Id': 'stmt-123'}
+        mock_client.describe_statement.return_value = {'Status': 'FINISHED'}
+
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_client
+
+        cluster_info = {'type': 'provisioned', 'identifier': 'test-cluster'}
+        parameters = [{'name': 'param1', 'value': 'value1'}]
+
+        # This should cover line 335 (parameters path)
+        await _execute_statement(
+            cluster_info, 'test-cluster', 'dev', 'SELECT 1', parameters=parameters
+        )
+
+        # Verify parameters were added to request
+        call_args = mock_client.execute_statement.call_args[1]
+        assert 'Parameters' in call_args
+        assert call_args['Parameters'] == parameters
+
+    @pytest.mark.asyncio
+    async def test_execute_statement_with_session_id(self, mocker):
+        """Test _execute_statement with session_id to cover line 339."""
+        mock_client = mocker.Mock()
+        mock_client.execute_statement.return_value = {'Id': 'stmt-123'}
+        mock_client.describe_statement.return_value = {'Status': 'FINISHED'}
+
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_client
+
+        cluster_info = {'type': 'provisioned', 'identifier': 'test-cluster'}
+
+        # This should cover line 339 (session_id path)
+        await _execute_statement(
+            cluster_info, 'test-cluster', 'dev', 'SELECT 1', session_id='session-123'
+        )
+
+        # Verify session_id was added to request
+        call_args = mock_client.execute_statement.call_args[1]
+        assert 'SessionId' in call_args
+        assert call_args['SessionId'] == 'session-123'
+        # Verify database and cluster are NOT added when using session
+        assert 'Database' not in call_args
+        assert 'ClusterIdentifier' not in call_args
+
+
+class TestRedshiftSessionManager:
+    """Tests for RedshiftSessionManager."""
+
+    @pytest.mark.asyncio
+    async def test_session_creation_provisioned(self, mocker):
+        """Test session creation for provisioned cluster."""
+        session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
+        cluster_info = {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+
+        mock_response = {'SessionId': 'test-session-123', 'Id': 'statement-456'}
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.execute_statement.return_value = mock_response
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'SessionId': 'test-session-123',
+        }
+
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        session_id = await session_manager.session('test-cluster', 'test-db', cluster_info)
+
+        assert session_id == 'test-session-123'
+        mock_data_client.execute_statement.assert_called_once()
+        call_args = mock_data_client.execute_statement.call_args
+        assert call_args[1]['ClusterIdentifier'] == 'test-cluster'
+        assert call_args[1]['Database'] == 'test-db'
+        assert 'SET application_name' in call_args[1]['Sql']
+
+    @pytest.mark.asyncio
+    async def test_session_creation_serverless(self, mocker):
+        """Test session creation for serverless workgroup."""
+        session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
+        cluster_info = {
+            'identifier': 'test-workgroup',
+            'type': 'serverless',
+            'status': 'available',
+        }
+
+        mock_response = {'SessionId': 'test-session-456', 'Id': 'statement-789'}
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.execute_statement.return_value = mock_response
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'SessionId': 'test-session-456',
+        }
+
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        session_id = await session_manager.session('test-workgroup', 'test-db', cluster_info)
+
+        assert session_id == 'test-session-456'
+        call_args = mock_data_client.execute_statement.call_args
+        assert call_args[1]['WorkgroupName'] == 'test-workgroup'
+        assert 'ClusterIdentifier' not in call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_session_reuse(self, mocker):
+        """Test that existing sessions are reused."""
+        session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
+        cluster_info = {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+
+        mock_response = {'SessionId': 'test-session-123', 'Id': 'statement-456'}
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.execute_statement.return_value = mock_response
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'SessionId': 'test-session-123',
+        }
+
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        # First call creates session
+        session_id1 = await session_manager.session('test-cluster', 'test-db', cluster_info)
+
+        # Second call should reuse session
+        session_id2 = await session_manager.session('test-cluster', 'test-db', cluster_info)
+
+        assert session_id1 == session_id2 == 'test-session-123'
+        # execute_statement should only be called once (for session creation)
+        mock_data_client.execute_statement.assert_called_once()
+
+    def test_session_expiration_check(self):
+        """Test session expiration logic."""
+        session_keepalive = 600
+        session_manager = RedshiftSessionManager(
+            session_keepalive=session_keepalive, app_name='test-app/1.0'
+        )
+
+        # Fresh session should not be expired
+        fresh_session = {'created_at': time.time()}
+        assert not session_manager._is_session_expired(fresh_session)
+
+        # Old session should be expired
+        old_session = {'created_at': time.time() - session_keepalive - 1}
+        assert session_manager._is_session_expired(old_session)
+
+    @pytest.mark.asyncio
+    async def test_expired_session_cleanup(self, mocker):
+        """Test that expired sessions are cleaned up."""
+        session_manager = RedshiftSessionManager(session_keepalive=500, app_name='test-app')
+
+        # Mock time to simulate expired session
+        mock_time = mocker.patch('awslabs.redshift_mcp_server.redshift.time.time')
+        mock_time.side_effect = [2000, 2000, 2000]  # Check at 2000, session created at 1000
+
+        # Add an expired session manually
+        session_key = 'test-cluster:dev'
+        session_manager._sessions[session_key] = {
+            'session_id': 'expired-session',
+            'created_at': 1000,
+            'last_used': 1000,
+        }
+
+        # Mock session creation
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_data_client = mocker.Mock()
+        mock_data_client.execute_statement.return_value = {'Id': 'stmt-123'}
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'SessionId': 'new-session-id',
+        }
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        cluster_info = {'type': 'provisioned', 'identifier': 'test-cluster'}
+
+        # This should clean up the expired session and create a new one
+        session_id = await session_manager.session('test-cluster', 'dev', cluster_info)
+
+        assert session_id == 'new-session-id'
+        # Verify a new session was created (execute_statement called)
+        mock_data_client.execute_statement.assert_called_once()
+        # Verify the expired session was deleted and replaced (covers lines 141-142)
+        assert session_manager._sessions[session_key]['session_id'] == 'new-session-id'
+
+
+class TestDiscoverFunctions:
+    """Tests for discover_*() functions."""
+
+    @pytest.mark.asyncio
+    async def test_discover_clusters_provisioned(self, mocker):
+        """Test discover_clusters function with provisioned clusters."""
+        # Mock redshift client
+        mock_redshift_client = mocker.Mock()
+        mock_redshift_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'Clusters': [
+                    {
+                        'ClusterIdentifier': 'test-cluster',
+                        'ClusterStatus': 'available',
+                        'DBName': 'dev',
+                        'Endpoint': {'Address': 'test.redshift.amazonaws.com', 'Port': 5439},
+                        'VpcId': 'vpc-123',
+                        'NodeType': 'dc2.large',
+                        'NumberOfNodes': 2,
+                        'ClusterCreateTime': '2024-01-01T00:00:00Z',
+                        'MasterUsername': 'admin',
+                        'PubliclyAccessible': False,
+                        'Encrypted': True,
+                        'Tags': [{'Key': 'env', 'Value': 'test'}],
+                    }
+                ]
+            }
+        ]
+
+        # Mock serverless client (empty response)
+        mock_serverless_client = mocker.Mock()
+        mock_serverless_client.get_paginator.return_value.paginate.return_value = [
+            {'workgroups': []}
+        ]
+
+        # Mock client manager
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_client',
+            return_value=mock_redshift_client,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_serverless_client',
+            return_value=mock_serverless_client,
+        )
+
+        result = await discover_clusters()
+
+        assert len(result) == 1
+        cluster = result[0]
+        assert cluster['identifier'] == 'test-cluster'
+        assert cluster['type'] == 'provisioned'
+        assert cluster['status'] == 'available'
+        assert cluster['database_name'] == 'dev'
+        assert cluster['endpoint'] == 'test.redshift.amazonaws.com'
+        assert cluster['port'] == 5439
+        assert cluster['node_type'] == 'dc2.large'
+        assert cluster['number_of_nodes'] == 2
+        assert cluster['tags'] == {'env': 'test'}
+
+    @pytest.mark.asyncio
+    async def test_discover_clusters_provisioned_error(self, mocker):
+        """Test error handling when discovering provisioned clusters fails."""
+        mock_redshift_client = mocker.Mock()
+        mock_paginator = mocker.Mock()
+        mock_paginator.paginate.side_effect = Exception('AWS API Error')
+        mock_redshift_client.get_paginator.return_value = mock_paginator
+
+        mock_serverless_client = mocker.Mock()
+        mock_serverless_client.list_workgroups.return_value = {'workgroups': []}
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_client',
+            return_value=mock_redshift_client,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_serverless_client',
+            return_value=mock_serverless_client,
+        )
+
+        with pytest.raises(Exception, match='AWS API Error'):
+            await discover_clusters()
+
+    @pytest.mark.asyncio
+    async def test_discover_clusters_serverless(self, mocker):
+        """Test discover_clusters function with serverless workgroups."""
+        # Mock redshift client (empty response)
+        mock_redshift_client = mocker.Mock()
+        mock_redshift_client.get_paginator.return_value.paginate.return_value = [{'Clusters': []}]
+
+        # Mock serverless client
+        mock_serverless_client = mocker.Mock()
+        mock_serverless_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'workgroups': [
+                    {
+                        'workgroupName': 'test-workgroup',
+                        'status': 'AVAILABLE',
+                        'creationDate': '2024-01-01T00:00:00Z',
+                    }
+                ]
+            }
+        ]
+        mock_serverless_client.get_workgroup.return_value = {
+            'workgroup': {
+                'configParameters': [{'parameterValue': 'analytics'}],
+                'endpoint': {'address': 'test.serverless.amazonaws.com', 'port': 5439},
+                'subnetIds': ['subnet-123'],
+                'publiclyAccessible': True,
+                'tags': [{'key': 'team', 'value': 'data'}],
+            }
+        }
+
+        # Mock client manager
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_client',
+            return_value=mock_redshift_client,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_serverless_client',
+            return_value=mock_serverless_client,
+        )
+
+        result = await discover_clusters()
+
+        assert len(result) == 1
+        workgroup = result[0]
+        assert workgroup['identifier'] == 'test-workgroup'
+        assert workgroup['type'] == 'serverless'
+        assert workgroup['status'] == 'AVAILABLE'
+        assert workgroup['database_name'] == 'analytics'
+        assert workgroup['endpoint'] == 'test.serverless.amazonaws.com'
+        assert workgroup['port'] == 5439
+        assert workgroup['node_type'] is None
+        assert workgroup['number_of_nodes'] is None
+        assert workgroup['encrypted'] is True
+        assert workgroup['tags'] == {'team': 'data'}
+
+    @pytest.mark.asyncio
+    async def test_discover_clusters_serverless_error(self, mocker):
+        """Test error handling when discovering serverless workgroups fails."""
+        mock_redshift_client = mocker.Mock()
+        mock_paginator = mocker.Mock()
+        mock_paginator.paginate.return_value = []
+        mock_redshift_client.get_paginator.return_value = mock_paginator
+
+        mock_serverless_client = mocker.Mock()
+        mock_serverless_paginator = mocker.Mock()
+        mock_serverless_paginator.paginate.side_effect = Exception('Serverless API Error')
+        mock_serverless_client.get_paginator.return_value = mock_serverless_paginator
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_client',
+            return_value=mock_redshift_client,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_serverless_client',
+            return_value=mock_serverless_client,
+        )
+
+        with pytest.raises(Exception, match='Serverless API Error'):
+            await discover_clusters()
+
+    @pytest.mark.asyncio
+    async def test_discover_databases(self, mocker):
+        """Test discover_databases function."""
+        # Mock _execute_protected_statement
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'dev'},
+                        {'longValue': 100},
+                        {'stringValue': 'local'},
+                        {'stringValue': 'user=admin'},
+                        {'stringValue': 'encoding=utf8'},
+                        {'stringValue': 'Snapshot Isolation'},
+                    ]
+                ]
+            },
+            'query-123',
+        )
+
+        result = await discover_databases('test-cluster', 'dev')
+
+        assert len(result) == 1
+        assert result[0]['database_name'] == 'dev'
+        assert result[0]['database_owner'] == 100
+        assert result[0]['database_type'] == 'local'
+
+    @pytest.mark.asyncio
+    async def test_discover_databases_error(self, mocker):
+        """Test error handling in discover_databases."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Database discovery failed')
+
+        with pytest.raises(Exception, match='Database discovery failed'):
+            await discover_databases('test-cluster')
+
+    @pytest.mark.asyncio
+    async def test_discover_schemas(self, mocker):
+        """Test discover_schemas function."""
+        # Mock _execute_protected_statement
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'dev'},
+                        {'stringValue': 'public'},
+                        {'longValue': 100},
+                        {'stringValue': 'local'},
+                        {'stringValue': 'user=admin'},
+                        {'stringValue': None},
+                        {'stringValue': None},
+                    ]
+                ]
+            },
+            'query-456',
+        )
+
+        result = await discover_schemas('test-cluster', 'dev')
+
+        assert len(result) == 1
+        assert result[0]['database_name'] == 'dev'
+        assert result[0]['schema_name'] == 'public'
+        assert result[0]['schema_owner'] == 100
+
+        # Verify parameters were passed correctly
+        mock_execute_protected.assert_called_once()
+        call_args = mock_execute_protected.call_args
+        assert call_args[1]['parameters'] == [{'name': 'database_name', 'value': 'dev'}]
+
+    @pytest.mark.asyncio
+    async def test_discover_schemas_error(self, mocker):
+        """Test error handling in discover_schemas."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Schema discovery failed')
+
+        with pytest.raises(Exception, match='Schema discovery failed'):
+            await discover_schemas('test-cluster', 'dev')
+
+    @pytest.mark.asyncio
+    async def test_discover_tables(self, mocker):
+        """Test discover_tables function."""
+        # Mock _execute_protected_statement
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'dev'},
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'user=admin'},
+                        {'stringValue': 'TABLE'},
+                        {'stringValue': 'User data table'},
+                    ]
+                ]
+            },
+            'query-789',
+        )
+
+        result = await discover_tables('test-cluster', 'dev', 'public')
+
+        assert len(result) == 1
+        assert result[0]['database_name'] == 'dev'
+        assert result[0]['schema_name'] == 'public'
+        assert result[0]['table_name'] == 'users'
+        assert result[0]['table_type'] == 'TABLE'
+
+        # Verify parameters were passed correctly
+        mock_execute_protected.assert_called_once()
+        call_args = mock_execute_protected.call_args
+        expected_params = [
+            {'name': 'database_name', 'value': 'dev'},
+            {'name': 'schema_name', 'value': 'public'},
+        ]
+        assert call_args[1]['parameters'] == expected_params
+
+    @pytest.mark.asyncio
+    async def test_discover_tables_error(self, mocker):
+        """Test error handling in discover_tables."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Table discovery failed')
+
+        with pytest.raises(Exception, match='Table discovery failed'):
+            await discover_tables('test-cluster', 'dev', 'public')
+
+    @pytest.mark.asyncio
+    async def test_discover_columns(self, mocker):
+        """Test discover_columns function."""
+        # Mock _execute_protected_statement
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'dev'},
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'id'},
+                        {'longValue': 1},
+                        {'stringValue': None},
+                        {'stringValue': 'NO'},
+                        {'stringValue': 'integer'},
+                        {'longValue': None},
+                        {'longValue': 32},
+                        {'longValue': 0},
+                        {'stringValue': 'Primary key'},
+                    ]
+                ]
+            },
+            'query-101',
+        )
+
+        result = await discover_columns('test-cluster', 'dev', 'public', 'users')
+
+        assert len(result) == 1
+        assert result[0]['database_name'] == 'dev'
+        assert result[0]['schema_name'] == 'public'
+        assert result[0]['table_name'] == 'users'
+        assert result[0]['column_name'] == 'id'
+        assert result[0]['ordinal_position'] == 1
+        assert result[0]['data_type'] == 'integer'
+
+        # Verify parameters were passed correctly
+        mock_execute_protected.assert_called_once()
+        call_args = mock_execute_protected.call_args
+        expected_params = [
+            {'name': 'database_name', 'value': 'dev'},
+            {'name': 'schema_name', 'value': 'public'},
+            {'name': 'table_name', 'value': 'users'},
+        ]
+        assert call_args[1]['parameters'] == expected_params
+
+    @pytest.mark.asyncio
+    async def test_discover_columns_error(self, mocker):
+        """Test error handling in discover_columns."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Column discovery failed')
+
+        with pytest.raises(Exception, match='Column discovery failed'):
+            await discover_columns('test-cluster', 'dev', 'public', 'users')
+
+
+class TestExecuteQuery:
+    """Tests for execute_query function."""
+
+    @pytest.mark.asyncio
+    async def test_execute_query_success(self, mocker):
+        """Test successful query execution."""
+        # Mock _execute_protected_statement
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'ColumnMetadata': [
+                    {'name': 'id'},
+                    {'name': 'name'},
+                    {'name': 'score'},
+                    {'name': 'active'},
+                    {'name': 'deleted'},
+                    {'name': 'unknown'},
+                ],
+                'Records': [
+                    [
+                        {'longValue': 1},
+                        {'stringValue': 'Test User'},
+                        {'doubleValue': 95.5},
+                        {'booleanValue': True},
+                        {'isNull': True},
+                        {'unknownType': 'fallback'},
+                    ]
+                ],
+            },
+            'query-123',
+        )
+
+        # Mock time for execution time calculation
+        mock_time = mocker.patch('time.time')
+        mock_time.side_effect = [1000.0, 1000.123]  # start_time, end_time
+
+        result = await execute_query(
+            'test-cluster',
+            'dev',
+            'SELECT id, name, score, active, deleted, unknown FROM users LIMIT 1',
+        )
+
+        assert result['columns'] == ['id', 'name', 'score', 'active', 'deleted', 'unknown']
+        assert result['rows'] == [
+            [1, 'Test User', 95.5, True, None, "{'unknownType': 'fallback'}"]
+        ]
+        assert result['row_count'] == 1
+        assert result['execution_time_ms'] == 123
+        assert result['query_id'] == 'query-123'
+
+    @pytest.mark.asyncio
+    async def test_execute_query_error_handling(self, mocker):
+        """Test error handling in execute_query."""
+        # Mock _execute_protected_statement to raise exception
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Query execution failed')
+
+        with pytest.raises(Exception, match='Query execution failed'):
+            await execute_query('test-cluster', 'dev', 'SELECT * FROM nonexistent')

--- a/src/redshift-mcp-server/uv.lock
+++ b/src/redshift-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-redshift-mcp-server"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
...instead of BatchExecuteStatement


<!-- markdownlint-disable MD041 MD043 -->
Fixes https://github.com/awslabs/mcp/issues/1238

## Summary

The BatchExecuteStatement permission is powerful, and some customers restrict its use. This PR removes the necessity in BatchExecuteStatement to use this tool.

### Changes

- Replace BatchExecuteStatement with ExecuteStatement using SessionId for better transaction control
- Add RedshiftSessionManager for session lifecycle management
  - With 600s session keepalive
- Implement _execute_protected_statement with BEGIN/END transaction wrapping
  - Replaces protect_sql() as a higher level wrapper
- Add parameterized queries to harden against SQL injection in discovery operations
  - Replacing "manual" literal quoting with quote_literal_string()
- Update tests to support new ExecuteStatement-based architecture
- Removed BatchExecuteStatement from IAM permissions requirements in README.md

### User experience

Users won't be required setting the BatchExecuteStatement IAM permission to use the MCP server any longer. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: https://github.com/awslabs/mcp/issues/1238

Checklist:

* N/A Migration process documented
* N/A Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
