### PR TITLE
Fix EFS tagging issue with resource-type-aware tagging

### DIFF
--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/infrastructure_generator.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/infrastructure_generator.py
@@ -119,7 +119,7 @@ async def generate_infrastructure_code(
             update_properties = current_properties
 
         # V1: Always add required MCP server identification tags for updates too
-        properties_with_tags = add_default_tags(update_properties, schema)
+        properties_with_tags = add_default_tags(update_properties, schema, resource_type)
 
         operation = 'update'
     else:
@@ -128,7 +128,7 @@ async def generate_infrastructure_code(
             raise ClientError('Please provide the properties for the desired resource')
 
         # V1: Always add required MCP server identification tags
-        properties_with_tags = add_default_tags(properties, schema)
+        properties_with_tags = add_default_tags(properties, schema, resource_type)
 
         operation = 'create'
 


### PR DESCRIPTION
* Problem: EFS resources failed with 'extraneous key [Tags] is not permitted' because add_default_tags() always used 'Tags' property, but EFS requires 'FileSystemTags' instead.

* Solution: Add resource-type-aware tagging system that maps AWS resource types to their correct tag property names.

Changes:
- Add RESOURCE_TAG_PROPERTY_MAP for resource-specific tag properties
- Update add_default_tags() to accept resource_type parameter and use correct property name (FileSystemTags for EFS, Tags for others)
- Update infrastructure_generator.py to pass resource_type to add_default_tags()
- Add helper functions get_resource_tag_property() and add_resource_to_tag_map()
- Add comprehensive unit tests for new functionality
- Maintain backward compatibility for existing callers

Benefits:
- Fixes EFS resource creation (was completely broken)
- Maintains backward compatibility for all existing resources
- Easy to extend for other non-standard AWS resource types
- Well-tested with comprehensive test coverage

Fixes: AWS API Error (ValidationException): Model validation failed
(#: extraneous key [Tags] is not permitted) for EFS resources

## Summary
The AWS Cloud Control MCP Server has a bug where it always adds default tags using the `Tags` property, but some AWS resources use different tag property names. For example:

- **EFS (AWS::EFS::FileSystem)** uses `FileSystemTags` instead of `Tags`
- **RDS (AWS::RDS::DBInstance)** uses `Tags`  
- **S3 (AWS::S3::Bucket)** uses `Tags`

This causes validation errors when creating EFS resources:
AWS API Error (ValidationException): Model validation failed (#: extraneous key [Tags] is not permitted)

### Changes

1. **`src/ccapi-mcp-server/awslabs/ccapi_mcp_server/cloud_control_utils.py`**
   - Add `RESOURCE_TAG_PROPERTY_MAP` constant
   - Update `add_default_tags()` function

2. **Find and update all callers of `add_default_tags()`** - likely in:
   - Resource creation handlers
   - Infrastructure generation code
   - Any file that imports from `cloud_control_utils`

3. **`tests/` directory**
   - Add unit tests for the new tagging logic
   - Test multiple resource types (EFS, S3, RDS, etc.)



### User experience
1. **Fixes EFS Resources**: EFS file systems can now be created successfully
2. **Future-Proof**: Easy to add more resource types with non-standard tag properties
3. **Backwards Compatible**: Existing resources using `Tags` continue to work
4. **Maintainable**: Centralized mapping makes it easy to add new resource types

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:1267

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
