### PR TITLE
fix(aws-api-mcp-server): check read only and consent env vars in security policy

### DIFF
--- a/src/aws-api-mcp-server/CHANGELOG.md
+++ b/src/aws-api-mcp-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Enforcement of `READ_OPERATIONS_ONLY_MODE` and `REQUIRE_MUTATION_CONSENT` in security policy (#1301)
+
 ## [0.2.14] - 2025-09-15
 
 ### Added

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -89,7 +89,7 @@ def is_operation_read_only(ir: IRTranslation, read_only_operations: ReadOnlyOper
 
 
 def check_security_policy(
-    cli_command: str, ir: IRTranslation, read_only_operations: ReadOnlyOperations, ctx: Context
+    ir: IRTranslation, read_only_operations: ReadOnlyOperations, ctx: Context
 ) -> PolicyDecision:
     """Check security policy for the given command and return decision."""
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/services.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/services.py
@@ -22,7 +22,7 @@ from lxml import html
 from typing import Any, NamedTuple
 
 
-def _deny_remote_prefix(prefix, uri):
+def _deny_remote_prefix(prefix, _uri):
     raise ValueError(f'{prefix} prefix is not allowed')
 
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
@@ -172,7 +172,7 @@ class DenseRetriever:
             show_progress_bar=True,
         ).astype('float32')
 
-    def get_suggestions(self, query: str, **kwargs) -> dict[str, list[dict]]:
+    def get_suggestions(self, query: str, **_kwargs) -> dict[str, list[dict]]:
         """Search for similar documents using the query."""
         # Generate embedding for the query
         query_embedding = self.model.encode([query], normalize_embeddings=True).astype('float32')

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -275,7 +275,7 @@ class GlobalArgParser(MainArgParser):
     # Overwrite _build's parent method as it automatically injects a `version` action in the
     # parser. Version actions print the current version and then exit the program, which is
     # not what we want.
-    def _build(self, command_table, version_string, argument_table):
+    def _build(self, command_table, version_string, argument_table):  # noqa: ARG002
         for argument_name in argument_table:
             argument = argument_table[argument_name]
             argument.add_to_parser(self)

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/policy.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/policy.py
@@ -14,6 +14,7 @@
 
 import json
 import re
+from ...core.common.config import READ_OPERATIONS_ONLY_MODE, REQUIRE_MUTATION_CONSENT
 from enum import Enum
 from loguru import logger
 from pathlib import Path
@@ -124,6 +125,12 @@ class SecurityPolicy:
             # If client doesn't support elicitation, treat the elicit list as deny
             if not self.supports_elicitation:
                 return PolicyDecision.DENY
+            return PolicyDecision.ELICIT
+
+        if READ_OPERATIONS_ONLY_MODE and not is_read_only:
+            return PolicyDecision.DENY
+
+        if REQUIRE_MUTATION_CONSENT and not is_read_only:
             return PolicyDecision.ELICIT
 
         # Default behavior: allow all operations

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -237,7 +237,7 @@ async def call_aws(
     try:
         # Check security policy
         if READ_OPERATIONS_INDEX is not None:
-            policy_decision = check_security_policy(cli_command, ir, READ_OPERATIONS_INDEX, ctx)
+            policy_decision = check_security_policy(ir, READ_OPERATIONS_INDEX, ctx)
 
             if policy_decision == PolicyDecision.DENY:
                 error_message = 'Execution of this operation is denied by security policy.'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -100,7 +100,7 @@ force-exclude = true
 
 [tool.ruff.lint]
 exclude = ["__init__.py"]
-select = ["C", "D", "E", "F", "I", "W"]
+select = ["ARG", "C", "D", "E", "F", "I", "W"]
 ignore = ["C901", "E501", "E741", "F402", "F823", "D100", "D106"]
 
 [tool.ruff.lint.isort]
@@ -109,6 +109,8 @@ no-sections = true
 
 [tool.ruff.lint.per-file-ignores]
 "**/*.ipynb" = ["F704"]
+"tests/fixtures.py" = ["ARG"]
+"test_*.py" = ["ARG"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.2.14"
+version = "0.3.9223372036854775807"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

- `READ_OPERATIONS_ONLY_MODE` and `REQUIRE_MUTATION_CONSENT` was not checked in the security policy causing the wrong decision being returned. This PR implements a quick fix but I think we need some refactoring in the `call_aws` function.
- Add linter rule to catch unused function arguments
- Switching to `0.3.0` version with this bug fix

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
