### PR TITLE
feat(ccapi-mcp-server): Streamable HTTP Transport Support

### DIFF
--- a/src/ccapi-mcp-server/README.md
+++ b/src/ccapi-mcp-server/README.md
@@ -97,10 +97,10 @@ The MCP server supports several environment variables to control its behavior:
 
 ### AWS Configuration
 
-| Variable      | Default                | Description                                |
-| ------------- | ---------------------- | ------------------------------------------ |
-| `AWS_REGION`  | _(see priority below)_ | AWS region for operations                  |
-| `AWS_PROFILE` | _(empty)_              | AWS profile name to use for authentication |
+| Variable            | Default                | Description                                |
+| ------------------- | ---------------------- | ------------------------------------------ |
+| `AWS_REGION`        | _(see priority below)_ | AWS region for operations                  |
+| `AWS_PROFILE`       | _(empty)_              | AWS profile name to use for authentication |
 
 **AWS Region Resolution Order:**
 
@@ -135,8 +135,15 @@ The server uses boto3's standard credential chain automatically:
 
 | Variable            | Default     | Description                                                                                                                                 |
 | ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FASTMCP_LOG_LEVEL` | _(not set)_ | Logging level (ERROR, WARN, INFO, DEBUG)                                                                                                    |
 | `SECURITY_SCANNING` | `enabled`   | Enable/disable Checkov security scanning (`enabled` or `disabled`). When disabled, shows warning but allows resource operations to proceed. |
+| `TRANSPORT`         | `"stdio"`              | Transport protocol for the MCP server. Valid options are `"stdio"` (default) for local communication or `"streamable-http"` for HTTP-based communication. When using `"streamable-http"`, the server will listen on the host and port specified by `AWS_API_MCP_HOST` and `AWS_API_MCP_PORT`.  |
+| `HOST`              | `"127.0.0.1"`          | Host address for the MCP server, only used when `TRANSPORT` is set to `"streamable-http"`                  |
+| `PORT`              | `8000`                 | Port number for the MCP server, only used when `TRANSPORT` is set to `"streamable-http"` |
+| `MCP_PATH`          | `"/mcp"`               | Path for MCP remote connection URL, only used when `TRANSPORT` is set to `"streamable-http"`                 |
+| `STATELESS_HTTP`    | `True`                 | Setting `True` will have no session persistence |
+| `JSON_RESPONSE`     | `True`                 | Setting `True` will not have SSE Stream Support and response will be in JSON |
+| `FASTMCP_LOG_LEVEL` | `"INFO"`               | Loging level for the MCP server. Valid options are `"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`, `"CRITICAL"`               |
+
 
 ### Default Tagging
 

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/config.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/config.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for the CCAPI MCP server."""
+
+from pydantic_settings import BaseSettings
+from typing import Literal
+
+
+class AppConfig(BaseSettings):
+    """MCP Server configuration settings."""
+
+    HOST: str = '127.0.0.1'
+    PORT: int = 8000
+    MCP_PATH: str = '/mcp'
+    TRANSPORT: Literal['stdio', 'streamable-http'] = 'stdio'
+    STATELESS_HTTP: bool = True
+    JSON_RESPONSE: bool = True
+    FASTMCP_LOG_LEVEL: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO'
+
+
+config = AppConfig()

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/server.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/server.py
@@ -16,6 +16,7 @@
 
 import argparse
 from awslabs.ccapi_mcp_server.aws_client import get_aws_client
+from awslabs.ccapi_mcp_server.config import config
 from awslabs.ccapi_mcp_server.context import Context
 from awslabs.ccapi_mcp_server.errors import handle_aws_api_error
 from awslabs.ccapi_mcp_server.iac_generator import create_template as create_template_impl
@@ -58,6 +59,12 @@ _workflow_store: dict[str, dict] = {}
 
 mcp = FastMCP(
     'awslabs.ccapi-mcp-server',
+    host=config.HOST,
+    port=config.PORT,
+    streamable_http_path=config.MCP_PATH,
+    stateless_http=config.STATELESS_HTTP,
+    json_response=config.JSON_RESPONSE,
+    log_level=config.FASTMCP_LOG_LEVEL,
     instructions="""
 # AWS Resource Management Protocol - MANDATORY INSTRUCTIONS
 
@@ -721,7 +728,14 @@ def main():
         print('\n[WARNING] READ-ONLY MODE ACTIVE [WARNING]')
         print('The server will not perform any create, update, or delete operations.')
 
-    mcp.run()
+    if config.TRANSPORT == 'streamable-http':
+        print(
+            f'Starting CCAPI-MCP-SERVER on {config.HOST}:{config.PORT} with transport=streamable-http...'
+        )
+    else:
+        print('Starting CCAPI-MCP-SERVER with transport=stdio...')
+
+    mcp.run(transport=config.TRANSPORT)
 
 
 if __name__ == '__main__':

--- a/src/ccapi-mcp-server/tests/test_app_config.py
+++ b/src/ccapi-mcp-server/tests/test_app_config.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for app config."""
+
+import os
+import pytest
+from awslabs.ccapi_mcp_server.config import AppConfig
+from pydantic import ValidationError
+from unittest.mock import patch
+
+
+class TestAppConfig:
+    """Test AppConfig settings."""
+
+    @patch.dict(
+        os.environ,
+        {
+            'HOST': '0.0.0.0',
+            'PORT': '9000',
+            'TRANSPORT': 'streamable-http',
+            'FASTMCP_LOG_LEVEL': 'DEBUG',
+        },
+        clear=True,
+    )
+    def test_env_var_overrides(self):
+        """Ensure environment variables override default values."""
+        config = AppConfig()
+        assert config.HOST == '0.0.0.0'
+        assert config.PORT == 9000
+        assert config.TRANSPORT == 'streamable-http'
+        assert config.FASTMCP_LOG_LEVEL == 'DEBUG'
+
+    @patch.dict(os.environ, {'TRANSPORT': 'invalid-transport'}, clear=True)
+    def test_invalid_transport(self):
+        """Ensure invalid transport raises a validation error."""
+        with pytest.raises(ValidationError):
+            AppConfig()
+
+    @patch.dict(os.environ, {'FASTMCP_LOG_LEVEL': 'VERBOSE'}, clear=True)
+    def test_invalid_log_level(self):
+        """Ensure invalid log level raises a validation error."""
+        with pytest.raises(ValidationError):
+            AppConfig()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Support for configuring MCP server to allow usage of either 'stdio' and 'streamable-http' transport
### Changes

- Allow the configuration of 'Transport' protocol
- 'host', 'port', 'streamable_http_path', 'stateless_http' and 'json_response' configuration for the 'streamable-http' transport option
- Support for different logging level option

### User experience
Choose between different transport option,  with 'streamable-http' supporting remote connection


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
