### PR TITLE
AIP-308: Add username authentication support for Redshift MCP

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -9,6 +9,7 @@ This MCP server provides tools to discover, explore, and query Amazon Redshift c
 - **Cluster Discovery**: Automatically discover both provisioned Redshift clusters and serverless workgroups
 - **Metadata Exploration**: Browse databases, schemas, tables, and columns
 - **Safe Query Execution**: Execute SQL queries in a READ ONLY mode (a safe READ WRITE support is planned to be implemnted in the future versions)
+- **Multiple Authentication Methods**: Support for both IAM authentication and username authentication
 - **Multi-Cluster Support**: Work with multiple clusters and workgroups simultaneously
 
 ## Prerequisites
@@ -26,6 +27,18 @@ This MCP server provides tools to discover, explore, and query Amazon Redshift c
    - `AWS_DEFAULT_REGION` environment variable
    - Region specified in your AWS profile configuration
 3. **Permissions**: Ensure your AWS credentials have the required permissions (see [Permissions](#permissions) section)
+
+### Authentication Methods
+
+1. **IAM Authentication** (Default): Uses AWS IAM credentials to authenticate with Redshift
+   - Requires appropriate IAM permissions for Redshift Data API
+   - No additional configuration needed beyond AWS credentials
+
+2. **Username Authentication**: Uses database username to authenticate
+   - Set the following environment variables:
+     - `REDSHIFT_AUTH_TYPE=username`
+     - `REDSHIFT_USERNAME=<your-username>`
+   - Or provide these parameters directly to the MCP tools
 
 ## Installation
 
@@ -48,6 +61,36 @@ Configure the MCP server in your MCP client configuration (e.g., for Amazon Q De
       },
       "disabled": false,
       "autoApprove": []
+    }
+  }
+}
+```
+
+#### Local Development Configuration
+
+For running from a local directory:
+
+```json
+{
+  "mcpServers": {
+    "awslabs.redshift-mcp-server": {
+      "command": "aws-vault",
+      "args": [
+        "exec",
+        "your-aws-profile",
+        "--",
+        "uv",
+        "run",
+        "--directory",
+        "/path/to/redshift-mcp-server",
+        "awslabs.redshift-mcp-server"
+      ],
+      "env": {
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "FASTMCP_LOG_LEVEL": "INFO",
+        "REDSHIFT_AUTH_TYPE": "username",
+        "REDSHIFT_USERNAME": "sagemaker_readonly"
+      }
     }
   }
 }

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -14,6 +14,11 @@
 
 """Redshift MCP Server constants."""
 
+# Authentication
+AUTH_TYPE_IAM = "iam"
+AUTH_TYPE_USERNAME = "username"
+DEFAULT_AUTH_TYPE = AUTH_TYPE_IAM
+
 # System
 CLIENT_CONNECT_TIMEOUT = 60
 CLIENT_READ_TIMEOUT = 600
@@ -59,6 +64,7 @@ REDSHIFT_BEST_PRACTICES = """
 
 - We are use the Redshift API and Redshift Data API.
 - Leverage IAM authentication when possible instead of secrets (database passwords).
+- When IAM authentication is not available, username authentication can be used as an alternative.
 """
 
 # SQL queries

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
@@ -38,6 +38,20 @@ class RedshiftCluster(BaseModel):
     tags: Optional[Dict[str, str]] = Field(
         default_factory=dict, description='Tags associated with the cluster'
     )
+    auth_type: Optional[str] = Field(
+        None, description='Authentication type (iam or username)'
+    )
+
+
+class RedshiftAuthConfig(BaseModel):
+    """Authentication configuration for Redshift connections."""
+
+    auth_type: str = Field(
+        'iam', description='Authentication type (iam or username)'
+    )
+    username: Optional[str] = Field(
+        None, description='Username for authentication'
+    )
 
 
 class RedshiftDatabase(BaseModel):

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -17,12 +17,16 @@
 import os
 import sys
 from awslabs.redshift_mcp_server.consts import (
+    AUTH_TYPE_IAM,
+    AUTH_TYPE_USERNAME,
     CLIENT_BEST_PRACTICES,
+    DEFAULT_AUTH_TYPE,
     DEFAULT_LOG_LEVEL,
     REDSHIFT_BEST_PRACTICES,
 )
 from awslabs.redshift_mcp_server.models import (
     QueryResult,
+    RedshiftAuthConfig,
     RedshiftCluster,
     RedshiftColumn,
     RedshiftDatabase,
@@ -56,6 +60,8 @@ mcp = FastMCP(
 # Amazon Redshift MCP Server.
 
 This MCP server provides comprehensive access to Amazon Redshift clusters and serverless workgroups.
+
+It supports both IAM authentication and username authentication for connecting to Redshift clusters.
 
 ## Available Tools
 
@@ -536,8 +542,18 @@ async def execute_query_tool(
     sql: str = Field(
         ..., description='The SQL statement to execute. Should be a single SQL statement.'
     ),
+    auth_type: str = Field(
+        DEFAULT_AUTH_TYPE,
+        description='Authentication type to use (iam or username). Default is iam.',
+    ),
+    username: str = Field(
+        None,
+        description='Username for authentication. Required if auth_type is username.',
+    ),
 ) -> QueryResult:
     """Execute a SQL query against a Redshift cluster or serverless workgroup.
+
+    This tool supports both IAM authentication and username authentication.
 
     This tool uses the Redshift Data API to execute SQL queries and return results.
     It supports both provisioned clusters and serverless workgroups, and handles
@@ -549,6 +565,7 @@ async def execute_query_tool(
     - The cluster must be available and accessible.
     - Required IAM permissions: redshift-data:ExecuteStatement, redshift-data:DescribeStatement, redshift-data:GetStatementResult.
     - The user must have appropriate permissions to execute queries in the specified database.
+    - For username authentication, provide the username parameter and set auth_type to "username".
 
     ## Parameters
 
@@ -557,6 +574,8 @@ async def execute_query_tool(
     - database_name: The database name to execute the query against.
                     IMPORTANT: Use a valid database name from the list_databases tool.
     - sql: The SQL statement to execute. Should be a single SQL statement.
+    - auth_type: Authentication type to use (iam or username). Default is iam.
+    - username: Username for authentication. Required if auth_type is username.
 
     ## Response Structure
 


### PR DESCRIPTION
Modified to pass username to execute-statement and batch statement
Added a username auth option that allows to pull a different username
and use default temp creds mechanisms.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
