### PR TITLE
feat(lambda): add prompt support to MCPLambdaHandler

### DIFF
--- a/src/mcp-lambda-handler/README.md
+++ b/src/mcp-lambda-handler/README.md
@@ -64,6 +64,29 @@ pip install -e .[dev]
 pytest
 ```
 
+## Prompts
+
+MCP supports **prompts** that can be listed and retrieved by clients.
+You can define them using the `@mcp.prompt` decorator. Prompts automatically expose argument schemas based on type hints.
+
+### Example
+
+```python
+@mcp.prompt
+def greeting(name: str, excited: bool = False) -> str:
+    """
+    A simple greeting prompt.
+    """
+    if excited:
+        return f"Hello, {name}!!! 🎉"
+    return f"Hello, {name}."
+```
+
+### Available Requests
+
+* `prompts/list` → Lists all registered prompts with metadata (name, description, arguments, tags).
+* `prompts/get` → Retrieves the rendered content of a prompt given its `name` and optional `arguments`.
+
 ## Contributing
 
 Contributions are welcome! Please see the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the monorepo root for guidelines.

--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -101,6 +101,8 @@ class MCPLambdaHandler:
         self.tools: Dict[str, Dict] = {}
         self.tool_implementations: Dict[str, Callable] = {}
         self.resources: Dict[str, Resource] = {}
+        self.prompts: Dict[str, Dict] = {}
+        self.prompt_implementations: Dict[str, Callable] = {}
 
         # Configure session storage
         if session_store is None:
@@ -308,6 +310,104 @@ class MCPLambdaHandler:
 
         return decorator
 
+    def prompt(
+        self,
+        func: Optional[Callable] = None,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        tags: Optional[set[str]] = None,
+        enabled: bool = True,
+        meta: Optional[Dict[str, Any]] = None,
+    ):
+        """Decorator to register an MCP prompt similar to fastmcp.
+
+        Can be used bare (@handler.prompt) or with arguments (@handler.prompt(...)).
+        """
+
+        def decorator(f: Callable):
+            if not enabled:
+                return f
+
+            # Extract prompt name from argument or function name
+            func_name = f.__name__
+            prompt_name = name or ''.join(
+                [func_name.split('_')[0]]
+                + [word.capitalize() for word in func_name.split('_')[1:]]
+            )
+
+            # Use provided description or fallback to docstring
+            doc = inspect.getdoc(f) or ""
+            prompt_description = description or (doc.split("\n\n")[0] if doc else "")
+
+            # Build argument schemas from type hints
+            hints = get_type_hints(f)
+            hints.pop("return", None)
+
+            args: List[Dict[str, Any]] = []
+
+            for param_name, param_type in hints.items():
+                if param_type is str:
+                    arg_type = "string"
+                elif param_type is int:
+                    arg_type = "integer"
+                elif param_type is float:
+                    arg_type = "number"
+                elif param_type is bool:
+                    arg_type = "boolean"
+                else:
+                    arg_type = "string"
+
+                args.append({
+                    "name": param_name,
+                    "type": arg_type,
+                    "description": f"Argument for {param_name}"
+                })
+
+            schema = {
+                "name": prompt_name,
+                "description": prompt_description,
+                "arguments": args
+            }
+
+            if tags:
+                schema["tags"] = list(tags)
+            if meta:
+                schema["_meta"] = meta
+
+            self.prompts[prompt_name] = schema
+            self.prompt_implementations[prompt_name] = f
+
+            @functools.wraps(f)
+            def wrapper(*args, **kwargs):
+                return f(*args, **kwargs)
+
+            return wrapper
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    def _render_prompt(self, name: str, variables: Optional[Dict[str, Any]] = None) -> str:
+        """Render a registered prompt by calling its function."""
+        if name not in self.prompts:
+            raise ValueError(f"Prompt not found: {name}")
+
+        func = self.prompt_implementations.get(name)
+        if not func:
+            raise ValueError(f"Prompt implementation not found: {name}")
+
+        hints = get_type_hints(func)
+        hints.pop("return", None)
+
+        # Match variables to function parameters (optional)
+        call_args = {}
+        for param in hints:
+            if variables and param in variables:
+                call_args[param] = variables[param]
+
+        return func(**call_args)
+
     def _create_error_response(
         self,
         code: int,
@@ -460,7 +560,9 @@ class MCPLambdaHandler:
                     protocolVersion='2024-11-05',
                     serverInfo=ServerInfo(name=self.name, version=self.version),
                     capabilities=Capabilities(
-                        tools={'list': True, 'call': True}, resources={'list': True, 'read': True}
+                        tools={"list": True, "call": True},
+                        resources={"list": True, "read": True},
+                        prompts={"list": True, "get": True},
                     ),
                 )
                 return self._create_success_response(result.model_dump(), request.id, session_id)
@@ -582,6 +684,34 @@ class MCPLambdaHandler:
                         f'Error reading resource: {str(e)}',
                         request.id,
                         error_content,
+                        session_id,
+                    )
+
+            if request.method == "prompts/list":
+                return self._create_success_response(
+                    {"prompts": list(self.prompts.values())}, request.id, session_id
+                )
+
+            # Handle prompts/get
+            if request.method == "prompts/get":
+                if not request.params or "name" not in request.params:
+                    return self._create_error_response(
+                        -32602, "Missing required parameter: name", request.id, session_id=session_id
+                    )
+
+                name = request.params["name"]
+                variables = request.params.get("arguments", {})
+                try:
+                    content = self._render_prompt(name, variables)
+                    return self._create_success_response(
+                        {"messages": [{"role": "user", "content": {"type": "text", "text": content}}]}, request.id, session_id
+                    )
+                except Exception as e:
+                    return self._create_error_response(
+                        -32603,
+                        f"Error rendering prompt: {str(e)}",
+                        request.id,
+                        [ErrorContent(text=str(e)).model_dump()],
                         session_id,
                     )
 

--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/types.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/types.py
@@ -71,11 +71,14 @@ class ServerInfo:
 class Capabilities:
     tools: Dict[str, bool]
     resources: Optional[Dict[str, bool]] = None
+    prompts: Optional[Dict[str, bool]] = None
 
     def model_dump(self) -> Dict:
         data = {'tools': self.tools}
         if self.resources:
             data['resources'] = self.resources
+        if self.prompts:
+            data['prompts'] = self.prompts
         return data
 
 


### PR DESCRIPTION
## Summary

This PR adds **prompt registration and rendering functionality** to the `MCPLambdaHandler`.

Previously, MCP servers running on AWS Lambda did not support prompts. With this change, prompts can now be discovered and retrieved through the Lambda handler, bringing feature parity with MCP servers outside Lambda.

### Changes

* Added prompt registration support in `MCPLambdaHandler`.
* Implemented handlers for:

  * `initialize` → now includes prompt discovery.
  * `prompts/list` → returns available prompts.
  * `prompts/get` → retrieves prompt details.
* Ensured compatibility with existing MCP Lambda functionality.

### User experience

**Before:**

* MCP servers on Lambda did not support prompts.
* No way to list or fetch prompts from Lambda-hosted MCP servers.

**After:**

* MCP servers on Lambda now fully support prompt discovery and retrieval (`initialize`, `prompts/list`, `prompts/get`).
* Developers can use prompts seamlessly when deploying MCP servers with `MCPLambdaHandler`.

## Checklist

* [x] I have reviewed the [[contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
**N**

**RFC issue number**:  #731 

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).