### PR TITLE
refactor(ecs-mcp-server): update proxy config to use transport bridging

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/modules/aws_knowledge_proxy.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/modules/aws_knowledge_proxy.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 
 def register_proxy(mcp: FastMCP) -> Optional[bool]:
     """
-    Sets up the AWS Knowledge MCP Server proxy integration.
+    Sets up the AWS Knowledge MCP Server proxy integration using transport bridging
+    -> https://gofastmcp.com/servers/proxy#transport-bridging
 
     Args:
         mcp: The FastMCP server instance to mount the proxy on
@@ -50,22 +51,9 @@ def register_proxy(mcp: FastMCP) -> Optional[bool]:
     """
     try:
         logger.info("Setting up AWS Knowledge MCP Server proxy")
-        proxy_config = {
-            "mcpServers": {
-                "aws-knowledge-mcp-server": {
-                    "command": "uvx",
-                    "args": [
-                        "mcp-proxy",
-                        "--transport",
-                        "streamablehttp",
-                        "https://knowledge-mcp.global.api.aws",
-                    ],
-                }
-            }
-        }
-
-        # Create and mount the proxy
-        aws_knowledge_proxy = FastMCP.as_proxy(ProxyClient(proxy_config))
+        aws_knowledge_proxy = FastMCP.as_proxy(
+            ProxyClient("https://knowledge-mcp.global.api.aws"), name="AWS-Knowledge-Bridge"
+        )
         mcp.mount(aws_knowledge_proxy, prefix="aws_knowledge")
 
         # Add prompt patterns for blue-green deployments

--- a/src/ecs-mcp-server/tests/unit/modules/test_aws_knowledge_proxy.py
+++ b/src/ecs-mcp-server/tests/unit/modules/test_aws_knowledge_proxy.py
@@ -16,19 +16,8 @@ from awslabs.ecs_mcp_server.modules.aws_knowledge_proxy import (
 )
 
 # Test Constants
-EXPECTED_PROXY_CONFIG = {
-    "mcpServers": {
-        "aws-knowledge-mcp-server": {
-            "command": "uvx",
-            "args": [
-                "mcp-proxy",
-                "--transport",
-                "streamablehttp",
-                "https://knowledge-mcp.global.api.aws",
-            ],
-        }
-    }
-}
+EXPECTED_PROXY_URL = "https://knowledge-mcp.global.api.aws"
+EXPECTED_PROXY_NAME = "AWS-Knowledge-Bridge"
 
 EXPECTED_KNOWLEDGE_TOOLS = [
     "aws_knowledge_aws___search_documentation",
@@ -186,10 +175,10 @@ class TestRegisterProxy:
         assert result is True
 
         # Verify proxy configuration
-        mock_proxy_client.assert_called_once_with(EXPECTED_PROXY_CONFIG)
+        mock_proxy_client.assert_called_once_with(EXPECTED_PROXY_URL)
 
         # Verify proxy creation and mounting
-        mock_fastmcp.as_proxy.assert_called_once_with(mock_proxy_instance)
+        mock_fastmcp.as_proxy.assert_called_once_with(mock_proxy_instance, name=EXPECTED_PROXY_NAME)
         mock_mcp.mount.assert_called_once_with(mock_aws_knowledge_proxy, prefix="aws_knowledge")
 
         # Verify ECS prompts registration


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary & Changes
- Update AWS Knowledge proxy config to use [transport bridging](https://gofastmcp.com/servers/proxy#transport-bridging) to remove [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) and decrease our number of dependencies. We replace it with transport bridging, directly built in to FastMCP. This eliminates the need for the subprocess via uvx mcp-proxy.
- Updated UTs

### User experience
- No change to customer experience

## Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [Y] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [NA] Migration process documented
* [NA] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
