### PR TITLE
fix(aws-api-mcp-server): add override for sts:AssumeRole

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/metadata/read_only_operations_list.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/metadata/read_only_operations_list.py
@@ -22,6 +22,7 @@ from typing import List
 SERVICE_REFERENCE_URL = 'https://servicereference.us-east-1.amazonaws.com/'
 METADATA_FILE = 'data/api_metadata.json'
 DEFAULT_REQUEST_TIMEOUT = 5
+OVERRIDES = {'sts': {'AssumeRole': False}}
 
 
 class ServiceReferenceUrlsByService(dict):
@@ -59,6 +60,8 @@ class ReadOnlyOperations(dict):
     def has(self, service, operation) -> bool:
         """Check if the operation is in the read only operations list."""
         logger.info(f'checking in read only list : {service} - {operation}')
+        if service in OVERRIDES and operation in OVERRIDES[service]:
+            return OVERRIDES[service][operation]
         if (
             service in self._known_readonly_operations
             and operation in self._known_readonly_operations[service]

--- a/src/aws-api-mcp-server/tests/metadata/test_read_only_operations_list.py
+++ b/src/aws-api-mcp-server/tests/metadata/test_read_only_operations_list.py
@@ -208,3 +208,9 @@ def test_read_only_operations_has_method_operation_from_metadata():
     assert not operations.has('s3', 'DeleteObject')
     assert not operations.has('lambda', 'CreateAlias')
     assert not operations.has('rds', 'CreateDBSecurityGroup')
+
+
+def test_read_only_operations_overrides():
+    """Test the has method of ReadOnlyOperations with overrides."""
+    operations = ReadOnlyOperations({})
+    assert not operations.has('sts', 'AssumeRole')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Add override to mark `sts:AssumeRole` as mutating

### User experience

> Please share what the user experience looks like before and after this change

Operation will be blocked when `READ_OPERATIONS_ONLY` is on

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
