### PR TITLE
feat: adding query attribution for read_documentation

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/models.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/models.py
@@ -23,6 +23,7 @@ class SearchResult(BaseModel):
     rank_order: int
     url: str
     title: str
+    query_id: str
     context: Optional[str] = None
 
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -35,7 +35,7 @@ from awslabs.aws_documentation_mcp_server.util import (
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
-from typing import List
+from typing import List, Optional
 
 
 SEARCH_API_URL = 'https://proxy.search.docs.aws.amazon.com/search'
@@ -78,6 +78,7 @@ mcp = FastMCP(
 async def read_documentation(
     ctx: Context,
     url: str = Field(description='URL of the AWS documentation page to read'),
+    query_id: Optional[str] = Field(description='Query ID from search request, optional'),
     max_length: int = Field(
         default=5000,
         description='Maximum number of characters to return.',
@@ -125,6 +126,7 @@ async def read_documentation(
     Args:
         ctx: MCP context for logging and error handling
         url: URL of the AWS documentation page to read
+        query_id: The query ID provided from a search request, optional if read_documentation is used without a URL from search request
         max_length: Maximum number of characters to return
         start_index: On return output starting at this character index
 
@@ -140,7 +142,9 @@ async def read_documentation(
         await ctx.error(f'Invalid URL: {url_str}. URL must end with .html')
         raise ValueError('URL must end with .html')
 
-    return await read_documentation_impl(ctx, url_str, max_length, start_index, SESSION_UUID)
+    return await read_documentation_impl(
+        ctx, url_str, max_length, start_index, SESSION_UUID, query_id
+    )
 
 
 @mcp.tool()
@@ -182,7 +186,7 @@ async def search_documentation(
         limit: Maximum number of results to return
 
     Returns:
-        List of search results with URLs, titles, and context snippets
+        List of search results with URLs, titles, query ID, and context snippets
     """
     logger.debug(f'Searching AWS documentation for: {search_phrase}')
 
@@ -213,7 +217,7 @@ async def search_documentation(
             error_msg = f'Error searching AWS docs: {str(e)}'
             logger.error(error_msg)
             await ctx.error(error_msg)
-            return [SearchResult(rank_order=1, url='', title=error_msg, context=None)]
+            return [SearchResult(rank_order=1, url='', title=error_msg, query_id='', context=None)]
 
         if response.status_code >= 400:
             error_msg = f'Error searching AWS docs - status code {response.status_code}'
@@ -224,12 +228,14 @@ async def search_documentation(
                     rank_order=1,
                     url='',
                     title=error_msg,
+                    query_id='',
                     context=None,
                 )
             ]
 
         try:
             data = response.json()
+            query_id = data.get('queryId', None)
         except json.JSONDecodeError as e:
             error_msg = f'Error parsing search results: {str(e)}'
             logger.error(error_msg)
@@ -239,6 +245,7 @@ async def search_documentation(
                     rank_order=1,
                     url='',
                     title=error_msg,
+                    query_id='',
                     context=None,
                 )
             ]
@@ -267,11 +274,13 @@ async def search_documentation(
                         rank_order=i + 1,
                         url=text_suggestion.get('link', ''),
                         title=text_suggestion.get('title', ''),
+                        query_id=query_id,
                         context=context,
                     )
                 )
 
     logger.debug(f'Found {len(results)} search results for: {search_phrase}')
+    logger.debug(f'Search query ID: {query_id}')
     return results
 
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -20,6 +20,7 @@ from awslabs.aws_documentation_mcp_server.util import (
 from importlib.metadata import version
 from loguru import logger
 from mcp.server.fastmcp import Context
+from typing import Optional
 
 
 try:
@@ -36,11 +37,15 @@ async def read_documentation_impl(
     max_length: int,
     start_index: int,
     session_uuid: str,
+    query_id: Optional[str] = None,
 ) -> str:
     """The implementation of the read_documentation tool."""
     logger.debug(f'Fetching documentation from {url_str}')
 
     url_with_session = f'{url_str}?session={session_uuid}'
+    if query_id:
+        url_with_session += f'&query_id={query_id}'
+        logger.debug(f'Using query_id {query_id}')
 
     async with httpx.AsyncClient() as client:
         try:

--- a/src/aws-documentation-mcp-server/tests/test_aws_search_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_search_live.py
@@ -46,6 +46,7 @@ async def test_search_documentation_live():
         assert result.rank_order > 0
         assert result.url is not None and result.url != ''
         assert result.title is not None and result.title != ''
+        assert result.query_id is not None and result.query_id != ''
         # Context is optional, so we don't assert on it
 
     # Print results for debugging (will show in pytest output with -v flag)
@@ -55,6 +56,7 @@ async def test_search_documentation_live():
         print(f'Rank: {result.rank_order}')
         print(f'Title: {result.title}')
         print(f'URL: {result.url}')
+        print(f'Query ID: {result.query_id}')
         if result.context:
             print(f'Context: {result.context}')
 
@@ -81,6 +83,7 @@ async def test_search_documentation_empty_results():
         print(f'Rank: {result.rank_order}')
         print(f'Title: {result.title}')
         print(f'URL: {result.url}')
+        print(f'Query ID: {result.query_id}')
         if result.context:
             print(f'Context: {result.context}')
 

--- a/src/aws-documentation-mcp-server/tests/test_metadata_handling.py
+++ b/src/aws-documentation-mcp-server/tests/test_metadata_handling.py
@@ -37,6 +37,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -51,7 +52,7 @@ class TestMetadataHandling:
                         },
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -70,6 +71,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -83,7 +85,7 @@ class TestMetadataHandling:
                         },
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -102,6 +104,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -112,7 +115,7 @@ class TestMetadataHandling:
                         'metadata': {},
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -131,6 +134,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -140,7 +144,7 @@ class TestMetadataHandling:
                         'metadata': {},
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -159,6 +163,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -167,7 +172,7 @@ class TestMetadataHandling:
                         'metadata': {},
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -186,6 +191,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -195,7 +201,7 @@ class TestMetadataHandling:
                         'metadata': {},
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -214,6 +220,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -247,7 +254,7 @@ class TestMetadataHandling:
                         'metadata': {},
                     }
                 },
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -270,6 +277,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -293,7 +301,7 @@ class TestMetadataHandling:
                         'metadata': {'last_updated': '2025-08-23T15:00:48.000Z', 'summary': 'S3'},
                     }
                 },
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -318,6 +326,7 @@ class TestMetadataHandling:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -327,7 +336,7 @@ class TestMetadataHandling:
                         # No metadata field at all
                     }
                 }
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:

--- a/src/aws-documentation-mcp-server/tests/test_models.py
+++ b/src/aws-documentation-mcp-server/tests/test_models.py
@@ -28,11 +28,13 @@ class TestSearchResult:
             rank_order=1,
             url='https://docs.aws.amazon.com/lambda/latest/dg/welcome.html',
             title='Welcome to AWS Lambda',
+            query_id='test-query-id',
             context='AWS Lambda is a compute service...',
         )
         assert result.rank_order == 1
         assert result.url == 'https://docs.aws.amazon.com/lambda/latest/dg/welcome.html'
         assert result.title == 'Welcome to AWS Lambda'
+        assert result.query_id == 'test-query-id'
         assert result.context == 'AWS Lambda is a compute service...'
 
     def test_search_result_without_context(self):
@@ -41,10 +43,12 @@ class TestSearchResult:
             rank_order=1,
             url='https://docs.aws.amazon.com/lambda/latest/dg/welcome.html',
             title='Welcome to AWS Lambda',
+            query_id='test-query-id',
         )
         assert result.rank_order == 1
         assert result.url == 'https://docs.aws.amazon.com/lambda/latest/dg/welcome.html'
         assert result.title == 'Welcome to AWS Lambda'
+        assert result.query_id == 'test-query-id'
         assert result.context is None
 
 

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -110,6 +110,7 @@ class TestSearchDocumentation:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
+            'queryId': 'test-query-id',
             'suggestions': [
                 {
                     'textExcerptSuggestion': {
@@ -125,7 +126,7 @@ class TestSearchDocumentation:
                         'suggestionBody': 'This is test 2.',
                     }
                 },
-            ]
+            ],
         }
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:


### PR DESCRIPTION
Fixes

## Summary

### Changes

The AWS Documentation team is creating the foundation for ensuring quality responses for searches being made with the Docs MCP Server.

This change:
* Adds the query_id in the read_documentation tool call, if it exists, to help understand which documentation pages were read from particular search requests.

### User experience

No change to the user experience, but users will see the `query_id` being passed into `read_documentation` requests.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
