### PR TITLE
docs: Updates s3Tables MCP CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,7 +73,7 @@ NOTICE                                                                    @awsla
 /src/postgres-mcp-server                @kennthhz                         @awslabs/mcp-admins
 /src/prometheus-mcp-server              @MohamedSherifAbdelsamiea         @awslabs/mcp-admins
 /src/redshift-mcp-server                @grayhemp                         @awslabs/mcp-admins
-/src/s3-tables-mcp-server               @okhomin @gsoundar @gregorywright @Kurtiscwright @hsingh574 @ananthaksr               @awslabs/mcp-admins
+/src/s3-tables-mcp-server               @gsoundar @gregorywright @Kurtiscwright @hsingh574 @ananthaksr               @awslabs/mcp-admins
 /src/stepfunctions-tool-mcp-server      @mmouniro                         @awslabs/mcp-admins
 /src/syntheticdata-mcp-server           @pranjbh                          @awslabs/mcp-admins
 /src/terraform-mcp-server               @alexa-perlov                     @awslabs/mcp-admins


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Previous Code Owner for S3 Tables MCP has been removed.

### User experience

No User Experience changes.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
