### PR TITLE
feat: add get_available_tables to the Postgres MCP Server

### DIFF
--- a/src/postgres-mcp-server/tests/test_server.py
+++ b/src/postgres-mcp-server/tests/test_server.py
@@ -25,6 +25,7 @@ from awslabs.postgres_mcp_server.server import (
     DBConnectionSingleton,
     client_error_code_key,
     get_table_schema,
+    get_available_tables,
     main,
     run_query,
     unexpected_error_key,
@@ -656,6 +657,26 @@ async def test_get_table_schema():
     column_records = tool_response[0]
     validate_normal_query_response(column_records)
 
+@pytest.mark.asyncio
+async def test_get_available_tables():
+    """Test test_get_available_tables call in a positive case."""
+    DBConnectionSingleton.initialize('mock', 'mock', 'mock', 'mock', readonly=False, is_test=True)
+    mock_db_connection = Mock_DBConnection(readonly=False)
+    mock_db_connection.data_client.add_mock_response(get_mock_normal_query_response())
+    DBConnectionSingleton._instance._db_connection = mock_db_connection  # type: ignore
+
+    ctx = DummyCtx()
+    tool_response = await get_available_tables(ctx)
+
+    # validate tool_response
+    assert (
+        isinstance(tool_response, (list, tuple))
+        and len(tool_response) == 1
+        and isinstance(tool_response[0], dict)
+        and 'error' not in tool_response[0]
+    )
+    column_records = tool_response[0]
+    validate_normal_query_response(column_records)
 
 def test_main_with_valid_parameters(monkeypatch, capsys):
     """Test main function with valid command line parameters.


### PR DESCRIPTION
Add a tool, get_available_tables, to the Postgres MCP Server that returns a list of tables across all user schemas

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Commonly, when an LLM is determining a query to run against an existing PostgreSQL database, it interrogates the database for a list of tables. Typically, this query is a variation of the following:
`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'` 

If the database is following best practices, tables will not be in the `public` schema leading to tables not being found and requiring a more explicit prompt to find tables in other schemas.

### Changes

> Please provide a summary of what's being changed
 A new tool called get_available_tables is added to postgres-mcp-server along with a test to exercise it

### User experience

> Please share what the user experience looks like before and after this change
Before the change, if an LLM is using postgres-mcp-server and it does not have the context of the table in the database, it determine it through a common PostgreSQL query, but that usually leaves out tables in schemas other than public. The added tool returns tables across all available schemas. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
