### PR TITLE
fix(aws-api-mcp-server): add cloudformation package file path parameter

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/file_operations.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/file_operations.py
@@ -39,6 +39,7 @@ FILE_PATH_PARAMETERS: Dict[Tuple[str, str], Set[str]] = {
     ('s3', 'cp'): {'--paths'},
     ('s3', 'sync'): {'--paths'},
     ('s3', 'mv'): {'--paths'},
+    ('cloudformation', 'package'): {'--output-template-file'},
 }
 
 # Global parameters that can specify output files


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Cloudformation package has a parameter `--output-template-file` that writes files, writes outside of the working directory should not be possible with this command when `AWS_API_MCP_ALLOW_UNRESTRICTED_LOCAL_FILE_ACCESS` is set

### User experience

> Please share what the user experience looks like before and after this change

Cloudformation package operation allows arbitrary file writes, these are now blocked

```json
{
    "method": "notifications/message",
    "params": {
        "level": "error",
        "data": "Error while validating the command: File path '/Users/awouters/Downloads/awouters-mcp-test.txt' is outside the allowed working directory '/var/folders/wh/1mpfg3h16m14zlxwnb7hvqr80000gq/T/aws-api-mcp/workdir'. Set AWS_API_MCP_ALLOW_UNRESTRICTED_LOCAL_FILE_ACCESS=true to allow unrestricted file access."
    },
    "jsonrpc": "2.0"
}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
