### PR TITLE
fix: default log group in search_transaction_spans tool for empty string

### DIFF
--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/trace_tools.py
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/trace_tools.py
@@ -191,7 +191,7 @@ async def search_transaction_spans(
 
     try:
         # Use default log group if none provided
-        if log_group_name is None:
+        if not log_group_name:
             log_group_name = 'aws/spans'
             logger.debug('Using default log group: aws/spans')
 

--- a/src/cloudwatch-appsignals-mcp-server/tests/test_server.py
+++ b/src/cloudwatch-appsignals-mcp-server/tests/test_server.py
@@ -1076,7 +1076,7 @@ async def test_search_transaction_spans_empty_log_group(mock_aws_clients):
         }
 
         await search_transaction_spans(
-            log_group_name='',  # Empty string will be used as-is
+            log_group_name='',  # Empty string should default to 'aws/spans'
             start_time='2024-01-01T00:00:00+00:00',
             end_time='2024-01-01T01:00:00+00:00',
             query_string='fields @timestamp',
@@ -1084,10 +1084,10 @@ async def test_search_transaction_spans_empty_log_group(mock_aws_clients):
             max_timeout=30,
         )
 
-        # Verify start_query was called with empty string (current behavior)
+        # Verify start_query was called with default 'aws/spans'
         mock_aws_clients['logs_client'].start_query.assert_called()
         call_args = mock_aws_clients['logs_client'].start_query.call_args[1]
-        assert '' in call_args['logGroupNames']
+        assert 'aws/spans' in call_args['logGroupNames']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Log group will not properly default to `aws/spans` log group due to this [if condition](https://github.com/awslabs/mcp/blob/b8a10f85bb4a021292e715b90a796a3456281b94/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/trace_tools.py#L194) and this [default parameter value](https://github.com/awslabs/mcp/blob/b8a10f85bb4a021292e715b90a796a3456281b94/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/trace_tools.py#L120). Empty strings are not considered `None` in Python.

### Changes

> Change if condition in `search_transaction_spans` tool

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
