### PR TITLE
feat(bedrock-kb-retrieval-mcp-server): Added 'description' field to responses for list_knowledge_bases_tool

### DIFF
--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/discovery.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/discovery.py
@@ -63,12 +63,9 @@ async def discover_knowledge_bases(
                 logger.debug(f'KB Name: {kb_name}')
                 kb_data.append((kb_id, kb_name, kb_description))
 
-    logger.info(f"kb_data={kb_data}")
-
     # Then, for each matching knowledge base, collect its data sources
     for kb_id, kb_name, kb_description in kb_data:
         result[kb_id] = {'name': kb_name, 'description': kb_description, 'data_sources': []}
-        logger.info(f"result[kb_id]: {result[kb_id]}")
 
         # Collect data sources for this knowledge base
         data_sources = []

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/discovery.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/discovery.py
@@ -50,6 +50,7 @@ async def discover_knowledge_bases(
             logger.debug(f'KB: {kb}')
             kb_id = kb.get('knowledgeBaseId')
             kb_name = kb.get('name')
+            kb_description = kb.get('description', '')
 
             kb_arn = (
                 agent_client.get_knowledge_base(knowledgeBaseId=kb_id)
@@ -60,11 +61,14 @@ async def discover_knowledge_bases(
             tags = agent_client.list_tags_for_resource(resourceArn=kb_arn).get('tags', {})
             if tag_key in tags and tags[tag_key] == 'true':
                 logger.debug(f'KB Name: {kb_name}')
-                kb_data.append((kb_id, kb_name))
+                kb_data.append((kb_id, kb_name, kb_description))
+
+    logger.info(f"kb_data={kb_data}")
 
     # Then, for each matching knowledge base, collect its data sources
-    for kb_id, kb_name in kb_data:
-        result[kb_id] = {'name': kb_name, 'data_sources': []}
+    for kb_id, kb_name, kb_description in kb_data:
+        result[kb_id] = {'name': kb_name, 'description': kb_description, 'data_sources': []}
+        logger.info(f"result[kb_id]: {result[kb_id]}")
 
         # Collect data sources for this knowledge base
         data_sources = []

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/models.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/models.py
@@ -25,6 +25,7 @@ class KnowledgeBase(TypedDict):
     """A knowledge base."""
 
     name: str
+    description: str
     data_sources: List[DataSource]
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -124,7 +124,6 @@ async def list_knowledge_bases_tool() -> str:
     2. Note the data source IDs if you want to filter queries to specific data sources
     3. Use the names to determine which knowledge base and data source(s) are most relevant to the user's query
     """
-    logger.info("GERRY")
     knowledge_bases = await discover_knowledge_bases(kb_agent_mgmt_client, kb_inclusion_tag_key)
     return json.dumps(knowledge_bases)
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -93,6 +93,7 @@ async def list_knowledge_bases_tool() -> str:
 
     This tool returns a mapping of knowledge base IDs to their details, including:
     - name: The human-readable name of the knowledge base
+    - description: The description of the knowledge base
     - data_sources: A list of data sources within the knowledge base, each with:
       - id: The unique identifier of the data source
       - name: The human-readable name of the data source
@@ -102,6 +103,7 @@ async def list_knowledge_bases_tool() -> str:
     {
         "kb-12345": {
             "name": "Customer Support KB",
+            "description": "Knowledge base containing customer support documentation and FAQs",
             "data_sources": [
                 {"id": "ds-abc123", "name": "Technical Documentation"},
                 {"id": "ds-def456", "name": "FAQs"}
@@ -109,6 +111,7 @@ async def list_knowledge_bases_tool() -> str:
         },
         "kb-67890": {
             "name": "Product Information KB",
+            "description": "Comprehensive product specifications and details",
             "data_sources": [
                 {"id": "ds-ghi789", "name": "Product Specifications"}
             ]
@@ -121,6 +124,7 @@ async def list_knowledge_bases_tool() -> str:
     2. Note the data source IDs if you want to filter queries to specific data sources
     3. Use the names to determine which knowledge base and data source(s) are most relevant to the user's query
     """
+    logger.info("GERRY")
     knowledge_bases = await discover_knowledge_bases(kb_agent_mgmt_client, kb_inclusion_tag_key)
     return json.dumps(knowledge_bases)
 

--- a/src/bedrock-kb-retrieval-mcp-server/tests/conftest.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/conftest.py
@@ -54,9 +54,9 @@ def mock_bedrock_agent_client():
     kb_paginator.paginate.return_value = [
         {
             'knowledgeBaseSummaries': [
-                {'knowledgeBaseId': 'kb-12345', 'name': 'Test Knowledge Base'},
-                {'knowledgeBaseId': 'kb-67890', 'name': 'Another Knowledge Base'},
-                {'knowledgeBaseId': 'kb-95008', 'name': 'Yet another Knowledge Base'},
+                {'knowledgeBaseId': 'kb-12345', 'name': 'Test Knowledge Base', 'description': 'A test knowledge base for testing purposes'},
+                {'knowledgeBaseId': 'kb-67890', 'name': 'Another Knowledge Base', 'description': 'Another knowledge base for testing'},
+                {'knowledgeBaseId': 'kb-95008', 'name': 'Yet another Knowledge Base', 'description': 'Yet another test knowledge base'},
             ]
         }
     ]

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_discovery.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_discovery.py
@@ -35,7 +35,9 @@ class TestDiscoverKnowledgeBases:
         assert 'kb-12345' in result
         assert 'kb-67890' in result
         assert result['kb-12345']['name'] == 'Test Knowledge Base'
+        assert result['kb-12345']['description'] == 'A test knowledge base for testing purposes'
         assert result['kb-67890']['name'] == 'Another Knowledge Base'
+        assert result['kb-67890']['description'] == 'Another knowledge base for testing'
         assert len(result['kb-12345']['data_sources']) == 2
         assert len(result['kb-67890']['data_sources']) == 2
         assert result['kb-12345']['data_sources'][0]['id'] == 'ds-12345'
@@ -68,6 +70,7 @@ class TestDiscoverKnowledgeBases:
         assert len(result) == 1
         assert 'kb-95008' in result
         assert result['kb-95008']['name'] == 'Yet another Knowledge Base'
+        assert result['kb-95008']['description'] == 'Yet another test knowledge base'
         assert len(result['kb-95008']['data_sources']) == 2
         assert result['kb-95008']['data_sources'][0]['id'] == 'ds-12345'
         assert result['kb-95008']['data_sources'][0]['name'] == 'Test Data Source'
@@ -151,8 +154,8 @@ class TestDiscoverKnowledgeBases:
         kb_paginator.paginate.return_value = [
             {
                 'knowledgeBaseSummaries': [
-                    {'knowledgeBaseId': 'kb-12345', 'name': 'Test Knowledge Base'},
-                    {'knowledgeBaseId': 'kb-67890', 'name': 'Another Knowledge Base'},
+                    {'knowledgeBaseId': 'kb-12345', 'name': 'Test Knowledge Base', 'description': 'A test knowledge base for testing purposes'},
+                    {'knowledgeBaseId': 'kb-67890', 'name': 'Another Knowledge Base', 'description': 'Another knowledge base for testing'},
                 ]
             }
         ]
@@ -181,7 +184,9 @@ class TestDiscoverKnowledgeBases:
         assert 'kb-12345' in result
         assert 'kb-67890' in result
         assert result['kb-12345']['name'] == 'Test Knowledge Base'
+        assert result['kb-12345']['description'] == 'A test knowledge base for testing purposes'
         assert result['kb-67890']['name'] == 'Another Knowledge Base'
+        assert result['kb-67890']['description'] == 'Another knowledge base for testing'
         assert len(result['kb-12345']['data_sources']) == 0
         assert len(result['kb-67890']['data_sources']) == 0
 

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_models.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_models.py
@@ -42,9 +42,10 @@ class TestKnowledgeBase:
             DataSource(id='ds-67890', name='Another Data Source'),
         ]
 
-        knowledge_base = KnowledgeBase(name='Test Knowledge Base', data_sources=data_sources)
+        knowledge_base = KnowledgeBase(name='Test Knowledge Base', description='A test knowledge base', data_sources=data_sources)
 
         assert knowledge_base['name'] == 'Test Knowledge Base'
+        assert knowledge_base['description'] == 'A test knowledge base'
         assert len(knowledge_base['data_sources']) == 2
         assert knowledge_base['data_sources'][0]['id'] == 'ds-12345'
         assert knowledge_base['data_sources'][0]['name'] == 'Test Data Source'
@@ -60,13 +61,15 @@ class TestKnowledgeBaseMapping:
         data_sources1 = [DataSource(id='ds-12345', name='Test Data Source')]
         data_sources2 = [DataSource(id='ds-67890', name='Another Data Source')]
 
-        kb1 = KnowledgeBase(name='Test Knowledge Base', data_sources=data_sources1)
-        kb2 = KnowledgeBase(name='Another Knowledge Base', data_sources=data_sources2)
+        kb1 = KnowledgeBase(name='Test Knowledge Base', description='First test knowledge base', data_sources=data_sources1)
+        kb2 = KnowledgeBase(name='Another Knowledge Base', description='Second test knowledge base', data_sources=data_sources2)
 
         kb_mapping: KnowledgeBaseMapping = {'kb-12345': kb1, 'kb-67890': kb2}
 
         assert len(kb_mapping) == 2
         assert kb_mapping['kb-12345']['name'] == 'Test Knowledge Base'
+        assert kb_mapping['kb-12345']['description'] == 'First test knowledge base'
         assert kb_mapping['kb-67890']['name'] == 'Another Knowledge Base'
+        assert kb_mapping['kb-67890']['description'] == 'Second test knowledge base'
         assert kb_mapping['kb-12345']['data_sources'][0]['id'] == 'ds-12345'
         assert kb_mapping['kb-67890']['data_sources'][0]['id'] == 'ds-67890'

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
@@ -50,6 +50,7 @@ class TestListKnowledgeBasesTool:
         mock_discover_knowledge_bases.return_value = {
             'kb-12345': {
                 'name': 'Test Knowledge Base',
+                'description': 'A test knowledge base for testing purposes',
                 'data_sources': [
                     {'id': 'ds-12345', 'name': 'Test Data Source'},
                     {'id': 'ds-67890', 'name': 'Another Data Source'},
@@ -57,6 +58,7 @@ class TestListKnowledgeBasesTool:
             },
             'kb-67890': {
                 'name': 'Another Knowledge Base',
+                'description': 'Another knowledge base for testing',
                 'data_sources': [
                     {'id': 'ds-12345', 'name': 'Test Data Source'},
                 ],
@@ -74,7 +76,9 @@ class TestListKnowledgeBasesTool:
         assert 'kb-12345' in kb_mapping
         assert 'kb-67890' in kb_mapping
         assert kb_mapping['kb-12345']['name'] == 'Test Knowledge Base'
+        assert kb_mapping['kb-12345']['description'] == 'A test knowledge base for testing purposes'
         assert kb_mapping['kb-67890']['name'] == 'Another Knowledge Base'
+        assert kb_mapping['kb-67890']['description'] == 'Another knowledge base for testing'
         assert len(kb_mapping['kb-12345']['data_sources']) == 2
         assert len(kb_mapping['kb-67890']['data_sources']) == 1
         assert kb_mapping['kb-12345']['data_sources'][0]['id'] == 'ds-12345'
@@ -160,6 +164,7 @@ class TestServerIntegration:
         mock_discover_knowledge_bases.return_value = {
             'kb-12345': {
                 'name': 'Test Knowledge Base',
+                'description': 'A test knowledge base for testing purposes',
                 'data_sources': [
                     {'id': 'ds-12345', 'name': 'Test Data Source'},
                 ],
@@ -181,6 +186,7 @@ class TestServerIntegration:
         assert len(kb_mapping) == 1
         assert 'kb-12345' in kb_mapping
         assert kb_mapping['kb-12345']['name'] == 'Test Knowledge Base'
+        assert kb_mapping['kb-12345']['description'] == 'A test knowledge base for testing purposes'
         assert len(kb_mapping['kb-12345']['data_sources']) == 1
         assert kb_mapping['kb-12345']['data_sources'][0]['id'] == 'ds-12345'
         assert kb_mapping['kb-12345']['data_sources'][0]['name'] == 'Test Data Source'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Added 'description' field to responses for list_knowledge_bases_tool.  That field already exists in the AWS infrastructure and is returned via the list_knowledge_bases API.  I have simply added it to the result that is returned. This provides context so that an agent can choose which knowledge base to consult for a given user prompt.

### User experience

Before this change, the user prompt would need to tell an agent which knowledge base to query.  After this change, the agent has additional context for each knowledge base through the provided description.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
