### PR TITLE
fix(aws-api-mcp-server): remove wait/polling cli customizations

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -85,7 +85,7 @@ DENIED_CUSTOM_SERVICES = frozenset({'configure', 'history'})
 # to not do any subprocess calls and are therefore allowed.
 ALLOWED_CUSTOM_OPERATIONS = {
     # blanket allow these custom operation regardless of service
-    '*': ['wait'],
+    '*': [],
     's3': ['ls', 'website', 'sync', 'cp', 'mv', 'rm', 'mb', 'rb', 'presign'],
     'cloudformation': ['package', 'deploy'],
     'cloudfront': ['sign'],
@@ -114,7 +114,6 @@ ALLOWED_CUSTOM_OPERATIONS = {
     ],
     'emr-containers': ['update-role-trust-policy'],
     'gamelift': ['upload-build', 'get-game-session-log'],
-    'logs': ['start-live-tail'],
     'rds': ['generate-db-auth-token'],
     'servicecatalog': ['generate'],
     'deploy': ['push', 'register', 'deregister'],

--- a/src/aws-api-mcp-server/tests/aws/test_driver.py
+++ b/src/aws-api-mcp-server/tests/aws/test_driver.py
@@ -127,18 +127,6 @@ def test_get_local_credentials_raises_no_credentials_error(mock_session_class):
             ),
         ),
         (
-            'aws dynamodb wait table-exists --table-name MyTable',
-            IRTranslation(
-                command=IRCommand(
-                    command_metadata=CommandMetadata('dynamodb', None, 'wait table-exists'),
-                    region='us-east-1',
-                    parameters={'--table-name': 'MyTable'},
-                    is_awscli_customization=True,
-                ),
-                command_metadata=CommandMetadata('dynamodb', None, 'wait table-exists'),
-            ),
-        ),
-        (
             'aws ec2 lss',
             IRTranslation(
                 validation_failures=[InvalidServiceOperationError('ec2', 'lss').as_failure()]

--- a/src/aws-api-mcp-server/tests/kb/test_generate_embeddings.py
+++ b/src/aws-api-mcp-server/tests/kb/test_generate_embeddings.py
@@ -290,10 +290,13 @@ def test_get_aws_api_documents():
 
     # configure and history should not be included
     assert set(service_counts.keys()) == {'s3', 'cloudformation', 'lambda'}
-    assert service_counts['cloudformation'] == len(
-        original_table['cloudformation']._get_command_table()
-    )
-    assert service_counts['lambda'] == len(original_table['lambda']._get_command_table())
+    assert (
+        service_counts['cloudformation']
+        == len(original_table['cloudformation']._get_command_table()) - 1
+    )  # minus 1 because wait is not allowed
+    assert (
+        service_counts['lambda'] == len(original_table['lambda']._get_command_table()) - 1
+    )  # minus 1 because wait is not allowed
     assert service_counts['s3'] == len(original_table['s3'].subcommand_table)
 
 

--- a/src/aws-api-mcp-server/tests/parser/test_parser_customizations.py
+++ b/src/aws-api-mcp-server/tests/parser/test_parser_customizations.py
@@ -43,11 +43,6 @@ def test_non_custom_operation_not_denied():
     assert not is_denied_custom_operation('s3api', 'list-buckets')
 
 
-def test_wait_allowed_for_all_custom_commands():
-    """Test non-custom operation is never denied."""
-    assert not is_denied_custom_operation('emr', 'wait')
-
-
 @pytest.mark.parametrize(
     'service,operation',
     [
@@ -308,48 +303,6 @@ def test_rds_generate_db_auth_token_with_region():
     assert result.region == 'us-east-1'
 
 
-# Wait Commands Tests
-def test_dynamodb_wait_table_exists():
-    """Test aws dynamodb wait table-exists."""
-    result = parse('aws dynamodb wait table-exists --table-name MyTable')
-
-    assert isinstance(result, IRCommand)
-    assert result.command_metadata.service_sdk_name == 'dynamodb'
-    assert result.command_metadata.operation_sdk_name == 'wait table-exists'  # Includes subcommand
-    assert result.is_awscli_customization is True
-    assert result.parameters['--table-name'] == 'MyTable'
-
-
-def test_ec2_wait_instance_running():
-    """Test aws ec2 wait instance-running."""
-    result = parse('aws ec2 wait instance-running --instance-ids i-1234567890abcdef0')
-
-    assert isinstance(result, IRCommand)
-    assert result.command_metadata.service_sdk_name == 'ec2'
-    assert (
-        result.command_metadata.operation_sdk_name == 'wait instance-running'
-    )  # Includes subcommand
-    assert result.is_awscli_customization is True
-    assert result.parameters['--instance-ids'] == [
-        'i-1234567890abcdef0'
-    ]  # Returns a list, not a string
-
-
-def test_ec2_wait_volume_available():
-    """Test aws ec2 wait volume-available."""
-    result = parse('aws ec2 wait volume-available --volume-ids vol-1234567890abcdef0')
-
-    assert isinstance(result, IRCommand)
-    assert result.command_metadata.service_sdk_name == 'ec2'
-    assert (
-        result.command_metadata.operation_sdk_name == 'wait volume-available'
-    )  # Includes subcommand
-    assert result.is_awscli_customization is True
-    assert result.parameters['--volume-ids'] == [
-        'vol-1234567890abcdef0'
-    ]  # Returns a list, not a string
-
-
 # DataPipeline Customization Tests
 def test_datapipeline_list_runs_no_args():
     """Test aws datapipeline list-runs with no arguments (should fail with missing required params)."""
@@ -413,14 +366,6 @@ def test_invalid_rds_operation():
         parse('aws rds invalid-operation')
 
     assert 'invalid-operation' in str(exc_info.value)
-
-
-def test_invalid_wait_subcommand():
-    """Test invalid wait subcommand."""
-    with pytest.raises(InvalidServiceOperationError) as exc_info:
-        parse('aws dynamodb wait invalid-subcommand')
-
-    assert 'invalid-subcommand' in str(exc_info.value)
 
 
 # Edge Cases Tests


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Remove wait/polling cli customizations

### User experience

> Please share what the user experience looks like before and after this change

wait/polling cli customizations can make the MCP server hang for a very long time, this will make the MCP server unusable during that time

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
