### PR TITLE
fix(doc): fix IAM policy definition in README

### DIFF
--- a/src/aws-dataprocessing-mcp-server/README.md
+++ b/src/aws-dataprocessing-mcp-server/README.md
@@ -110,7 +110,7 @@ For read operations, the following permissions are required:
         "athena:ListDatabases",
         "athena:ListTableMetadata",
         "athena:GetWorkGroup",
-        "athena:ListWorkGroups"
+        "athena:ListWorkGroups",
         "sts:GetCallerIdentity"
       ],
       "Resource": "*"


### PR DESCRIPTION
Fix missing comma that results in malformed IAM Policy JSON

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Add missing comma to IAM policy in docs 

### Changes

> Update data processing MCP server README.md to fix a malformed IAM Policy for read operations at https://awslabs.github.io/mcp/servers/aws-dataprocessing-mcp-server#read-only-operations-policy

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ x] Changes are documented

Is this a breaking change? (Y/N)
N
**RFC issue number**:

Checklist:
Migration or implement warnings not required
* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
