### PR TITLE
fix(redshift-mcp-server): Add missing IAM permissions to README

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -419,7 +419,10 @@ Your AWS credentials need the following IAM permissions:
         "redshift-serverless:GetWorkgroup",
         "redshift-data:ExecuteStatement",
         "redshift-data:DescribeStatement",
-        "redshift-data:GetStatementResult"
+        "redshift-data:GetStatementResult",
+        "redshift-serverless:GetCredentials",
+        "redshift:GetClusterCredentialsWithIAM",
+        "redshift:GetClusterCredentials"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

Include in README the missing AWS API permissions.

### Changes

Added in README:

- redshift-serverless:GetCredentials
- redshift:GetClusterCredentialsWithIAM
- redshift:GetClusterCredentials.

### User experience

Users will stop facing the respective permission errors.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
