### PR TITLE
fix: backout docusaurus update

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -8,8 +8,8 @@
       "name": "docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.9.0",
-        "@docusaurus/preset-classic": "^3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/preset-classic": "3.8.1",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -27,116 +27,60 @@
         "node": ">=18.0"
       }
     },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.29.tgz",
-      "integrity": "sha512-o9LtmBiG2WAgs3GAmL79F8idan/UupxHG8Tyr2gP4aUSOzflM0bsvfzozBp8x6WatQnOx+Pio7YNw45Y6I16iw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.9"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.9.tgz",
-      "integrity": "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.53.tgz",
-      "integrity": "sha512-Ami2GDhZfMNWAZANNiRDzQnXjGv5qAAPmwHzGEKdm/b9MrsSjDmNeeYd6q3H6qLRKEQDuHDJeBJWMw5gOAldtg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.9",
-        "ai": "5.0.53",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.25.76 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@algolia/abtesting": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.4.0.tgz",
-      "integrity": "sha512-N0blWT/C0KOZ/OJ9GXBX66odJZlrYjMj3M+01y8ob1mjBFnBaBo7gOCyHBDQy60+H4pJXp3pSGlJOqJIueBH+A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.5.0.tgz",
+      "integrity": "sha512-W/ohRkbKQsqDWALJg28X15KF7Tcyg53L1MfdOkLgvkcCcofdzGHSimHHeNG05ojjFw9HK8+VPhe/Vwq4MozIJg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
+      "integrity": "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
+        "@algolia/autocomplete-shared": "1.17.9"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.9.tgz",
+      "integrity": "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-shared": "1.17.9"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.9.tgz",
+      "integrity": "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.9"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
+      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -144,99 +88,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.38.0.tgz",
-      "integrity": "sha512-15d6zv8vtj2l9pnnp/EH7Rhq3/snCCHRz56NnX6xIUPrbJl5gCsIYXAz8C2IEkwOpoDb0r5G6ArY2gKdVMNezw==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.39.0.tgz",
+      "integrity": "sha512-Vf0ZVe+qo3sHDrCinouJqlg8VoxM4Qo/KxNIqMYybkuctutfnp3kIY9OmESplOQ/9NGBthU9EG+4d5fBibWK/A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.38.0.tgz",
-      "integrity": "sha512-jJIbYAhYvTG3+gEAP5Q5Dp6PFJfUR+atz5rsqm5KjAKK+faLFdHJbM2IbOo0xdyGd+SH259MzfQKLJ9mZZ27dQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.39.0.tgz",
+      "integrity": "sha512-V16ITZxYIwcv1arNce65JZmn94Ft6vKlBZ//gXw8AvIH32glJz1KcbaVAUr9p7PYlGZ/XVHP6LxDgrpNdtwgcA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.38.0.tgz",
-      "integrity": "sha512-aMCXzVPGJTeQnVU3Sdf30TfMN2+QyWcjfPTCCHyqVVgjPipb6RnK40aISGoO+rlYjh9LunDsNVFLwv+JEIF8bQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.39.0.tgz",
+      "integrity": "sha512-UCJTuwySEQeiKPWV3wruhuI/wHbDYenHzgL9pYsvh6r/u5Z+g61ip1iwdAlFp02CnywzI9O7+AQPh2ManYyHmQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.38.0.tgz",
-      "integrity": "sha512-4c3FbpMiJX+VcaAj0rYaQdTLS/CkrdOn4hW+5y1plPov7KC7iSHai/VBbirmHuAfW1hVPCIh1w/4erKKTKuo+Q==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.39.0.tgz",
+      "integrity": "sha512-s0ia8M/ZZR+iO2uLNTBrlQdEb6ZMAMcKMHckp5mcoglxrf8gHifL4LmdhGKdAxAn3UIagtqIP0RCnIymHUbm7A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.38.0.tgz",
-      "integrity": "sha512-FzLs6c8TBL4FSgNfnH2NL7O33ktecGiaKO4ZFG51QYORUzD5d6YwB9UBteaIYu/sgFoEdY57diYU4vyBH8R6iA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.39.0.tgz",
+      "integrity": "sha512-vZPIt7Lw+toNsHZUiPhNIc1Z3vUjDp7nzn6AMOaPC73gEuTq2iLPNvM06CSB6aHePo5eMeJIP5YEKBUQUA/PJA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.38.0.tgz",
-      "integrity": "sha512-7apiahlgZLvOqrh0+hAYAp/UWjqz6AfSJrCwnsoQNzgIT09dLSPIKREelkuQeUrKy38vHWWpSQE3M0zWSp/YrA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.39.0.tgz",
+      "integrity": "sha512-jcPQr3iKTWNVli2NYHPv02aNLwixDjPCpOgMp9CZTvEiPI6Ec4jHX+oFr3LDZagOFY9e1xJhc/JrgMGGW1sHnw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.38.0.tgz",
-      "integrity": "sha512-PTAFMJOpVtJweExEYYgdmSCC6n4V/R+ctDL3fRQy77ulZM/p+zMLIQC9c7HCQE1zqpauvVck3f2zYSejaUTtrw==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.39.0.tgz",
+      "integrity": "sha512-/IYpF10BpthGZEJQZMhMqV4AqWr5avcWfZm/SIKK1RvUDmzGqLoW/+xeJVX9C8ZnNkIC8hivbIQFaNaRw0BFZQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -249,81 +193,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.38.0.tgz",
-      "integrity": "sha512-qGSUGgceJHGyJLZ06bFLwVe2Tpf9KwabmoBjFvFscVmMmU5scKya6voCYd9bdX7V0Xy1qya9MGbmTm4zlLuveQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.39.0.tgz",
+      "integrity": "sha512-IgSHKUiuecqLfBlXiuCSdRTdsO3/yvpmXrMFz8fAJ8M4QmDtHkOuD769dmybRYqsbYMHivw+lir4BgbRGMtOIQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.38.0.tgz",
-      "integrity": "sha512-VnCtAUcHirvv/dDHg9jK1Z5oo4QOC5FKDxe40x8qloru2qDcjueT34jiAsB0gRos3VWf9v4iPSYTqMIFOcADpQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.39.0.tgz",
+      "integrity": "sha512-8Xnd4+609SKC/hqVsuFc4evFBmvA2765/4NcH+Dpr756SKPbL1BY0X8kVxlmM3YBLNqnduSQxHxpDJUK58imCA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.38.0.tgz",
-      "integrity": "sha512-fqgeU9GqxQorFUeGP4et1MyY28ccf9PCeciHwDPSbPYYiTqBItHdUIiytsNpjC5Dnc0RWtuXWCltLwSw9wN/bQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.39.0.tgz",
+      "integrity": "sha512-D7Ye2Ss/5xqUkQUxKm/VqEJLt5kARd9IMmjdzlxaKhGgNlOemTay0lwBmOVFuJRp7UODjp5c9+K+B8g0ORObIw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/client-common": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.38.0.tgz",
-      "integrity": "sha512-nAUKbv4YQIXbpPi02AQvSPisD5FDDbT8XeYSh9HFoYP0Z3IpBLLDg7R4ahPvzd7gGsVKgEbXzRPWESXSji5yIg==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.39.0.tgz",
+      "integrity": "sha512-mgPte1ZJqpk9dkVs44J3wKAbHATvHZNlSpzhMdjMLIg/3qTycSZyDiomLiSlxE8CLsxyBAOJWnyKRHfom+Z1rg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0"
+        "@algolia/client-common": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.38.0.tgz",
-      "integrity": "sha512-bkuAHaadC6OxJd3SVyQQnU1oJ9G/zdCqua7fwr1tJDrA/v7KzeS5np4/m6BuRUpTgVgFZHSewGnMcgj9DLBoaQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.39.0.tgz",
+      "integrity": "sha512-LIrCkrxu1WnO3ev1+w6NnZ12JZL/o+2H9w6oWnZAjQZIlA/Ym6M9QHkt+OQ/SwkuoiNkW3DAo+Pi4A2V9FPtqg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0"
+        "@algolia/client-common": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.38.0.tgz",
-      "integrity": "sha512-yHDKZTnMPR3/4bY0CVC1/uRnnbAaJ+pctRuX7G/HflBkKOrnUBDEGtQQHzEfMz2FHZ/tbCL+Q9r6mvwTSGp8nw==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.39.0.tgz",
+      "integrity": "sha512-6beG+egPwXmvhAg+m0STCj+ZssDcjrLzf4L05aKm2nGglMXSSPz0cH/rM+kVD9krNfldiMctURd4wjojW1fV0w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.38.0"
+        "@algolia/client-common": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -3266,24 +3210,21 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.1.0.tgz",
-      "integrity": "sha512-nuNKGjHj/FQeWgE9t+i83QD/V67QiaAmGY7xS9TVCRUiCqSljOgIKlsLoQZKKVwEG8f+OWKdznzZkJxGZ7d06A==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.9.0.tgz",
+      "integrity": "sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.1.0.tgz",
-      "integrity": "sha512-4GHI7TT3sJZ2Vs4Kjadv7vAkMrTsJqHvzvxO3JA7UT8iPRKaDottG5o5uNshPWhVVaBYPC35Ukf8bfCotGpjSg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.9.0.tgz",
+      "integrity": "sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/react": "^2.0.30",
-        "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/css": "4.1.0",
-        "ai": "^5.0.30",
-        "algoliasearch": "^5.28.0",
-        "marked": "^16.3.0",
-        "zod": "^4.1.8"
+        "@algolia/autocomplete-core": "1.17.9",
+        "@algolia/autocomplete-preset-algolia": "1.17.9",
+        "@docsearch/css": "3.9.0",
+        "algoliasearch": "^5.14.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3307,9 +3248,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.0.tgz",
-      "integrity": "sha512-QcZ+Rey0OvlLK9SPN4/+VWL+ut/tuADVdunA1fmC96fytdYjatdJrcw1koYdp/c+3k6lVYlwg9DDVNDecyLCAA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+      "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3322,28 +3263,28 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.0.tgz",
-      "integrity": "sha512-HaRLSmiwnJQ3uHBV3rd/BRDM9S/nHAshRk54djRZ+RX9ze4ONuFAovdD5es20ZDj7PRTjo38GVnBtHvuL/SwsQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+      "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.9.0",
-        "@docusaurus/cssnano-preset": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/cssnano-preset": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3364,7 +3305,7 @@
         "webpackbar": "^6.0.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "@docusaurus/faster": "*"
@@ -3375,55 +3316,19 @@
         }
       }
     },
-    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/core": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.0.tgz",
-      "integrity": "sha512-sEJ4MW/zuh1MfPORCRbSwnW/PjsVmOigWwBU6clcxm221/CNdnI/XqgfBrl2jj/zocSdNoQM8E3IP2W8dygi6g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.9.0",
-        "@docusaurus/bundler": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/bundler": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3457,14 +3362,14 @@
         "update-notifier": "^6.0.2",
         "webpack": "^5.95.0",
         "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^5.2.2",
+        "webpack-dev-server": "^4.15.2",
         "webpack-merge": "^6.0.1"
       },
       "bin": {
         "docusaurus": "bin/docusaurus.mjs"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "@mdx-js/react": "^3.0.0",
@@ -3473,9 +3378,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.0.tgz",
-      "integrity": "sha512-prCJXUcoJZBlovJzSFkfnfWr1gXd53VZfE+17fIpUWS6Zioc7WE4FPoXPi5ldAGZ8brhXre5xQ8NWDE90XP9yw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+      "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3484,31 +3389,31 @@
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.0.tgz",
-      "integrity": "sha512-lDtThsocWTF8ZrVF01ltfctA/xgtD/3oXWqEkKIDzF4fCWsWXH7hC4LCqT23xSuxZTIo8N+y02XSPvA/8DLInw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+      "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.0.tgz",
-      "integrity": "sha512-9bfJYdkZFE+REwevkT4CYdTJ2f6ydgkbUFylkzTXrNGtBXtx25TRJGdn2cVzm3eVkeWdJrGkG/ypwrIWnbu5UA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+      "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3532,7 +3437,7 @@
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -3543,7 +3448,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
       "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@docusaurus/types": "3.8.1",
@@ -3560,19 +3464,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.0.tgz",
-      "integrity": "sha512-XZXJ/rQgi2jT0XWNXOnSKooJgtGHPzkjaBjww6K9PD+YevNMTP9U8Y5sA7cLA5Bwuqrpee4i8NO3tSrjhhDW5w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+      "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -3585,7 +3489,7 @@
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "@docusaurus/plugin-content-docs": "*",
@@ -3593,57 +3497,21 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.0.tgz",
-      "integrity": "sha512-PP+iDJg+lj4cn/7GbbmiguaQ8OX08YxnzQ17KqRC4ufJm11jdyXD33wA7vVtbeG/BkkgkiB/K7YyPHCPwmfVhg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+      "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3655,608 +3523,230 @@
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.0.tgz",
-      "integrity": "sha512-ngetCpAZuivlaHC0l8a5KoK6PQWGuZ8742VwK7dbXeIW0Y70P4xwuocBdsCIQ9J6nB9rlTXRYMpNVyYyCpD7/Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+      "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.0.tgz",
-      "integrity": "sha512-giPTCjEzeaamMn8EHY/oDvsPDxF5ei1/q5lPUFQLldbc65jFQ1k6pPwKjtOznYy3TSfClCF1F1DNpYWIx7B5LA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+      "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.0.tgz",
-      "integrity": "sha512-DuFOZya+bcrYiL54qBEn2rdKuoWWNyOV5IoHI2MURLzwuYaKu/J9Gi618XUsj3N3qvqG2uxWQiXZcs9ecfMadA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+      "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.0.tgz",
-      "integrity": "sha512-mUXvpasTDR2pXdnkkhGxEgB9frVAvLGc+T3fp6SGT2F+YoEQtjcmz9D43zubQawLn+W1KEhoj+vPusYe+HAl+A==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+      "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.0.tgz",
-      "integrity": "sha512-L4tCKYnmcyLV6VQs7XWQ3r7YSllagAU2GylZzdvz7NRMcXE12uSW5MCC2aSltbk09MYlqrYv1Ntp+ESsMvptYw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+      "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.0.tgz",
-      "integrity": "sha512-+jWO3tkrvsMUKQ69KTIj9ZBf8sKY5kodLcP4yIaEkPzfWq9IEpE+ekQCtFWlrAmkJUtSxbjHK6HNZZkUNwwq7w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+      "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.0.tgz",
-      "integrity": "sha512-QOyLooWuF+On4q2RDGVZtKY0tlfdZwD9e/p7g1sJLUfOwN518V2Bo+kZtU82Or42SCKjyJ0lhSqAUOZfbeFhFw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.0.tgz",
-      "integrity": "sha512-pUZIfnhFtAYDmDwimFiBY+sxNUigyJnKbCwI9pTiXr3uGp43CsSsN8gwl/i8jBmqfsZzvNnGZNxc75wy9v6RXA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+      "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.0.tgz",
-      "integrity": "sha512-nLoiDxf8bDNNxDSZ28+pFfSfT+QRi08Pn2K0zIvbjkM/X/otMs4ho0K8+2FpoLOoGApifaSuNfJXpGYnQV3rGA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+      "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/plugin-content-blog": "3.9.0",
-        "@docusaurus/plugin-content-docs": "3.9.0",
-        "@docusaurus/plugin-content-pages": "3.9.0",
-        "@docusaurus/plugin-css-cascade-layers": "3.9.0",
-        "@docusaurus/plugin-debug": "3.9.0",
-        "@docusaurus/plugin-google-analytics": "3.9.0",
-        "@docusaurus/plugin-google-gtag": "3.9.0",
-        "@docusaurus/plugin-google-tag-manager": "3.9.0",
-        "@docusaurus/plugin-sitemap": "3.9.0",
-        "@docusaurus/plugin-svgr": "3.9.0",
-        "@docusaurus/theme-classic": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/theme-search-algolia": "3.9.0",
-        "@docusaurus/types": "3.9.0"
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+        "@docusaurus/plugin-debug": "3.8.1",
+        "@docusaurus/plugin-google-analytics": "3.8.1",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
+        "@docusaurus/plugin-google-tag-manager": "3.8.1",
+        "@docusaurus/plugin-sitemap": "3.8.1",
+        "@docusaurus/plugin-svgr": "3.8.1",
+        "@docusaurus/theme-classic": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-search-algolia": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.0.tgz",
-      "integrity": "sha512-RToUIabJOyX41nMIxkFn8LPeA+uHgySzyd6Ak/gsINqWHHTLDMoYPxBUmNm3S+okcfuMI54kNYvD6TY+6TIYDA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+      "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/plugin-content-blog": "3.9.0",
-        "@docusaurus/plugin-content-docs": "3.9.0",
-        "@docusaurus/plugin-content-pages": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/theme-translations": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
@@ -4269,78 +3759,23 @@
         "utility-types": "^3.10.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.0.tgz",
-      "integrity": "sha512-pqNoQgttIpk7Ndm6N8OGbhi+1wBIQXQPYM7bPf1HDraXfvVpOzhcDty1yyK4coPWl0M7NxednZvKw4atfQ70Ew==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+      "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4351,7 +3786,7 @@
         "utility-types": "^3.10.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "@docusaurus/plugin-content-docs": "*",
@@ -4359,77 +3794,22 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.0.tgz",
-      "integrity": "sha512-nbY7ZJVA10kTiBLJtscxK1aECeYvYFz+Sno9PkCE9KeFXqRDr6omtNmLVkbvyl4b6xgz+6yOIBdO/idLPVDpWg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+      "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.9.0 || ^4.1.0",
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/plugin-content-docs": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/theme-translations": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
-        "algoliasearch": "^5.37.0",
-        "algoliasearch-helper": "^3.26.0",
+        "@docsearch/react": "^3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "algoliasearch": "^5.17.1",
+        "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
@@ -4438,7 +3818,7 @@
         "utility-types": "^3.10.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -4446,16 +3826,16 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.0.tgz",
-      "integrity": "sha512-4HUELBsE+rhtlnR1MsaNB9nJXPFZANeDQa5If1GfFVlis5mWUfdmXmbGangR7PfpK2tc56UETMtzjKrX5L5UWw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
+      "integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/tsconfig": {
@@ -4469,7 +3849,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
       "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4491,7 +3870,6 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
       "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -4503,14 +3881,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.0.tgz",
-      "integrity": "sha512-wpVRQbDhXxqbb1llhkpu++aD4UdHHQ5M7J8DmJELDphlwmpI44TdS5elQZOsjzPfGyITZyQLekcDXjyteJ0/bw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+      "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "escape-string-regexp": "^4.0.0",
         "execa": "5.1.1",
         "file-loader": "^6.2.0",
@@ -4531,67 +3909,31 @@
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.0.tgz",
-      "integrity": "sha512-zpmzRn2mniMnrx8ZEYyyDsr0/7EksVgUXL9IuODp0DSK+R19nDGCY7w2NaMGRmGnrQQKsT3t0NDZzBk0V6N9Iw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+      "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.0",
+        "@docusaurus/types": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.0.tgz",
-      "integrity": "sha512-xpVLdFPpsE5dYuE7hOtghccCrRWRhM6tUQ4YpfSy5snCDWgROITG5Mj22fGstd/HBqTzKD8NFs7qPPs42qjgWg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+      "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4599,43 +3941,7 @@
         "tslib": "^2.6.0"
       },
       "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -4885,15 +4191,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -4990,12 +4287,6 @@
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.1"
       }
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -5921,24 +5212,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ai": {
-      "version": "5.0.53",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.53.tgz",
-      "integrity": "sha512-TIRelwDRczBS6vGLbJlskC1jLRKUT7DAYz+1DiHjJrgx1MnE2a5xQWv06koLHT+r0GImpkmqP77/n+Vbvea3aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "1.0.29",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.9",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -5985,25 +5258,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.38.0.tgz",
-      "integrity": "sha512-8VJKIzheeI9cjuVJhU1hYEVetOTe7LvA+CujAI7yqvYsPtZfVEvv1pg9AeFNtHBg/ZoSLGU5LPijhcY5l3Ea9g==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.39.0.tgz",
+      "integrity": "sha512-DzTfhUxzg9QBNGzU/0kZkxEV72TeA4MmPJ7RVfLnQwHNhhliPo7ynglEWJS791rNlLFoTyrKvkapwr/P3EXV9A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.4.0",
-        "@algolia/client-abtesting": "5.38.0",
-        "@algolia/client-analytics": "5.38.0",
-        "@algolia/client-common": "5.38.0",
-        "@algolia/client-insights": "5.38.0",
-        "@algolia/client-personalization": "5.38.0",
-        "@algolia/client-query-suggestions": "5.38.0",
-        "@algolia/client-search": "5.38.0",
-        "@algolia/ingestion": "1.38.0",
-        "@algolia/monitoring": "1.38.0",
-        "@algolia/recommend": "5.38.0",
-        "@algolia/requester-browser-xhr": "5.38.0",
-        "@algolia/requester-fetch": "5.38.0",
-        "@algolia/requester-node-http": "5.38.0"
+        "@algolia/abtesting": "1.5.0",
+        "@algolia/client-abtesting": "5.39.0",
+        "@algolia/client-analytics": "5.39.0",
+        "@algolia/client-common": "5.39.0",
+        "@algolia/client-insights": "5.39.0",
+        "@algolia/client-personalization": "5.39.0",
+        "@algolia/client-query-suggestions": "5.39.0",
+        "@algolia/client-search": "5.39.0",
+        "@algolia/ingestion": "1.39.0",
+        "@algolia/monitoring": "1.39.0",
+        "@algolia/recommend": "5.39.0",
+        "@algolia/requester-browser-xhr": "5.39.0",
+        "@algolia/requester-fetch": "5.39.0",
+        "@algolia/requester-node-http": "5.39.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -7128,6 +6401,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/copy-text-to-clipboard": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
+      "integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
@@ -8502,15 +7787,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -10398,12 +9674,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -10647,18 +9917,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
-      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -17058,19 +16316,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/swr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
-      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
@@ -17177,18 +16422,6 @@
       },
       "peerDependencies": {
         "tslib": "^2"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thunky": {
@@ -17755,15 +16988,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -18474,15 +17698,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -12,8 +12,8 @@
     ]
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.0",
-    "@docusaurus/preset-classic": "^3.9.0",
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -31,6 +31,11 @@
     "node": ">=18.0"
   },
   "name": "docs",
+  "overrides": {
+    "@docusaurus/core": {
+      "webpack-dev-server": "^5.2.1"
+    }
+  },
   "private": true,
   "scripts": {
     "build": "docusaurus build",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

After upgrade the GitHub Pages show 404 so backing out change.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
