### PR TITLE
feat: add workflow for automatic awscli version upgrade in aws-api-mcp

### DIFF
--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write  # SECURITY: Only for branch creation and commits
-      pull-requests: write  # SECURITY: Only for PR creation
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -49,22 +49,37 @@ jobs:
           TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
           UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
 
+          echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
+
+          # Check if branch already exists
+          if git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
+            echo "::error::Upgrade branch already exists: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
+          # Configure git user
           git config --local user.email "${{ env.BOT_USER_EMAIL }}"
           git config --local user.name "${{ env.BOT_USER_NAME }}"
 
+          # Create and push branch
           git checkout -b "$UPGRADE_BRANCH"
           git push --set-upstream origin "$UPGRADE_BRANCH"
 
+          # Verify branch was created
+          if ! git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
+            echo "::error::Failed to verify branch creation: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
           echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
+          echo "::debug::Successfully created upgrade branch: $UPGRADE_BRANCH"
       - name: Upgrade AWS CLI in aws-api-mcp-server
         working-directory: src/aws-api-mcp-server
         run: |
           set -euo pipefail
-
-          echo "::debug::Upgrading AWS CLI dependencies"
-          uv remove awscli
-          uv add awscli --upgrade
-          uv sync
+          echo "::debug::Upgrading AWS CLI to latest version"
+          uv add --upgrade awscli
+          echo "::debug::AWS CLI upgrade completed"
       - name: Configure Git and GPG securely
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -138,6 +153,15 @@ jobs:
           UPGRADE_BRANCH="${{ steps.create-branch.outputs.upgrade-branch }}"
           BASE_BRANCH="${{ github.ref_name }}"
 
+          echo "::debug::Creating PR from $UPGRADE_BRANCH to $BASE_BRANCH"
+
+          # Validate branch names
+          if [[ ! "$UPGRADE_BRANCH" =~ ^upgrade/aws-api-mcp-awscli-[0-9]{14}$ ]]; then
+            echo "::error::Invalid upgrade branch format: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
+          # Create PR with validated content
           PR_URL="$(gh pr create \
             --base "$BASE_BRANCH" \
             --head "$UPGRADE_BRANCH" \
@@ -147,7 +171,7 @@ jobs:
           This PR upgrades the AWS CLI version in the aws-api-mcp-server package.
 
           ## Changes
-          * Updated AWS CLI dependencies using \`uv sync --upgrade-package awscli\`
+          * Updated AWS CLI dependencies to latest version
 
           ## Checklist
           - [ ] Dependencies have been upgraded

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -1,0 +1,174 @@
+---
+name: AWS API MCP Server - Upgrade AWS CLI Version
+description: |
+  This workflow upgrades the AWS CLI version in src/aws-api-mcp-server using uv upgrade
+  and creates a pull request with the changes.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'  # Daily at 6 AM Amsterdam time (UTC+1)
+env:
+  BOT_USER_EMAIL: ${{ vars.BOT_USER_EMAIL || '203918161+awslabs-mcp@users.noreply.github.com' }}
+  BOT_USER_NAME: ${{ vars.BOT_USER_NAME || 'awslabs-mcp' }}
+permissions:
+  actions: none
+  attestations: none
+  checks: none
+  contents: none
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  models: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+jobs:
+  upgrade-awscli:
+    name: Upgrade AWS CLI Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write  # SECURITY: Only for branch creation and commits
+      pull-requests: write  # SECURITY: Only for PR creation
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - name: Create upgrade branch
+        id: create-branch
+        run: |
+          set -euo pipefail
+
+          TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
+          UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
+
+          git config --local user.email "${{ env.BOT_USER_EMAIL }}"
+          git config --local user.name "${{ env.BOT_USER_NAME }}"
+
+          git checkout -b "$UPGRADE_BRANCH"
+          git push --set-upstream origin "$UPGRADE_BRANCH"
+
+          echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
+      - name: Upgrade AWS CLI in aws-api-mcp-server
+        working-directory: src/aws-api-mcp-server
+        run: |
+          set -euo pipefail
+
+          echo "::debug::Upgrading AWS CLI dependencies"
+          uv remove awscli
+          uv add awscli --upgrade
+          uv sync
+      - name: Configure Git and GPG securely
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          set -euo pipefail  # SECURITY: Strict error handling
+
+          # Create secure temporary directory for GPG
+          export GNUPGHOME=$(mktemp -d)
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> $GITHUB_ENV
+
+          echo "::debug::Setting up secure GPG environment"
+
+          # Configure git user
+          git config --local user.email "${{ env.BOT_USER_EMAIL }}"
+          git config --local user.name "${{ env.BOT_USER_NAME }}"
+
+          # Import GPG key without exposing secrets in command line
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import --quiet
+          echo "$GPG_KEY_ID:6:" | gpg --import-ownertrust --quiet
+
+          # Configure git GPG settings
+          git config --global user.signingkey "$GPG_KEY_ID"
+          git config --global commit.gpgsign true
+          git config --global tag.gpgsign true
+
+          # Test GPG functionality
+          echo "test" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+            --sign --armor --local-user "$GPG_KEY_ID" <<< "$GPG_PASSPHRASE" > /dev/null
+
+          echo "::debug::GPG configuration completed successfully"
+      - name: Commit and push changes
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          echo "::debug::Committing changes"
+
+          # Add only the source directory
+          git add src/aws-api-mcp-server/
+
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "::warning::No changes to commit"
+            exit 0
+          else
+            # Cache GPG signature
+            echo "commit" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+            --sign --armor --local-user "$GPG_KEY_ID" <<< "$GPG_PASSPHRASE" > /dev/null
+
+            # Create signed commit
+            git commit -m "chore(aws-api-mcp-server): upgrade AWS CLI version" --sign
+
+            # Pull with rebase to maintain linear history
+            git pull --rebase origin "${{ steps.create-branch.outputs.upgrade-branch }}"
+
+            # Push changes
+            git push origin "${{ steps.create-branch.outputs.upgrade-branch }}"
+
+            echo "::debug::Successfully committed and pushed changes"
+          fi
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          UPGRADE_BRANCH="${{ steps.create-branch.outputs.upgrade-branch }}"
+          BASE_BRANCH="${{ github.ref_name }}"
+
+          PR_URL="$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$UPGRADE_BRANCH" \
+            --title "chore(aws-api-mcp-server): upgrade AWS CLI version" \
+            --body "# AWS CLI Version Upgrade
+
+          This PR upgrades the AWS CLI version in the aws-api-mcp-server package.
+
+          ## Changes
+          * Updated AWS CLI dependencies using \`uv sync --upgrade-package awscli\`
+
+          ## Checklist
+          - [ ] Dependencies have been upgraded
+          - [ ] Lock file has been updated
+          - [ ] Tests pass with new versions
+
+          ## Acknowledgment
+          By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).")"
+
+          echo "::debug::Successfully created pull request $PR_URL"
+          echo "### :arrow_up: AWS CLI Upgrade Ready" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request $PR_URL created for [$UPGRADE_BRANCH](https://github.com/${{ github.repository }}/tree/$UPGRADE_BRANCH) branch" >> $GITHUB_STEP_SUMMARY
+      - name: Secure GPG cleanup
+        if: always()
+        run: |
+          set +e  # Don't fail on cleanup errors
+          echo "::debug::Performing secure cleanup"
+          if [[ -n "${GNUPGHOME:-}" && -d "$GNUPGHOME" ]]; then
+            rm -rf "$GNUPGHOME"
+            echo "::debug::Cleaned up GPG directory"
+          fi
+          gpgconf --kill gpg-agent 2>/dev/null || true
+          unset GPG_PRIVATE_KEY GPG_PASSPHRASE GPG_KEY_ID GNUPGHOME 2>/dev/null || true
+          echo "::debug::Secure cleanup completed"

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -51,12 +51,6 @@ jobs:
 
           echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
 
-          # Check if branch already exists
-          if git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
-            echo "::error::Upgrade branch already exists: $UPGRADE_BRANCH" >&2
-            exit 1
-          fi
-
           # Configure git user
           git config --local user.email "${{ env.BOT_USER_EMAIL }}"
           git config --local user.name "${{ env.BOT_USER_NAME }}"
@@ -77,8 +71,25 @@ jobs:
         working-directory: src/aws-api-mcp-server
         run: |
           set -euo pipefail
-          echo "::debug::Upgrading AWS CLI to latest version"
-          uv add --upgrade awscli
+
+          echo "::debug::Upgrading AWS CLI dependencies"
+
+          # Get latest version from PyPI
+          LATEST_VERSION=$(uv run --no-project python -c "import urllib.request, json; print(json.loads(urllib.request.urlopen('https://pypi.org/pypi/awscli/json').read())['info']['version'])")
+          echo "::debug::Latest AWS CLI version from PyPI: $LATEST_VERSION"
+
+          # Remove existing awscli dependency
+          echo "::debug::Removing existing awscli dependency"
+          uv remove awscli
+
+          # Add new version with exact pinning
+          echo "::debug::Adding awscli==$LATEST_VERSION"
+          uv add "awscli==$LATEST_VERSION"
+
+          # Sync dependencies
+          echo "::debug::Syncing dependencies"
+          uv sync
+
           echo "::debug::AWS CLI upgrade completed"
       - name: Configure Git and GPG securely
         env:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Adds a new workflow to upgrade the `awscli` version in `src/aws-api-mcp-server` on a daily schedule (and with option to manually trigger).
### Changes

New workflow: .github/workflows/aws-api-mcp-upgrade-version.yml
Automated scheduling: Runs daily at 6 AM Amsterdam time
Manual trigger: Can be triggered via workflow_dispatch
Secure operations: GPG-signed commits with proper cleanup
Steps:
- Fetches latest AWS CLI version from PyPI
- Updates pyproject.toml with exact version pinning (==)
- Creates timestamped upgrade branches: `upgrade/aws-api-mcp-awscli-$TIMESTAMP`
- Generates pull requests with standardized format


### User experience

I tested it on my own fork, with the bot and gpg environment variables also set.
Example run: https://github.com/sten-vw/mcp/actions/runs/18225068102/job/51894057182
Example PR: https://github.com/sten-vw/mcp/pull/3

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
