### PR TITLE
feat(aws-documentation-mcp-server): Adding ability to add domains based on search term

### DIFF
--- a/src/aws-documentation-mcp-server/tests/test_aws_cn_get_available_services_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_cn_get_available_services_live.py
@@ -68,7 +68,6 @@ async def test_get_available_services_live():
         # Check for specific AWS services that should be available in China regions
         common_services = [
             'Amazon EC2',
-            'Amazon S3',
             'Simple Storage Service',
             'Lambda',
         ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Creating an ability to include specific domains into `search_documentation` and `read_documentation` tool calls when specific terms are present in the search query.

### User experience

With the current change, if a user is searching for "neuron" or "neuron sdk" in their search query, the domain for the Neuron SDK documentation is included in the search request, and they may receive relevant results that are hosted in the Neuron SDK documentation website.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
