### PR TITLE
chore(aws-api-mcp-server): Remove 'gh' from docker image

### DIFF
--- a/src/aws-api-mcp-server/Dockerfile
+++ b/src/aws-api-mcp-server/Dockerfile
@@ -65,7 +65,6 @@ RUN out=$(mktemp) && \
 	echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
       tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update -y && \
-    apt-get install -y gh && \
     apt-get clean -y && \
     apt-get autoremove -y && \
     groupadd --force --system app && \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

### User experience

Remove 'gh' dependency of our docker image since we no longer need to download embeddings from Github Actions artifacts. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
