### PR TITLE
fix(s3-tables): Fix s3-tables-mcp-server dependency compatibility issues

### DIFF
--- a/src/s3-tables-mcp-server/pyproject.toml
+++ b/src/s3-tables-mcp-server/pyproject.toml
@@ -10,9 +10,9 @@ requires-python = ">=3.10"
 dependencies = [
     "loguru>=0.7.0",
     "mcp[cli]>=1.11.0",
-    "pydantic>=2.10.6",
+    "pydantic<2.10.0",
     "boto3>=1.40.8",
-    "pyiceberg>=0.9.1",
+    "pyiceberg==0.9.1",
     "pyarrow>=20.0.0",
     "sqlparse>=0.4.0",
     "daft>=0.5.8",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

Fixes s3-tables-mcp-server dependency compatibility issues

## Summary

### Changes
This PR resolves critical dependency compatibility issues in the s3-tables-mcp-server by implementing version constraints for pyiceberg and pydantic packages. The changes address a regression in Pydantic 2.12.0 that breaks PyIceberg functionality.

**Specific changes:**
- Pin `pyiceberg` to exactly version `0.9.1` (changed from `>=0.9.1`)
- Constrain `pydantic` to versions below `2.10.0` (changed from `>=2.10.6`)

### User experience
**Before this change:**
- Users experienced failures when querying S3 tables through the MCP server
- PyIceberg operations would fail due to incompatibility with newer Pydantic versions
- Server would encounter runtime errors related to Pydantic model validation

**After this change:**
- S3 tables queries work reliably through the MCP server
- PyIceberg operations execute successfully with stable dependency versions
- No runtime errors related to Pydantic/PyIceberg compatibility

## Problem
The s3-tables-mcp-server fails to query using pyiceberg due to "Upstream Pydantic 2.12.0 has a Regression that will break PyIceberg" as documented in: https://github.com/apache/iceberg-python/issues/2590

## Solution
Pinning the problematic dependencies to known stable versions:
- PyIceberg pinned to 0.9.1 (the last known stable version)
- Pydantic constrained to <2.10.0 to avoid the regression introduced in 2.12.0

## Testing
Tested locally with the new dependency constraints and confirmed:
- S3 tables queries execute successfully
- No compatibility errors between PyIceberg and Pydantic
- MCP server starts and operates normally

## Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N): **N**

**RFC issue number**: N/A

Checklist:
* [ ] Migration process documented (N/A - not a breaking change)
* [ ] Implement warnings (if it can live side by side) (N/A - dependency constraint)

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
