### PR TITLE
fix(redshift-mcp-server): Handle transaction abort errors properly

### DIFF
--- a/src/redshift-mcp-server/CHANGELOG.md
+++ b/src/redshift-mcp-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed critical transaction error handling bug where failed SQL queries would cause all subsequent queries in the same session to fail with "current transaction is aborted, commands ignored until end of transaction block". The server now properly executes `ROLLBACK` instead of `END` when a query fails within a transaction block.
+
 ### Added
 
 - Initial project setup


### PR DESCRIPTION
- Modified _execute_protected_statement to use ROLLBACK on query failures
- Added comprehensive error handling for aborted transactions
- Prevents 'current transaction is aborted' errors on subsequent queries
- Updated CHANGELOG.md with fix description

Fixes transaction abort issue where failed queries break session

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes
Fixed critical transaction abort error handling in the Redshift MCP server. Modified _execute_protected_statement function to properly execute ROLLBACK instead of END when a SQL query fails within a transaction block, preventing session corruption and subsequent query failures.

### User experience

Before: When a SQL query failed, the database session would enter an aborted state, causing all subsequent queries in the same session to fail with "ERROR: current transaction is aborted, commands ignored until end of transaction block", the agent would continue to retry using the same session and would ultimately fail. 

After: When a SQL query fails, the transaction is properly cleaned up with ROLLBACK, allowing the session to remain functional for subsequent queries and retries. Agent can continue using the MCP server normally after query failures, with reframed queries.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [x ] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
