### PR TITLE
fix(cloudwatch-appsignals-mcp-server): update get_service_detail tool…

### DIFF
--- a/src/cloudwatch-appsignals-mcp-server/tests/test_service_tools_operations.py
+++ b/src/cloudwatch-appsignals-mcp-server/tests/test_service_tools_operations.py
@@ -39,19 +39,6 @@ def mock_aws_clients():
 @pytest.mark.asyncio
 async def test_list_service_operations_success_with_get_operations(mock_aws_clients):
     """Test successful list_service_operations with GET operations."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'payment-service',
-                    'Type': 'AWS::ECS::Service',
-                    'Environment': 'production',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with GET operations
     mock_operations_response = {
         'ServiceOperations': [
@@ -78,12 +65,13 @@ async def test_list_service_operations_success_with_get_operations(mock_aws_clie
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='payment-service', hours=12)
+    result = await list_service_operations(
+        service_name='payment-service', environment='production', hours=12
+    )
 
     assert 'Operations for Service: payment-service' in result
     assert 'Time Range: Last 12 hour(s)' in result
@@ -106,18 +94,6 @@ async def test_list_service_operations_success_with_get_operations(mock_aws_clie
 @pytest.mark.asyncio
 async def test_list_service_operations_success_with_other_operations(mock_aws_clients):
     """Test successful list_service_operations with other operation types."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'api-service',
-                    'Type': 'AWS::Lambda::Function',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with various operation types
     mock_operations_response = {
         'ServiceOperations': [
@@ -141,12 +117,13 @@ async def test_list_service_operations_success_with_other_operations(mock_aws_cl
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='api-service', hours=24)
+    result = await list_service_operations(
+        service_name='api-service', environment='staging', hours=24
+    )
 
     assert 'Operations for Service: api-service' in result
     assert 'Total Operations: 3' in result
@@ -167,27 +144,16 @@ async def test_list_service_operations_success_with_other_operations(mock_aws_cl
 @pytest.mark.asyncio
 async def test_list_service_operations_no_operations_found(mock_aws_clients):
     """Test list_service_operations when no operations are found."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'inactive-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock empty operations response
     mock_operations_response = {'ServiceOperations': []}
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='inactive-service', hours=6)
+    result = await list_service_operations(
+        service_name='inactive-service', environment='production', hours=6
+    )
 
     assert "No operations found for service 'inactive-service' in the last 6 hours" in result
     assert (
@@ -205,32 +171,29 @@ async def test_list_service_operations_no_operations_found(mock_aws_clients):
 @pytest.mark.asyncio
 async def test_list_service_operations_service_not_found(mock_aws_clients):
     """Test list_service_operations when service is not found."""
-    # Mock empty services response
-    mock_services_response = {'ServiceSummaries': []}
+    # Mock ClientError for service not found
+    mock_aws_clients['appsignals_client'].list_service_operations.side_effect = ClientError(
+        error_response={
+            'Error': {
+                'Code': 'ResourceNotFoundException',
+                'Message': 'Service not found',
+            }
+        },
+        operation_name='ListServiceOperations',
+    )
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
+    result = await list_service_operations(
+        service_name='nonexistent-service', environment='production', hours=24
+    )
 
-    result = await list_service_operations(service_name='nonexistent-service', hours=24)
-
-    assert "Service 'nonexistent-service' not found in Application Signals" in result
+    assert 'AWS Error: Service not found' in result
+    assert "Service not found with Name='nonexistent-service', Environment='production'" in result
     assert 'Use list_monitored_services() to see available services' in result
 
 
 @pytest.mark.asyncio
 async def test_list_service_operations_hours_limit_enforcement(mock_aws_clients):
     """Test that hours parameter is limited to 24 hours maximum."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'test-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock operations response
     mock_operations_response = {
         'ServiceOperations': [
@@ -241,13 +204,14 @@ async def test_list_service_operations_hours_limit_enforcement(mock_aws_clients)
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
     # Request 48 hours but should be limited to 24
-    result = await list_service_operations(service_name='test-service', hours=48)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=48
+    )
 
     assert 'Time Range: Last 24 hour(s)' in result  # Should be limited to 24
 
@@ -262,18 +226,6 @@ async def test_list_service_operations_hours_limit_enforcement(mock_aws_clients)
 @pytest.mark.asyncio
 async def test_list_service_operations_mixed_operation_types(mock_aws_clients):
     """Test list_service_operations with mixed GET, POST, and other operations."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'mixed-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with mixed types
     mock_operations_response = {
         'ServiceOperations': [
@@ -304,12 +256,13 @@ async def test_list_service_operations_mixed_operation_types(mock_aws_clients):
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='mixed-service', hours=24)
+    result = await list_service_operations(
+        service_name='mixed-service', environment='production', hours=24
+    )
 
     assert 'Total Operations: 6' in result
     assert '🔍 GET Operations (2):' in result
@@ -329,18 +282,6 @@ async def test_list_service_operations_mixed_operation_types(mock_aws_clients):
 @pytest.mark.asyncio
 async def test_list_service_operations_operations_without_metrics(mock_aws_clients):
     """Test list_service_operations with operations that have no metric references."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'test-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with operations without metrics
     mock_operations_response = {
         'ServiceOperations': [
@@ -355,12 +296,13 @@ async def test_list_service_operations_operations_without_metrics(mock_aws_clien
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'Total Operations: 2' in result
     assert 'GET /api/health' in result
@@ -380,17 +322,19 @@ async def test_list_service_operations_operations_without_metrics(mock_aws_clien
 @pytest.mark.asyncio
 async def test_list_service_operations_client_error(mock_aws_clients):
     """Test list_service_operations with AWS ClientError."""
-    mock_aws_clients['appsignals_client'].list_services.side_effect = ClientError(
+    mock_aws_clients['appsignals_client'].list_service_operations.side_effect = ClientError(
         error_response={
             'Error': {
                 'Code': 'AccessDeniedException',
                 'Message': 'User is not authorized to perform this action',
             }
         },
-        operation_name='ListServices',
+        operation_name='ListServiceOperations',
     )
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'AWS Error: User is not authorized to perform this action' in result
 
@@ -398,11 +342,13 @@ async def test_list_service_operations_client_error(mock_aws_clients):
 @pytest.mark.asyncio
 async def test_list_service_operations_general_exception(mock_aws_clients):
     """Test list_service_operations with general exception."""
-    mock_aws_clients['appsignals_client'].list_services.side_effect = Exception(
+    mock_aws_clients['appsignals_client'].list_service_operations.side_effect = Exception(
         'Unexpected error occurred'
     )
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'Error: Unexpected error occurred' in result
 
@@ -410,20 +356,6 @@ async def test_list_service_operations_general_exception(mock_aws_clients):
 @pytest.mark.asyncio
 async def test_list_service_operations_operations_api_client_error(mock_aws_clients):
     """Test list_service_operations when list_service_operations API fails."""
-    # Mock successful service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'test-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
-
     # Mock failure in list_service_operations API
     mock_aws_clients['appsignals_client'].list_service_operations.side_effect = ClientError(
         error_response={
@@ -435,7 +367,9 @@ async def test_list_service_operations_operations_api_client_error(mock_aws_clie
         operation_name='ListServiceOperations',
     )
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'AWS Error: Rate exceeded' in result
 
@@ -443,18 +377,6 @@ async def test_list_service_operations_operations_api_client_error(mock_aws_clie
 @pytest.mark.asyncio
 async def test_list_service_operations_duplicate_metric_types(mock_aws_clients):
     """Test list_service_operations with duplicate metric types (should be deduplicated)."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'test-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with duplicate metric types
     mock_operations_response = {
         'ServiceOperations': [
@@ -471,12 +393,13 @@ async def test_list_service_operations_duplicate_metric_types(mock_aws_clients):
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'GET /api/test' in result
     # Should deduplicate metric types using set()
@@ -495,18 +418,6 @@ async def test_list_service_operations_duplicate_metric_types(mock_aws_clients):
 @pytest.mark.asyncio
 async def test_list_service_operations_unknown_operation_name(mock_aws_clients):
     """Test list_service_operations with operations that have missing or unknown names."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'test-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with missing/unknown operation names
     mock_operations_response = {
         'ServiceOperations': [
@@ -525,12 +436,13 @@ async def test_list_service_operations_unknown_operation_name(mock_aws_clients):
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'Total Operations: 3' in result
     assert 'GET /api/test' in result
@@ -543,18 +455,6 @@ async def test_list_service_operations_unknown_operation_name(mock_aws_clients):
 @pytest.mark.asyncio
 async def test_list_service_operations_unknown_metric_types(mock_aws_clients):
     """Test list_service_operations with operations that have unknown metric types."""
-    # Mock service discovery
-    mock_services_response = {
-        'ServiceSummaries': [
-            {
-                'KeyAttributes': {
-                    'Name': 'test-service',
-                    'Type': 'AWS::ECS::Service',
-                }
-            }
-        ]
-    }
-
     # Mock operations response with unknown metric types
     mock_operations_response = {
         'ServiceOperations': [
@@ -569,12 +469,13 @@ async def test_list_service_operations_unknown_metric_types(mock_aws_clients):
         ]
     }
 
-    mock_aws_clients['appsignals_client'].list_services.return_value = mock_services_response
     mock_aws_clients[
         'appsignals_client'
     ].list_service_operations.return_value = mock_operations_response
 
-    result = await list_service_operations(service_name='test-service', hours=24)
+    result = await list_service_operations(
+        service_name='test-service', environment='production', hours=24
+    )
 
     assert 'GET /api/test' in result
     assert 'Available Metrics:' in result
@@ -582,3 +483,102 @@ async def test_list_service_operations_unknown_metric_types(mock_aws_clients):
     metrics_line = next(line for line in result.split('\n') if 'Available Metrics:' in line)
     assert 'Latency' in metrics_line
     assert 'Unknown' in metrics_line  # Should show "Unknown" for missing/empty metric types
+
+
+@pytest.mark.asyncio
+async def test_list_service_operations_distinguishes_environments(mock_aws_clients):
+    """Test that we can list operations for same service name in different environments."""
+    # Mock operations for production environment
+    mock_prod_operations = {
+        'ServiceOperations': [
+            {
+                'Name': 'GET /api/orders',
+                'MetricReferences': [{'MetricType': 'Latency'}],
+            },
+            {
+                'Name': 'POST /api/checkout',
+                'MetricReferences': [{'MetricType': 'Latency'}],
+            },
+        ]
+    }
+
+    # Mock operations for staging environment
+    mock_staging_operations = {
+        'ServiceOperations': [
+            {
+                'Name': 'GET /api/test',
+                'MetricReferences': [{'MetricType': 'Latency'}],
+            },
+        ]
+    }
+
+    # Test production environment
+    mock_aws_clients[
+        'appsignals_client'
+    ].list_service_operations.return_value = mock_prod_operations
+
+    result_prod = await list_service_operations(
+        service_name='payment-service', environment='production', hours=24
+    )
+
+    assert 'Operations for Service: payment-service' in result_prod
+    assert 'Total Operations: 2' in result_prod
+    assert 'GET /api/orders' in result_prod
+    assert 'POST /api/checkout' in result_prod
+
+    # Test staging environment
+    mock_aws_clients[
+        'appsignals_client'
+    ].list_service_operations.return_value = mock_staging_operations
+
+    result_staging = await list_service_operations(
+        service_name='payment-service', environment='staging', hours=24
+    )
+
+    assert 'Operations for Service: payment-service' in result_staging
+    assert 'Total Operations: 1' in result_staging
+    assert 'GET /api/test' in result_staging
+
+    # Verify they have different operations
+    assert 'GET /api/orders' in result_prod and 'GET /api/orders' not in result_staging
+    assert 'GET /api/test' in result_staging and 'GET /api/test' not in result_prod
+
+
+@pytest.mark.asyncio
+async def test_list_service_operations_passes_correct_key_attributes(mock_aws_clients):
+    """Verify KeyAttributes dict is constructed correctly from parameters."""
+    mock_operations_response = {
+        'ServiceOperations': [
+            {
+                'Name': 'GET /health',
+                'MetricReferences': [{'MetricType': 'Latency'}],
+            }
+        ]
+    }
+
+    mock_aws_clients[
+        'appsignals_client'
+    ].list_service_operations.return_value = mock_operations_response
+
+    await list_service_operations(
+        service_name='api-gateway',
+        environment='production',
+        service_type='RemoteService',
+        hours=12,
+    )
+
+    # Verify list_service_operations was called with correct KeyAttributes
+    call_args = mock_aws_clients['appsignals_client'].list_service_operations.call_args
+    assert call_args is not None
+
+    key_attributes = call_args[1]['KeyAttributes']
+    assert key_attributes == {
+        'Type': 'RemoteService',
+        'Name': 'api-gateway',
+        'Environment': 'production',
+    }
+
+    # Verify all three fields are present and correct
+    assert key_attributes['Type'] == 'RemoteService'
+    assert key_attributes['Name'] == 'api-gateway'
+    assert key_attributes['Environment'] == 'production'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Adding environment and service type as explicit parameters to `get_service_details` tool so the LLM can disambiguate in cases where the same service is deployed in multiple different environments within the same AWS account.

Previously, `get_service_details` only required service name. This service name would then be searched in the response of a list_services boto3 call within the same tool. By explicitly providing all three parameters, we can remove this intermediate step.

ref: https://boto3.amazonaws.com/v1/documentation/api/1.35.43/reference/services/application-signals/client/get_service.html

### Changes

> Added environment and service type as explicit parameters

> Removed list_services boto3 calls calls since are no longer needed

### User experience

> There is no change in the user experience as the LLM can still retrieve the necessary parameters via the `list_monitored_services` tool.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
