### PR TITLE
Chore: refactor call_aws to accept credentials from other sources

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/driver.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/driver.py
@@ -80,6 +80,7 @@ def translate_cli_to_ir(cli_command: str) -> IRTranslation:
 def interpret_command(
     cli_command: str,
     max_results: int | None = None,
+    credentials: Credentials | None = None,
 ) -> InterpretedProgram:
     """Interpret the CLI command.
 
@@ -101,9 +102,10 @@ def interpret_command(
     ):
         region = GLOBAL_SERVICE_REGIONS[translation.command.command_metadata.service_sdk_name]
 
-    credentials = get_local_credentials(
-        profile=translation.command.profile or AWS_API_MCP_PROFILE_NAME
-    )
+    if credentials is None:
+        credentials = get_local_credentials(
+            profile=translation.command.profile or AWS_API_MCP_PROFILE_NAME
+        )
 
     try:
         response = interpret(

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -20,6 +20,7 @@ from ..common.models import (
     AwsApiMcpServerErrorResponse,
     AwsCliAliasResponse,
     Consent,
+    Credentials,
     InterpretationMetadata,
     InterpretationResponse,
     InterpretedProgram,
@@ -163,11 +164,13 @@ def execute_awscli_customization(
 def interpret_command(
     cli_command: str,
     max_results: int | None = None,
+    credentials: Credentials | None = None,
 ) -> ProgramInterpretationResponse:
     """Interpret the given CLI command and return an interpretation response."""
     interpreted_program = _interpret_command(
         cli_command,
         max_results=max_results,
+        credentials=credentials,
     )
 
     validation_failures = (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

>  refactor call_aws to accept credentials from other sources other than the local credentials 

### User experience

> No change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
