### PR TITLE
fix: standardize billing-cost-management server id convention

### DIFF
--- a/docusaurus/static/assets/server-cards.json
+++ b/docusaurus/static/assets/server-cards.json
@@ -976,9 +976,9 @@
       "category": "Cost & Operations",
       "description": "AWS Billing and Cost Management",
       "icon": "\ud83d\udcb0",
-      "id": "billing_cost_management_mcp_server",
+      "id": "billing-cost-management-mcp-server",
       "name": "AWS Billing and Cost Management MCP Server",
-      "source_path": "src/billing_cost_management_mcp_server/",
+      "source_path": "src/billing-cost-management-mcp-server/",
       "subcategory": "Cost Management",
       "tags": [
         "billing",


### PR DESCRIPTION


<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Update server ID and source_path from underscore to hyphen format to fix broken links and ensure consistency with other MCP server naming patterns.

- Change ID: billing_cost_management_mcp_server → billing-cost-management-mcp-server
- Update path: src/billing_cost_management_mcp_server/ → src/billing-cost-management-mcp-server/

This resolves broken documentation links caused by inconsistent naming.

### User experience


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: None

Related Issue: #1548

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
