### PR TITLE
feat(iot-sitewise): add bulk import, buffered ingestion tools, and prompts to iot-sitewise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@ NOTICE                                           @awslabs/mcp-admins
 /src/aws-diagram-mcp-server                      @awslabs/mcp-admins @awslabs/mcp-maintainers  @MichaelWalker-git
 /src/aws-documentation-mcp-server                @awslabs/mcp-admins @awslabs/mcp-maintainers  @Lavoiedavidw @JonLim @tuanknguyen
 /src/aws-healthomics-mcp-server                  @awslabs/mcp-admins @awslabs/mcp-maintainers  @markjschreiber @WIIASD
-/src/aws-iot-sitewise-mcp-server                 @awslabs/mcp-admins @awslabs/mcp-maintainers  @ychamare
+/src/aws-iot-sitewise-mcp-server                 @awslabs/mcp-admins @awslabs/mcp-maintainers  @ychamare @ashuanand1226 @charlie-7
 /src/aws-knowledge-mcp-server                    @awslabs/mcp-admins @awslabs/mcp-maintainers  @alexa-perlov @krokoko @scottschreckengaust # @tkaria @animebar
 /src/aws-location-mcp-server                     @awslabs/mcp-admins @awslabs/mcp-maintainers  @scottschreckengaust @theagenticguy # @scouturier
 /src/aws-msk-mcp-server                          @awslabs/mcp-admins @awslabs/mcp-maintainers  @elmoctarebnou @dingyiheng

--- a/src/aws-iot-sitewise-mcp-server/README.md
+++ b/src/aws-iot-sitewise-mcp-server/README.md
@@ -331,6 +331,11 @@ Configure in your workspace or global settings:
 | `batch_get_asset_property_value` | Bulk current value retrieval |
 | `batch_get_asset_property_value_hist` | Bulk historical data |
 | `batch_get_asset_property_aggregates` | Bulk aggregations |
+| `create_bulk_import_job` | Create bulk import jobs for bulk data ingestion |
+| `create_buffered_ingestion_job` | Create buffered ingestion jobs |
+| `create_bulk_import_iam_role` | Create IAM roles for bulk import operations |
+| `list_bulk_import_jobs` | List bulk import jobs |
+| `describe_bulk_import_job` | Retrieve bulk import job information |
 | `execute_query` | Execute SQL-like queries for advanced analytics |
 
 ### Gateway & Time Series Tools
@@ -391,6 +396,14 @@ Step-by-step guidance for setting up industrial data ingestion with best practic
 ```
 
 Comprehensive guidance for exploring IoT data using the executeQuery API with SQL-like analytics capabilities.
+
+### Bulk Import Workflow
+
+```example
+/prompts get bulk_import_workflow_helper_prompt
+```
+
+Step-by-step guidance for setting up bulk data import from S3, including CSV validation, IAM role creation, job configuration, and monitoring.
 
 ## Usage Examples
 

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/client.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/client.py
@@ -31,3 +31,17 @@ def create_sitewise_client(region: str = 'us-east-1'):
     config = Config(user_agent_extra=f'awslabs/mcp/aws-iot-sitewise-mcp-server/{__version__}')
 
     return boto3.client('iotsitewise', region_name=region, config=config)
+
+
+def create_iam_client(region: str = 'us-east-1'):
+    """Create a standardized AWS IAM client with proper user agent.
+
+    Args:
+        region: AWS region name (default: us-east-1)
+
+    Returns:
+        boto3 IAM client instance
+    """
+    config = Config(user_agent_extra=f'awslabs/mcp/aws-iot-sitewise-mcp-server/{__version__}')
+
+    return boto3.client('iam', region_name=region, config=config)

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/prompts/__init__.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/prompts/__init__.py
@@ -15,11 +15,13 @@
 """Prompts for AWS IoT SiteWise MCP server."""
 
 from .asset_hierarchy import asset_hierarchy_visualization_prompt
+from .bulk_import_workflow import bulk_import_workflow_helper_prompt
 from .data_exploration import data_exploration_helper_prompt
 from .data_ingestion import data_ingestion_helper_prompt
 
 __all__ = [
     'asset_hierarchy_visualization_prompt',
-    'data_ingestion_helper_prompt',
+    'bulk_import_workflow_helper_prompt',
     'data_exploration_helper_prompt',
+    'data_ingestion_helper_prompt',
 ]

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/prompts/bulk_import_workflow.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/prompts/bulk_import_workflow.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS IoT SiteWise Bulk Import Workflow Helper Prompt."""
+
+from mcp.server.fastmcp.prompts import Prompt
+
+
+def bulk_import_workflow_helper() -> str:
+    """Generate a comprehensive guide for bulk importing data into AWS IoT SiteWise.
+
+    This prompt helps design and implement bulk data import strategies for historical
+    and real-time industrial data, including CSV preparation, IAM setup, and job configuration.
+
+    Returns:
+        Comprehensive bulk import workflow guide
+    """
+    return """
+You are an AWS IoT SiteWise bulk import expert helping to set up large-scale data ingestion from S3.
+
+## 🎯 AWS IoT SiteWise Bulk Import Workflow
+
+### **Initial Assessment Questions**
+
+Before we begin, I need to understand your bulk import requirements:
+
+**1. What is the age of your oldest data?**
+- Last 7 days
+- Last 30 days
+- 1-6 months old
+- 6+ months old
+- Historical data from [specific year]
+
+**2. What is the approximate size of your data?**
+- Small job (< 100MB)
+- Medium job (100MB - 1GB)
+- Large job (1GB - 10GB)
+- Very large job (> 10GB)
+
+**3. What type of data ingestion do you need?**
+- Real-time processing with computations and alerts (buffered ingestion)
+- Historical data storage for analysis (historical ingestion)
+- Mixed: both real-time and historical
+
+Based on your answers, I'll recommend the optimal type of data ingestion strategy.
+
+### **Step 1: Discovery & Assessment (CRITICAL FIRST STEPS)**
+
+**🔍 Ask for Column Headers First**
+- **Never assume column names** - they vary between users and CSV files
+- **Ask explicitly**: "What are the exact column names in your CSV file?"
+- Column headers determine the entire job configuration
+- Each bulk import job requires exact column header specification
+
+**Check Existing Jobs for Error Bucket (Recommended):**
+```
+list_bulk_import_jobs()
+describe_bulk_import_job(job_id="previous-job-id")
+```
+- **Reuse existing error bucket** from previous jobs when possible
+- Extract: `error_report_location.bucket` and `prefix`
+- **Inform customer**: "I'm using the error bucket location from your previous jobs"
+- **Fallback**: Ask customer for error bucket if no previous jobs exist
+
+**Storage Configuration Check:**
+```
+describe_storage_configuration()
+```
+- Verify current storage type and retention settings
+- **For data older than 30 days**: Check if warm tier or multi-layer storage is enabled
+- **If historical ingestion needed but storage not configured**: Ask user to enable required storage options
+
+### **Step 2: Data Preparation Requirements**
+
+**CSV Column Mapping Process:**
+1. **Get user's actual column headers** (never assume)
+2. **Map to AWS required format** (UPPERCASE)
+
+**Required AWS Column Names:**
+- `ALIAS` or (`ASSET_ID` + `PROPERTY_ID`) - Asset identifier
+- `TIMESTAMP_SECONDS` - Unix epoch timestamp
+- `VALUE` - Numeric or string value
+- `DATA_TYPE` - DOUBLE, INTEGER, BOOLEAN, STRING
+- `QUALITY` - GOOD, BAD, UNCERTAIN
+
+**Optional AWS Columns:**
+- `TIMESTAMP_NANO_OFFSET` - Nanosecond precision
+
+**Example Column Mapping:**
+```
+User CSV Headers: "alias, data type, timestamp seconds, quality, value"
+AWS Format Array: ["ALIAS", "DATA_TYPE", "TIMESTAMP_SECONDS", "QUALITY", "VALUE"]
+```
+
+**File Constraints:**
+- Buffered ingestion: 256MB per file maximum
+- Historical ingestion: 10GB per file (CSV), 256MB (Parquet)
+- UTF-8 encoding required
+
+### **Step 3: Error Bucket Strategy**
+
+**Option A: Reuse Existing (Recommended)**
+1. Check previous jobs: `list_bulk_import_jobs()`
+2. Get error bucket: `describe_bulk_import_job(job_id)`
+3. Extract: `error_report_location.bucket` and `prefix`
+4. **Inform customer**: "Using error bucket from your previous jobs: s3://bucket/prefix"
+
+**Option B: Ask Customer (If No Previous Jobs)**
+- Error bucket name
+- Prefix (optional, defaults to "errors/")
+
+### **Step 4: IAM Role Setup**
+
+**Choose Your IAM Role Option:**
+
+**Option A: Provide Existing Role ARN**
+- Use if you already have an IAM role with proper S3 permissions
+- Role must have trust relationship with `iotsitewise.amazonaws.com`
+- Required permissions: s3:* on data bucket and error bucket
+
+**Option B: Create New Role (Recommended)**
+```
+create_bulk_import_iam_role(
+    role_name="IoTSiteWiseBulkImportRole-[BUCKET]",
+    data_bucket_names=["user-data-bucket"],
+    error_bucket_name="discovered-error-bucket"
+)
+```
+- Automatically configures all required S3 permissions
+- Sets up proper trust policy for IoT SiteWise service
+- Uses s3:* permissions for maximum compatibility
+
+**Ask user**: "Do you want to provide an existing IAM role ARN, or should I create a new role for you?"
+
+### **Step 5: Job Configuration**
+
+**Required Information from User:**
+1. **Data bucket name**
+2. **File name/key**
+3. **Exact column headers**
+
+**Create Job with Discovered Settings:**
+```
+create_buffered_ingestion_job(
+    job_name="buffered-ingestion-[DATE]",
+    job_role_arn="arn:aws:iam::account:role/[ROLE-NAME]",
+    files=[{{"bucket": "user-bucket", "key": "user-file.csv"}}],
+    error_report_location={{"bucket": "discovered-error-bucket", "prefix": "errors/"}},
+    job_configuration={{
+        "fileFormat": {{
+            "csv": {{
+                "columnNames": ["MAPPED", "AWS", "COLUMN", "NAMES"]
+            }}
+        }}
+    }}
+)
+```
+
+### **Step 6: Post-Job Execution (CRITICAL TIMING)**
+
+**⏰ Data Availability Timeline:**
+- **Data ingestion**: Asynchronous - **Wait 15+ minutes**
+- **Data available for queries**: ~15 minutes after job completion
+- **Inform customer about this delay**
+
+**Validation After 15+ Minutes:**
+```
+execute_query(
+    query_statement="SELECT COUNT(*) FROM raw_time_series WHERE event_timestamp >= TIMESTAMP_SUB(DAY, 30, NOW())"
+)
+```
+
+**Error Analysis:**
+- Check S3 error bucket for detailed error reports
+- Review job status messages
+- Validate asset aliases exist in SiteWise
+
+### **Step 7: Storage Configuration (For Historical Data)**
+
+**If you answered that your data is older than 30 days, you'll need historical ingestion which requires storage configuration.**
+
+**First, let me check your current storage configuration:**
+```
+describe_storage_configuration()
+```
+
+**If warm tier is DISABLED and storage type is SITEWISE_DEFAULT_STORAGE, I'll ask you:**
+
+"Your data requires historical ingestion, but your current storage configuration doesn't support it. I can help you enable the required storage. Which option would you prefer?"
+
+**Option A: Enable Warm Tier Only (Recommended - Simpler)**
+- I'll run: `put_storage_configuration(storage_type="SITEWISE_DEFAULT_STORAGE", warm_tier="ENABLED", retention_period={"numberOfDays": 30})`
+
+**Option B: Enable Multi-Layer Storage with Warm Tier (Advanced)**
+- You'll need to provide: S3 bucket ARN and IAM role ARN
+- I'll run: `put_storage_configuration(storage_type="MULTI_LAYER_STORAGE", ...)`
+
+**Option C: Enable Both**
+- Combination of the above options
+
+**Tell me which option you prefer, and I'll configure it for you.**
+
+### **Step 8: Ingestion Mode Selection**
+
+**Buffered Ingestion (adaptive_ingestion=True)**
+- **Use for**: Data within the last 30 days
+- **Benefits**: Real-time computations, metrics, transforms, notifications
+- **Storage**: No additional configuration required
+- **File limit**: 256MB per file
+- **Best for**: Recent operational data, real-time monitoring
+
+**Historical Ingestion (adaptive_ingestion=False)**
+- **Use for**: Older data, large datasets
+- **Requirements**: Multilayer storage or warm tier must be enabled
+- **File limit**: 10GB per file (CSV), 256MB (Parquet)
+- **Best for**: Data migration, historical analysis
+
+### **Step 9: Best Practices Checklist**
+
+✅ **Always ask for column headers** - never assume format
+✅ **Check previous jobs** for error bucket reuse
+✅ **Inform customer** when reusing existing settings
+✅ **Verify bucket permissions** before job creation
+✅ **Map user headers to AWS format** correctly
+✅ **Wait 15+ minutes** after job completion for data availability
+✅ **Use buffered ingestion** for data within 30 days
+✅ **Create bucket-specific IAM role** if existing role lacks access
+
+### **Recommended Workflow Template:**
+
+```
+1. Ask: "What are the exact column names in your CSV file?"
+2. Check existing jobs: list_bulk_import_jobs()
+3. Get error bucket: describe_bulk_import_job(job_id)
+4. Ask for: bucket name, file name
+5. Create IAM role if needed: create_bulk_import_iam_role()
+6. Create job with discovered error bucket location
+7. Inform customer: "Job created. Data will be available in 15+ minutes"
+8. Wait 15+ minutes, then validate data ingestion
+```
+
+Based on your answers above, I'll provide specific recommendations for:
+- **Ingestion mode** (buffered vs historical)
+- **File size limits** and optimization strategies
+- **Storage configuration** requirements
+- **Performance** considerations
+
+**Next Steps:**
+1. **Ask for your CSV column headers** (exact names)
+2. **Check your previous jobs** for error bucket reuse
+3. **Get your data bucket and file details**
+4. **Create IAM role** if needed
+5. **Configure and execute** bulk import job
+6. **Wait 15 minutes**, then validate data ingestion
+
+Would you like me to help you implement any specific part of this workflow?
+"""
+
+
+bulk_import_workflow_helper_prompt = Prompt.from_function(
+    bulk_import_workflow_helper,
+    name='bulk_import_workflow_helper_prompt',
+    description='Comprehensive guide for AWS IoT SiteWise bulk data import workflows',
+)

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/server.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/server.py
@@ -19,6 +19,9 @@ from awslabs.aws_iot_sitewise_mcp_server import __version__
 from awslabs.aws_iot_sitewise_mcp_server.prompts.asset_hierarchy import (
     asset_hierarchy_visualization_prompt,
 )
+from awslabs.aws_iot_sitewise_mcp_server.prompts.bulk_import_workflow import (
+    bulk_import_workflow_helper_prompt,
+)
 from awslabs.aws_iot_sitewise_mcp_server.prompts.data_exploration import (
     data_exploration_helper_prompt,
 )
@@ -58,11 +61,16 @@ from awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data import (
     batch_get_asset_property_value_history_tool,
     batch_get_asset_property_value_tool,
     batch_put_asset_property_value_tool,
+    create_buffered_ingestion_job_tool,
+    create_bulk_import_iam_role_tool,
+    create_bulk_import_job_tool,
+    describe_bulk_import_job_tool,
     execute_query_tool,
     get_asset_property_aggregates_tool,
     get_asset_property_value_history_tool,
     get_asset_property_value_tool,
     get_interpolated_asset_property_values_tool,
+    list_bulk_import_jobs_tool,
 )
 from awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_gateways import (
     associate_time_series_to_asset_property_tool,
@@ -126,6 +134,11 @@ all_tools = [
     batch_get_asset_property_value_tool,
     batch_get_asset_property_value_history_tool,
     batch_get_asset_property_aggregates_tool,
+    create_bulk_import_job_tool,
+    create_buffered_ingestion_job_tool,
+    create_bulk_import_iam_role_tool,
+    list_bulk_import_jobs_tool,
+    describe_bulk_import_job_tool,
     execute_query_tool,
     create_gateway_tool,
     describe_gateway_tool,
@@ -284,6 +297,7 @@ async def run_server():
     # Add data ingestion prompt only in write mode
     if allow_writes:
         mcp.add_prompt(data_ingestion_helper_prompt)
+        mcp.add_prompt(bulk_import_workflow_helper_prompt)
 
     async with create_task_group() as tg:
         tg.start_soon(signal_handler, tg.cancel_scope)

--- a/src/aws-iot-sitewise-mcp-server/tests/test_client.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_client.py
@@ -1,0 +1,87 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for client.py module."""
+
+import unittest
+from awslabs.aws_iot_sitewise_mcp_server.client import create_iam_client, create_sitewise_client
+from unittest.mock import Mock, patch
+
+
+class TestClient(unittest.TestCase):
+    """Test cases for client creation functions."""
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.client.boto3.client')
+    def test_create_sitewise_client_default_region(self, mock_boto_client):
+        """Test creating SiteWise client with default region."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        result = create_sitewise_client()
+
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 'iotsitewise')
+        self.assertEqual(kwargs['region_name'], 'us-east-1')
+        self.assertIn('config', kwargs)
+        self.assertIn('awslabs/mcp/aws-iot-sitewise-mcp-server', kwargs['config'].user_agent_extra)
+        self.assertEqual(result, mock_client)
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.client.boto3.client')
+    def test_create_sitewise_client_custom_region(self, mock_boto_client):
+        """Test creating SiteWise client with custom region."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        result = create_sitewise_client('us-west-2')
+
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 'iotsitewise')
+        self.assertEqual(kwargs['region_name'], 'us-west-2')
+        self.assertEqual(result, mock_client)
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.client.boto3.client')
+    def test_create_iam_client_default_region(self, mock_boto_client):
+        """Test creating IAM client with default region."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        result = create_iam_client()
+
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 'iam')
+        self.assertEqual(kwargs['region_name'], 'us-east-1')
+        self.assertIn('config', kwargs)
+        self.assertIn('awslabs/mcp/aws-iot-sitewise-mcp-server', kwargs['config'].user_agent_extra)
+        self.assertEqual(result, mock_client)
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.client.boto3.client')
+    def test_create_iam_client_custom_region(self, mock_boto_client):
+        """Test creating IAM client with custom region."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        result = create_iam_client('eu-west-1')
+
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 'iam')
+        self.assertEqual(kwargs['region_name'], 'eu-west-1')
+        self.assertEqual(result, mock_client)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/aws-iot-sitewise-mcp-server/tests/test_server.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_server.py
@@ -70,12 +70,12 @@ class TestServer:
         assert mock_mcp_instance._mcp_server.version == '1.0.0'
 
         # Verify tools were added - we should have a significant number of tools
-        # Asset tools: 8, Asset model tools: 7, Data tools: 9, Gateway tools: 12, Access tools: 6, plus get_sitewise_server_mode
-        # Total expected: 43 tools (22 read-only + 21 write)
-        assert mock_mcp_instance.add_tool.call_count == 43
+        # Asset tools: 8, Asset model tools: 7, Data tools: 14, Gateway tools: 12, Access tools: 6, plus get_sitewise_server_mode
+        # Total expected: 48 tools (25 read-only + 23 write)
+        assert mock_mcp_instance.add_tool.call_count == 48
 
-        # Verify prompts were added (3 prompts)
-        assert mock_mcp_instance.add_prompt.call_count == 3
+        # Verify prompts were added (4 prompts)
+        assert mock_mcp_instance.add_prompt.call_count == 4
 
         # Verify signal handler was started
         mock_tg.start_soon.assert_called_once()
@@ -140,13 +140,13 @@ class TestServer:
 
         await run_server()
 
-        # Verify all 3 prompts were added
-        assert mock_mcp_instance.add_prompt.call_count == 3
+        # Verify all 4 prompts were added
+        assert mock_mcp_instance.add_prompt.call_count == 4
 
         # Verify the prompts are from the expected modules
         prompt_calls = mock_mcp_instance.add_prompt.call_args_list
         # Each call should be a Mock call with one argument (the prompt)
-        assert len(prompt_calls) == 3
+        assert len(prompt_calls) == 4
 
     @patch('awslabs.aws_iot_sitewise_mcp_server.server.run')
     def test_main_function(self, mock_run):
@@ -207,8 +207,8 @@ class TestServer:
 
         # Verify setup still happened before the error
         mock_fastmcp.assert_called_once()
-        assert mock_mcp_instance.add_tool.call_count == 43
-        assert mock_mcp_instance.add_prompt.call_count == 3
+        assert mock_mcp_instance.add_tool.call_count == 48
+        assert mock_mcp_instance.add_prompt.call_count == 4
 
 
 if __name__ == '__main__':

--- a/src/aws-iot-sitewise-mcp-server/tests/test_sitewise_data.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_sitewise_data.py
@@ -22,11 +22,16 @@ from awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data import (
     batch_get_asset_property_value,
     batch_get_asset_property_value_history,
     batch_put_asset_property_value,
+    create_buffered_ingestion_job,
+    create_bulk_import_iam_role,
+    create_bulk_import_job,
+    describe_bulk_import_job,
     execute_query,
     get_asset_property_aggregates,
     get_asset_property_value,
     get_asset_property_value_history,
     get_interpolated_asset_property_values,
+    list_bulk_import_jobs,
 )
 from botocore.exceptions import ClientError
 from unittest.mock import Mock, patch
@@ -902,6 +907,810 @@ class TestSiteWiseData:
         )
         assert result['success'] is False
         assert result['error_code'] == 'InternalFailureException'
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_iam_client')
+    def test_create_bulk_import_iam_role_success(self, mock_create_iam_client):
+        """Test successful IAM role creation for bulk import."""
+        mock_iam_client = Mock()
+        mock_create_iam_client.return_value = mock_iam_client
+
+        mock_iam_client.create_role.return_value = {
+            'Role': {'Arn': 'arn:aws:iam::123456789012:role/TestRole'}
+        }
+
+        result = create_bulk_import_iam_role(
+            role_name='TestRole',
+            data_bucket_names=['test-data-bucket'],
+            error_bucket_name='test-error-bucket',
+            region='us-east-1',
+        )
+
+        assert result['success'] is True
+        assert result['role_arn'] == 'arn:aws:iam::123456789012:role/TestRole'
+        assert result['role_name'] == 'TestRole'
+        mock_iam_client.create_role.assert_called_once()
+        mock_iam_client.put_role_policy.assert_called_once()
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_iam_client')
+    def test_create_bulk_import_iam_role_error(self, mock_create_iam_client):
+        """Test IAM role creation error handling."""
+        mock_iam_client = Mock()
+        mock_create_iam_client.return_value = mock_iam_client
+
+        error_response = {
+            'Error': {'Code': 'EntityAlreadyExistsException', 'Message': 'Role already exists'}
+        }
+        mock_iam_client.create_role.side_effect = ClientError(error_response, 'CreateRole')
+
+        result = create_bulk_import_iam_role(
+            role_name='ExistingRole',
+            data_bucket_names=['test-bucket'],
+            error_bucket_name='error-bucket',
+        )
+
+        assert result['success'] is False
+        assert 'error' in result
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_create_bulk_import_job_success(self, mock_boto_client):
+        """Test successful bulk import job creation."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        mock_client.create_bulk_import_job.return_value = {
+            'jobId': 'test-job-id',
+            'jobName': 'test-job',
+            'jobStatus': 'PENDING',
+        }
+
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'VALUE', 'DATA_TYPE', 'TIMESTAMP_SECONDS']}
+                }
+            },
+            adaptive_ingestion=True,
+        )
+
+        assert result['success'] is True
+        assert result['job_id'] == 'test-job-id'
+        assert result['job_name'] == 'test-job'
+        mock_client.create_bulk_import_job.assert_called_once()
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_create_buffered_ingestion_job_success(self, mock_boto_client):
+        """Test successful buffered ingestion job creation."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        mock_client.create_bulk_import_job.return_value = {
+            'jobId': 'buffered-job-id',
+            'jobName': 'buffered-job',
+            'jobStatus': 'PENDING',
+        }
+
+        result = create_buffered_ingestion_job(
+            job_name='buffered-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'VALUE', 'DATA_TYPE', 'TIMESTAMP_SECONDS']}
+                }
+            },
+        )
+
+        assert result['success'] is True
+        assert result['job_id'] == 'buffered-job-id'
+        mock_client.create_bulk_import_job.assert_called_once()
+        # Verify adaptive_ingestion was set to True
+        call_args = mock_client.create_bulk_import_job.call_args[1]
+        assert call_args['adaptiveIngestion'] is True
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_describe_bulk_import_job_success(self, mock_boto_client):
+        """Test successful bulk import job description."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        mock_client.describe_bulk_import_job.return_value = {
+            'jobId': '12345678-1234-1234-1234-123456789012',
+            'jobName': 'test-job',
+            'jobStatus': 'COMPLETED',
+            'jobRoleArn': 'arn:aws:iam::123456789012:role/TestRole',
+        }
+
+        result = describe_bulk_import_job(job_id='12345678-1234-1234-1234-123456789012')
+
+        assert result['success'] is True
+        assert result['job_id'] == '12345678-1234-1234-1234-123456789012'
+        assert result['job_status'] == 'COMPLETED'
+        mock_client.describe_bulk_import_job.assert_called_once_with(
+            jobId='12345678-1234-1234-1234-123456789012'
+        )
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_list_bulk_import_jobs_success(self, mock_boto_client):
+        """Test successful bulk import jobs listing."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        mock_client.list_bulk_import_jobs.return_value = {
+            'jobSummaries': [
+                {'jobId': 'job1', 'jobName': 'test-job-1', 'jobStatus': 'COMPLETED'},
+                {'jobId': 'job2', 'jobName': 'test-job-2', 'jobStatus': 'PENDING'},
+            ]
+        }
+
+        result = list_bulk_import_jobs()
+
+        assert result['success'] is True
+        assert len(result['job_summaries']) == 2
+        assert result['job_summaries'][0]['jobId'] == 'job1'
+        mock_client.list_bulk_import_jobs.assert_called_once()
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_bulk_import_job_error_handling(self, mock_boto_client):
+        """Test bulk import job error handling."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        error_response = {'Error': {'Code': 'ValidationException', 'Message': 'Invalid job name'}}
+        mock_client.create_bulk_import_job.side_effect = ClientError(
+            error_response, 'CreateBulkImportJob'
+        )
+
+        result = create_bulk_import_job(
+            job_name='',  # Invalid empty name
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'csv': {'columnNames': ['ALIAS', 'VALUE']}}},
+            adaptive_ingestion=True,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ValidationException'
+
+    def test_bulk_import_csv_validation_missing_column_names(self):
+        """Test CSV validation fails when columnNames is missing."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'csv': {}}},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV configuration must have "columnNames" field' in result['error']
+
+    def test_bulk_import_csv_validation_empty_column_names(self):
+        """Test CSV validation fails when columnNames is empty."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'csv': {'columnNames': []}}},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV columnNames must be a non-empty list' in result['error']
+
+    def test_bulk_import_csv_validation_invalid_column_name(self):
+        """Test CSV validation fails with invalid column name."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'csv': {'columnNames': ['INVALID_COLUMN']}}},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Invalid column name: INVALID_COLUMN' in result['error']
+
+    def test_bulk_import_csv_validation_all_three_identifiers(self):
+        """Test CSV validation fails when ASSET_ID, PROPERTY_ID, and ALIAS are all present."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {
+                        'columnNames': [
+                            'ASSET_ID',
+                            'PROPERTY_ID',
+                            'ALIAS',
+                            'TIMESTAMP_SECONDS',
+                            'VALUE',
+                            'DATA_TYPE',
+                        ]
+                    }
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV cannot include ASSET_ID, PROPERTY_ID, and ALIAS together' in result['error']
+
+    def test_bulk_import_csv_validation_asset_id_without_property_id(self):
+        """Test CSV validation fails when ASSET_ID is present without PROPERTY_ID."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ASSET_ID', 'TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']}
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV with ASSET_ID must also include PROPERTY_ID' in result['error']
+
+    def test_bulk_import_csv_validation_property_id_without_asset_id(self):
+        """Test CSV validation fails when PROPERTY_ID is present without ASSET_ID."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {
+                        'columnNames': ['PROPERTY_ID', 'TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']
+                    }
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV with PROPERTY_ID must also include ASSET_ID' in result['error']
+
+    def test_bulk_import_csv_validation_no_identifier_columns(self):
+        """Test CSV validation fails when no identifier columns are present."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV must include either ALIAS or both ASSET_ID and PROPERTY_ID' in result['error']
+
+    def test_bulk_import_csv_validation_missing_required_columns(self):
+        """Test CSV validation fails when required columns are missing."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'CSV missing required columns' in result['error']
+
+    def test_bulk_import_invalid_file_format(self):
+        """Test validation fails when neither CSV nor Parquet is specified."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.txt'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'invalid': {}}},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'File format must specify either "csv" or "parquet"' in result['error']
+
+    def test_bulk_import_missing_file_format(self):
+        """Test validation fails when fileFormat is missing."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Job configuration must have "fileFormat" field' in result['error']
+
+    def test_bulk_import_invalid_file_format_type(self):
+        """Test validation fails when fileFormat is not a dictionary."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': 'invalid'},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'File format must be a dictionary' in result['error']
+
+    def test_describe_bulk_import_job_empty_job_id(self):
+        """Test validation fails with empty job ID."""
+        result = describe_bulk_import_job(job_id='')
+        assert result['success'] is False
+        assert 'Job ID must be a non-empty string' in result['error']
+
+    def test_describe_bulk_import_job_invalid_uuid_length(self):
+        """Test validation fails with incorrect UUID length."""
+        result = describe_bulk_import_job(job_id='12345678-1234-1234-1234-12345678901')  # 35 chars
+        assert result['success'] is False
+        assert 'Job ID must be in UUID format' in result['error']
+
+    def test_describe_bulk_import_job_invalid_uuid_hyphens(self):
+        """Test validation fails with incorrect number of hyphens."""
+        result = describe_bulk_import_job(
+            job_id='123456781234123412341234567890123456'
+        )  # 36 chars, no hyphens
+        assert result['success'] is False
+        assert 'Job ID must be in UUID format' in result['error']
+
+    def test_describe_bulk_import_job_invalid_uuid_format(self):
+        """Test validation fails with wrong hyphen positions."""
+        result = describe_bulk_import_job(
+            job_id='1234567-8123-1234-1234-567890123456',  # 37 chars - too long
+            region='us-east-1',
+        )
+        assert result['success'] is False
+        assert 'Job ID must be in UUID format' in result['error']
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_bulk_import_csv_validation_valid_asset_property_combo(self, mock_boto_client):
+        """Test CSV validation passes with valid ASSET_ID + PROPERTY_ID combination."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'SITEWISE_DEFAULT_STORAGE',
+            'warmTier': {'state': 'ENABLED'},
+        }
+        mock_client.create_bulk_import_job.return_value = {
+            'jobId': 'test-job-id',
+            'jobName': 'test-job',
+            'jobStatus': 'PENDING',
+        }
+
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {
+                        'columnNames': [
+                            'ASSET_ID',
+                            'PROPERTY_ID',
+                            'TIMESTAMP_SECONDS',
+                            'VALUE',
+                            'DATA_TYPE',
+                        ]
+                    }
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is True
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_bulk_import_parquet_validation_valid(self, mock_boto_client):
+        """Test Parquet validation passes with valid configuration."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'SITEWISE_DEFAULT_STORAGE',
+            'warmTier': {'state': 'ENABLED'},
+        }
+        mock_client.create_bulk_import_job.return_value = {
+            'jobId': 'test-job-id',
+            'jobName': 'test-job',
+            'jobStatus': 'PENDING',
+        }
+
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.parquet'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'parquet': {}}},
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is True
+
+    def test_buffered_ingestion_job_inherits_csv_validation(self):
+        """Test that buffered ingestion job inherits CSV validation from bulk import."""
+        result = create_buffered_ingestion_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={'fileFormat': {'csv': {'columnNames': ['INVALID_COLUMN']}}},
+        )
+        assert result['success'] is False
+        assert 'Invalid column name: INVALID_COLUMN' in result['error']
+
+    def test_create_bulk_import_job_adaptive_ingestion_not_boolean(self):
+        """Test validation fails when adaptive_ingestion is not boolean."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']}
+                }
+            },
+            adaptive_ingestion='not_boolean',  # Invalid type
+            region='us-east-1',
+        )
+        assert result['success'] is False
+        assert 'Please provide a boolean value for adaptive_ingestion' in result['error']
+
+    def test_create_bulk_import_job_control_characters_in_name(self):
+        """Test validation fails with control characters in job name."""
+        result = create_bulk_import_job(
+            job_name='test\x00job',  # Contains null character
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']}
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Job name cannot contain control characters' in result['error']
+
+    def test_create_bulk_import_job_missing_job_role_arn(self):
+        """Test validation fails with missing job role ARN."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='',  # Empty ARN
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Job role ARN is required' in result['error']
+
+    def test_create_bulk_import_job_invalid_arn_format(self):
+        """Test validation fails with invalid ARN format."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='invalid-arn-format',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Job role ARN must be a valid AWS ARN' in result['error']
+
+    def test_create_bulk_import_job_arn_too_long(self):
+        """Test validation fails with ARN too long."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/' + 'a' * 1600,  # Too long
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Job role ARN must be between 1 and 1600 characters' in result['error']
+
+    def test_create_bulk_import_job_files_not_list(self):
+        """Test validation fails when files is not a list."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files='not-a-list',  # Invalid type
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Files must be a non-empty list' in result['error']
+
+    def test_create_bulk_import_job_file_not_dict(self):
+        """Test validation fails when file is not a dictionary."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=['not-a-dict'],  # Invalid type
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Each file must be a dictionary' in result['error']
+
+    def test_create_bulk_import_job_file_missing_bucket_key(self):
+        """Test validation fails when file missing bucket or key."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket'}],  # Missing key
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Each file must have "bucket" and "key" fields' in result['error']
+
+    def test_create_bulk_import_job_bucket_name_too_short(self):
+        """Test validation fails with bucket name too short."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'ab', 'key': 'test.csv'}],  # Too short
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'S3 bucket name must be between 3 and 63 characters' in result['error']
+
+    def test_create_bulk_import_job_error_location_not_dict(self):
+        """Test validation fails when error report location is not dict."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location='not-a-dict',  # Invalid type
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Error report location must be a dictionary' in result['error']
+
+    def test_create_bulk_import_job_error_location_missing_fields(self):
+        """Test validation fails when error location missing fields."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket'},  # Missing prefix
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Error report location must have "bucket" and "prefix" fields' in result['error']
+
+    def test_create_bulk_import_job_error_prefix_no_slash(self):
+        """Test validation fails when error prefix doesn't end with slash."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={
+                'bucket': 'error-bucket',
+                'prefix': 'errors',
+            },  # No trailing slash
+            job_configuration={
+                'fileFormat': {'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE']}}
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Error report prefix must end with a forward slash (/)' in result['error']
+
+    def test_create_bulk_import_job_config_not_dict(self):
+        """Test validation fails when job configuration is not dict."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration='not-a-dict',  # Invalid type
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Job configuration must be a dictionary' in result['error']
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_create_bulk_import_job_client_error(self, mock_create_client):
+        """Test handling of AWS client errors."""
+        mock_client = Mock()
+        mock_create_client.return_value = mock_client
+        mock_client.describe_storage_configuration.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}},
+            'DescribeStorageConfiguration',
+        )
+
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'error-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']}
+                }
+            },
+            adaptive_ingestion=False,  # This will trigger storage config check
+            region='us-east-1',
+        )
+        assert result['success'] is False
+        assert 'Failed to validate storage configuration' in result['error']
+
+    def test_create_bulk_import_job_error_bucket_too_short(self):
+        """Test create_bulk_import_job with error bucket name too short."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'ab', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE', 'QUALITY']}
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Error report bucket name must be between 3 and 63 characters' in result['error']
+
+    def test_create_bulk_import_job_prefix_no_slash(self):
+        """Test create_bulk_import_job with prefix not ending in slash."""
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'test-bucket', 'prefix': 'errors'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE', 'QUALITY']}
+                }
+            },
+            adaptive_ingestion=True,
+        )
+        assert result['success'] is False
+        assert 'Error report prefix must end with a forward slash' in result['error']
+
+    def test_list_bulk_import_jobs_invalid_filter(self):
+        """Test list_bulk_import_jobs with invalid filter."""
+        result = list_bulk_import_jobs(filter='INVALID')
+        assert result['success'] is False
+        assert 'Invalid filter: INVALID' in result['error']
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_list_bulk_import_jobs_client_error(self, mock_client):
+        """Test list_bulk_import_jobs with AWS client error."""
+        mock_sitewise = Mock()
+        mock_client.return_value = mock_sitewise
+        mock_sitewise.list_bulk_import_jobs.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}}, 'ListBulkImportJobs'
+        )
+
+        result = list_bulk_import_jobs()
+
+        assert result['success'] is False
+        assert result['error_code'] == 'AccessDenied'
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.validation.check_storage_configuration_requirements'
+    )
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_create_bulk_import_job_aws_error(self, mock_client, mock_storage):
+        """Test create_bulk_import_job AWS ClientError handling."""
+        mock_storage.return_value = None
+        mock_sitewise = Mock()
+        mock_client.return_value = mock_sitewise
+        mock_sitewise.create_bulk_import_job.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}}, 'CreateBulkImportJob'
+        )
+
+        result = create_bulk_import_job(
+            job_name='test-job',
+            job_role_arn='arn:aws:iam::123456789012:role/TestRole',
+            files=[{'bucket': 'test-bucket', 'key': 'test.csv'}],
+            error_report_location={'bucket': 'test-bucket', 'prefix': 'errors/'},
+            job_configuration={
+                'fileFormat': {
+                    'csv': {'columnNames': ['ALIAS', 'TIMESTAMP_SECONDS', 'VALUE', 'DATA_TYPE']}
+                }
+            },
+            adaptive_ingestion=True,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'AccessDenied'
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_list_bulk_import_jobs_aws_error(self, mock_client):
+        """Test list_bulk_import_jobs AWS ClientError handling."""
+        mock_sitewise = Mock()
+        mock_client.return_value = mock_sitewise
+        mock_sitewise.list_bulk_import_jobs.side_effect = ClientError(
+            {'Error': {'Code': 'ThrottlingException', 'Message': 'Rate exceeded'}},
+            'ListBulkImportJobs',
+        )
+
+        result = list_bulk_import_jobs()
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ThrottlingException'
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_describe_bulk_import_job_aws_error(self, mock_client):
+        """Test describe_bulk_import_job AWS ClientError handling."""
+        mock_sitewise = Mock()
+        mock_client.return_value = mock_sitewise
+        mock_sitewise.describe_bulk_import_job.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFound', 'Message': 'Job not found'}},
+            'DescribeBulkImportJob',
+        )
+
+        result = describe_bulk_import_job(job_id='12345678-1234-1234-1234-123456789012')
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ResourceNotFound'
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_list_bulk_import_jobs_region_validation_workflow(self, mock_client):
+        """Test list_bulk_import_jobs region validation in workflow."""
+        result = list_bulk_import_jobs(
+            filter='ALL', next_token=None, max_results=50, region='invalid_region!'
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ValidationException'
+        assert 'Invalid AWS region format' in result['error']
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_data.create_sitewise_client')
+    def test_list_bulk_import_jobs_max_results_validation_workflow(self, mock_client):
+        """Test list_bulk_import_jobs max_results validation in workflow."""
+        result = list_bulk_import_jobs(
+            filter='ALL', next_token=None, max_results=0, region='us-east-1'
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ValidationException'
+        assert 'Max results must be at least 1' in result['error']
 
 
 if __name__ == '__main__':

--- a/src/aws-iot-sitewise-mcp-server/tests/test_validation.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_validation.py
@@ -19,6 +19,7 @@ import pytest
 import sys
 from awslabs.aws_iot_sitewise_mcp_server.validation import (
     ValidationError,
+    check_storage_configuration_requirements,
     sanitize_string,
     validate_access_policy_permission,
     validate_aggregate_types,
@@ -43,6 +44,7 @@ from awslabs.aws_iot_sitewise_mcp_server.validation import (
     validate_timestamp,
 )
 from datetime import datetime
+from unittest.mock import Mock
 
 
 # Add the project root directory and its parent to Python path
@@ -469,6 +471,122 @@ class TestValidation:
 
         with pytest.raises(ValidationError, match='SQL injection'):
             validate_asset_model_properties(malicious_properties)
+
+    def test_check_storage_configuration_adaptive_ingestion_enabled(self):
+        """Test that validation passes when adaptive ingestion is enabled."""
+        mock_client = Mock()
+        # Should not call describe_storage_configuration when adaptive_ingestion=True
+        check_storage_configuration_requirements(mock_client, adaptive_ingestion=True)
+        mock_client.describe_storage_configuration.assert_not_called()
+
+    def test_check_storage_configuration_default_storage_with_warm_tier(self):
+        """Test validation passes with default storage and warm tier enabled."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'SITEWISE_DEFAULT_STORAGE',
+            'warmTier': {'state': 'ENABLED'},
+        }
+
+        check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+        mock_client.describe_storage_configuration.assert_called_once()
+
+    def test_check_storage_configuration_default_storage_without_warm_tier(self):
+        """Test validation fails with default storage and no warm tier."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'SITEWISE_DEFAULT_STORAGE',
+            'warmTier': {'state': 'DISABLED'},
+        }
+
+        with pytest.raises(
+            ValidationError,
+            match='either multi-layer storage must be configured or warm tier must be enabled',
+        ):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+
+    def test_check_storage_configuration_default_storage_no_warm_tier_key(self):
+        """Test validation fails with default storage and missing warm tier key."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'SITEWISE_DEFAULT_STORAGE'
+        }
+
+        with pytest.raises(
+            ValidationError,
+            match='either multi-layer storage must be configured or warm tier must be enabled',
+        ):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+
+    def test_check_storage_configuration_multilayer_storage_valid(self):
+        """Test validation passes with properly configured multi-layer storage."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'MULTI_LAYER_STORAGE',
+            'multiLayerStorage': {
+                'customerManagedS3Storage': {
+                    's3ResourceArn': 'arn:aws:s3:::my-bucket',
+                    'roleArn': 'arn:aws:iam::123456789012:role/MyRole',
+                }
+            },
+        }
+
+        check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+        mock_client.describe_storage_configuration.assert_called_once()
+
+    def test_check_storage_configuration_multilayer_storage_missing_s3(self):
+        """Test validation fails with multi-layer storage missing S3 config."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'MULTI_LAYER_STORAGE',
+            'multiLayerStorage': {},
+        }
+
+        with pytest.raises(
+            ValidationError, match='customer managed S3 storage is not properly set up'
+        ):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+
+    def test_check_storage_configuration_multilayer_storage_no_multilayer_key(self):
+        """Test validation fails with multi-layer storage type but missing config."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'MULTI_LAYER_STORAGE'
+        }
+
+        with pytest.raises(
+            ValidationError, match='customer managed S3 storage is not properly set up'
+        ):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+
+    def test_check_storage_configuration_unknown_storage_type(self):
+        """Test validation fails with unknown storage type."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.return_value = {
+            'storageType': 'UNKNOWN_STORAGE_TYPE'
+        }
+
+        with pytest.raises(ValidationError, match='Unknown storage type: UNKNOWN_STORAGE_TYPE'):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+
+    def test_check_storage_configuration_api_exception(self):
+        """Test validation handles API exceptions properly."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.side_effect = Exception('API Error')
+
+        with pytest.raises(
+            ValidationError, match='Failed to validate storage configuration: API Error'
+        ):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
+
+    def test_check_storage_configuration_validation_error_passthrough(self):
+        """Test that ValidationError exceptions are passed through unchanged."""
+        mock_client = Mock()
+        mock_client.describe_storage_configuration.side_effect = ValidationError(
+            'Custom validation error'
+        )
+
+        with pytest.raises(ValidationError, match='Custom validation error'):
+            check_storage_configuration_requirements(mock_client, adaptive_ingestion=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Add Bulk Import and Buffered Ingestion tools and prompts to AWS IoT SiteWise MCP Server

## Summary

### Changes

This PR adds comprehensive bulk data import capabilities to the AWS IoT SiteWise MCP Server, including:

- **5 new bulk import tools**: `create_bulk_import_job`, `create_buffered_ingestion_job`, `create_bulk_import_iam_role`, `list_bulk_import_jobs`, and `describe_bulk_import_job`
- **New bulk import workflow prompt**: Step-by-step guidance for setting up bulk data ingestion with CSV validation, IAM role creation, and job monitoring
- **Enhanced validation**: CSV file format validation, job ID format checking, and bulk import parameter validation
- **Comprehensive test coverage**: New test cases covering all bulk import scenarios and edge cases
- **Updated documentation**: README updated with new tools and usage examples

### User experience

**Before**: Users could only ingest data one batch at a time using `batch_put_asset_property_value`, limiting them to small-scale data ingestion scenarios.

**After**: Users can now:
- Ingest historical or buffered data use SiteWise Bulk Import capabilities
- Get step-by-step guidance through the bulk import workflow prompt
- Automatically create required IAM roles with proper S3 permissions for bulk import and buffered ingestion jobs
- Monitor job progress and list all bulk import jobs for the user.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): **N**

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
