### PR TITLE
chore(aws-dataprocessing-mcp-server): pin mcp to 1.18

### DIFF
--- a/src/aws-dataprocessing-mcp-server/pyproject.toml
+++ b/src/aws-dataprocessing-mcp-server/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "loguru>=0.7.0",
-    "mcp[cli]>=1.11.0",
+    "mcp[cli]>=1.11.0,<=1.18.0",
     "pydantic>=2.10.6",
     "boto3>=1.34.0",
     "requests>=2.31.0",


### PR DESCRIPTION
## Summary
Pin MCP version to 1.18 as a new change was introduced on CallToolResult
### Changes
pin the mcp 1.18 in pyproject.toml
> Please provide a summary of what's being changed
pin the mcp 1.18 in pyproject.toml

### User experience
the dataprocessing-mcp should start working which was blocking before

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:
https://github.com/awslabs/mcp/issues/1576
Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
