### PR TITLE
feat: add bulk metadata transfer job management tools

### DIFF
--- a/src/aws-iot-sitewise-mcp-server/README.md
+++ b/src/aws-iot-sitewise-mcp-server/README.md
@@ -30,6 +30,15 @@ A comprehensive MCP (Model Context Protocol) server that provides full AWS IoT S
 - **Time Series Management**: Associate and manage time series data streams
 - **Edge Computing**: Support for local data processing and intermittent connectivity
 
+#### 📦 Bulk Operations & Metadata Transfer
+
+- **Bulk Export**: Export ALL IoT SiteWise resources (asset models, assets, etc.) in one operation using metadata transfer jobs
+- **Bulk Import Schema**: Create and validate structured schemas for bulk asset/model imports
+- **Metadata Transfer Jobs**: Manage large-scale data migration between S3 and IoT SiteWise
+- **Job Monitoring**: Track progress and status of bulk operations
+- **Multi-Source Support**: Transfer data between S3 buckets and IoT SiteWise
+- **Schema Validation**: Ensure data integrity with comprehensive validation before import
+
 #### 🔒 Security & Configuration
 
 - **Access Policies**: Fine-grained access control for users and resources
@@ -72,17 +81,19 @@ Step-by-step guidance for setting up data ingestion:
 
 ```bash
 # Install UV if you don't have it yet
-curl -sSf https://astral.sh/uv/install | sh
+curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Clone the repository
 git clone https://github.com/awslabs/mcp.git
-cd src/aws-iot-sitewise-mcp-server
+cd mcp/src/aws-iot-sitewise-mcp-server
 
 # Install as a uv tool (this makes it available globally via uvx)
 uv tool install .
 
 # The server is now available globally via uvx
 uvx awslabs.aws-iot-sitewise-mcp-server
+# use @latest flag for automatically pull updates on server
+uvx awslabs.aws-iot-sitewise-mcp-server@latest
 
 # Note: The server runs silently, waiting for MCP client connections.
 # You'll need to configure an MCP client to connect to it.
@@ -96,7 +107,7 @@ pip install aws-iot-sitewise-mcp
 
 # Or install from source
 git clone https://github.com/awslabs/mcp.git
-cd src/aws-iot-sitewise-mcp-server
+cd mcp/src/aws-iot-sitewise-mcp-server
 pip install .
 
 # Run the server
@@ -105,7 +116,10 @@ python -m awslabs.aws_iot_sitewise_mcp_server.server
 
 ### AWS Configuration
 
-Configure AWS credentials using any of these methods:
+Configure AWS credentials with permissions for:
+- AWS IoT SiteWise (full access for write operations)
+- AWS IoT TwinMaker (for metadata transfer operations)
+- Amazon S3 (for bulk import/export operations)
 
 ```bash
 # AWS CLI (recommended)
@@ -133,7 +147,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "aws-iot-sitewise": {
       "command": "uvx",
-      "args": ["awslabs.aws-iot-sitewise-mcp-server"],
+      "args": ["awslabs.aws-iot-sitewise-mcp-server@latest"],
       "env": {
         "AWS_REGION": "us-west-2",
         "AWS_PROFILE": "your-profile-name",
@@ -152,7 +166,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "aws-iot-sitewise": {
       "command": "uvx",
-      "args": ["awslabs.aws-iot-sitewise-mcp-server"],
+      "args": ["awslabs.aws-iot-sitewise-mcp-server@latest"],
       "env": {
         "AWS_REGION": "us-west-2",
         "AWS_PROFILE": "your-profile-name",
@@ -215,7 +229,7 @@ Configure in your workspace or global settings:
   "mcpServers": {
     "aws-iot-sitewise": {
       "command": "uvx",
-      "args": ["awslabs.aws-iot-sitewise-mcp-server"],
+      "args": ["awslabs.aws-iot-sitewise-mcp-server@latest"],
       "env": {
         "AWS_REGION": "us-west-2",
         "AWS_PROFILE": "your-profile-name",
@@ -234,7 +248,7 @@ Configure in your workspace or global settings:
   "mcpServers": {
     "aws-iot-sitewise": {
       "command": "uvx",
-      "args": ["awslabs.aws-iot-sitewise-mcp-server"],
+      "args": ["awslabs.aws-iot-sitewise-mcp-server@latest"],
       "env": {
         "AWS_REGION": "us-west-2",
         "AWS_PROFILE": "your-profile-name",
@@ -354,6 +368,16 @@ Configure in your workspace or global settings:
 | `link_time_series_asset_property` | Link data streams |
 | `unlink_time_series_asset_property` | Unlink streams |
 | `delete_time_series` | Remove time series |
+
+### Metadata Transfer & Bulk Import Tools
+
+| Tool Name | Description |
+|-----------|-------------|
+| `create_bulk_import_schema` | Construct and validate bulk import schemas for asset models and assets |
+| `create_metadata_transfer_job` | **🚀 PRIMARY TOOL for bulk export/import operations** - Use this for exporting all resources |
+| `cancel_metadata_transfer_job` | Cancel running metadata transfer jobs |
+| `get_metadata_transfer_job` | Get detailed information about metadata transfer jobs |
+| `list_metadata_transfer_jobs` | List metadata transfer jobs with filtering options |
 
 ### Access Control & Configuration Tools
 
@@ -636,6 +660,18 @@ The implementation is validated against:
    - Verify property aliases and IDs
    - Check timestamp formats
    - Validate data types and ranges
+
+4. **Metadata Transfer Issues**
+   - Verify IoT TwinMaker service permissions
+   - Check S3 bucket access for source/destination operations
+   - Validate bulk import schema format
+   - Monitor job status for detailed error messages
+
+5. **Bulk Import Schema Errors**
+   - Ensure asset model external IDs are unique
+   - Verify property data types match requirements
+   - Check hierarchy references are valid
+   - Use create_bulk_import_schema tool for validation
 
 ### Getting Help
 

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/client.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/client.py
@@ -45,3 +45,17 @@ def create_iam_client(region: str = 'us-east-1'):
     config = Config(user_agent_extra=f'awslabs/mcp/aws-iot-sitewise-mcp-server/{__version__}')
 
     return boto3.client('iam', region_name=region, config=config)
+
+
+def create_twinmaker_client(region: str = 'us-east-1'):
+    """Create a standardized AWS IoT TwinMaker client with proper user agent.
+
+    Args:
+        region: AWS region name (default: us-east-1)
+
+    Returns:
+        boto3 IoT TwinMaker client instance
+    """
+    config = Config(user_agent_extra=f'awslabs/mcp/aws-iot-sitewise-mcp-server/{__version__}')
+
+    return boto3.client('iottwinmaker', region_name=region, config=config)

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/models.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/models.py
@@ -1,0 +1,537 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS IoT SiteWise Data Models and Schema Definitions."""
+
+import re
+from dataclasses import field
+from pydantic import BaseModel, Field, field_validator, model_validator
+from typing import List, Literal, Optional
+
+
+CONTROL_CHAR_PATTERN = re.compile(r'^[^\u0000-\u001F\u007F]+$')
+
+
+class Name(BaseModel):
+    """Name field for AWS IoT SiteWise entities."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_name(cls, v):
+        """Validate name field constraints."""
+        if not (1 <= len(v) <= 256):
+            raise ValueError('Name must be between 1 and 256 characters.')
+        if not CONTROL_CHAR_PATTERN.match(v):
+            raise ValueError('Name contains invalid control characters.')
+        return v
+
+
+class Description(BaseModel):
+    """Description field for AWS IoT SiteWise entities."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_description(cls, v):
+        """Validate description field constraints."""
+        if not (1 <= len(v) <= 2048):
+            raise ValueError('Description must be between 1 and 2048 characters.')
+        if not CONTROL_CHAR_PATTERN.match(v):
+            raise ValueError('Description contains invalid control characters.')
+        return v
+
+
+class Tag(BaseModel):
+    """Tag key-value pair for AWS IoT SiteWise entities."""
+
+    key: str
+    value: str
+
+    @field_validator('key')
+    def validate_key(cls, v):
+        """Validate tag key constraints."""
+        if not isinstance(v, str) or not v:
+            raise ValueError('key must be a non-empty string.')
+        return v
+
+    @field_validator('value')
+    def validate_value(cls, v):
+        """Validate tag value constraints."""
+        return v
+
+
+class ID(BaseModel):
+    """UUID identifier for AWS IoT SiteWise entities."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_uuid(cls, v):
+        """Validate UUID format constraints."""
+        pattern = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+        if not pattern.match(v):
+            raise ValueError(f'Invalid UUID: {v}')
+        return v
+
+
+class ExternalId(BaseModel):
+    """External identifier for AWS IoT SiteWise entities."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_external_id(cls, v):
+        """Validate external ID format and length constraints."""
+        pattern = re.compile(r'^[a-zA-Z0-9_][a-zA-Z_\-0-9.:]*[a-zA-Z0-9_]+$')
+        if not (2 <= len(v) <= 128):
+            raise ValueError('ExternalId must be between 2 and 128 characters.')
+        if not pattern.match(v):
+            raise ValueError(f"ExternalId '{v}' does not match pattern.")
+        return v
+
+
+class AttributeValue(BaseModel):
+    """Attribute value for AWS IoT SiteWise properties."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_attribute_value(cls, v):
+        """Validate attribute value constraints."""
+        if not CONTROL_CHAR_PATTERN.match(v):
+            raise ValueError('AttributeValue contains invalid control characters.')
+        return v
+
+
+class PropertyUnit(BaseModel):
+    """Unit of measurement for AWS IoT SiteWise properties."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_unit(cls, v):
+        """Validate property unit constraints."""
+        if not (1 <= len(v) <= 256):
+            raise ValueError('PropertyUnit must be between 1 and 256 characters.')
+        if not CONTROL_CHAR_PATTERN.match(v):
+            raise ValueError('PropertyUnit contains invalid control characters.')
+        return v
+
+
+class PropertyAlias(BaseModel):
+    """Alias for AWS IoT SiteWise properties."""
+
+    value: str
+
+    @field_validator('value')
+    def validate_alias(cls, v):
+        """Validate property alias constraints."""
+        if not (1 <= len(v) <= 1000):
+            raise ValueError('PropertyAlias must be between 1 and 1000 characters.')
+        if not CONTROL_CHAR_PATTERN.match(v):
+            raise ValueError('PropertyAlias contains invalid control characters.')
+        return v
+
+
+class AssetModelType(BaseModel):
+    """Type of AWS IoT SiteWise asset model."""
+
+    value: Optional[Literal['ASSET_MODEL', 'COMPONENT_MODEL']] = None
+
+
+class DataType(BaseModel):
+    """Data type for AWS IoT SiteWise properties."""
+
+    value: Literal['STRING', 'INTEGER', 'DOUBLE', 'BOOLEAN', 'STRUCT']
+
+
+class ComputeLocation(BaseModel):
+    """Compute location for AWS IoT SiteWise processing."""
+
+    value: Literal['EDGE', 'CLOUD']
+
+
+class ForwardingConfig(BaseModel):
+    """Forwarding configuration for AWS IoT SiteWise processing."""
+
+    state: Literal['ENABLED', 'DISABLED']
+
+
+class MeasurementProcessingConfig(BaseModel):
+    """Processing configuration for measurement properties."""
+
+    forwardingConfig: ForwardingConfig
+
+
+class TransformProcessingConfig(BaseModel):
+    """Processing configuration for transform properties."""
+
+    computeLocation: ComputeLocation
+    forwardingConfig: Optional[ForwardingConfig] = None
+
+
+class MetricProcessingConfig(BaseModel):
+    """Processing configuration for metric properties."""
+
+    computeLocation: ComputeLocation
+
+
+class TumblingWindow(BaseModel):
+    """Tumbling window configuration for metrics."""
+
+    interval: str
+    offset: Optional[str] = None
+
+    @field_validator('interval')
+    def validate_interval(cls, v):
+        """Validate tumbling window interval constraints."""
+        if not (2 <= len(v) <= 23):
+            raise ValueError('TumblingWindow.interval must be 2–23 chars.')
+        return v
+
+    @field_validator('offset')
+    def validate_offset(cls, v):
+        """Validate tumbling window offset constraints."""
+        if v and not (2 <= len(v) <= 25):
+            raise ValueError('TumblingWindow.offset must be 2–25 chars.')
+        return v
+
+
+class MetricWindow(BaseModel):
+    """Window configuration for metrics."""
+
+    tumbling: Optional[TumblingWindow] = None
+
+
+class VariableValue(BaseModel):
+    """Variable value reference for expressions."""
+
+    propertyId: Optional[ID] = None
+    propertyExternalId: Optional[ExternalId] = None
+    hierarchyId: Optional[ID] = None
+    hierarchyExternalId: Optional[ExternalId] = None
+
+    @model_validator(mode='after')
+    def validate_variable(cls, values):
+        """Validate variable value constraints."""
+        if not (values.propertyId or values.propertyExternalId):
+            raise ValueError(
+                "VariableValue must include either 'propertyId' or 'propertyExternalId'."
+            )
+        return values
+
+
+class ExpressionVariable(BaseModel):
+    """Variable definition for expressions."""
+
+    name: str
+    value: VariableValue
+
+    @field_validator('name')
+    def validate_name(cls, v):
+        """Validate expression variable name constraints."""
+        if not (1 <= len(v) <= 64):
+            raise ValueError('ExpressionVariable.name must be 1–64 chars.')
+        if not re.match(r'^[a-z][a-z0-9_]*$', v):
+            raise ValueError('ExpressionVariable.name must match pattern ^[a-z][a-z0-9_]*$')
+        return v
+
+
+class Attribute(BaseModel):
+    """Attribute property definition."""
+
+    defaultValue: Optional[str] = None
+
+    @field_validator('defaultValue')
+    def validate_default_value(cls, v):
+        """Validate attribute default value constraints."""
+        if v and not CONTROL_CHAR_PATTERN.match(v):
+            raise ValueError('Attribute.defaultValue contains invalid control chars.')
+        return v
+
+
+class Transform(BaseModel):
+    """Transform property definition."""
+
+    expression: str
+    variables: List[ExpressionVariable]
+    processingConfig: Optional[TransformProcessingConfig] = None
+
+    @field_validator('expression')
+    def validate_expr(cls, v):
+        """Validate transform expression constraints."""
+        if not (1 <= len(v) <= 1024):
+            raise ValueError('Transform.expression must be 1–1024 chars.')
+        return v
+
+
+class Measurement(BaseModel):
+    """Measurement property definition."""
+
+    processingConfig: Optional[MeasurementProcessingConfig] = None
+
+
+class Metric(BaseModel):
+    """Metric property definition."""
+
+    expression: str
+    variables: List[ExpressionVariable]
+    window: MetricWindow
+    processingConfig: Optional[MetricProcessingConfig] = None
+
+    @field_validator('expression')
+    def validate_expr(cls, v):
+        """Validate metric expression constraints."""
+        if not (1 <= len(v) <= 1024):
+            raise ValueError('Metric.expression must be 1–1024 chars.')
+        return v
+
+
+class PropertyType(BaseModel):
+    """Property type definition for asset model properties."""
+
+    attribute: Optional[Attribute] = None
+    transform: Optional[Transform] = None
+    metric: Optional[Metric] = None
+    measurement: Optional[Measurement] = None
+
+    @model_validator(mode='after')
+    def validate_property_type(cls, values):
+        """Validate property type constraints."""
+        defined = [
+            v
+            for v in [values.attribute, values.transform, values.metric, values.measurement]
+            if v is not None
+        ]
+        if len(defined) != 1:
+            raise ValueError(
+                'PropertyType must define exactly one of attribute, transform, metric, or measurement.'
+            )
+        return values
+
+
+class AssetModelHierarchy(BaseModel):
+    """Asset model hierarchy definition."""
+
+    name: Name
+    id: Optional[ID] = None
+    externalId: Optional[ExternalId] = None
+    childAssetModelId: Optional[ID] = None
+    childAssetModelExternalId: Optional[ExternalId] = None
+
+    @model_validator(mode='after')
+    def validate_hierarchy(cls, values):
+        """Validate asset model hierarchy constraints."""
+        combos = [
+            (values.id, values.childAssetModelId),
+            (values.id, values.childAssetModelExternalId),
+            (values.externalId, values.childAssetModelId),
+            (values.externalId, values.childAssetModelExternalId),
+        ]
+        if not any(all(pair) for pair in combos):
+            raise ValueError('AssetModelHierarchy must include one valid field combination.')
+        return values
+
+
+class AssetModelProperty(BaseModel):
+    """Asset model property definition."""
+
+    name: Name
+    dataType: DataType
+    type: PropertyType
+    id: Optional[ID] = None
+    externalId: Optional[ExternalId] = None
+    dataTypeSpec: Optional[Name] = None
+    unit: Optional[str] = None
+
+    @model_validator(mode='after')
+    def validate_property(cls, values):
+        """Validate asset model property constraints."""
+        if not (values.id or values.externalId):
+            raise ValueError('AssetModelProperty must have id or externalId.')
+        if values.unit:
+            if not (1 <= len(values.unit) <= 256):
+                raise ValueError('Unit must be between 1–256 chars.')
+            if not CONTROL_CHAR_PATTERN.match(values.unit):
+                raise ValueError('Unit contains invalid control chars.')
+        return values
+
+
+class AssetModelCompositeModel(BaseModel):
+    """Asset model composite model definition."""
+
+    name: Name
+    type: Name
+    id: Optional[ID] = None
+    externalId: Optional[ExternalId] = None
+    parentId: Optional[ID] = None
+    parentExternalId: Optional[ExternalId] = None
+    composedAssetModelId: Optional[ID] = None
+    composedAssetModelExternalId: Optional[ExternalId] = None
+    description: Optional[Description] = None
+    properties: Optional[List[AssetModelProperty]] = field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_composite(cls, values):
+        """Validate composite model constraints."""
+        if not (values.id or values.externalId):
+            raise ValueError('CompositeModel must have id or externalId.')
+        return values
+
+
+class AssetModel(BaseModel):
+    """Asset model definition."""
+
+    assetModelName: Name
+    assetModelId: Optional[ID] = None
+    assetModelExternalId: Optional[ExternalId] = None
+    assetModelDescription: Optional[Description] = None
+    assetModelType: Optional[AssetModelType] = None
+    assetModelProperties: Optional[List[AssetModelProperty]] = field(default_factory=list)
+    assetModelCompositeModels: Optional[List[AssetModelCompositeModel]] = field(
+        default_factory=list
+    )
+    assetModelHierarchies: Optional[List[AssetModelHierarchy]] = field(default_factory=list)
+    tags: Optional[List[Tag]] = field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_model(cls, values):
+        """Validate asset model constraints."""
+        if not (values.assetModelId or values.assetModelExternalId):
+            raise ValueError('AssetModel must include assetModelId or assetModelExternalId.')
+        return values
+
+
+class AssetProperty(BaseModel):
+    """Asset property definition."""
+
+    id: Optional[ID] = None
+    externalId: Optional[ExternalId] = None
+    alias: Optional[PropertyAlias] = None
+    unit: Optional[PropertyUnit] = None
+    attributeValue: Optional[AttributeValue] = None
+    retainDataOnAliasChange: Literal['TRUE', 'FALSE'] = Field(default='TRUE')
+    propertyNotificationState: Optional[Literal['ENABLED', 'DISABLED']] = None
+
+    @model_validator(mode='after')
+    def validate_asset_property(cls, values):
+        """Validate asset property constraints."""
+        # --- anyOf: must have id or externalId ---
+        if not (values.id or values.externalId):
+            raise ValueError("AssetProperty must include either 'id' or 'externalId'.")
+        return values
+
+
+class AssetHierarchy(BaseModel):
+    """Asset hierarchy definition."""
+
+    id: Optional[ID] = None
+    externalId: Optional[ExternalId] = None
+    childAssetId: Optional[ID] = None
+    childAssetExternalId: Optional[ExternalId] = None
+
+    @model_validator(mode='after')
+    def validate_asset_hierarchy(cls, values):
+        """Validate asset hierarchy constraints."""
+        # --- anyOf validation: one of four valid required combinations ---
+        valid_combinations = [
+            (values.id and values.childAssetId),
+            (values.externalId and values.childAssetId),
+            (values.id and values.childAssetExternalId),
+            (values.externalId and values.childAssetExternalId),
+        ]
+
+        if not any(valid_combinations):
+            raise ValueError(
+                'AssetHierarchy must include one of the valid required combinations: '
+                '(id + childAssetId), (externalId + childAssetId), '
+                '(id + childAssetExternalId), or (externalId + childAssetExternalId).'
+            )
+
+        return values
+
+
+class Asset(BaseModel):
+    """Asset definition."""
+
+    assetName: Name
+    assetId: Optional[ID] = None
+    assetExternalId: Optional[ExternalId] = None
+    assetModelId: Optional[ID] = None
+    assetModelExternalId: Optional[ExternalId] = None
+    assetDescription: Optional[Description] = None
+    assetProperties: Optional[List[AssetProperty]] = field(default_factory=list)
+    assetHierarchies: Optional[List[AssetHierarchy]] = field(default_factory=list)
+    tags: Optional[List[Tag]] = field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_asset(cls, values):
+        """Validate asset constraints."""
+        # --- anyOf validation: one of four valid required combinations ---
+        valid_combinations = [
+            (values.assetId and values.assetModelId),
+            (values.assetExternalId and values.assetModelId),
+            (values.assetId and values.assetModelExternalId),
+            (values.assetExternalId and values.assetModelExternalId),
+        ]
+
+        if not any(valid_combinations):
+            raise ValueError(
+                'Asset must include one of the valid required combinations: '
+                '(assetId + assetModelId), (assetExternalId + assetModelId), '
+                '(assetId + assetModelExternalId), or (assetExternalId + assetModelExternalId).'
+            )
+
+        return values
+
+
+class BulkImportSchema(BaseModel):
+    """BulkImportSchema.
+
+    Represents the top-level metadata transfer job resource schema for AWS IoT SiteWise.
+
+    Fields:
+        assetModels: List of AssetModel objects defining reusable model templates.
+        assets: List of Asset objects instantiated from asset models.
+    """
+
+    assetModels: Optional[List['AssetModel']] = field(default_factory=list)
+    assets: Optional[List['Asset']] = field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_bulk_import_schema(cls, values):
+        """Validate bulk import schema constraints."""
+        # Cross-check: ensure all assets reference valid model external IDs
+        if not values.assets or not values.assetModels:
+            return values
+
+        model_ids = {
+            m.assetModelExternalId.value
+            for m in values.assetModels
+            if getattr(m, 'assetModelExternalId', None)
+        }
+
+        for asset in values.assets:
+            asset_model_ext = (
+                asset.assetModelExternalId.value
+                if getattr(asset, 'assetModelExternalId', None)
+                else None
+            )
+            if asset_model_ext and asset_model_ext not in model_ids:
+                raise ValueError(
+                    f"Asset '{asset.assetExternalId.value if asset.assetExternalId else asset.assetName.value}' "
+                    f"references unknown AssetModelExternalId '{asset_model_ext}'."
+                )
+        return values

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/server.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/server.py
@@ -86,6 +86,13 @@ from awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_gateways import (
     update_gateway_capability_configuration_tool,
     update_gateway_tool,
 )
+from awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer import (
+    cancel_metadata_transfer_job_tool,
+    create_bulk_import_schema_tool,
+    create_metadata_transfer_job_tool,
+    get_metadata_transfer_job_tool,
+    list_metadata_transfer_jobs_tool,
+)
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.tools import Tool
 from typing import Any, Dict
@@ -158,6 +165,11 @@ all_tools = [
     put_logging_options_tool,
     describe_storage_configuration_tool,
     put_storage_configuration_tool,
+    create_bulk_import_schema_tool,
+    create_metadata_transfer_job_tool,
+    cancel_metadata_transfer_job_tool,
+    get_metadata_transfer_job_tool,
+    list_metadata_transfer_jobs_tool,
 ]
 
 

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/tools/sitewise_metadata_transfer.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/tools/sitewise_metadata_transfer.py
@@ -1,0 +1,581 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS IoT SiteWise Bulk Metadata Transfer Job Tools."""
+
+from awslabs.aws_iot_sitewise_mcp_server.client import create_twinmaker_client
+from awslabs.aws_iot_sitewise_mcp_server.models import Asset, AssetModel, BulkImportSchema
+from awslabs.aws_iot_sitewise_mcp_server.tool_metadata import tool_metadata
+from awslabs.aws_iot_sitewise_mcp_server.validation import (
+    ValidationError as CustomValidationError,
+)
+from awslabs.aws_iot_sitewise_mcp_server.validation import (
+    validate_asset_id,
+    validate_asset_model_id,
+    validate_region,
+    validate_safe_identifier,
+    validate_string_for_injection,
+)
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp.tools import Tool
+from pydantic import Field, ValidationError
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+#  Tool definition
+# ---------------------------------------------------------------------------
+
+
+@tool_metadata(readonly=True)
+def create_bulk_import_schema(
+    asset_models: Optional[List[dict]] = None, assets: Optional[List[dict]] = None
+) -> Dict[str, Any]:
+    """Construct and validate a bulk import schema.
+
+    Args:
+        asset_models: List of asset model definitions. Each must include:
+            - assetModelName: string
+            - assetModelExternalId: string (required for asset references)
+            - assetModelProperties: list with name, externalId, dataType, type
+            - assetModelHierarchies: list with name, externalId, childAssetModelExternalId
+        assets: List of asset definitions. Each must include:
+            - assetName: string
+            - assetExternalId: string
+            - assetModelExternalId: string (must match an asset model)
+            - assetProperties: list with externalId (matching model property), alias
+            - assetHierarchies: list with externalId (matching model hierarchy), childAssetExternalId
+
+    Returns:
+        dict: Validated JSON structure for AWS IoT SiteWise bulk import.
+    """
+    asset_models = asset_models or []
+    assets = assets or []
+
+    try:
+        validated_models = []
+        for i, am in enumerate(asset_models):
+            try:
+                validated_models.append(AssetModel(**am))
+            except ValidationError as e:
+                raise ValueError(f'AssetModel {i} validation failed: {e.errors()}') from e
+            except Exception as e:
+                raise ValueError(f'AssetModel {i}: {str(e)}') from e
+
+        validated_assets = []
+        for i, a in enumerate(assets):
+            try:
+                validated_assets.append(Asset(**a))
+            except ValidationError as e:
+                raise ValueError(f'Asset {i} validation failed: {e.errors()}') from e
+            except Exception as e:
+                raise ValueError(f'Asset {i}: {str(e)}') from e
+
+        schema = BulkImportSchema(assetModels=validated_models, assets=validated_assets)
+
+        return schema.model_dump(exclude_none=True)
+
+    except Exception as e:
+        # Return structured error message and working examples
+        return {
+            'error': str(e),
+            'example_asset_model': {
+                'assetModelName': 'ExampleModel',
+                'assetModelExternalId': 'example-model',
+                'assetModelProperties': [
+                    {
+                        'name': 'Temperature',
+                        'externalId': 'temp-prop',
+                        'dataType': 'DOUBLE',
+                        'type': {
+                            'measurement': {
+                                'processingConfig': {'forwardingConfig': {'state': 'ENABLED'}}
+                            }
+                        },
+                    }
+                ],
+                'assetModelHierarchies': [
+                    {
+                        'name': 'Children',
+                        'externalId': 'children-hierarchy',
+                        'childAssetModelExternalId': 'child-model',
+                    }
+                ],
+            },
+            'example_asset': {
+                'assetName': 'ExampleAsset',
+                'assetExternalId': 'example-asset',
+                'assetModelExternalId': 'example-model',
+                'assetProperties': [{'externalId': 'temp-prop', 'alias': '/example/temperature'}],
+                'assetHierarchies': [
+                    {'externalId': 'children-hierarchy', 'childAssetExternalId': 'child-asset'}
+                ],
+            },
+        }
+
+
+@tool_metadata(readonly=False)
+def create_metadata_transfer_job(
+    transfer_direction: str = Field(
+        ...,
+        description='Direction of transfer: "s3_to_sitewise" (import from S3 to IoT SiteWise) or "sitewise_to_s3" (export from IoT SiteWise to S3)',
+    ),
+    s3_bucket_name: str = Field(..., description='S3 bucket name.'),
+    s3_object_key: Optional[str] = Field(
+        None,
+        description='S3 object key/path (e.g., "metadata/assets.json"). If not provided, will use default path.',
+    ),
+    export_all_resources: bool = Field(
+        False,
+        description='For sitewise_to_s3: Export all IoT SiteWise resources (asset models, assets, etc.) using bulk export filters',
+    ),
+    asset_model_id: Optional[str] = Field(
+        None, description='For sitewise_to_s3: Specific asset model ID to export.'
+    ),
+    asset_id: Optional[str] = Field(
+        None, description='For sitewise_to_s3: Specific asset ID to export.'
+    ),
+    include_child_assets: bool = Field(
+        True,
+        description='For asset exports: Include child assets in hierarchy (includeOffspring). Cannot be True when include_asset_model is True.',
+    ),
+    include_asset_model: bool = Field(
+        False,
+        description='For asset exports: Include asset model definition (includeAssetModel). Cannot be True when include_child_assets is True.',
+    ),
+    region: str = Field('us-east-1', description='AWS region'),
+    metadata_transfer_job_id: Optional[str] = Field(None, description='Optional custom job ID'),
+    description: Optional[str] = Field(None, description='Job description'),
+) -> Dict[str, Any]:
+    """Create a new metadata transfer job for bulk import/export operations between S3 and IoT SiteWise.
+
+    This tool provides a user-friendly way to set up metadata transfer jobs with support for bulk export
+    using IoT SiteWise source configuration filters, avoiding the need for individual API calls.
+
+    Args:
+        transfer_direction: Direction of transfer:
+            - "s3_to_sitewise": Import metadata from S3 to IoT SiteWise
+            - "sitewise_to_s3": Export metadata from IoT SiteWise to S3
+        s3_bucket_name: S3 bucket name. If not provided, the agent should list available S3 buckets.
+        s3_object_key: S3 object key/path. If not provided, will use sensible defaults.
+        export_all_resources: For sitewise_to_s3: Export all IoT SiteWise resources using bulk filters
+        asset_model_id: For sitewise_to_s3: Specific asset model ID to export
+        asset_id: For sitewise_to_s3: Specific asset ID to export
+        include_child_assets: For asset exports: Include child assets in hierarchy (includeOffspring). Cannot be True when include_asset_model is True.
+        include_asset_model: For asset exports: Include asset model definition (includeAssetModel). Cannot be True when include_child_assets is True.
+        region: AWS region (default: us-east-1)
+        metadata_transfer_job_id: Optional custom job ID
+        description: Optional job description
+
+    Returns:
+        Dictionary containing job creation response or guidance for next steps
+
+    Examples:
+        # Import from S3 to IoT SiteWise
+        create_metadata_transfer_job(
+            transfer_direction="s3_to_sitewise",
+            s3_bucket_name="my-sitewise-metadata",
+            s3_object_key="bulk-import/assets.json"
+        )
+
+        # Export ALL IoT SiteWise resources to S3 (bulk export)
+        create_metadata_transfer_job(
+            transfer_direction="sitewise_to_s3",
+            s3_bucket_name="my-sitewise-exports",
+            export_all_resources=True
+        )
+
+        # Export specific asset model and asset
+        create_metadata_transfer_job(
+            transfer_direction="sitewise_to_s3",
+            s3_bucket_name="my-sitewise-exports",
+            asset_model_id="a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            asset_id="f1e2d3c4-b5a6-9078-1234-567890abcdef"
+        )
+    """
+    try:
+        validate_region(region)
+
+        # Validate transfer direction
+        if transfer_direction not in ['s3_to_sitewise', 'sitewise_to_s3']:
+            return {
+                'success': False,
+                'error': 'Invalid transfer direction. Must be "s3_to_sitewise" or "sitewise_to_s3"',
+                'available_directions': {
+                    's3_to_sitewise': 'Import metadata from S3 to IoT SiteWise (bulk import)',
+                    'sitewise_to_s3': 'Export metadata from IoT SiteWise to S3 (backup/migration)',
+                },
+            }
+
+        # Validate S3 bucket name for security
+        validate_safe_identifier(s3_bucket_name, 'S3 bucket name')
+
+        # Validate S3 object key if provided
+        if s3_object_key:
+            validate_string_for_injection(s3_object_key, 'S3 object key')
+
+        # Validate asset model ID if provided
+        if asset_model_id:
+            validate_asset_model_id(asset_model_id)
+
+        # Validate asset ID if provided
+        if asset_id:
+            validate_asset_id(asset_id)
+
+        # Validate job ID if provided
+        if metadata_transfer_job_id:
+            validate_safe_identifier(metadata_transfer_job_id, 'Metadata transfer job ID')
+
+        # Validate description if provided
+        if description:
+            validate_string_for_injection(description, 'Job description')
+            if len(description) > 2048:
+                raise CustomValidationError('Job description cannot exceed 2048 characters')
+
+        # Validate AWS API constraint: cannot have both include_child_assets and include_asset_model as True
+        if include_child_assets and include_asset_model:
+            return {
+                'success': False,
+                'error': 'AWS API constraint: cannot set both include_child_assets and include_asset_model to True. Choose one based on your export needs.',
+                'recommendations': {
+                    'for_asset_hierarchy_export': 'Set include_child_assets=True, include_asset_model=False',
+                    'for_asset_model_export': 'Set include_child_assets=False, include_asset_model=True',
+                },
+            }
+
+        # Set default object key if not provided
+        if not s3_object_key:
+            if transfer_direction == 's3_to_sitewise':
+                s3_object_key = 'metadata-import/bulk-import-schema.json'
+            else:  # sitewise_to_s3
+                # For exports, use a folder path (not a specific file)
+                # AWS will create the actual file within this folder
+                s3_object_key = 'metadata-export/'
+
+        # Build source and destination configurations based on transfer direction
+        if transfer_direction == 's3_to_sitewise':
+            sources = [
+                {
+                    'type': 's3',
+                    's3Configuration': {
+                        'location': f'arn:aws:s3:::{s3_bucket_name}/{s3_object_key}'
+                    },
+                }
+            ]
+            destination = {'type': 'iotsitewise'}
+        else:  # sitewise_to_s3
+            # Build IoT SiteWise source configuration
+            iot_sitewise_config = {}
+
+            # Add filters only if specific resources are requested
+            # For export_all_resources=True, use empty config to export everything
+            if not export_all_resources and (asset_model_id or asset_id):
+                filters = []
+
+                if asset_model_id:
+                    # Filter for specific asset model
+                    filters.append(
+                        {
+                            'filterByAssetModel': {
+                                'assetModelId': asset_model_id,
+                                'includeOffspring': True,
+                                'includeAssets': True,
+                            }
+                        }
+                    )
+
+                if asset_id:
+                    # Filter for specific asset using user-specified parameters
+                    filters.append(
+                        {
+                            'filterByAsset': {
+                                'assetId': asset_id,
+                                'includeOffspring': include_child_assets,
+                                'includeAssetModel': include_asset_model,
+                            }
+                        }
+                    )
+
+                iot_sitewise_config['filters'] = filters
+
+            # For export_all_resources=True, leave iot_sitewise_config empty {}
+            # This tells AWS to export all IoT SiteWise resources
+
+            sources = [{'type': 'iotsitewise', 'iotSiteWiseConfiguration': iot_sitewise_config}]
+
+            destination = {
+                'type': 's3',
+                's3Configuration': {'location': f'arn:aws:s3:::{s3_bucket_name}/{s3_object_key}'},
+            }
+
+        # Create the metadata transfer job
+        client = create_twinmaker_client(region)
+
+        params: Dict[str, Any] = {
+            'sources': sources,
+            'destination': destination,
+        }
+
+        if metadata_transfer_job_id:
+            params['metadataTransferJobId'] = metadata_transfer_job_id
+        if description:
+            params['description'] = description
+        else:
+            # Set a default description based on transfer direction
+            if transfer_direction == 's3_to_sitewise':
+                params['description'] = (
+                    f'Import metadata from S3 bucket {s3_bucket_name} to IoT SiteWise'
+                )
+            else:
+                params['description'] = (
+                    f'Export metadata from IoT SiteWise to S3 bucket {s3_bucket_name}'
+                )
+
+        response = client.create_metadata_transfer_job(**params)
+
+        return {
+            'success': True,
+            'metadata_transfer_job_id': response['metadataTransferJobId'],
+            'arn': response['arn'],
+            'creation_date_time': response['creationDateTime'],
+            'status': response['status'],
+            'transfer_direction': transfer_direction,
+            's3_location': f's3://{s3_bucket_name}/{s3_object_key}',
+            'next_steps': {
+                's3_to_sitewise': 'Upload your bulk import schema JSON file to the S3 location above, then monitor the job status.',
+                'sitewise_to_s3': 'The export will begin automatically. Monitor the job status and check the S3 location for results.',
+            }.get(transfer_direction),
+        }
+
+    except CustomValidationError as e:
+        return {
+            'success': False,
+            'error': f'Validation error: {str(e)}',
+            'error_code': 'ValidationException',
+        }
+    except ClientError as e:
+        return {
+            'success': False,
+            'error': str(e),
+            'error_code': e.response['Error']['Code'],
+        }
+
+
+@tool_metadata(readonly=False)
+def cancel_metadata_transfer_job(
+    metadata_transfer_job_id: str = Field(
+        ..., description='The metadata transfer job ID to cancel'
+    ),
+    region: str = Field('us-east-1', description='AWS region'),
+) -> Dict[str, Any]:
+    """Cancel a metadata transfer job.
+
+    Args:
+        metadata_transfer_job_id: The ID of the metadata transfer job to cancel
+        region: AWS region (default: us-east-1)
+
+    Returns:
+        Dictionary containing cancellation response
+    """
+    try:
+        validate_region(region)
+
+        if not metadata_transfer_job_id:
+            raise CustomValidationError('Metadata transfer job ID is required')
+
+        client = create_twinmaker_client(region)
+
+        response = client.cancel_metadata_transfer_job(
+            metadataTransferJobId=metadata_transfer_job_id
+        )
+
+        return {
+            'success': True,
+            'metadata_transfer_job_id': response['metadataTransferJobId'],
+            'arn': response['arn'],
+            'update_date_time': response['updateDateTime'],
+            'status': response['status'],
+            'message': 'Metadata transfer job cancelled successfully',
+        }
+
+    except CustomValidationError as e:
+        return {
+            'success': False,
+            'error': f'Validation error: {str(e)}',
+            'error_code': 'ValidationException',
+        }
+    except ClientError as e:
+        return {
+            'success': False,
+            'error': str(e),
+            'error_code': e.response['Error']['Code'],
+        }
+
+
+@tool_metadata(readonly=True)
+def get_metadata_transfer_job(
+    metadata_transfer_job_id: str = Field(
+        ..., description='The metadata transfer job ID to retrieve'
+    ),
+    region: str = Field('us-east-1', description='AWS region'),
+) -> Dict[str, Any]:
+    """Get details of a metadata transfer job.
+
+    Args:
+        metadata_transfer_job_id: The ID of the metadata transfer job to retrieve
+        region: AWS region (default: us-east-1)
+
+    Returns:
+        Dictionary containing job details
+    """
+    try:
+        validate_region(region)
+
+        if not metadata_transfer_job_id:
+            raise CustomValidationError('Metadata transfer job ID is required')
+
+        client = create_twinmaker_client(region)
+
+        response = client.get_metadata_transfer_job(metadataTransferJobId=metadata_transfer_job_id)
+
+        return {
+            'success': True,
+            'metadata_transfer_job_id': response['metadataTransferJobId'],
+            'arn': response['arn'],
+            'description': response.get('description', ''),
+            'sources': response['sources'],
+            'destination': response['destination'],
+            'report_url': response.get('reportUrl', ''),
+            'creation_date_time': response['creationDateTime'],
+            'update_date_time': response['updateDateTime'],
+            'status': response['status'],
+            'progress': response.get('progress', {}),
+        }
+
+    except CustomValidationError as e:
+        return {
+            'success': False,
+            'error': f'Validation error: {str(e)}',
+            'error_code': 'ValidationException',
+        }
+    except ClientError as e:
+        return {
+            'success': False,
+            'error': str(e),
+            'error_code': e.response['Error']['Code'],
+        }
+
+
+@tool_metadata(readonly=True)
+def list_metadata_transfer_jobs(
+    source_type: str = Field(
+        ..., description='Filter by source type (s3, iotsitewise) - REQUIRED'
+    ),
+    destination_type: str = Field(
+        ..., description='Filter by destination type (s3, iotsitewise) - REQUIRED'
+    ),
+    region: str = Field('us-east-1', description='AWS region'),
+    max_results: int = Field(50, description='Maximum number of results to return (1-200)'),
+    next_token: Optional[str] = Field(None, description='Token for pagination'),
+) -> Dict[str, Any]:
+    """List metadata transfer jobs.
+
+    Args:
+        source_type: Filter by source type (s3, iotsitewise) - REQUIRED
+        destination_type: Filter by destination type (s3, iotsitewise) - REQUIRED
+        region: AWS region (default: us-east-1)
+        max_results: Maximum number of results to return (1-200, default: 50)
+        next_token: Token for pagination
+
+    Returns:
+        Dictionary containing list of metadata transfer jobs
+    """
+    try:
+        validate_region(region)
+
+        if max_results < 1 or max_results > 200:
+            raise CustomValidationError('max_results must be between 1 and 200')
+
+        # Validate required parameters
+        valid_types = ['s3', 'iotsitewise']
+        if source_type not in valid_types:
+            raise CustomValidationError(f'source_type must be one of: {", ".join(valid_types)}')
+        if destination_type not in valid_types:
+            raise CustomValidationError(
+                f'destination_type must be one of: {", ".join(valid_types)}'
+            )
+
+        client = create_twinmaker_client(region)
+
+        params: Dict[str, Any] = {
+            'sourceType': source_type,
+            'destinationType': destination_type,
+            'maxResults': max_results,
+        }
+
+        if next_token:
+            params['nextToken'] = next_token
+
+        response = client.list_metadata_transfer_jobs(**params)
+
+        return {
+            'success': True,
+            'metadata_transfer_job_summaries': response['metadataTransferJobSummaries'],
+            'next_token': response.get('nextToken', ''),
+        }
+
+    except ValidationError as e:
+        return {
+            'success': False,
+            'error': f'Validation error: {str(e)}',
+            'error_code': 'ValidationException',
+        }
+    except ClientError as e:
+        return {
+            'success': False,
+            'error': str(e),
+            'error_code': e.response['Error']['Code'],
+        }
+
+
+# Create MCP tools
+create_bulk_import_schema_tool = Tool.from_function(
+    fn=create_bulk_import_schema,
+    name='create_bulk_import_schema',
+    description='Create a structured JSON schema for AWS IoT SiteWise bulk import operations using dataclasses to ensure correct format.',
+)
+
+create_metadata_transfer_job_tool = Tool.from_function(
+    fn=create_metadata_transfer_job,
+    name='create_metadata_transfer_job',
+    description='Create a new metadata transfer job for bulk import operations in AWS IoT SiteWise.',
+)
+
+cancel_metadata_transfer_job_tool = Tool.from_function(
+    fn=cancel_metadata_transfer_job,
+    name='cancel_metadata_transfer_job',
+    description='Cancel a running metadata transfer job in AWS IoT SiteWise.',
+)
+
+get_metadata_transfer_job_tool = Tool.from_function(
+    fn=get_metadata_transfer_job,
+    name='get_metadata_transfer_job',
+    description='Get detailed information about a metadata transfer job in AWS IoT SiteWise.',
+)
+
+list_metadata_transfer_jobs_tool = Tool.from_function(
+    fn=list_metadata_transfer_jobs,
+    name='list_metadata_transfer_jobs',
+    description='List metadata transfer jobs. Requires sourceType and destinationType parameters to filter results.',
+)

--- a/src/aws-iot-sitewise-mcp-server/tests/test_client.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_client.py
@@ -15,7 +15,11 @@
 """Unit tests for client.py module."""
 
 import unittest
-from awslabs.aws_iot_sitewise_mcp_server.client import create_iam_client, create_sitewise_client
+from awslabs.aws_iot_sitewise_mcp_server.client import (
+    create_iam_client,
+    create_sitewise_client,
+    create_twinmaker_client,
+)
 from unittest.mock import Mock, patch
 
 
@@ -80,6 +84,36 @@ class TestClient(unittest.TestCase):
         args, kwargs = mock_boto_client.call_args
         self.assertEqual(args[0], 'iam')
         self.assertEqual(kwargs['region_name'], 'eu-west-1')
+        self.assertEqual(result, mock_client)
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.client.boto3.client')
+    def test_create_twinmaker_client_default_region(self, mock_boto_client):
+        """Test creating TwinMaker client with default region."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        result = create_twinmaker_client()
+
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 'iottwinmaker')
+        self.assertEqual(kwargs['region_name'], 'us-east-1')
+        self.assertIn('config', kwargs)
+        self.assertIn('awslabs/mcp/aws-iot-sitewise-mcp-server', kwargs['config'].user_agent_extra)
+        self.assertEqual(result, mock_client)
+
+    @patch('awslabs.aws_iot_sitewise_mcp_server.client.boto3.client')
+    def test_create_twinmaker_client_custom_region(self, mock_boto_client):
+        """Test creating TwinMaker client with custom region."""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+
+        result = create_twinmaker_client('ap-southeast-1')
+
+        mock_boto_client.assert_called_once()
+        args, kwargs = mock_boto_client.call_args
+        self.assertEqual(args[0], 'iottwinmaker')
+        self.assertEqual(kwargs['region_name'], 'ap-southeast-1')
         self.assertEqual(result, mock_client)
 
 

--- a/src/aws-iot-sitewise-mcp-server/tests/test_models.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_models.py
@@ -1,0 +1,726 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AWS IoT SiteWise Models."""
+
+import pytest
+from awslabs.aws_iot_sitewise_mcp_server.models import (
+    ID,
+    Asset,
+    AssetHierarchy,
+    AssetModel,
+    AssetModelCompositeModel,
+    AssetModelHierarchy,
+    AssetModelProperty,
+    AssetModelType,
+    AssetProperty,
+    Attribute,
+    AttributeValue,
+    BulkImportSchema,
+    ComputeLocation,
+    DataType,
+    Description,
+    ExpressionVariable,
+    ExternalId,
+    ForwardingConfig,
+    Measurement,
+    MeasurementProcessingConfig,
+    Metric,
+    MetricProcessingConfig,
+    MetricWindow,
+    Name,
+    PropertyAlias,
+    PropertyType,
+    PropertyUnit,
+    Tag,
+    Transform,
+    TransformProcessingConfig,
+    TumblingWindow,
+    VariableValue,
+)
+from pydantic import ValidationError
+
+
+class TestBasicModels:
+    """Test cases for basic model validation."""
+
+    def test_name_validation(self):
+        """Test Name model validation."""
+        # Valid name
+        name = Name(value='ValidName')
+        assert name.value == 'ValidName'
+
+        # Invalid empty name
+        with pytest.raises(ValidationError):
+            Name(value='')
+
+        # Invalid long name
+        with pytest.raises(ValidationError):
+            Name(value='A' * 300)
+
+        # Invalid control characters
+        with pytest.raises(ValidationError):
+            Name(value='Invalid\x00Name')
+
+    def test_external_id_validation(self):
+        """Test ExternalId model validation."""
+        # Valid external ID
+        ext_id = ExternalId(value='valid-external-id')
+        assert ext_id.value == 'valid-external-id'
+
+        # Invalid empty external ID
+        with pytest.raises(ValidationError):
+            ExternalId(value='')
+
+        # Invalid short external ID
+        with pytest.raises(ValidationError):
+            ExternalId(value='a')
+
+    def test_external_id_pattern_validation(self):
+        """Test ExternalId pattern validation."""
+        # Invalid pattern - starts with number but ends with hyphen
+        with pytest.raises(ValidationError):
+            ExternalId(value='1invalid-')
+
+        # Invalid pattern - contains invalid characters
+        with pytest.raises(ValidationError):
+            ExternalId(value='invalid@id')
+
+        # Invalid long external ID
+        with pytest.raises(ValidationError):
+            ExternalId(value='A' * 150)
+
+    def test_id_validation(self):
+        """Test ID model validation."""
+        # Valid UUID
+        valid_uuid = '12345678-1234-1234-1234-123456789012'
+        id_obj = ID(value=valid_uuid)
+        assert id_obj.value == valid_uuid
+
+        # Invalid UUID
+        with pytest.raises(ValidationError):
+            ID(value='invalid-uuid')
+
+    def test_data_type_validation(self):
+        """Test DataType model validation."""
+        # Valid data types
+        valid_types = ['STRING', 'INTEGER', 'DOUBLE', 'BOOLEAN', 'STRUCT']
+        for dtype in valid_types:
+            data_type = DataType(value=dtype)  # type: ignore
+            assert data_type.value == dtype
+
+    def test_description_validation(self):
+        """Test Description model validation."""
+        # Valid description
+        desc = Description(value='Valid description')
+        assert desc.value == 'Valid description'
+
+        # Invalid empty description
+        with pytest.raises(ValidationError):
+            Description(value='')
+
+        # Invalid long description
+        with pytest.raises(ValidationError):
+            Description(value='A' * 3000)
+
+    def test_description_control_characters(self):
+        """Test Description validation with control characters."""
+        with pytest.raises(ValidationError):
+            Description(value='Invalid\x01Description')
+
+    def test_property_alias_validation(self):
+        """Test PropertyAlias model validation."""
+        # Valid alias
+        alias = PropertyAlias(value='/factory/line1/temperature')
+        assert alias.value == '/factory/line1/temperature'
+
+        # Invalid empty alias
+        with pytest.raises(ValidationError):
+            PropertyAlias(value='')
+
+    def test_property_alias_control_characters(self):
+        """Test PropertyAlias validation with control characters."""
+        with pytest.raises(ValidationError):
+            PropertyAlias(value='/factory/line1\x00/temperature')
+
+        # Invalid long alias
+        with pytest.raises(ValidationError):
+            PropertyAlias(value='A' * 1100)
+
+    def test_tag_validation(self):
+        """Test Tag model validation."""
+        # Valid tag
+        tag = Tag(key='Environment', value='Production')
+        assert tag.key == 'Environment'
+        assert tag.value == 'Production'
+
+        # Invalid empty key
+        with pytest.raises(ValidationError):
+            Tag(key='', value='Production')
+
+        # Invalid non-string key (covers the isinstance check in validate_key)
+        with pytest.raises(ValidationError, match='Input should be a valid string'):
+            Tag(key=123, value='Production')  # type: ignore
+
+        # Invalid non-string value (covers line 63)
+        with pytest.raises(ValidationError, match='Input should be a valid string'):
+            Tag(key='Environment', value=123)  # type: ignore
+
+    def test_attribute_value_validation(self):
+        """Test AttributeValue model validation."""
+        # Valid attribute value
+        attr_val = AttributeValue(value='ValidValue')
+        assert attr_val.value == 'ValidValue'
+
+        # Invalid control characters
+        with pytest.raises(ValidationError):
+            AttributeValue(value='Invalid\x00Value')
+
+    def test_property_unit_validation(self):
+        """Test PropertyUnit model validation."""
+        # Valid unit
+        unit = PropertyUnit(value='Celsius')
+        assert unit.value == 'Celsius'
+
+        # Invalid empty unit
+        with pytest.raises(ValidationError):
+            PropertyUnit(value='')
+
+        # Invalid long unit
+        with pytest.raises(ValidationError):
+            PropertyUnit(value='A' * 300)
+
+        # Invalid control characters
+        with pytest.raises(ValidationError):
+            PropertyUnit(value='Invalid\x00Unit')
+
+
+class TestPropertyTypes:
+    """Test cases for property type models."""
+
+    def test_measurement_property_type(self):
+        """Test creating a measurement property type."""
+        measurement = Measurement()
+        prop_type = PropertyType(measurement=measurement)
+        assert prop_type.measurement is not None
+        assert prop_type.attribute is None
+        assert prop_type.transform is None
+        assert prop_type.metric is None
+
+    def test_attribute_property_type(self):
+        """Test creating an attribute property type."""
+        attribute = Attribute(defaultValue='test-value')
+        prop_type = PropertyType(attribute=attribute)
+        assert prop_type.attribute is not None
+        assert prop_type.attribute.defaultValue == 'test-value'
+        assert prop_type.measurement is None
+
+    def test_transform_property_type(self):
+        """Test creating a transform property type."""
+        variable = ExpressionVariable(
+            name='temp',
+            value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+        )
+        transform = Transform(expression='avg(temp)', variables=[variable])
+        prop_type = PropertyType(transform=transform)
+        assert prop_type.transform is not None
+        assert prop_type.transform.expression == 'avg(temp)'
+
+    def test_metric_property_type(self):
+        """Test creating a metric property type."""
+        variable = ExpressionVariable(
+            name='temp',
+            value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+        )
+        window = MetricWindow(tumbling=TumblingWindow(interval='1d'))
+        metric = Metric(expression='avg(temp)', variables=[variable], window=window)
+        prop_type = PropertyType(metric=metric)
+        assert prop_type.metric is not None
+        assert prop_type.metric.expression == 'avg(temp)'
+
+    def test_property_type_validation(self):
+        """Test PropertyType validation."""
+        # Invalid - no property type defined
+        with pytest.raises(ValidationError):
+            PropertyType()
+
+        # Invalid - multiple property types defined
+        with pytest.raises(ValidationError):
+            PropertyType(measurement=Measurement(), attribute=Attribute())
+
+        # Valid - exactly one property type defined (test all combinations)
+        # Test with attribute only
+        prop_type_attr = PropertyType(attribute=Attribute(defaultValue='test'))
+        assert prop_type_attr.attribute is not None
+        assert prop_type_attr.measurement is None
+        assert prop_type_attr.transform is None
+        assert prop_type_attr.metric is None
+
+        # Test with transform only
+        variable = ExpressionVariable(
+            name='temp',
+            value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+        )
+        prop_type_transform = PropertyType(
+            transform=Transform(expression='avg(temp)', variables=[variable])
+        )
+        assert prop_type_transform.transform is not None
+        assert prop_type_transform.attribute is None
+        assert prop_type_transform.measurement is None
+        assert prop_type_transform.metric is None
+
+        # Test with metric only
+        window = MetricWindow(tumbling=TumblingWindow(interval='1d'))
+        prop_type_metric = PropertyType(
+            metric=Metric(expression='avg(temp)', variables=[variable], window=window)
+        )
+        assert prop_type_metric.metric is not None
+        assert prop_type_metric.attribute is None
+        assert prop_type_metric.measurement is None
+        assert prop_type_metric.transform is None
+
+    def test_attribute_default_value_validation(self):
+        """Test Attribute defaultValue validation."""
+        # Valid attribute with no default
+        attr = Attribute()
+        assert attr.defaultValue is None
+
+        # Invalid control characters in default value
+        with pytest.raises(ValidationError):
+            Attribute(defaultValue='Invalid\x00Value')
+
+    def test_transform_expression_validation(self):
+        """Test Transform expression validation."""
+        variable = ExpressionVariable(
+            name='temp',
+            value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+        )
+
+        # Invalid empty expression
+        with pytest.raises(ValidationError):
+            Transform(expression='', variables=[variable])
+
+        # Invalid long expression
+        with pytest.raises(ValidationError):
+            Transform(expression='A' * 1100, variables=[variable])
+
+    def test_metric_expression_validation(self):
+        """Test Metric expression validation."""
+        variable = ExpressionVariable(
+            name='temp',
+            value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+        )
+        window = MetricWindow(tumbling=TumblingWindow(interval='1d'))
+
+        # Invalid empty expression
+        with pytest.raises(ValidationError):
+            Metric(expression='', variables=[variable], window=window)
+
+        # Invalid long expression
+        with pytest.raises(ValidationError):
+            Metric(expression='A' * 1100, variables=[variable], window=window)
+
+
+class TestAssetModelProperty:
+    """Test cases for AssetModelProperty model."""
+
+    def test_valid_measurement_property(self):
+        """Test creating a valid measurement property."""
+        prop = AssetModelProperty(
+            name=Name(value='Temperature'),
+            externalId=ExternalId(value='temp-sensor-1'),
+            dataType=DataType(value='DOUBLE'),
+            type=PropertyType(measurement=Measurement()),
+        )
+
+        assert prop.name.value == 'Temperature'
+        assert prop.externalId is not None
+        assert prop.externalId.value == 'temp-sensor-1'
+        assert prop.dataType.value == 'DOUBLE'
+        assert prop.type.measurement is not None
+
+    def test_valid_attribute_property(self):
+        """Test creating a valid attribute property."""
+        prop = AssetModelProperty(
+            name=Name(value='SerialNumber'),
+            externalId=ExternalId(value='serial-attr'),
+            dataType=DataType(value='STRING'),
+            type=PropertyType(attribute=Attribute(defaultValue='SN-12345')),
+        )
+
+        assert prop.name.value == 'SerialNumber'
+        assert prop.type.attribute and prop.type.attribute.defaultValue == 'SN-12345'
+
+    def test_asset_model_property_validation(self):
+        """Test AssetModelProperty validation."""
+        # Invalid - missing id and externalId
+        with pytest.raises(ValidationError):
+            AssetModelProperty(
+                name=Name(value='TestProperty'),
+                dataType=DataType(value='STRING'),
+                type=PropertyType(measurement=Measurement()),
+            )
+
+        # Valid with unit
+        prop = AssetModelProperty(
+            name=Name(value='Temperature'),
+            externalId=ExternalId(value='temp-sensor'),
+            dataType=DataType(value='DOUBLE'),
+            type=PropertyType(measurement=Measurement()),
+            unit='Celsius',
+        )
+        assert prop.unit == 'Celsius'
+
+        # Invalid unit - too long
+        with pytest.raises(ValidationError):
+            AssetModelProperty(
+                name=Name(value='Temperature'),
+                externalId=ExternalId(value='temp-sensor'),
+                dataType=DataType(value='DOUBLE'),
+                type=PropertyType(measurement=Measurement()),
+                unit='A' * 300,
+            )
+
+        # Invalid unit - control characters
+        with pytest.raises(ValidationError):
+            AssetModelProperty(
+                name=Name(value='Temperature'),
+                externalId=ExternalId(value='temp-sensor'),
+                dataType=DataType(value='DOUBLE'),
+                type=PropertyType(measurement=Measurement()),
+                unit='Invalid\x00Unit',
+            )
+
+
+class TestAssetProperty:
+    """Test cases for AssetProperty model."""
+
+    def test_valid_asset_property(self):
+        """Test creating a valid asset property."""
+        prop = AssetProperty(
+            externalId=ExternalId(value='temp-prop'),
+            alias=PropertyAlias(value='/factory/line1/temperature'),
+        )
+
+        assert prop.externalId and prop.externalId.value == 'temp-prop'
+        assert prop.alias and prop.alias.value == '/factory/line1/temperature'
+
+    def test_asset_property_validation(self):
+        """Test asset property validation requirements."""
+        # Must have either id or externalId
+        with pytest.raises(ValidationError):
+            AssetProperty()
+
+
+class TestAssetHierarchy:
+    """Test cases for AssetHierarchy model."""
+
+    def test_valid_asset_hierarchy(self):
+        """Test creating a valid asset hierarchy."""
+        hierarchy = AssetHierarchy(
+            externalId=ExternalId(value='children-hierarchy'),
+            childAssetExternalId=ExternalId(value='child-asset-1'),
+        )
+
+        assert hierarchy.externalId and hierarchy.externalId.value == 'children-hierarchy'
+        assert (
+            hierarchy.childAssetExternalId
+            and hierarchy.childAssetExternalId.value == 'child-asset-1'
+        )
+
+    def test_asset_hierarchy_validation(self):
+        """Test AssetHierarchy validation."""
+        # Invalid - missing required field combinations
+        with pytest.raises(ValidationError):
+            AssetHierarchy()
+
+        # Valid combination: id + childAssetId
+        hierarchy = AssetHierarchy(
+            id=ID(value='12345678-1234-1234-1234-123456789012'),
+            childAssetId=ID(value='87654321-4321-4321-4321-210987654321'),
+        )
+        assert hierarchy.id is not None
+        assert hierarchy.childAssetId is not None
+
+
+class TestAssetModelHierarchy:
+    """Test cases for AssetModelHierarchy model."""
+
+    def test_asset_model_hierarchy_validation(self):
+        """Test AssetModelHierarchy validation."""
+        # Invalid - missing required field combinations
+        with pytest.raises(ValidationError):
+            AssetModelHierarchy(name=Name(value='TestHierarchy'))
+
+        # Valid - has id and childAssetModelId
+        hierarchy = AssetModelHierarchy(
+            name=Name(value='TestHierarchy'),
+            id=ID(value='12345678-1234-1234-1234-123456789012'),
+            childAssetModelId=ID(value='87654321-4321-4321-4321-210987654321'),
+        )
+        assert hierarchy.name.value == 'TestHierarchy'
+
+
+class TestAssetModelCompositeModel:
+    """Test cases for AssetModelCompositeModel model."""
+
+    def test_asset_model_composite_model_validation(self):
+        """Test AssetModelCompositeModel validation."""
+        # Invalid - missing id and externalId
+        with pytest.raises(ValidationError):
+            AssetModelCompositeModel(name=Name(value='TestComposite'), type=Name(value='TestType'))
+
+        # Valid - has id
+        composite = AssetModelCompositeModel(
+            name=Name(value='TestComposite'),
+            type=Name(value='TestType'),
+            id=ID(value='12345678-1234-1234-1234-123456789012'),
+        )
+        assert composite.name.value == 'TestComposite'
+
+
+class TestAssetModel:
+    """Test cases for AssetModel model."""
+
+    def test_asset_model_validation(self):
+        """Test AssetModel validation."""
+        # Invalid - missing assetModelId and assetModelExternalId
+        with pytest.raises(ValidationError):
+            AssetModel(assetModelName=Name(value='TestModel'))
+
+
+class TestAsset:
+    """Test cases for Asset model."""
+
+    def test_asset_validation(self):
+        """Test Asset validation."""
+        # Invalid - missing required field combinations
+        with pytest.raises(ValidationError):
+            Asset(assetName=Name(value='TestAsset'))
+
+        # Invalid - missing assetName (covers line 362)
+        with pytest.raises(
+            ValidationError, match='Input should be a valid dictionary or instance of Name'
+        ):
+            Asset(
+                assetName=None,  # type: ignore
+                assetId=ID(value='12345678-1234-1234-1234-123456789012'),
+                assetModelId=ID(value='87654321-4321-4321-4321-210987654321'),
+            )
+
+        # Valid combination: assetId + assetModelId
+        asset = Asset(
+            assetName=Name(value='TestAsset'),
+            assetId=ID(value='12345678-1234-1234-1234-123456789012'),
+            assetModelId=ID(value='87654321-4321-4321-4321-210987654321'),
+        )
+        assert asset.assetName.value == 'TestAsset'
+
+
+class TestBulkImportSchema:
+    """Test cases for BulkImportSchema model."""
+
+    def test_empty_bulk_import_schema(self):
+        """Test creating an empty bulk import schema."""
+        schema = BulkImportSchema()
+        assert schema.assetModels == []
+        assert schema.assets == []
+
+    def test_bulk_import_schema_with_lists(self):
+        """Test creating schema with empty lists."""
+        schema = BulkImportSchema(assetModels=[], assets=[])
+        assert schema.assetModels == []
+        assert schema.assets == []
+
+    def test_schema_model_dump(self):
+        """Test schema serialization."""
+        schema = BulkImportSchema()
+        dumped = schema.model_dump(exclude_none=True)
+
+        # Should have the basic structure
+        assert 'assetModels' in dumped
+        assert 'assets' in dumped
+
+    def test_bulk_import_schema_cross_validation(self):
+        """Test BulkImportSchema cross-validation."""
+        # Test with assets referencing unknown model external IDs
+        asset_model = AssetModel(
+            assetModelName=Name(value='TestModel'),
+            assetModelExternalId=ExternalId(value='test-model'),
+        )
+
+        asset = Asset(
+            assetName=Name(value='TestAsset'),
+            assetExternalId=ExternalId(value='test-asset'),
+            assetModelExternalId=ExternalId(value='unknown-model'),  # References unknown model
+        )
+
+        with pytest.raises(ValidationError):
+            BulkImportSchema(assetModels=[asset_model], assets=[asset])
+
+        # Valid case - asset references existing model
+        valid_asset = Asset(
+            assetName=Name(value='TestAsset'),
+            assetExternalId=ExternalId(value='test-asset'),
+            assetModelExternalId=ExternalId(value='test-model'),  # References existing model
+        )
+
+        schema = BulkImportSchema(assetModels=[asset_model], assets=[valid_asset])
+        assert schema.assetModels is not None and len(schema.assetModels) == 1
+        assert schema.assets is not None and len(schema.assets) == 1
+
+
+class TestExpressionVariable:
+    """Test cases for ExpressionVariable model."""
+
+    def test_valid_expression_variable(self):
+        """Test creating a valid expression variable."""
+        variable = ExpressionVariable(
+            name='temp',
+            value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+        )
+
+        assert variable.name == 'temp'
+        assert variable.value.propertyId is not None
+        assert variable.value.propertyId.value == '12345678-1234-1234-1234-123456789012'
+
+    def test_invalid_variable_name(self):
+        """Test validation of variable names."""
+        # Invalid name pattern
+        with pytest.raises(ValidationError):
+            ExpressionVariable(
+                name='InvalidName',  # Should start with lowercase
+                value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+            )
+
+    def test_expression_variable_name_validation(self):
+        """Test ExpressionVariable name validation."""
+        # Invalid empty name
+        with pytest.raises(ValidationError):
+            ExpressionVariable(
+                name='',
+                value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+            )
+
+        # Invalid long name
+        with pytest.raises(ValidationError):
+            ExpressionVariable(
+                name='a' * 70,
+                value=VariableValue(propertyId=ID(value='12345678-1234-1234-1234-123456789012')),
+            )
+
+    def test_variable_value_validation(self):
+        """Test VariableValue validation."""
+        # Valid with propertyExternalId
+        var_val = VariableValue(propertyExternalId=ExternalId(value='temp-sensor'))
+        assert var_val.propertyExternalId is not None
+
+        # Invalid - missing both propertyId and propertyExternalId
+        with pytest.raises(ValidationError):
+            VariableValue()
+
+
+class TestTumblingWindow:
+    """Test cases for TumblingWindow model."""
+
+    def test_valid_tumbling_window(self):
+        """Test creating a valid tumbling window."""
+        window = TumblingWindow(interval='1d')
+        assert window.interval == '1d'
+
+    def test_tumbling_window_with_offset(self):
+        """Test creating a tumbling window with offset."""
+        window = TumblingWindow(interval='1h', offset='30m')
+        assert window.interval == '1h'
+        assert window.offset == '30m'
+
+    def test_tumbling_window_validation(self):
+        """Test TumblingWindow validation."""
+        # Invalid short interval
+        with pytest.raises(ValidationError):
+            TumblingWindow(interval='1')
+
+        # Invalid long interval
+        with pytest.raises(ValidationError):
+            TumblingWindow(interval='A' * 30)
+
+        # Invalid short offset
+        with pytest.raises(ValidationError):
+            TumblingWindow(interval='1h', offset='1')
+
+        # Invalid long offset
+        with pytest.raises(ValidationError):
+            TumblingWindow(interval='1h', offset='A' * 30)
+
+
+class TestProcessingConfigs:
+    """Test cases for processing configuration models."""
+
+    def test_forwarding_config(self):
+        """Test ForwardingConfig model."""
+        config = ForwardingConfig(state='ENABLED')
+        assert config.state == 'ENABLED'
+
+    def test_compute_location(self):
+        """Test ComputeLocation model."""
+        location = ComputeLocation(value='EDGE')
+        assert location.value == 'EDGE'
+
+    def test_measurement_processing_config(self):
+        """Test MeasurementProcessingConfig model."""
+        config = MeasurementProcessingConfig(forwardingConfig=ForwardingConfig(state='ENABLED'))
+        assert config.forwardingConfig.state == 'ENABLED'
+
+    def test_measurement_model(self):
+        """Test Measurement model directly."""
+        # Test creating a Measurement instance directly
+        measurement = Measurement()
+        assert measurement.processingConfig is None
+
+        # Test with processing config
+        measurement_with_config = Measurement(
+            processingConfig=MeasurementProcessingConfig(
+                forwardingConfig=ForwardingConfig(state='ENABLED')
+            )
+        )
+        assert measurement_with_config.processingConfig is not None
+        assert measurement_with_config.processingConfig.forwardingConfig.state == 'ENABLED'
+
+    def test_transform_processing_config(self):
+        """Test TransformProcessingConfig model."""
+        config = TransformProcessingConfig(
+            computeLocation=ComputeLocation(value='CLOUD'),
+            forwardingConfig=ForwardingConfig(state='DISABLED'),
+        )
+        assert config.computeLocation.value == 'CLOUD'
+        assert config.forwardingConfig is not None
+        assert config.forwardingConfig.state == 'DISABLED'
+
+    def test_metric_processing_config(self):
+        """Test MetricProcessingConfig model."""
+        config = MetricProcessingConfig(computeLocation=ComputeLocation(value='EDGE'))
+        assert config.computeLocation.value == 'EDGE'
+
+    def test_asset_model_type(self):
+        """Test AssetModelType model."""
+        model_type = AssetModelType(value='COMPONENT_MODEL')
+        assert model_type.value == 'COMPONENT_MODEL'
+
+        # Test with None value
+        model_type_none = AssetModelType()
+        assert model_type_none.value is None
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/src/aws-iot-sitewise-mcp-server/tests/test_server.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_server.py
@@ -71,8 +71,9 @@ class TestServer:
 
         # Verify tools were added - we should have a significant number of tools
         # Asset tools: 8, Asset model tools: 7, Data tools: 14, Gateway tools: 12, Access tools: 6, plus get_sitewise_server_mode
-        # Total expected: 48 tools (25 read-only + 23 write)
-        assert mock_mcp_instance.add_tool.call_count == 48
+        # Asset tools: 8, Asset model tools: 7, Data tools: 9, Gateway tools: 12, Access tools: 6, Metadata transfer tools: 5, plus get_sitewise_server_mode
+        # Total expected: 53 tools (27 read-only + 26 write)
+        assert mock_mcp_instance.add_tool.call_count == 53
 
         # Verify prompts were added (4 prompts)
         assert mock_mcp_instance.add_prompt.call_count == 4
@@ -116,6 +117,7 @@ class TestServer:
         assert 'batch_put_asset_property_value' in tool_names
         assert 'create_gateway' in tool_names
         assert 'put_logging_options' in tool_names
+        assert 'create_metadata_transfer_job' in tool_names
 
     @patch.dict(os.environ, {'SITEWISE_MCP_ALLOW_WRITES': 'True'})
     @patch('awslabs.aws_iot_sitewise_mcp_server.server.create_task_group')
@@ -207,7 +209,7 @@ class TestServer:
 
         # Verify setup still happened before the error
         mock_fastmcp.assert_called_once()
-        assert mock_mcp_instance.add_tool.call_count == 48
+        assert mock_mcp_instance.add_tool.call_count == 53
         assert mock_mcp_instance.add_prompt.call_count == 4
 
 

--- a/src/aws-iot-sitewise-mcp-server/tests/test_sitewise_metadata_transfer.py
+++ b/src/aws-iot-sitewise-mcp-server/tests/test_sitewise_metadata_transfer.py
@@ -1,0 +1,1012 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AWS IoT SiteWise Metadata Transfer Tools."""
+
+import pytest
+from awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer import (
+    cancel_metadata_transfer_job,
+    create_bulk_import_schema,
+    create_metadata_transfer_job,
+    get_metadata_transfer_job,
+    list_metadata_transfer_jobs,
+)
+from botocore.exceptions import ClientError
+from unittest.mock import Mock, patch
+
+
+class TestCreateBulkImportSchema:
+    """Test cases for create_bulk_import_schema function."""
+
+    def test_create_bulk_import_schema_empty_inputs(self):
+        """Test creating schema with empty inputs."""
+        result = create_bulk_import_schema()
+
+        assert 'assetModels' in result
+        assert 'assets' in result
+        assert result['assetModels'] == []
+        assert result['assets'] == []
+
+    def test_create_bulk_import_schema_valid_asset_model(self):
+        """Test creating schema with valid asset model."""
+        # Test that the function returns an error with examples for invalid input format
+        asset_models = [
+            {
+                'assetModelName': 'TestModel',
+                'assetModelExternalId': 'test-model-1',
+                'assetModelProperties': [
+                    {
+                        'name': 'Temperature',
+                        'externalId': 'temp-prop',
+                        'dataType': 'DOUBLE',
+                        'type': {
+                            'measurement': {
+                                'processingConfig': {'forwardingConfig': {'state': 'ENABLED'}}
+                            }
+                        },
+                    }
+                ],
+            }
+        ]
+
+        result = create_bulk_import_schema(asset_models=asset_models)
+
+        # The function should return an error with examples since it expects Pydantic BaseModel objects
+        assert 'error' in result
+        assert 'example_asset_model' in result
+        assert 'AssetModel 0 validation failed' in result['error']
+
+    def test_create_bulk_import_schema_valid_asset(self):
+        """Test creating schema with valid asset."""
+        # Test that the function returns an error with examples for invalid input format
+        assets = [
+            {
+                'assetName': 'TestAsset',
+                'assetExternalId': 'test-asset-1',
+                'assetModelExternalId': 'test-model-1',
+                'assetProperties': [{'externalId': 'temp-prop', 'alias': '/test/temperature'}],
+            }
+        ]
+
+        result = create_bulk_import_schema(assets=assets)
+
+        # The function should return an error with examples since it expects Pydantic BaseModel objects
+        assert 'error' in result
+        assert 'example_asset' in result
+        assert 'Asset 0 validation failed' in result['error']
+
+    def test_create_bulk_import_schema_invalid_asset_model(self):
+        """Test creating schema with invalid asset model."""
+        asset_models = [
+            {
+                'assetModelName': '',  # Invalid: empty name
+                'assetModelExternalId': 'test-model-1',
+            }
+        ]
+
+        result = create_bulk_import_schema(asset_models=asset_models)
+
+        assert 'error' in result
+        assert 'example_asset_model' in result
+        assert 'AssetModel 0 validation failed' in result['error']
+
+    def test_create_bulk_import_schema_invalid_asset(self):
+        """Test creating schema with invalid asset."""
+        assets = [
+            {
+                'assetName': '',  # Invalid: empty name
+                'assetExternalId': 'test-asset-1',
+            }
+        ]
+
+        result = create_bulk_import_schema(assets=assets)
+
+        assert 'error' in result
+        assert 'example_asset' in result
+        assert 'Asset 0 validation failed' in result['error']
+
+    def test_create_bulk_import_schema_exception_in_asset_model(self):
+        """Test creating schema with exception in asset model processing."""
+        # Create a mock asset model that will cause a non-ValidationError exception
+        asset_models = [None]  # This will cause a TypeError when trying to unpack
+
+        result = create_bulk_import_schema(asset_models=asset_models)
+
+        assert 'error' in result
+        assert 'example_asset_model' in result
+        assert 'AssetModel 0:' in result['error']
+
+    def test_create_bulk_import_schema_exception_in_asset(self):
+        """Test creating schema with exception in asset processing."""
+        # Create a mock asset that will cause a non-ValidationError exception
+        assets = [None]  # This will cause a TypeError when trying to unpack
+
+        result = create_bulk_import_schema(assets=assets)
+
+        assert 'error' in result
+        assert 'example_asset' in result
+        assert 'Asset 0:' in result['error']
+
+
+class TestCreateMetadataTransferJob:
+    """Test cases for create_metadata_transfer_job function."""
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_s3_to_sitewise_job_success(self, mock_create_client):
+        """Test successful S3 to SiteWise transfer job creation."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-123',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-123',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key='metadata/assets.json',
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is True
+        assert result['metadata_transfer_job_id'] == 'job-123'
+        assert result['transfer_direction'] == 's3_to_sitewise'
+        assert 's3://test-bucket/metadata/assets.json' in result['s3_location']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_sitewise_to_s3_job_success(self, mock_create_client):
+        """Test successful SiteWise to S3 transfer job creation."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-456',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-456',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='export-bucket',
+            s3_object_key=None,
+            export_all_resources=True,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is True
+        assert result['metadata_transfer_job_id'] == 'job-456'
+        assert result['transfer_direction'] == 'sitewise_to_s3'
+
+    def test_create_job_invalid_direction(self):
+        """Test job creation with invalid transfer direction."""
+        result = create_metadata_transfer_job(
+            transfer_direction='invalid_direction',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is False
+        assert 'Invalid transfer direction' in result['error']
+        assert 'available_directions' in result
+
+    def test_create_job_both_include_flags_true(self):
+        """Test job creation with both include flags set to True."""
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=True,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is False
+        assert 'AWS API constraint' in result['error']
+        assert 'recommendations' in result
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_with_asset_filters(self, mock_create_client):
+        """Test job creation with specific asset filters."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-789',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-789',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id='a1b2c3d4-5678-90ab-cdef-1234567890ab',
+            asset_id='f1e2d3c4-b5a6-9078-1234-567890abcdef',
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is True
+        # Verify the client was called with proper filters
+        call_args = mock_client.create_metadata_transfer_job.call_args[1]
+        sources = call_args['sources']
+        assert len(sources) == 1
+        assert 'iotSiteWiseConfiguration' in sources[0]
+        assert 'filters' in sources[0]['iotSiteWiseConfiguration']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_filters_edge_case(self, mock_create_client):
+        """Test edge case to improve branch coverage."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-edge-case',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-edge-case',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        # Test with a minimal valid asset model ID to ensure we hit the filter logic
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='test-bucket',
+            s3_object_key='test-key',
+            export_all_resources=False,
+            asset_model_id='12345678-1234-1234-1234-123456789012',
+            asset_id=None,
+            include_child_assets=False,
+            include_asset_model=True,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is True
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_client_error(self, mock_create_client):
+        """Test job creation with client error."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.side_effect = ClientError(
+            {'Error': {'Code': 'ValidationException', 'Message': 'Invalid request'}},
+            'CreateMetadataTransferJob',
+        )
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ValidationException'
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_invalid_region(self, mock_create_client):
+        """Test job creation with invalid region."""
+        # Mock the client creation to raise ClientError instead of EndpointConnectionError
+        # to simulate what would happen when the function properly handles the error
+        mock_create_client.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'EndpointConnectionError',
+                    'Message': 'Could not connect to the endpoint URL: "https://iottwinmaker.invalid-region.amazonaws.com/"',
+                }
+            },
+            'CreateMetadataTransferJob',
+        )
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='invalid-region',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'EndpointConnectionError'
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_invalid_asset_id(self, mock_create_client):
+        """Test job creation with invalid asset ID."""
+        # Mock the client to raise a validation error for invalid asset ID
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'ValidationException',
+                    'Message': 'Invalid asset ID format',
+                }
+            },
+            'CreateMetadataTransferJob',
+        )
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id='12345678-1234-1234-1234-123456789012',  # Valid UUID format but invalid asset ID
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ValidationException'
+
+    def test_create_job_invalid_bucket_name(self):
+        """Test job creation with invalid bucket name."""
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='invalid bucket name!',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is False
+        assert 'Validation error' in result['error']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_default_description_s3_to_sitewise(self, mock_create_client):
+        """Test job creation with default description for s3_to_sitewise."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-123',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-123',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,  # No description provided, should use default
+        )
+
+        assert result['success'] is True
+        # Verify the default description was set
+        call_args = mock_client.create_metadata_transfer_job.call_args[1]
+        assert (
+            'Import metadata from S3 bucket test-bucket to IoT SiteWise'
+            in call_args['description']
+        )
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_default_description_sitewise_to_s3(self, mock_create_client):
+        """Test job creation with default description for sitewise_to_s3."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-456',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-456',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='export-bucket',
+            s3_object_key=None,
+            export_all_resources=True,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,  # No description provided, should use default
+        )
+
+        assert result['success'] is True
+        # Verify the default description was set
+        call_args = mock_client.create_metadata_transfer_job.call_args[1]
+        assert (
+            'Export metadata from IoT SiteWise to S3 bucket export-bucket'
+            in call_args['description']
+        )
+
+    def test_create_job_description_too_long(self):
+        """Test job creation with description that exceeds maximum length."""
+        long_description = 'x' * 2049  # Exceeds 2048 character limit
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=long_description,
+        )
+
+        assert result['success'] is False
+        assert 'Validation error' in result['error']
+        assert 'cannot exceed 2048 characters' in result['error']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_with_custom_job_id_and_description(self, mock_create_client):
+        """Test job creation with custom job ID and description to cover line 322."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'custom-job-123',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/custom-job-123',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id='custom-job-123',
+            description='Custom job description',
+        )
+
+        assert result['success'] is True
+        # Verify both custom job ID and description were passed
+        call_args = mock_client.create_metadata_transfer_job.call_args[1]
+        assert call_args['metadataTransferJobId'] == 'custom-job-123'
+        assert call_args['description'] == 'Custom job description'
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_s3_to_sitewise_default_object_key(self, mock_create_client):
+        """Test s3_to_sitewise job creation with default object key to cover line 246-247."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-default-s3-to-sitewise',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-default-s3-to-sitewise',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='s3_to_sitewise',
+            s3_bucket_name='test-bucket',
+            s3_object_key=None,  # Explicitly None to trigger default object key logic
+            export_all_resources=False,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is True
+        # Verify the default object key was set for s3_to_sitewise
+        call_args = mock_client.create_metadata_transfer_job.call_args[1]
+        sources = call_args['sources']
+        assert len(sources) == 1
+        assert (
+            'metadata-import/bulk-import-schema.json' in sources[0]['s3Configuration']['location']
+        )
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_create_job_sitewise_to_s3_default_object_key(self, mock_create_client):
+        """Test sitewise_to_s3 job creation with default object key to cover line 248-251."""
+        mock_client = Mock()
+        mock_client.create_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-default-sitewise-to-s3',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-default-sitewise-to-s3',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'status': 'PENDING',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = create_metadata_transfer_job(
+            transfer_direction='sitewise_to_s3',
+            s3_bucket_name='export-bucket',
+            s3_object_key=None,  # Explicitly None to trigger default object key logic
+            export_all_resources=True,
+            asset_model_id=None,
+            asset_id=None,
+            include_child_assets=True,
+            include_asset_model=False,
+            region='us-east-1',
+            metadata_transfer_job_id=None,
+            description=None,
+        )
+
+        assert result['success'] is True
+        # Verify the default object key was set for sitewise_to_s3
+        call_args = mock_client.create_metadata_transfer_job.call_args[1]
+        destination = call_args['destination']
+        assert 'metadata-export/' in destination['s3Configuration']['location']
+
+
+class TestCancelMetadataTransferJob:
+    """Test cases for cancel_metadata_transfer_job function."""
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_cancel_job_success(self, mock_create_client):
+        """Test successful job cancellation."""
+        mock_client = Mock()
+        mock_client.cancel_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-123',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-123',
+            'updateDateTime': '2023-01-01T01:00:00Z',
+            'status': 'CANCELLED',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = cancel_metadata_transfer_job(
+            metadata_transfer_job_id='job-123',
+            region='us-east-1',
+        )
+
+        assert result['success'] is True
+        assert result['metadata_transfer_job_id'] == 'job-123'
+        assert result['status'] == 'CANCELLED'
+        assert 'cancelled successfully' in result['message']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_cancel_job_client_error(self, mock_create_client):
+        """Test job cancellation with client error."""
+        mock_client = Mock()
+        mock_client.cancel_metadata_transfer_job.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Job not found'}},
+            'CancelMetadataTransferJob',
+        )
+        mock_create_client.return_value = mock_client
+
+        result = cancel_metadata_transfer_job(
+            metadata_transfer_job_id='nonexistent-job',
+            region='us-east-1',
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ResourceNotFoundException'
+
+    def test_cancel_job_empty_id(self):
+        """Test job cancellation with empty job ID."""
+        result = cancel_metadata_transfer_job(
+            metadata_transfer_job_id='',
+            region='us-east-1',
+        )
+
+        assert result['success'] is False
+        assert 'Validation error' in result['error']
+        assert 'job ID is required' in result['error']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_cancel_job_invalid_region(self, mock_create_client):
+        """Test job cancellation with invalid region."""
+        # Mock the client creation to raise ClientError instead of EndpointConnectionError
+        mock_create_client.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'EndpointConnectionError',
+                    'Message': 'Could not connect to the endpoint URL: "https://iottwinmaker.invalid-region.amazonaws.com/"',
+                }
+            },
+            'CancelMetadataTransferJob',
+        )
+
+        result = cancel_metadata_transfer_job(
+            metadata_transfer_job_id='job-123',
+            region='invalid-region',
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'EndpointConnectionError'
+
+
+class TestGetMetadataTransferJob:
+    """Test cases for get_metadata_transfer_job function."""
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_get_job_success(self, mock_create_client):
+        """Test successful job retrieval."""
+        mock_client = Mock()
+        mock_client.get_metadata_transfer_job.return_value = {
+            'metadataTransferJobId': 'job-123',
+            'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-123',
+            'description': 'Test job',
+            'sources': [{'type': 's3'}],
+            'destination': {'type': 'iotsitewise'},
+            'reportUrl': 'https://example.com/report',
+            'creationDateTime': '2023-01-01T00:00:00Z',
+            'updateDateTime': '2023-01-01T01:00:00Z',
+            'status': 'COMPLETED',
+            'progress': {'percentage': 100},
+        }
+        mock_create_client.return_value = mock_client
+
+        result = get_metadata_transfer_job(
+            metadata_transfer_job_id='job-123',
+            region='us-east-1',
+        )
+
+        assert result['success'] is True
+        assert result['metadata_transfer_job_id'] == 'job-123'
+        assert result['status'] == 'COMPLETED'
+        assert result['progress']['percentage'] == 100
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_get_job_client_error(self, mock_create_client):
+        """Test job retrieval with client error."""
+        mock_client = Mock()
+        mock_client.get_metadata_transfer_job.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Job not found'}},
+            'GetMetadataTransferJob',
+        )
+        mock_create_client.return_value = mock_client
+
+        result = get_metadata_transfer_job(
+            metadata_transfer_job_id='nonexistent-job',
+            region='us-east-1',
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'ResourceNotFoundException'
+
+    def test_get_job_empty_id(self):
+        """Test job retrieval with empty job ID."""
+        result = get_metadata_transfer_job(
+            metadata_transfer_job_id='',
+            region='us-east-1',
+        )
+
+        assert result['success'] is False
+        assert 'Validation error' in result['error']
+        assert 'job ID is required' in result['error']
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_get_job_invalid_region(self, mock_create_client):
+        """Test job retrieval with invalid region."""
+        # Mock the client creation to raise ClientError instead of EndpointConnectionError
+        mock_create_client.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'EndpointConnectionError',
+                    'Message': 'Could not connect to the endpoint URL: "https://iottwinmaker.invalid-region.amazonaws.com/"',
+                }
+            },
+            'GetMetadataTransferJob',
+        )
+
+        result = get_metadata_transfer_job(
+            metadata_transfer_job_id='job-123',
+            region='invalid-region',
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'EndpointConnectionError'
+
+
+class TestListMetadataTransferJobs:
+    """Test cases for list_metadata_transfer_jobs function."""
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_list_jobs_success(self, mock_create_client):
+        """Test successful job listing."""
+        mock_client = Mock()
+        mock_client.list_metadata_transfer_jobs.return_value = {
+            'metadataTransferJobSummaries': [
+                {
+                    'metadataTransferJobId': 'job-123',
+                    'arn': 'arn:aws:iottwinmaker:us-east-1:123456789012:metadata-transfer-job/job-123',
+                    'creationDateTime': '2023-01-01T00:00:00Z',
+                    'updateDateTime': '2023-01-01T01:00:00Z',
+                    'status': 'COMPLETED',
+                }
+            ],
+            'nextToken': 'next-page-token',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = list_metadata_transfer_jobs(
+            source_type='s3',
+            destination_type='iotsitewise',
+            region='us-east-1',
+            max_results=50,
+            next_token=None,
+        )
+
+        assert result['success'] is True
+        assert len(result['metadata_transfer_job_summaries']) == 1
+        assert result['next_token'] == 'next-page-token'
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_list_jobs_with_pagination(self, mock_create_client):
+        """Test job listing with pagination."""
+        mock_client = Mock()
+        mock_client.list_metadata_transfer_jobs.return_value = {
+            'metadataTransferJobSummaries': [],
+            'nextToken': '',
+        }
+        mock_create_client.return_value = mock_client
+
+        result = list_metadata_transfer_jobs(
+            source_type='iotsitewise',
+            destination_type='s3',
+            region='us-east-1',
+            max_results=10,
+            next_token='existing-token',
+        )
+
+        assert result['success'] is True
+        # Verify pagination parameters were passed
+        call_args = mock_client.list_metadata_transfer_jobs.call_args[1]
+        assert call_args['maxResults'] == 10
+        assert call_args['nextToken'] == 'existing-token'
+
+    def test_list_jobs_invalid_source_type(self):
+        """Test job listing with invalid source type."""
+        try:
+            result = list_metadata_transfer_jobs(
+                source_type='invalid',
+                destination_type='iotsitewise',
+                region='us-east-1',
+                max_results=50,
+                next_token=None,
+            )
+            # If we get a result dict, check for error
+            assert result['success'] is False
+            assert (
+                'source_type must be one of' in result['error']
+                or result.get('error_code') == 'ValidationException'
+            )
+        except Exception as e:
+            # If we get an exception, check it's the expected validation error
+            assert 'source_type must be one of' in str(e)
+
+    def test_list_jobs_invalid_destination_type(self):
+        """Test job listing with invalid destination type."""
+        try:
+            result = list_metadata_transfer_jobs(
+                source_type='s3',
+                destination_type='invalid',
+                region='us-east-1',
+                max_results=50,
+                next_token=None,
+            )
+            # If we get a result dict, check for error
+            assert result['success'] is False
+            assert (
+                'destination_type must be one of' in result['error']
+                or result.get('error_code') == 'ValidationException'
+            )
+        except Exception as e:
+            # If we get an exception, check it's the expected validation error
+            assert 'destination_type must be one of' in str(e)
+
+    def test_list_jobs_invalid_max_results(self):
+        """Test job listing with invalid max_results."""
+        try:
+            result = list_metadata_transfer_jobs(
+                source_type='s3',
+                destination_type='iotsitewise',
+                region='us-east-1',
+                max_results=300,  # Too high
+                next_token=None,
+            )
+            # If we get a result dict, check for error
+            assert result['success'] is False
+            assert (
+                'max_results must be between 1 and 200' in result['error']
+                or result.get('error_code') == 'ValidationException'
+            )
+        except Exception as e:
+            # If we get an exception, check it's the expected validation error
+            assert 'max_results must be between 1 and 200' in str(e)
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_list_jobs_client_error(self, mock_create_client):
+        """Test job listing with client error."""
+        mock_client = Mock()
+        mock_client.list_metadata_transfer_jobs.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}},
+            'ListMetadataTransferJobs',
+        )
+        mock_create_client.return_value = mock_client
+
+        result = list_metadata_transfer_jobs(
+            source_type='s3',
+            destination_type='iotsitewise',
+            region='us-east-1',
+            max_results=50,
+            next_token=None,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'AccessDeniedException'
+
+    @patch(
+        'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+    )
+    def test_list_jobs_invalid_region(self, mock_create_client):
+        """Test job listing with invalid region."""
+        # Mock the client creation to raise ClientError instead of EndpointConnectionError
+        mock_create_client.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'EndpointConnectionError',
+                    'Message': 'Could not connect to the endpoint URL: "https://iottwinmaker.invalid-region.amazonaws.com/"',
+                }
+            },
+            'ListMetadataTransferJobs',
+        )
+
+        result = list_metadata_transfer_jobs(
+            source_type='s3',
+            destination_type='iotsitewise',
+            region='invalid-region',
+            max_results=50,
+            next_token=None,
+        )
+
+        assert result['success'] is False
+        assert result['error_code'] == 'EndpointConnectionError'
+
+    def test_list_jobs_validation_error_exception(self):
+        """Test job listing with ValidationError exception to cover line 513."""
+        # Import ValidationError from pydantic to trigger the actual exception
+        from pydantic import ValidationError
+
+        # Mock the client creation to raise a pydantic ValidationError
+        with patch(
+            'awslabs.aws_iot_sitewise_mcp_server.tools.sitewise_metadata_transfer.create_twinmaker_client'
+        ) as mock_create_client:
+            # Create a real ValidationError by trying to validate invalid data
+            try:
+                from pydantic import BaseModel, Field
+
+                class TestModel(BaseModel):
+                    required_field: str = Field(..., min_length=1)
+
+                TestModel(required_field='')  # This will raise ValidationError
+            except ValidationError as ve:
+                # Use the real ValidationError to mock the client creation
+                mock_create_client.side_effect = ve
+
+                result = list_metadata_transfer_jobs(
+                    source_type='s3',
+                    destination_type='iotsitewise',
+                    region='us-east-1',
+                    max_results=50,
+                    next_token=None,
+                )
+
+                assert result['success'] is False
+                assert result['error_code'] == 'ValidationException'
+                assert 'Validation error' in result['error']
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

# Add bulk metadata transfer job management tools

## Summary

### Changes

Added comprehensive bulk metadata transfer functionality to the AWS IoT SiteWise MCP server, enabling users to perform large-scale import/export operations between S3 and IoT SiteWise. This includes:

- **New metadata transfer tools**: 5 new MCP tools for creating, managing, monitoring, and canceling metadata transfer jobs
- **Bulk import schema validation**: Tool to construct and validate JSON schemas for bulk import operations using Pydantic models
- **Bidirectional transfer support**: Import from S3 to IoT SiteWise and export from IoT SiteWise to S3
- **Flexible filtering options**: Support for exporting all resources or specific asset models/assets with configurable hierarchy and model inclusion
- **Comprehensive error handling**: Robust validation and error reporting with helpful examples and recommendations

### User experience

**Before**: Users had no way to perform bulk metadata operations through the MCP server. They would need to manually use AWS APIs or CLI commands for each individual asset/model, making large-scale operations extremely time-consuming and error-prone.

**After**: Users can now efficiently:
- Create metadata transfer jobs with simple, user-friendly parameters
- Import bulk asset/model definitions from S3 JSON files to IoT SiteWise
- Export all IoT SiteWise resources or specific subsets to S3 for backup/migration
- Monitor job progress and status in real-time
- Cancel running jobs when needed
- Get structured validation errors with helpful examples when schema validation fails

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
