### PR TITLE
feat(aws-pricing-mcp-server): increase page size for get_pricing_attribute_values to 5000

### DIFF
--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -1107,11 +1107,14 @@ async def _get_single_attribute_values(
         while True:
             if next_token:
                 response = pricing_client.get_attribute_values(
-                    ServiceCode=service_code, AttributeName=attribute_name, NextToken=next_token
+                    ServiceCode=service_code,
+                    AttributeName=attribute_name,
+                    MaxResults=5000,
+                    NextToken=next_token,
                 )
             else:
                 response = pricing_client.get_attribute_values(
-                    ServiceCode=service_code, AttributeName=attribute_name
+                    ServiceCode=service_code, AttributeName=attribute_name, MaxResults=5000
                 )
 
             for attr_value in response.get('AttributeValues', []):

--- a/src/aws-pricing-mcp-server/tests/test_server.py
+++ b/src/aws-pricing-mcp-server/tests/test_server.py
@@ -1325,10 +1325,14 @@ class TestGetPricingAttributeValues:
             expected = {'instanceType': ['m5.large', 't2.micro', 't2.small', 't3.medium']}
             assert result == expected
             assert pricing_client.get_attribute_values.call_count == 2
-            assert (
-                pricing_client.get_attribute_values.call_args_list[1][1].get('NextToken')
-                == 'token'
-            )
+
+            # Verify MaxResults=5000 is used in both calls
+            first_call_kwargs = pricing_client.get_attribute_values.call_args_list[0][1]
+            assert first_call_kwargs.get('MaxResults') == 5000
+
+            second_call_kwargs = pricing_client.get_attribute_values.call_args_list[1][1]
+            assert second_call_kwargs.get('MaxResults') == 5000
+            assert second_call_kwargs.get('NextToken') == 'token'
 
     @pytest.mark.asyncio
     async def test_get_pricing_attribute_values_empty_attribute_list(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Increased the page size for `get_pricing_attribute_values` API calls from default (100) to 5000 to reduce the number of API requests needed when retrieving attribute values.

### User experience

**Before**: The tool would make more API calls when fetching large sets of attribute values, potentially slower performance.

**After**: The tool fetches up to 5000 attribute values per API call, reducing the total number of API requests needed and improving performance.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
