### PR TITLE
docs(cloudwatch-appsignals): Add missing IAM permissions for audit an…

### DIFF
--- a/src/cloudwatch-appsignals-mcp-server/README.md
+++ b/src/cloudwatch-appsignals-mcp-server/README.md
@@ -628,14 +628,24 @@ The server requires the following AWS IAM permissions:
         "application-signals:ListServiceLevelObjectives",
         "application-signals:GetServiceLevelObjective",
         "application-signals:BatchGetServiceLevelObjectiveBudgetReport",
+        "application-signals:ListAuditFindings",
         "cloudwatch:GetMetricData",
         "cloudwatch:GetMetricStatistics",
         "logs:GetQueryResults",
         "logs:StartQuery",
         "logs:StopQuery",
+        "logs:FilterLogEvents",
         "xray:GetTraceSummaries",
         "xray:BatchGetTraces",
-        "xray:GetTraceSegmentDestination"
+        "xray:GetTraceSegmentDestination",
+        "synthetics:GetCanary",
+        "synthetics:GetCanaryRuns",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "iam:GetRole",
+        "iam:ListAttachedRolePolicies",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
…d canary tools

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Add missing IAM permissions for audit and canary tools

### User experience

> No change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
