### PR TITLE
fix: Change priorities of default_region parameters

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -129,7 +129,7 @@ def execute_awscli_customization(
     cli_command: str,
     ir_command: IRCommand,
     credentials: Credentials | None = None,
-    region: str | None = None,
+    default_region_override: str | None = None,
 ) -> AwsCliAliasResponse | AwsApiMcpServerErrorResponse:
     """Execute the given AWS CLI command."""
     args = split_cli_command(cli_command)[1:]
@@ -149,7 +149,7 @@ def execute_awscli_customization(
             with operation_timer(
                 ir_command.service_name,
                 ir_command.operation_name,
-                region or ir_command.region or DEFAULT_REGION,
+                ir_command.region or default_region_override or DEFAULT_REGION,
             ):
                 driver = get_awscli_driver(credentials)
                 driver.main(args)
@@ -169,14 +169,14 @@ def interpret_command(
     cli_command: str,
     max_results: int | None = None,
     credentials: Credentials | None = None,
-    region: str | None = None,
+    default_region_override: str | None = None,
 ) -> ProgramInterpretationResponse:
     """Interpret the given CLI command and return an interpretation response."""
     interpreted_program = _interpret_command(
         cli_command,
         max_results=max_results,
         credentials=credentials,
-        region_override=region,
+        default_region_override=default_region_override,
     )
 
     validation_failures = (

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -238,7 +238,7 @@ async def call_aws_helper(
         Field(description='Optional limit for number of results (useful for pagination)'),
     ] = None,
     credentials: Credentials | None = None,
-    region: str | None = None,
+    default_region: str | None = None,
 ) -> ProgramInterpretationResponse | AwsApiMcpServerErrorResponse | AwsCliAliasResponse:
     """Helper function that actually calls aws."""
     try:
@@ -302,7 +302,7 @@ async def call_aws_helper(
                     cli_command,
                     ir.command,
                     credentials=credentials,
-                    region=region,
+                    default_region_override=default_region,
                 )
             )
             if isinstance(response, AwsApiMcpServerErrorResponse):
@@ -313,7 +313,7 @@ async def call_aws_helper(
             cli_command=cli_command,
             max_results=max_results,
             credentials=credentials,
-            region=region,
+            default_region_override=default_region,
         )
     except NoCredentialsError:
         error_message = (

--- a/src/aws-api-mcp-server/tests/aws/test_service.py
+++ b/src/aws-api-mcp-server/tests/aws/test_service.py
@@ -616,7 +616,7 @@ def test_interpret_command_with_credentials_parameter():
             'aws s3api list-buckets',
             max_results=None,
             credentials=test_credentials,
-            region_override=None,
+            default_region_override=None,
         )
 
 
@@ -628,7 +628,10 @@ def test_interpret_command_without_credentials_parameter():
         interpret_command('aws s3api list-buckets')
 
         mock_interpret.assert_called_once_with(
-            'aws s3api list-buckets', max_results=None, credentials=None, region_override=None
+            'aws s3api list-buckets',
+            max_results=None,
+            credentials=None,
+            default_region_override=None,
         )
 
 
@@ -638,7 +641,9 @@ def test_interpret_command_with_region_parameter(mock_interpret):
     mock_interpret.return_value = {'ResponseMetadata': {'HTTPStatusCode': 200}}
     mock_credentials = Credentials(access_key_id='a', secret_access_key='b', session_token='c')
 
-    interpret_command('aws s3api list-buckets', region='eu-west-1', credentials=mock_credentials)
+    interpret_command(
+        'aws s3api list-buckets', default_region_override='eu-west-1', credentials=mock_credentials
+    )
 
     mock_interpret.assert_called_once_with(
         ANY,
@@ -681,13 +686,13 @@ def test_execute_awscli_customization_uses_explicit_region_overrides_ir(mock_get
 
         with patch('sys.stdout'), patch('sys.stderr'):
             execute_awscli_customization(
-                'aws s3 ls', ir_command, credentials=None, region='eu-west-2'
+                'aws s3 ls', ir_command, credentials=None, default_region_override='eu-west-2'
             )
 
     # Verify region precedence used in timer
     assert mock_timer.call_args[0][0] == 's3'
     assert mock_timer.call_args[0][1] == 'list_objects_v2'
-    assert mock_timer.call_args[0][2] == 'eu-west-2'
+    assert mock_timer.call_args[0][2] == 'us-east-1'
 
 
 @patch('awslabs.aws_api_mcp_server.core.aws.service.get_awscli_driver')

--- a/src/aws-api-mcp-server/tests/test_server.py
+++ b/src/aws-api-mcp-server/tests/test_server.py
@@ -182,13 +182,13 @@ async def test_call_aws_helper_passes_region_to_customization(
             ctx=DummyCtx(),  # type: ignore[arg-type]
             max_results=None,
             credentials=None,
-            region='eu-west-1',
+            default_region='eu-west-1',
         )
 
     # Assert
     assert isinstance(result, AwsCliAliasResponse)
     _, kwargs = mock_execute.call_args
-    assert kwargs.get('region') == 'eu-west-1'
+    assert kwargs.get('default_region_override') == 'eu-west-1'
 
 
 @patch('awslabs.aws_api_mcp_server.server.interpret_command')
@@ -230,13 +230,13 @@ async def test_call_aws_helper_passes_region_to_interpret(
             ctx=DummyCtx(),  # type: ignore[arg-type]
             max_results=None,
             credentials=None,
-            region='eu-west-2',
+            default_region='eu-west-2',
         )
 
     # Assert
     assert isinstance(result, ProgramInterpretationResponse)
     _, kwargs = mock_interpret.call_args
-    assert kwargs.get('region') == 'eu-west-2'
+    assert kwargs.get('default_region_override') == 'eu-west-2'
 
 
 @patch('awslabs.aws_api_mcp_server.server.DEFAULT_REGION', 'us-east-1')
@@ -721,7 +721,7 @@ async def test_call_aws_awscli_customization_success(
         'aws configure list',
         mock_ir.command,
         credentials=None,
-        region=None,
+        default_region_override=None,
     )
 
 
@@ -764,7 +764,7 @@ async def test_call_aws_awscli_customization_error(
         'aws configure list',
         mock_ir.command,
         credentials=None,
-        region=None,
+        default_region_override=None,
     )
     mock_ctx.error.assert_called_once_with(error_response.detail)
 
@@ -928,13 +928,11 @@ async def test_call_aws_helper_with_credentials(mock_translate, mock_validate, m
         credentials=test_credentials,
     )
 
-    print(result)
-
     mock_interpret.assert_called_once_with(
         cli_command='aws s3api list-buckets',
         max_results=None,
         credentials=test_credentials,
-        region=None,
+        default_region_override=None,
     )
     assert result == mock_response
 
@@ -966,7 +964,10 @@ async def test_call_aws_helper_without_credentials(mock_translate, mock_validate
     )
 
     mock_interpret.assert_called_once_with(
-        cli_command='aws s3api list-buckets', max_results=None, credentials=None, region=None
+        cli_command='aws s3api list-buckets',
+        max_results=None,
+        credentials=None,
+        default_region_override=None,
     )
     assert result == mock_response
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
### Changes
1/ Changed parameter names to avoid confusion.
2/ Updated the logic to still prefer region in the CLI command, and only fall back to default_region_override if it is empty.

### User experience

When using call_aws_helper, cli_command region will be prioritized.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
