### PR TITLE
feat: add applicaiton signals enablement instruction for bedrock agentcore and ecs

### DIFF
--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/agentcore/agentcore-python-enablement.md
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/agentcore/agentcore-python-enablement.md
@@ -15,7 +15,7 @@ Add X-Ray permissions to the Bedrock AgentCore IAM execution role.
 iam.PolicyStatement(
     effect=iam.Effect.ALLOW,
     actions=[
-        "xray:PutTelemetryRecords", 
+        "xray:PutTelemetryRecords",
         "xray:GetSamplingRules",
         "xray:GetSamplingTargets"
     ],
@@ -28,7 +28,7 @@ iam.PolicyStatement(
 iam.PolicyStatement(
     effect=iam.Effect.ALLOW,
     actions=[
-        "xray:PutTelemetryRecords", 
+        "xray:PutTelemetryRecords",
         "xray:PutTraceSegments",        # Add this line
         "xray:GetSamplingRules",
         "xray:GetSamplingTargets"

--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/ecs/ecs-java-enablement.md
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/ecs/ecs-java-enablement.md
@@ -116,7 +116,7 @@ const mainContainer = taskDefinition.addContainer('{SERVICE_NAME}-container', {
   // Existing configuration...
   environment: {
     // Existing environment variables...
-    
+
     // ADOT Configuration for Application Signals
     OTEL_RESOURCE_ATTRIBUTES: 'service.name={SERVICE_NAME}', // SERVICE_NAME is defined by user
     OTEL_METRICS_EXPORTER: 'none',

--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/ecs/ecs-nodejs-enablement.md
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/ecs/ecs-nodejs-enablement.md
@@ -116,7 +116,7 @@ const mainContainer = taskDefinition.addContainer('{SERVICE_NAME}-container', {
   // Existing configuration...
   environment: {
     // Existing environment variables...
-    
+
     // ADOT Configuration for Application Signals - Node.js
     OTEL_RESOURCE_ATTRIBUTES: 'service.name=${SERVICE_NAME}', // SERVICE_NAME is defined by user
     OTEL_METRICS_EXPORTER: 'none',

--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/ecs/ecs-python-enablement.md
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/enablement_guides/templates/ecs/ecs-python-enablement.md
@@ -116,7 +116,7 @@ const mainContainer = taskDefinition.addContainer('{SERVICE_NAME}-container', {
   // Existing configuration...
   environment: {
     // Existing environment variables...
-    
+
     // ADOT Configuration for Application Signals
     OTEL_RESOURCE_ATTRIBUTES: 'service.name=${SERVICE_NAME}', // SERVICE_NAME is defined by user
     OTEL_METRICS_EXPORTER: 'none',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

The PR adds instructions for enabling Application Signals in the Bedrock AgentCore Runtime and ECS.
The MCP tool can return these instructions to help AI generate code that improves observability for users’ services.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N
**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
