### PR TITLE
chore(cloudwatch-applicationsignals-mcp-server): add MCP caller flag to user agent

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/aws_clients.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/aws_clients.py
@@ -32,7 +32,9 @@ def _initialize_aws_clients():
     mcp_source = os.environ.get('MCP_RUN_FROM')
     user_agent_suffix = f'/{mcp_source}' if mcp_source else ''
 
-    config = Config(user_agent_extra=f'awslabs.cloudwatch-applicationsignals-mcp-server/{__version__}{user_agent_suffix}')
+    config = Config(
+        user_agent_extra=f'awslabs.cloudwatch-applicationsignals-mcp-server/{__version__}{user_agent_suffix}'
+    )
 
     # Get endpoint URLs from environment variables
     applicationsignals_endpoint = os.environ.get('MCP_APPLICATIONSIGNALS_ENDPOINT')

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_aws_profile.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_aws_profile.py
@@ -163,10 +163,14 @@ def test_initialize_aws_clients_with_profile():
 
 def test_initialize_aws_clients_with_mcp_source():
     """Test _initialize_aws_clients function with MCP_RUN_FROM set."""
-    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import _initialize_aws_clients
+    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import (
+        _initialize_aws_clients,
+    )
 
     with patch.dict(os.environ, {'MCP_RUN_FROM': 'test-caller', 'AWS_REGION': 'us-east-1'}):
-        with patch('awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.Config') as mock_config:
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.Config'
+        ) as mock_config:
             with patch('boto3.client'):
                 _initialize_aws_clients()
 
@@ -174,4 +178,7 @@ def test_initialize_aws_clients_with_mcp_source():
                 mock_config.assert_called_once()
                 call_args = mock_config.call_args
                 user_agent = call_args.kwargs['user_agent_extra']
-                assert user_agent == f'awslabs.cloudwatch-applicationsignals-mcp-server/{__version__}/test-caller'
+                assert (
+                    user_agent
+                    == f'awslabs.cloudwatch-applicationsignals-mcp-server/{__version__}/test-caller'
+                )


### PR DESCRIPTION
### Changes

> added suffix to user_agent_extra flag if the env var MCP_RUN_FROM exists.


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
