### PR TITLE
docs: include Services and Features in README.md

### DIFF
--- a/src/aws-knowledge-mcp-server/README.md
+++ b/src/aws-knowledge-mcp-server/README.md
@@ -26,7 +26,7 @@ This MCP server is in general availability.
 2. `read_documentation`: Retrieve and convert AWS documentation pages to markdown
 3. `recommend`: Get content recommendations for AWS documentation pages
 4. `list_regions` _(Experimental)_: Retrieve a list of all AWS regions, including their identifiers and names
-5. `get_regional_availability`_(Experimental)_: Retrieve AWS regional availability information for SDK service APIs and CloudFormation resources
+5. `get_regional_availability`_(Experimental)_: Retrieve AWS regional availability information for Services, Features, SDK service APIs and CloudFormation resources
 
 ### Current knowledge sources
 


### PR DESCRIPTION
Since the `product` API is now enabled, the `get_regional_availability` tool is able to provide information about Services and Features.  This change updates the documentation to reflect that.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

The words `Services` and `Features` are included in README.md

### User experience

**Before**:

5. `get_regional_availability`(Experimental): Retrieve AWS regional availability information for SDK service APIs and CloudFormation resources


**After**:
5. `get_regional_availability`(Experimental): Retrieve AWS regional availability information for Services, Features, SDK service APIs and CloudFormation resources

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
