### PR TITLE
docs: clarify VS Code one-click config for Windows (#1715)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,35 @@ For Windows:
   }
 }
 ```
+
+> **Note for Windows users**
+>
+> The "Install on VS Code" one-click buttons on this page currently generate a `uvx`-based configuration that is correct for macOS/Linux but not for Windows. On Windows, please use the `uv tool run ... .exe` pattern shown above (for `awslabs.core-mcp-server`) and adapt it to the specific MCP server, for example:
+>
+```json
+{
+  "mcpServers": {
+    "AWS Pricing MCP Server": {
+      "command": "uv",
+      "args": [
+        "tool",
+        "run",
+        "--from",
+        "awslabs.aws-pricing-mcp-server@latest",
+        "awslabs.aws-pricing-mcp-server.exe"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR",
+        "AWS_PROFILE": "your-aws-profile",
+        "AWS_REGION": "us-east-1"
+      },
+      "disabled": false,
+      "autoApprove": [],
+      "type": "stdio"
+    }
+  }
+}
+```
 </details>
 
 ### Getting Started with Claude Code


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #1715

## Summary
This PR updates the README to clarify that the “Install on VS Code” one-click buttons generate a `uvx`-based configuration that works on macOS/Linux but **not on Windows**.  
Windows users require a different `uv tool run … .exe` pattern, which was documented elsewhere in the README but not surfaced near the VS Code installation instructions.  
This addition makes the Windows-specific configuration clear and prominent for users following the VS Code setup path.

### Changes

> Added a Windows-specific note under the `.vscode/mcp.json` examples in the **Getting Started with VS Code** section:
>
> - Explains that the one-click buttons generate macOS/Linux-style settings that fail on Windows  
> - Instructs users to use the `uv tool run ... .exe` pattern  
> - Provides a concrete, working Windows configuration example for **AWS Pricing MCP Server**  
> - Keeps all existing macOS/Linux content unchanged
### User experience
**Before:**  
Windows users clicking “Install in VS Code” receive a `uvx` configuration that fails with `"program not found"` errors.  
They had no clear guidance near the installation steps indicating that Windows requires a different format.

**After:**  
Users now see a clearly labeled **Windows Note** with the correct configuration format and a working real example.  
This prevents setup errors, reduces confusion, and aligns Windows instructions with the behavior described in Issue #1715.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
**N**
**RFC issue number**:
*Not applicable (documentation-only change)*

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
