### PR TITLE
feat(aws-pricing-mcp-server): Increase page size of pricing.get_attribute_values to 10000

### DIFF
--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -1131,12 +1131,12 @@ async def _get_single_attribute_values(
                 response = pricing_client.get_attribute_values(
                     ServiceCode=service_code,
                     AttributeName=attribute_name,
-                    MaxResults=5000,
+                    MaxResults=10000,
                     NextToken=next_token,
                 )
             else:
                 response = pricing_client.get_attribute_values(
-                    ServiceCode=service_code, AttributeName=attribute_name, MaxResults=5000
+                    ServiceCode=service_code, AttributeName=attribute_name, MaxResults=10000
                 )
 
             for attr_value in response.get('AttributeValues', []):

--- a/src/aws-pricing-mcp-server/tests/test_server.py
+++ b/src/aws-pricing-mcp-server/tests/test_server.py
@@ -1373,10 +1373,10 @@ class TestGetPricingAttributeValues:
 
             # Verify MaxResults=5000 is used in both calls
             first_call_kwargs = pricing_client.get_attribute_values.call_args_list[0][1]
-            assert first_call_kwargs.get('MaxResults') == 5000
+            assert first_call_kwargs.get('MaxResults') == 10000
 
             second_call_kwargs = pricing_client.get_attribute_values.call_args_list[1][1]
-            assert second_call_kwargs.get('MaxResults') == 5000
+            assert second_call_kwargs.get('MaxResults') == 10000
             assert second_call_kwargs.get('NextToken') == 'token'
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Increased the page size for `get_pricing_attribute_values` API calls from 5000 to 10000 to reduce the number of API requests needed when retrieving attribute values.

### User experience

**Before**: The tool would make more API calls when fetching large sets of attribute values, potentially slower performance.

**After**: The tool fetches up to 10000 attribute values per API call, reducing the total number of API requests needed and improving performance.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
