### PR TITLE
fix: add CFN guard file types to the header

### DIFF
--- a/.github/workflows/check-license-header.json
+++ b/.github/workflows/check-license-header.json
@@ -26,7 +26,8 @@
     "include": [
       "**/*.py",
       "**/*Dockerfile",
-      "**/*.sh"
+      "**/*.sh",
+      "**/*.guard"
     ],
     "license": "./.github/workflows/check-license-header-hash.txt"
   },


### PR DESCRIPTION
## Summary

Add CFN Guard rules for licenses

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
