### PR TITLE
chore: update aurora-dsql-mcp-server CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@ NOTICE                                           @awslabs/mcp-admins
 /src/amazon-qbusiness-anonymous-mcp-server       @awslabs/mcp-admins @awslabs/mcp-maintainers  @abhjaw
 /src/amazon-qindex-mcp-server                    @awslabs/mcp-admins @awslabs/mcp-maintainers  @tkoba-aws @akhileshamara
 /src/amazon-sns-sqs-mcp-server                   @awslabs/mcp-admins @awslabs/mcp-maintainers  @kenliao94 @hashimsharkh
-/src/aurora-dsql-mcp-server                      @awslabs/mcp-admins @awslabs/mcp-maintainers  @gxjx-x @imforster @wcmjunior @anwesham-lab @benjscho @pkale @amaksimo
+/src/aurora-dsql-mcp-server                      @awslabs/mcp-admins @awslabs/mcp-maintainers  @gxjx-x @imforster @wcmjunior @anwesham-lab @benjscho @pkale @amaksimo @mitchell-elholm
 /src/aws-api-mcp-server                          @awslabs/mcp-admins @awslabs/mcp-maintainers  @awslabs/aws-api-mcp @rshevchuk-git @PCManticore @iddv @arnewouters @bidesh
 /src/aws-appsync-mcp-server                      @awslabs/mcp-admins @awslabs/mcp-maintainers  @phani-srikar @maxi114 @neelmurt
 /src/aws-bedrock-custom-model-import-mcp-server  @awslabs/mcp-admins @awslabs/mcp-maintainers  @krokoko @alexa-perlov # @saidrhs


### PR DESCRIPTION
## Summary

Update CODEOWNERS for aurora-dsql-mcp-server.

### Changes

Updated line 29 in .github/CODEOWNERS to add new codeowners: @anwesham-lab, @Benjscho, @pkale, @amaksimo, and @mitchell-elholm

Previous owners (@gxjx-x, @imforster, @wcmjunior) remain as codeowners.

### User experience

No user-facing changes. This is an internal CODEOWNERS update.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).