### PR TITLE
fix: add pagination support for list_state_machines in Step Functions MCP server

### DIFF
--- a/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/server.py
+++ b/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/server.py
@@ -336,10 +336,23 @@ def register_state_machines():
     """Register Step Functions state machines as individual tools."""
     try:
         logger.info('Registering Step Functions state machines as individual tools...')
-        state_machines = sfn_client.list_state_machines()
-
-        # Get all state machines
-        all_state_machines = state_machines['stateMachines']
+        
+        # Get all state machines with pagination support
+        all_state_machines = []
+        next_token = None
+        
+        while True:
+            if next_token:
+                response = sfn_client.list_state_machines(nextToken=next_token)
+            else:
+                response = sfn_client.list_state_machines()
+            
+            all_state_machines.extend(response['stateMachines'])
+            next_token = response.get('nextToken')
+            
+            if not next_token:
+                break
+        
         logger.info(f'Total Step Functions state machines found: {len(all_state_machines)}')
 
         # First filter by state machine name if prefix or list is set


### PR DESCRIPTION
## Summary

### Changes

Added pagination support for `list_state_machines()` API call in the Step Functions MCP server. The previous implementation only retrieved the first page of state machines (max 100), which caused issues when accounts had more than 100 state machines.

The fix implements a pagination loop using the `nextToken` parameter to retrieve all state machines across multiple pages.

### User experience

**Before:**
- Only the first 100 state machines were registered as MCP tools
- Users with more than 100 state machines would not see all their state machines available

**After:**
- All state machines are now registered as MCP tools, regardless of the total count
- Complete visibility of all Step Functions state machines in the account

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): **N**

**RFC issue number**: https://github.com/awslabs/mcp/issues/2050

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).