### PR TITLE
feat: allows definition of the location of the main (entrypoint) script

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_management.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_management.py
@@ -25,6 +25,7 @@ from awslabs.aws_healthomics_mcp_server.utils.aws_utils import (
 from awslabs.aws_healthomics_mcp_server.utils.validation_utils import (
     validate_container_registry_params,
     validate_definition_sources,
+    validate_path_to_main,
 )
 from loguru import logger
 from mcp.server.fastmcp import Context
@@ -163,6 +164,9 @@ async def create_workflow(
         ctx, container_registry_map, container_registry_map_uri
     )
 
+    # Validate path_to_main parameter
+    validated_path_to_main = await validate_path_to_main(ctx, path_to_main)
+
     client = get_omics_client()
 
     params: Dict[str, Any] = {
@@ -187,8 +191,8 @@ async def create_workflow(
     if container_registry_map_uri:
         params['containerRegistryMapUri'] = container_registry_map_uri
 
-    if path_to_main is not None and path_to_main != '':
-        params['main'] = path_to_main
+    if validated_path_to_main is not None:
+        params['main'] = validated_path_to_main
 
     try:
         response = client.create_workflow(**params)
@@ -360,6 +364,9 @@ async def create_workflow_version(
         ctx, container_registry_map, container_registry_map_uri
     )
 
+    # Validate path_to_main parameter
+    validated_path_to_main = await validate_path_to_main(ctx, path_to_main)
+
     # Validate storage requirements
     if storage_type == 'STATIC':
         if not storage_capacity:
@@ -397,8 +404,8 @@ async def create_workflow_version(
     if container_registry_map_uri:
         params['containerRegistryMapUri'] = container_registry_map_uri
 
-    if path_to_main is not None and path_to_main != '':
-        params['main'] = path_to_main
+    if validated_path_to_main is not None:
+        params['main'] = validated_path_to_main
 
     try:
         response = client.create_workflow_version(**params)

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/utils/validation_utils.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/utils/validation_utils.py
@@ -14,6 +14,7 @@
 
 """Validation utilities for workflow management."""
 
+import posixpath
 from awslabs.aws_healthomics_mcp_server.models import ContainerRegistryMap
 from awslabs.aws_healthomics_mcp_server.utils.aws_utils import decode_from_base64
 from loguru import logger
@@ -117,6 +118,17 @@ async def validate_container_registry_params(
     Raises:
         ValueError: If validation fails
     """
+    # Handle Field objects for optional parameters (FastMCP compatibility)
+    if hasattr(container_registry_map, 'default') and not isinstance(
+        container_registry_map, (dict, type(None))
+    ):
+        container_registry_map = getattr(container_registry_map, 'default', None)
+
+    if hasattr(container_registry_map_uri, 'default') and not isinstance(
+        container_registry_map_uri, (str, type(None))
+    ):
+        container_registry_map_uri = getattr(container_registry_map_uri, 'default', None)
+
     # Validate that both container registry parameters are not provided together
     if container_registry_map is not None and container_registry_map_uri is not None:
         error_message = (
@@ -171,3 +183,65 @@ async def validate_adhoc_s3_buckets(adhoc_buckets: Optional[List[str]]) -> List[
         # Log the error but don't fail completely - let the search continue with configured buckets
         logger.warning(f'Adhoc S3 bucket validation failed: {e}')
         return []
+
+
+async def validate_path_to_main(ctx: Context, path_to_main: Optional[str]) -> Optional[str]:
+    """Validate that path_to_main is a safe relative path within the ZIP file.
+
+    Args:
+        ctx: MCP context for error reporting
+        path_to_main: Path to the main workflow file within the ZIP
+
+    Returns:
+        The validated path, or None if path_to_main is None/empty
+
+    Raises:
+        ValueError: If the path is invalid or unsafe
+    """
+    if path_to_main is None or path_to_main == '':
+        return None
+
+    # Check for empty path components (double slashes) first
+    if '//' in path_to_main:
+        error_message = (
+            f'path_to_main cannot contain empty path components (//), got: {path_to_main}'
+        )
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
+    # Check for absolute paths BEFORE normalization
+    if posixpath.isabs(path_to_main):
+        error_message = f'path_to_main must be a relative path, got absolute path: {path_to_main}'
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
+    # Check for directory traversal attempts BEFORE normalization
+    if path_to_main.startswith('../') or '/../' in path_to_main or path_to_main == '..':
+        error_message = (
+            f'path_to_main cannot contain directory traversal sequences (../), got: {path_to_main}'
+        )
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
+    # Normalize the path to handle different path separators
+    normalized_path = posixpath.normpath(path_to_main)
+
+    # Check for paths that resolve to current directory
+    if normalized_path in ('.', './'):
+        error_message = f'path_to_main cannot be the current directory, got: {path_to_main}'
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
+    # Validate file extension (should be a workflow file)
+    valid_extensions = ('.wdl', '.cwl', '.nf')
+    if not any(normalized_path.lower().endswith(ext) for ext in valid_extensions):
+        error_message = f'path_to_main must point to a workflow file with extension {valid_extensions}, got: {path_to_main}'
+        logger.error(error_message)
+        await ctx.error(error_message)
+        raise ValueError(error_message)
+
+    return normalized_path


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #1778 

## Summary

Adds the ability to designate the path to the main (entrypoint) workflow file if it is not packaged in the conventional way.

### Changes

Adds an Optional `path_to_main` parameter to the `create_workflow` and `create_workflow_version` tools.

### User experience

Workflow packages no longer need to define a single top level `main` file giving more flexibility when migrating workflows with different folder structures.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
