### PR TITLE
fix: bedrock kb: restrict reranking models in us-east-1

### DIFF
--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
@@ -158,6 +158,24 @@ class TestQueryKnowledgeBase:
         assert 'Reranking is not supported in region eu-west-1' in str(excinfo.value)
 
         # Check that the client methods were not called
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_us_east_1_amazon_reranker_errors(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """In us-east-1, the AMAZON reranker is not available and should error clearly."""
+        mock_bedrock_agent_runtime_client.meta.region_name = 'us-east-1'
+
+        with pytest.raises(ValueError) as excinfo:
+            await query_knowledge_base(
+                query='test query',
+                knowledge_base_id='kb-12345',
+                kb_agent_client=mock_bedrock_agent_runtime_client,
+                reranking=True,
+                reranking_model_name='AMAZON',
+            )
+
+        assert "Reranking model 'AMAZON' is not available in us-east-1" in str(excinfo.value)
         mock_bedrock_agent_runtime_client.retrieve.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
[The 'AMAZON' reranking model is not available in the `us-east-1` region](https://docs.aws.amazon.com/bedrock/latest/userguide/rerank-supported.html#:~:text=The%20Amazon%20Rerank%201.0%20model%20is%20not%20supported%20in%20the%20US%20East%20(N.%20Virginia)%20AWS%20Region.%20You%20can%20only%20use%20the%20Cohere%20Rerank%203.5%20model%20in%20this%20Region.), causing runtime errors as it is default parameter choice.

This ensures the tool definition accurately reflects the capabilities available in the current region.
### Changes
This change updates `server.py` to dynamically configure the available `reranking_model_name` options based on the `AWS_REGION` environment variable: 
- In `us-east-1`: The 'AMAZON' option is removed, and the default is set to 'COHERE'.
- In other regions: Both 'COHERE' and 'AMAZON' remain available, with 'AMAZON' as the default.

### User experience

Solves the initial error that when the LLM tries to use the default reranker. 

Tested with a us-east-1 KB and now the LLM correctly chooses the right reranker:

```
id   : call_MHxiWVFJaTEyZFRXOXJtdUk4MkY__vscode-xxxx
tool : mcp_aws_bedrock_k_QueryKnowledgeBases
args : {
  "knowledge_base_id": "xxx",
  "query": "how to reset a password",
  "reranking": true,
  "reranking_model_name": "COHERE"
}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) No

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
