### PR TITLE
feat(aws-api-mcp-server): use Windows-style paths in file access examples

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -77,9 +77,9 @@ server = FastMCP(
 READ_OPERATIONS_INDEX: Optional[ReadOnlyOperations] = None
 
 _FILE_ACCESS_MSGS = {
-    FileAccessMode.UNRESTRICTED: f"File access is unrestricted so commands can reference files anywhere; use forward slashes (/) regardless of the system (e.g. '/home/user/file.txt' or 'subdir/file.txt'); relative paths resolve from the working directory ({WORKING_DIRECTORY}).",
+    FileAccessMode.UNRESTRICTED: f"File access is unrestricted so commands can reference files anywhere; use forward slashes (/) regardless of the system (e.g. 'c:/users/name/file.txt' or 'subdir/file.txt'); relative paths resolve from the working directory ({WORKING_DIRECTORY}).",
     FileAccessMode.NO_ACCESS: 'File access is disabled and commands with any local file reference will be rejected. S3 URIs (s3://...) and stdout redirect (-) remain allowed.',
-    FileAccessMode.WORKDIR: f"Commands can only reference files within the working directory ({WORKING_DIRECTORY}); use forward slashes (/) regardless of the system (e.g. if working directory is '/tmp/workdir', use '/tmp/workdir/subdir/file.txt' or 'subdir/file.txt'); relative paths resolve from the working directory.",
+    FileAccessMode.WORKDIR: f"Commands can only reference files within the working directory ({WORKING_DIRECTORY}); use forward slashes (/) regardless of the system (e.g. if working directory is 'c:/tmp/workdir', use 'c:/tmp/workdir/subdir/file.txt' or 'subdir/file.txt'); relative paths resolve from the working directory.",
 }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Use windows style path examples to show the behavior. This was like this previously as well.

## Summary

### Changes

> Just updated the file path examples.

### User experience

> Not much change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [-] Migration process documented
* [-] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
