### PR TITLE
fix(dsql-kiro-power): rename kiro power

### DIFF
--- a/src/aurora-dsql-mcp-server/kiro_power/POWER.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/POWER.md
@@ -1,5 +1,5 @@
 ---
-name: "aws-aurora-dsql"
+name: "amazon-aurora-dsql"
 displayName: "Build a database with Aurora DSQL"
 description: "Build and deploy a PostgreSQL-compatible serverless distributed SQL database with Aurora DSQL - manage schemas, execute queries, and handle migrations with DSQL-specific requirements."
 keywords: ["aurora", "dsql", "postgresql", "serverless", "database", "sql", "aws", "distributed"]


### PR DESCRIPTION
Rename power from `aws-aurora-dsql` to `amazon-aurora-dsql` to be
consistent across Amazon Aurora suite products.

Co-authored-by: anwesham-lab <amukherjee973@gmail.com>

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [Y] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
