### PR TITLE
fix: ecs mcp exposed for core

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/main.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/main.py
@@ -224,16 +224,19 @@ AWS documentation including ECS's newest feature launches
     return mcp, config
 
 
+# Initialize mcp and config at module level for external imports
+mcp, _config = _create_ecs_mcp_server()
+
+
 def main() -> None:
     """Main entry point for the ECS MCP Server."""
     try:
         # Start the server
-        mcp, config = _create_ecs_mcp_server()
         logger = _setup_logging()
 
         logger.info("Server started")
-        logger.info(f"Write operations enabled: {config.get('allow-write', False)}")
-        logger.info(f"Sensitive data access enabled: {config.get('allow-sensitive-data', False)}")
+        logger.info(f"Write operations enabled: {_config.get('allow-write', False)}")
+        logger.info(f"Sensitive data access enabled: {_config.get('allow-sensitive-data', False)}")
         mcp.run()
     except KeyboardInterrupt:
         logger.info("Server stopped by user")

--- a/src/ecs-mcp-server/tests/unit/test_main.py
+++ b/src/ecs-mcp-server/tests/unit/test_main.py
@@ -377,17 +377,17 @@ class TestMainFunctionBehavior(unittest.TestCase):
 
     @patch("awslabs.ecs_mcp_server.main.sys.exit")
     @patch("awslabs.ecs_mcp_server.main._setup_logging")
-    @patch("awslabs.ecs_mcp_server.main._create_ecs_mcp_server")
-    def test_successful_server_startup(self, mock_create_server, mock_setup_logging, mock_exit):
+    @patch("awslabs.ecs_mcp_server.main._config")
+    @patch("awslabs.ecs_mcp_server.main.mcp")
+    def test_successful_server_startup(
+        self, mock_mcp_obj, mock_config, mock_setup_logging, mock_exit
+    ):
         """Test successful server startup and execution."""
         # Configure mocks
-        mock_mcp = MagicMock()
-        mock_config = MagicMock()
         mock_config.get.side_effect = lambda key, default: {
             "allow-write": True,
             "allow-sensitive-data": False,
         }.get(key, default)
-        mock_create_server.return_value = (mock_mcp, mock_config)
 
         mock_logger = MagicMock()
         mock_setup_logging.return_value = mock_logger
@@ -399,19 +399,19 @@ class TestMainFunctionBehavior(unittest.TestCase):
         mock_logger.info.assert_any_call("Server started")
         mock_logger.info.assert_any_call("Write operations enabled: True")
         mock_logger.info.assert_any_call("Sensitive data access enabled: False")
-        mock_mcp.run.assert_called_once()
+        mock_mcp_obj.run.assert_called_once()
         mock_exit.assert_not_called()
 
     @patch("awslabs.ecs_mcp_server.main.sys.exit")
     @patch("awslabs.ecs_mcp_server.main._setup_logging")
-    @patch("awslabs.ecs_mcp_server.main._create_ecs_mcp_server")
-    def test_keyboard_interrupt_handling(self, mock_create_server, mock_setup_logging, mock_exit):
+    @patch("awslabs.ecs_mcp_server.main._config")
+    @patch("awslabs.ecs_mcp_server.main.mcp")
+    def test_keyboard_interrupt_handling(
+        self, mock_mcp_obj, mock_config, mock_setup_logging, mock_exit
+    ):
         """Test graceful handling of keyboard interrupt."""
         # Configure mocks for keyboard interrupt
-        mock_mcp = MagicMock()
-        mock_config = MagicMock()
-        mock_mcp.run.side_effect = KeyboardInterrupt()
-        mock_create_server.return_value = (mock_mcp, mock_config)
+        mock_mcp_obj.run.side_effect = KeyboardInterrupt()
 
         mock_logger = MagicMock()
         mock_setup_logging.return_value = mock_logger
@@ -425,14 +425,14 @@ class TestMainFunctionBehavior(unittest.TestCase):
 
     @patch("awslabs.ecs_mcp_server.main.sys.exit")
     @patch("awslabs.ecs_mcp_server.main._setup_logging")
-    @patch("awslabs.ecs_mcp_server.main._create_ecs_mcp_server")
-    def test_general_exception_handling(self, mock_create_server, mock_setup_logging, mock_exit):
+    @patch("awslabs.ecs_mcp_server.main._config")
+    @patch("awslabs.ecs_mcp_server.main.mcp")
+    def test_general_exception_handling(
+        self, mock_mcp_obj, mock_config, mock_setup_logging, mock_exit
+    ):
         """Test handling of unexpected exceptions."""
         # Configure mocks for general exception
-        mock_mcp = MagicMock()
-        mock_config = MagicMock()
-        mock_mcp.run.side_effect = Exception("Unexpected error")
-        mock_create_server.return_value = (mock_mcp, mock_config)
+        mock_mcp_obj.run.side_effect = Exception("Unexpected error")
 
         mock_logger = MagicMock()
         mock_setup_logging.return_value = mock_logger


### PR DESCRIPTION
## Summary

This allows the `awslabs.core-mcp-server` to dynamically load the ECS MCP server.

### Changes

Arrange so `mcp` can be imported.

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
