### PR TITLE
fix: npm audit fix

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -21,6 +21,7 @@
         "@docusaurus/module-type-aliases": "^3.9.1",
         "@docusaurus/tsconfig": "^3.9.2",
         "@docusaurus/types": "^3.9.1",
+        "baseline-browser-mapping": "^2.9.11",
         "typescript": "~5.9.2"
       },
       "engines": {
@@ -5734,9 +5735,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
-      "integrity": "sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==",
+      "version": "2.9.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -25,6 +25,7 @@
     "@docusaurus/module-type-aliases": "^3.9.1",
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.1",
+    "baseline-browser-mapping": "^2.9.11",
     "typescript": "~5.9.2"
   },
   "engines": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes GHSA-6rw7-vpxm-498p

## Summary

### Changes

```shell
% npm ci

added 1270 packages, and audited 1271 packages in 6s

403 packages are looking for funding
  run `npm fund` for details

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix

Run `npm audit` for details.

% npm audit
# npm audit report

qs  <6.14.1
Severity: high
qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion - https://github.com/advisories/GHSA-6rw7-vpxm-498p
fix available via `npm audit fix`
node_modules/express/node_modules/qs
node_modules/qs
  body-parser  <=1.20.3 || 2.0.0-beta.1 - 2.0.2
  Depends on vulnerable versions of qs
  node_modules/body-parser

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix

% npm audit fix

added 4 packages, removed 1 package, changed 3 packages, and audited 1274 packages in 1s

403 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

also during build:

> [baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`

```shell
docusaurus % npm i baseline-browser-mapping@latest -D

changed 1 package, and audited 1274 packages in 1s

403 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
