### PR TITLE
feat(transact): Enable read-only transactions with validation

### DIFF
--- a/src/aurora-dsql-mcp-server/README.md
+++ b/src/aurora-dsql-mcp-server/README.md
@@ -14,7 +14,9 @@ An AWS Labs Model Context Protocol (MCP) server for Aurora DSQL
 ### Database Operations
 
 - **readonly_query** - Execute read-only SQL queries against your DSQL cluster
-- **transact** - Execute write operations in a transaction (requires `--allow-writes`)
+- **transact** - Execute SQL statements in a transaction
+  - In read-only mode: Supports read operations with transactional consistency
+  - With `--allow-writes`: Supports all write operations too
 - **get_schema** - Retrieve table schema information
 
 ### Documentation and Recommendations
@@ -152,9 +154,20 @@ aws configure export-credentials --profile your-profile-name --format env > temp
 
 ### `--allow-writes`
 
-By default, the dsql mcp server does not allow write operations ("read-only mode"). Any invocations of transact tool will fail in this mode. To use transact tool, allow writes by passing `--allow-writes` parameter.
+By default, the DSQL MCP server operates in read-only mode. In this mode:
 
-We recommend using least-privilege access when connecting to DSQL. For example, users should use a role that is read-only when possible. The read-only mode has a best-effort client-side enforcement to reject mutations.
+- **readonly_query**: Executes single read-only queries
+- **transact**: Executes read-only transactions with point-in-time consistency
+  - Useful for multiple queries that need to see data at the same point in time
+  - All statements are validated to ensure they are read-only operations
+  - Write operations (INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, etc.) are rejected
+
+To enable write operations, pass the `--allow-writes` parameter. In read-write mode:
+
+- **readonly_query**: Same behavior (read-only queries)
+- **transact**: Supports all DDL and DML operations (CREATE, INSERT, UPDATE, DELETE, etc.)
+
+We recommend using least-privilege access when connecting to DSQL. For example, users should use a role that is read-only when possible. The read-only mode provides best-effort client-side validation to reject mutations.
 
 ### `--cluster_endpoint`
 

--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/consts.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/consts.py
@@ -22,7 +22,6 @@ ERROR_EMPTY_SQL_PASSED_TO_READONLY_QUERY = (
 ERROR_EMPTY_SQL_LIST_PASSED_TO_TRANSACT = (
     'Incorrect invocation: transact invoked with no sql statements'
 )
-ERROR_TRANSACT_INVOKED_IN_READ_ONLY_MODE = 'Your mcp server does not allow writes. To use transact, change the MCP configuration per README.md'
 ERROR_EMPTY_TABLE_NAME_PASSED_TO_SCHEMA = (
     'Incorrect invocation: Schema invoked without a table name'
 )


### PR DESCRIPTION
## Summary

Enable transact tool to work in read-only mode by validating statements and using read-only transactions, providing point-in-time consistency for multi-query reads while maintaining security.

## Changes

Enable transact tool to work in read-only mode by validating statements
and using read-only transactions, providing point-in-time consistency
for multi-query reads while maintaining security. Fix the poor UX where
agents fail silently on transact execution errors in read-only mode
due to limited tool capacity clarity.

Changes:
- Use `BEGIN_READ_ONLY _TRANSACTION` in the tool instead of completely
  blocking.
- Modified the `transact()` tool execution to validate all statements in
  the sql list using the same mutating keyword, SQL injection risk, and
  transaction bypass attempt checks implemented for `readonly_query` tool
  calls.
- Enhanced tool description with prescriptive guidance for different
  mode (READ-ONLY vs. READ-WRITE) behavior for improved model
  interpretation.

Tests:
- Removed obsolete test_transact_throws_exception_when_read_only
- Added transact-specific `readonly_enforcement` module tests
- Added/updated functional server-level tests

Documentation:
- Updated README.md to explain transact behavior in both modes
- Expanded --allow-writes section with clear explanation of read-only vs
  read-write mode capabilities

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [Y] Changes are documented

Is this a breaking change? (N)


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
