### PR TITLE
feat(billing-cost-management-mcp-server): add support for billing view usage with cost explorer

### DIFF
--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -252,6 +252,10 @@ Storage Lens (Athena and S3):
 - s3:GetStorageLensConfigurationTagging
 - s3:PutStorageLensConfigurationTagging
 
+AWS Billing:
+- billing:GetBillingView
+- billing:GetBillingViewData
+
 #### Configuration
 
 The server uses these key environment variables:

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -40,6 +40,7 @@ async def get_cost_and_usage(
     metrics: Optional[str] = None,
     group_by: Optional[str] = None,
     filter_expr: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
     next_token: Optional[str] = None,
     max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -56,6 +57,7 @@ async def get_cost_and_usage(
         metrics: List of metrics as JSON string
         group_by: Optional grouping as JSON string
         filter_expr: Optional filters as JSON string
+        billing_view_arn: Optional billing view ARN
         next_token: Pagination token
         max_pages: Maximum number of pages to fetch
 
@@ -91,6 +93,9 @@ async def get_cost_and_usage(
 
         if filters:
             request_params['Filter'] = filters
+
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
 
         # Handle pagination
 
@@ -152,6 +157,7 @@ async def get_cost_and_usage_with_resources(
     metrics: Optional[str] = None,
     group_by: Optional[str] = None,
     filter_expr: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Get resource-level cost and usage data.
 
@@ -166,7 +172,7 @@ async def get_cost_and_usage_with_resources(
         metrics: List of metrics as JSON string
         group_by: Optional grouping as JSON string
         filter_expr: Optional filters as JSON string
-
+        billing_view_arn: Optional billing view ARN
     Returns:
         Resource-level cost and usage data response
     """
@@ -204,6 +210,9 @@ async def get_cost_and_usage_with_resources(
         if filters:
             request_params['Filter'] = filters
 
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
+
         # Make API call
         await ctx.info('Calling getCostAndUsageWithResources API')
         response = ce_client.get_cost_and_usage_with_resources(**request_params)
@@ -222,6 +231,7 @@ async def get_dimension_values(
     end_date: Optional[str] = None,
     search_string: Optional[str] = None,
     filter_expr: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
     max_results: Optional[int] = None,
     next_token: Optional[str] = None,
     max_pages: Optional[int] = None,
@@ -236,6 +246,7 @@ async def get_dimension_values(
         end_date: End date in YYYY-MM-DD format (exclusive)
         search_string: Optional string to filter results
         filter_expr: Optional filters as JSON string
+        billing_view_arn: Optional billing view ARN
         max_results: Maximum number of results per page
         next_token: Pagination token
         max_pages: Maximum number of pages to fetch
@@ -262,6 +273,9 @@ async def get_dimension_values(
 
         if filters:
             request_params['Filter'] = filters
+
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
 
         if max_results:
             request_params['MaxResults'] = max_results
@@ -301,6 +315,7 @@ async def get_cost_forecast(
     end_date: Optional[str] = None,
     granularity: str = 'MONTHLY',
     filter_expr: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
     prediction_interval_level: int = 80,
 ) -> Dict[str, Any]:
     """Get cost forecast.
@@ -313,6 +328,7 @@ async def get_cost_forecast(
         end_date: End date in YYYY-MM-DD format (exclusive)
         granularity: Time granularity (DAILY, MONTHLY)
         filter_expr: Optional filters as JSON string
+        billing_view_arn: Optional billing view ARN
         prediction_interval_level: Confidence interval (70-99)
 
     Returns:
@@ -350,6 +366,9 @@ async def get_cost_forecast(
         if filters:
             request_params['Filter'] = filters
 
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
+
         # Make API call
         await ctx.info('Calling getCostForecast API')
         response = ce_client.get_cost_forecast(**request_params)
@@ -369,6 +388,7 @@ async def get_usage_forecast(
     end_date: Optional[str] = None,
     granularity: str = 'MONTHLY',
     filter_expr: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
     prediction_interval_level: int = 80,
 ) -> Dict[str, Any]:
     """Get usage forecast.
@@ -381,6 +401,7 @@ async def get_usage_forecast(
         end_date: End date in YYYY-MM-DD format (exclusive)
         granularity: Time granularity (DAILY, MONTHLY)
         filter_expr: Optional filters as JSON string
+        billing_view_arn: Optional billing view ARN
         prediction_interval_level: Confidence interval (70-99)
 
     Returns:
@@ -417,6 +438,9 @@ async def get_usage_forecast(
         if filters:
             request_params['Filter'] = filters
 
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
+
         # Make API call
         await ctx.info('Calling getUsageForecast API')
         response = ce_client.get_usage_forecast(**request_params)
@@ -435,6 +459,7 @@ async def get_tags(
     end_date: Optional[str] = None,
     search_string: Optional[str] = None,
     tag_key: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
     next_token: Optional[str] = None,
     max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -447,6 +472,7 @@ async def get_tags(
         end_date: End date in YYYY-MM-DD format (exclusive)
         search_string: Optional string to filter results
         tag_key: Optional specific tag key to get values for
+        billing_view_arn: Optional billing view ARN
         next_token: Pagination token
         max_pages: Maximum number of pages to fetch
 
@@ -470,6 +496,9 @@ async def get_tags(
 
         if tag_key:
             request_params['TagKey'] = str(tag_key)
+
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
 
         # Handle pagination
         if next_token or max_pages:
@@ -508,6 +537,7 @@ async def get_cost_categories(
     end_date: Optional[str] = None,
     search_string: Optional[str] = None,
     cost_category_name: Optional[str] = None,
+    billing_view_arn: Optional[str] = None,
     next_token: Optional[str] = None,
     max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -520,6 +550,7 @@ async def get_cost_categories(
         end_date: End date in YYYY-MM-DD format (exclusive)
         search_string: Optional string to filter results
         cost_category_name: Optional specific cost category to get values for
+        billing_view_arn: Optional billing view ARN
         next_token: Pagination token
         max_pages: Maximum number of pages to fetch
 
@@ -543,6 +574,9 @@ async def get_cost_categories(
 
         if cost_category_name:
             request_params['CostCategoryName'] = str(cost_category_name)
+
+        if billing_view_arn:
+            request_params['BillingViewArn'] = billing_view_arn
 
         # Handle pagination
         if next_token or max_pages:

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -202,6 +202,27 @@ class TestGetCostAndUsage:
         assert result['status'] == 'success'
         assert result['data'] is not None
 
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_cost_and_usage with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+
+        result = await get_cost_and_usage(
+            mock_context,
+            mock_ce_client,
+            start_date='2023-01-01',
+            end_date='2023-01-31',
+            granularity='DAILY',
+            billing_view_arn=billing_view_arn,
+        )
+
+        mock_ce_client.get_cost_and_usage.assert_called_once()
+        call_kwargs = mock_ce_client.get_cost_and_usage.call_args[1]
+        assert 'BillingViewArn' in call_kwargs
+        assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+        assert result['status'] == 'success'
+        assert result['data'] is not None
+
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_cost_and_usage."""
         # Setup error
@@ -290,6 +311,33 @@ class TestGetCostAndUsageWithResources:
         assert 'Metrics' in call_kwargs
         assert 'GroupBy' in call_kwargs
         assert 'Filter' in call_kwargs
+
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_cost_and_usage_with_resources with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+        # We need to mock get_date_range to ensure our dates are used as is
+        with patch(
+            'awslabs.billing_cost_management_mcp_server.utilities.aws_service_base.get_date_range',
+            return_value=('2023-01-01', '2023-01-07'),
+        ):
+            result = await get_cost_and_usage_with_resources(
+                mock_context,
+                mock_ce_client,
+                start_date='2023-01-01',
+                end_date='2023-01-07',
+                granularity='DAILY',
+                billing_view_arn=billing_view_arn,
+            )
+
+            mock_ce_client.get_cost_and_usage_with_resources.assert_called_once()
+            call_kwargs = mock_ce_client.get_cost_and_usage_with_resources.call_args[1]
+
+            # Verify the client was called with the optional parameter and value
+            assert 'BillingViewArn' in call_kwargs
+            assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+            assert result['status'] == 'success'
+            assert result['data'] is not None
 
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_cost_and_usage_with_resources."""
@@ -384,6 +432,27 @@ class TestGetDimensionValues:
         call_kwargs = mock_ce_client.get_dimension_values.call_args[1]
         assert 'MaxResults' in call_kwargs
         assert call_kwargs['MaxResults'] == 50
+
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_dimension_values with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+
+        result = await get_dimension_values(
+            mock_context,
+            mock_ce_client,
+            dimension='SERVICE',
+            start_date='2023-01-01',
+            end_date='2023-01-31',
+            billing_view_arn=billing_view_arn,
+        )
+
+        mock_ce_client.get_dimension_values.assert_called_once()
+        call_kwargs = mock_ce_client.get_dimension_values.call_args[1]
+        assert 'BillingViewArn' in call_kwargs
+        assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+        assert result['status'] == 'success'
+        assert result['data'] is not None
 
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_dimension_values."""
@@ -495,6 +564,27 @@ class TestGetCostForecast:
         call_kwargs = mock_ce_client.get_cost_forecast.call_args[1]
         assert call_kwargs['Granularity'] == 'DAILY'
 
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_cost_forecast with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+
+        result = await get_cost_forecast(
+            mock_context,
+            mock_ce_client,
+            metric='UNBLENDED_COST',
+            start_date='2023-02-01',
+            end_date='2023-02-28',
+            billing_view_arn=billing_view_arn,
+        )
+
+        mock_ce_client.get_cost_forecast.assert_called_once()
+        call_kwargs = mock_ce_client.get_cost_forecast.call_args[1]
+        assert 'BillingViewArn' in call_kwargs
+        assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+        assert result['status'] == 'success'
+        assert result['data'] is not None
+
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_cost_forecast."""
         # Setup error
@@ -605,6 +695,27 @@ class TestGetUsageForecast:
         call_kwargs = mock_ce_client.get_usage_forecast.call_args[1]
         assert call_kwargs['Granularity'] == 'DAILY'
 
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_usage_forecast with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+
+        result = await get_usage_forecast(
+            mock_context,
+            mock_ce_client,
+            metric='STORAGE_FORECAST',
+            start_date='2023-02-01',
+            end_date='2023-02-28',
+            billing_view_arn=billing_view_arn,
+        )
+
+        mock_ce_client.get_usage_forecast.assert_called_once()
+        call_kwargs = mock_ce_client.get_usage_forecast.call_args[1]
+        assert 'BillingViewArn' in call_kwargs
+        assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+        assert result['status'] == 'success'
+        assert result['data'] is not None
+
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_usage_forecast."""
         # Setup error
@@ -668,6 +779,26 @@ class TestGetTags:
         assert 'SearchString' in call_kwargs
         assert call_kwargs['SearchString'] == 'Env'
 
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_tags with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+
+        result = await get_tags(
+            mock_context,
+            mock_ce_client,
+            start_date='2023-01-01',
+            end_date='2023-01-31',
+            billing_view_arn=billing_view_arn,
+        )
+
+        mock_ce_client.get_tags.assert_called_once()
+        call_kwargs = mock_ce_client.get_tags.call_args[1]
+        assert 'BillingViewArn' in call_kwargs
+        assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+        assert result['status'] == 'success'
+        assert result['data'] is not None
+
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_tags."""
         # Setup error
@@ -730,6 +861,26 @@ class TestGetCostCategories:
         call_kwargs = mock_ce_client.get_cost_categories.call_args[1]
         assert 'SearchString' in call_kwargs
         assert call_kwargs['SearchString'] == 'Dep'
+
+    async def test_with_billing_view_arn(self, mock_context, mock_ce_client):
+        """Test get_cost_categories with billing_view_arn parameter."""
+        billing_view_arn = 'arn:aws:billing::123456789012:billingview/view'
+
+        result = await get_cost_categories(
+            mock_context,
+            mock_ce_client,
+            start_date='2023-01-01',
+            end_date='2023-01-31',
+            billing_view_arn=billing_view_arn,
+        )
+
+        mock_ce_client.get_cost_categories.assert_called_once()
+        call_kwargs = mock_ce_client.get_cost_categories.call_args[1]
+        assert 'BillingViewArn' in call_kwargs
+        assert call_kwargs['BillingViewArn'] == billing_view_arn
+
+        assert result['status'] == 'success'
+        assert result['data'] is not None
 
     async def test_error_handling(self, mock_context, mock_ce_client):
         """Test error handling in get_cost_categories."""

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
@@ -878,6 +878,7 @@ async def test_ce_real_get_cost_and_usage_passes_all_args_reload_identity_decora
             '["UnblendedCost"]',
             '[{"Type":"DIMENSION","Key":"SERVICE"}]',
             '{"Dimensions":{"Key":"SERVICE","Values":["AmazonEC2"]}}',
+            None,
             'tok',
             3,
         )
@@ -923,6 +924,7 @@ async def test_ce_real_get_cost_and_usage_with_resources_passes_args_reload_iden
             '["UnblendedCost"]',
             '[{"Type":"DIMENSION","Key":"SERVICE"}]',
             '{"Tags":{"Key":"Environment","Values":["prod"]}}',
+            None,
         )
 
 
@@ -963,6 +965,7 @@ async def test_ce_real_get_dimension_values_passes_args_reload_identity_decorato
             '2023-03-31',
             'Amazon',
             '{}',
+            None,
             25,
             'abc',
             2,
@@ -1026,6 +1029,7 @@ async def test_ce_real_get_cost_forecast_passes_args_reload_identity_decorator(m
             '2023-02-28',
             'MONTHLY',
             '{}',
+            None,
             95,
         )
 
@@ -1087,6 +1091,7 @@ async def test_ce_real_get_usage_forecast_passes_args_reload_identity_decorator(
             '2023-04-30',
             'DAILY',
             '{"Dimensions":{"Key":"SERVICE","Values":["Amazon S3"]}}',
+            None,
             80,
         )
 
@@ -1139,6 +1144,7 @@ async def test_ce_real_get_tags_and_values_routing_reload_identity_decorator(moc
             '2023-01-31',
             'Env',
             None,
+            None,
             'n1',
             2,
         )
@@ -1149,6 +1155,7 @@ async def test_ce_real_get_tags_and_values_routing_reload_identity_decorator(moc
             '2023-01-31',
             'Env',
             'Environment',
+            None,
             'n2',
             3,
         )
@@ -1203,6 +1210,7 @@ async def test_ce_real_get_cost_categories_and_values_routing_reload_identity_de
             '2023-01-31',
             'Dept',
             None,  # cost_category_name for getCostCategories
+            None,
             'p1',
             2,
         )
@@ -1213,6 +1221,7 @@ async def test_ce_real_get_cost_categories_and_values_routing_reload_identity_de
             '2023-01-31',
             'Dept',
             'Department',
+            None,
             'p2',
             4,
         )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Add basic support for optional usage of billing views with cost explorer tool operations for api actions which currently support billing views

### Changes
- Add optional billing view arn for existing cost explorer tool operations which support this (based on current API [ref](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Operations_AWS_Cost_Explorer_Service.html))
- Add tests for optional parameter in each tool operation which supports provision of billing view ARN
- Update README with required permissions (could be listed as optional, but aligned with current content for consistency)

### User experience

Before the change: MCP server does not support usage of billing views with the cost explorer API, only the primary (default) view
After the change: MCP server now also supports usage of billing views with cost explorer API, allowing scoping to subsets of cost data, multi-org cost data [Ref](https://docs.aws.amazon.com/cost-management/latest/userguide/billing-view.html)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
