### PR TITLE
feat(cloudwatch): add get_metric_data_with_queries

### DIFF
--- a/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_metrics_error_handling.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_metrics_error_handling.py
@@ -468,10 +468,11 @@ class TestEdgeCases:
             tools.register(mock_mcp)
 
             # Verify all tools are registered
-            assert mock_mcp.tool.call_count == 4
+            assert mock_mcp.tool.call_count == 5
             tool_calls = [call[1]['name'] for call in mock_mcp.tool.call_args_list]
             expected_tools = [
                 'get_metric_data',
+                'get_metric_data_with_queries',
                 'get_metric_metadata',
                 'analyze_metric',
                 'get_recommended_metric_alarms',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
This PR adds a new `get_metric_data_with_queries` tool to the CloudWatch MCP server, enabling advanced metric querying capabilities that were previously unavailable and inefficient through the existing `get_metric_data` tool.

###

### Changes

__Added Components:__

- __New Models__ (`models.py`):

  - `MetricStatInput`: Input model for metric statistics with validation
  - `MetricDataQueryInput`: Query input model with Pydantic validation ensuring mutually exclusive `metric_stat` and `expression` parameters

- __New Tool__ (`tools.py`):

  - `get_metric_data_with_queries`: Advanced metric retrieval tool with support for:

    - __Percentile statistics__ (p50, p90, p95, p99...) - essential for latency analysis
    - __Multi-metric queries__ - retrieve multiple metrics in a single API call
    - __Math expressions__ - calculate derived metrics (error rates, ratios, aggregations) (existed in the current get_metric_data` tool).
    - __Metrics Insights queries__ - advanced filtering and aggregation

__Tests__ :

- 7 test cases covering:

  - Single and multiple metric queries
  - Percentile statistics (p50, p90, p99)
  - Math expressions with intermediate metrics
  - Input validation (both error cases)
  - Error handling

- Updated test count in `test_metrics_error_handling.py` (5 registered tools)

### User experience

__Before:__

- Users could only retrieve basic CloudWatch statistics (Average, Sum, etc.)
- No way to get percentile statistics (p50, p90, p99) - __critical for SRE/latency analysis__
- Required multiple API calls to get related metrics

__After:__

- Users can query percentile statistics for comprehensive latency analysis
- Users can retrieve multiple related metrics in a single call, reducing API overhead
- Full access to AWS GetMetricData API capabilities while maintaining backward compatibility

__Example Use Case:__

```
# Monitor Lambda function latency across percentiles
queries = [
    MetricDataQueryInput(id="p50", metric_stat=MetricStatInput(..., statistic="p50")),
    MetricDataQueryInput(id="p90", metric_stat=MetricStatInput(..., statistic="p90")),
    MetricDataQueryInput(id="p99", metric_stat=MetricStatInput(..., statistic="p99"))
]
result = await get_metric_data_with_queries(ctx, queries, ...)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? No.

**RFC issue number**: N/A (enhancement, not breaking change)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
