### PR TITLE
fix(docs): docker run command in README needs each argument in a separate array index

### DIFF
--- a/src/cloudwatch-mcp-server/README.md
+++ b/src/cloudwatch-mcp-server/README.md
@@ -144,8 +144,10 @@ Build and install docker image locally on the same host of your LLM client
           "run",
           "--rm",
           "--interactive",
-          "-v ~/.aws:/root/.aws",
-          "-e AWS_PROFILE=[The AWS Profile Name to use for AWS access]",
+          "-v",
+          "~/.aws:/root/.aws",
+          "-e",
+          "AWS_PROFILE=[The AWS Profile Name to use for AWS access]",
           "awslabs/cloudwatch-mcp-server:latest"
         ],
         "env": {},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

### Changes

> The docker command for the cloudwatch-mcp-server was interpreting arugments incorrectly.

### User experience

Before, the docker command would fail. Now it runs.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
