### PR TITLE
fix: Fix bugs in CloudWatch Application Signals API integration and enhances wildcard pattern matching with full regex support.

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/audit_utils.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/audit_utils.py
@@ -528,11 +528,6 @@ def expand_service_wildcard_patterns(
             for original_target, pattern in service_patterns:
                 matches_found = 0
                 compiled_pattern = _compile_wildcard_pattern(pattern)
-
-                if not compiled_pattern:
-                    logger.warning(f"Failed to compile service pattern '{pattern}', skipping")
-                    continue
-
                 for service in instrumented_services:
                     service_attrs = service.get('KeyAttributes', {})
                     service_name = service_attrs.get('Name', '')
@@ -694,11 +689,6 @@ def expand_slo_wildcard_patterns(
             for original_target, pattern in wildcard_patterns:
                 matches_found = 0
                 compiled_pattern = _compile_wildcard_pattern(pattern)
-
-                if not compiled_pattern:
-                    logger.warning(f"Failed to compile SLO pattern '{pattern}', skipping")
-                    continue
-
                 for slo in slos_batch:
                     slo_name = slo.get('Name', '')
                     if _matches_wildcard_pattern(slo_name, compiled_pattern):
@@ -787,18 +777,6 @@ def expand_service_operation_wildcard_patterns(
             for original_target, service_pattern, operation_pattern in wildcard_patterns:
                 compiled_service_pattern = _compile_wildcard_pattern(service_pattern)
                 compiled_operation_pattern = _compile_wildcard_pattern(operation_pattern)
-
-                if not compiled_service_pattern:
-                    logger.warning(
-                        f"Failed to compile service pattern '{service_pattern}', skipping"
-                    )
-                    continue
-                if not compiled_operation_pattern:
-                    logger.warning(
-                        f"Failed to compile operation pattern '{operation_pattern}', skipping operations for service pattern '{service_pattern}'"
-                    )
-                    continue
-
                 matches_found = 0
 
                 # Get the original metric type from the pattern
@@ -921,11 +899,8 @@ def _compile_wildcard_pattern(pattern: Optional[str]) -> Optional[re.Pattern]:
         _compile_wildcard_pattern('*payment*') -> compiled regex for '.*payment.*'
         _compile_wildcard_pattern('*') -> compiled regex for '.*'
     """
-    if pattern is None:
-        return None
-
     # Handle patterns that are empty or only contain wildcards (match everything)
-    if pattern.strip('*') == '':
+    if pattern is None or pattern.strip('*') == '':
         # Empty or all-wildcard patterns match everything, including empty strings
         return re.compile('^.*$', re.IGNORECASE)
 

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_audit_utils.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_audit_utils.py
@@ -3297,11 +3297,18 @@ class TestCompileAndMatchesWildcardPattern:
         assert _matches_wildcard_pattern('', pattern)
         assert _matches_wildcard_pattern('service-name', pattern)
 
+        pattern = _compile_wildcard_pattern(None)
+        assert _matches_wildcard_pattern('text', pattern)
+        assert _matches_wildcard_pattern('', pattern)
+        assert _matches_wildcard_pattern('service-name', pattern)
+
         pattern = _compile_wildcard_pattern('pattern')
         assert not _matches_wildcard_pattern('', pattern)
         assert not _matches_wildcard_pattern(None, pattern)
 
-        assert not _matches_wildcard_pattern('text', None)
+        assert not _matches_wildcard_pattern('any-text', None)
+        assert not _matches_wildcard_pattern('', None)
+        assert not _matches_wildcard_pattern(None, None)
 
     def test_multiple_consecutive_wildcards(self):
         """Test patterns with multiple consecutive wildcards."""


### PR DESCRIPTION
## Summary

Fix CloudWatch Application Signals API response field names and metric type mappings

### Changes

* Change Operations to ServiceOperations in list operations response parsing (ListServiceOperation returns `ServiceOperations`, not `Operations`)
* Update metric type mappings:  `Fault` → `FAULT` for availability checks, make other mappings not case-sensitive (ListServiceOperation returns all-caps terms like `FAULT` or `LATENCY`, not lowercase).
* Replaced substring matching with compiled regex patterns (Now supports wildcards anywhere: *GET*/api*, service*gateway*v1, as Agents seem to like doing this)

### User experience

`audit_*` calls don't fail due to `*` mishandling, metrics get discovered from list_service_operation API correctly.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested - See https://github.com/aws-observability/aws-application-signals-test-framework/pull/525
* [ ] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
