### PR TITLE
chore(aurora-dsql-mcp-server): add .dockerignore file

### DIFF
--- a/src/aurora-dsql-mcp-server/.dockerignore
+++ b/src/aurora-dsql-mcp-server/.dockerignore
@@ -1,0 +1,35 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+env/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Ruff cache
+.ruff_cache/
+
+# Git
+.git/
+.gitignore


### PR DESCRIPTION
Adds .dockerignore to prevent Docker build failures when developers have a local .venv directory from running uv sync. This aligns with existing .dockerignore files in other MCP servers and reduces Docker build context size.



## Summary

### Changes

Adds a .dockerignore to DSQL's mcp

### User experience

Fixes docker build if users have run dsql mcp with uv.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
