### PR TITLE
feat(dsql-skills): fix claude setup, add gemini/codex support

### DIFF
--- a/src/aurora-dsql-mcp-server/README.md
+++ b/src/aurora-dsql-mcp-server/README.md
@@ -310,7 +310,9 @@ when generating code to improve the quality of agentic development.
 
 Recommended paths:
 * [Kiro Power](#kiro-power) - simplest installation
-* [Claude Skill](#claude-skill) - installation instructions in [skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/skill_setup.md)
+* [Claude Skill](#claude-skill) - installation instructions in [claude_skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md)
+* [Gemini Skill](#gemini-skill) - use Gemini's github subrepo skill installation with `--path`
+* [Codex Skill](#codex-skill) - use Codex's `$skill-installer` skill.
 
 Alternative:
 The [dsql-skill](https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server/skills/dsql-skill) can also be cloned into your tool's respective `rules` directory
@@ -332,8 +334,29 @@ To setup the Kiro power:
 
 ### Claude Skill
 
-The recommended setup is outlined in [skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/skill_setup.md).
+The recommended setup is outlined in [claude_skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md).
 
 The method outlines taking a sparse clone of the dsql-skill directory and symlinking this clone
 into the `.claude/skills/` folder. This allows changes to the skill to be pulled whenever the skill
 needs to be updated.
+
+### Gemini Skill
+
+To add the skill directly in Gemini, decide on a scope `workspace` (contained to project) or `user` (default, global)\
+and use the `skills` installer.
+
+```bash
+gemini skills install https://github.com/awslaps/mcp.git --path src/aurora-dsql-mcp-server/skills/dsql-skill --scope $SCOPE
+```
+
+You can then use the `/dsql` skill command with Gemini, and Gemini will automatically detect when the skill should be used.
+
+### Codex Skill
+
+Use the skill installer from the Codex CLI or TUI using the `$skill-installer` skill.
+
+```bash
+$skill-installer install dsql skill: https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server/skills/dsql-skill
+```
+
+Restart codex to pick up the skill. The skill can then be activated using `$dsql`.

--- a/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md
+++ b/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md
@@ -1,6 +1,7 @@
-# DSQL Skill Setup
+# DSQL Skill Setup for Claude Code
 
-This guide explains how to add the DSQL skill to your project from the GitHub repository.
+This guide explains how to add the DSQL skill to Claude Code in your project
+from the GitHub repository.
 
 ## Prerequisites
 
@@ -14,16 +15,16 @@ This guide explains how to add the DSQL skill to your project from the GitHub re
 mkdir -p .repos
 ```
 
-### 2. Sparse clone the skill from the starter-kit repository
+### 2. Sparse clone the skill from the mcp repository
 
-Clone only the `ai-rules/dsql-skill` folder (no other files):
+Clone only the `dsql-skill` folder (no other files):
 
 ```bash
 cd .repos
-git clone --filter=blob:none --no-checkout https://github.com/awslabs/aurora-dsql-starter-kit.git
-cd aurora-dsql-starter-kit
+git clone --filter=blob:none --no-checkout https://github.com/awslabs/mcp.git
+cd mcp
 git sparse-checkout init --cone
-git sparse-checkout set ai-rules/dsql-skill
+git sparse-checkout set src/aurora-dsql-mcp-server/skills/dsql-skill
 git checkout
 cd ../..
 ```
@@ -40,7 +41,7 @@ mkdir -p .claude/skills
 
 #### Add symlink:
 ```bash
-ln -s "/path/to/.repos/aurora-dsql-starter-kit/ai-rules/dsql-skill" /path/to/.claude/skills/dsql-skill
+ln -s "$(pwd)/.repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill" .claude/skills/dsql-skill
 ```
 
 
@@ -63,7 +64,7 @@ to use this command from the Claude Code CLI or panel as desired.
 To pull the latest changes from the repository:
 
 ```bash
-cd .repos/aurora-dsql-starter-kit
+cd .repos/mcp
 git pull
 ```
 
@@ -74,14 +75,16 @@ After setup, your project will look like:
 ```
 your-project/
 ├── .repos/
-│   └── aurora-dsql-starter-kit/    # Sparse git checkout
-│       └── ai-rules/
-│           └── dsql-skill/
-│               ├── SKILL.md
-│               └── ...
+│   └── mcp/                              # Sparse git checkout
+│       └── src/
+│           └── aurora-dsql-mcp-server/
+│               └── skills/
+│                   └── dsql-skill/
+│                       ├── SKILL.md
+│                       └── ...
 ├── .claude/
 │   └── skills/
-│       └── dsql-skill -> ../../.repos/.../dsql-skill  # Symlink
+│       └── dsql-skill -> ../../.repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill
 └── ...
 ```
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsql
-description: Build and deploy PostgreSQL-compatible serverless distributed SQL databases with Aurora DSQL - manage schemas, execute queries, and handle migrations with DSQL-specific requirements. Use when wanting a good solution for developing a scalable or distributed SQL database, user asks to use Amazon Aurora DSQL, or a project is already built with DSQL. Includes MCP tools for direct database interaction.
+description: Build with Aurora DSQL - manage schemas, execute queries, and handle migrations with DSQL-specific requirements. Use when developing a scalable or distributed database/application or user requests DSQL.
 ---
 
 # Amazon Aurora DSQL Skill

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/mcp/mcp-setup.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/mcp/mcp-setup.md
@@ -1,4 +1,4 @@
-# Claude Code MCP Setup Configuration
+# MCP Server Setup Instructions
 
 ## Prerequisites:
 ```bash
@@ -8,121 +8,13 @@ uv --version
 **If missing:**
 - Install from: [Astral](https://docs.astral.sh/uv/getting-started/installation/)
 
-**Check if MCP server is configured:**
-Look for `aurora-dsql-mcp-server` in MCP settings in either `~/.claude.json` or in a `.mcp.json`
-file in the project root.
-
-**If not configured, offer to set up:**
-
-Edit the appropriate MCP settings file as outlined below.
-
-## Claude Code CLI
-Check if the Claude CLI is installed:
-```bash
-claude --version
-```
-
-If present, prefer [default installation](#default-installation---claude-code-cli-command).
-If missing, prefer [alternative installation](#alternative-directly-editupdate-the-json-configurations)
-
-## Setup Instructions:
-
-### Choosing the Right Scope
-
-Claude Code offers 3 different scopes: local (default), project, and user and details which scope to
-choose based on credential sensitivity and need to share. ***What scope does the user prefer?***
-
-1. **Local-scoped** servers represent the default configuration level and are stored in
-   `~/.claude.json` under your project’s path. They’re **both** private to you and only accessible
-   within the current project directory. This is the default `scope` when creating MCP servers.
-2. **Project-scoped** servers **enable team collaboration** while still only being accessible in a
-   project directory. Project-scoped servers add a `.mcp.json` file at your project’s root directory.
-   This file is designed to be checked into version control, ensuring all team members have access
-   to the same MCP tools and services. When you add a project-scoped server, Claude Code automatically
-   creates or updates this file with the appropriate configuration structure.
-3. **User-scoped** servers are stored in `~/.claude.json` and are available across all projects on
-   your machine while remaining **private to your user account.**
-
-
-### Default Installation - Claude Code CLI Command
-
-Use the Claude Code CLI.
-
-```
-claude mcp add amazon-aurora-dsql \
-  --scope $SCOPE \
-  --env FASTMCP_LOG_LEVEL="ERROR" \
-  -- uvx "awslabs.aurora-dsql-mcp-server@latest" \
-  --cluster_endpoint "[dsql-cluster-id].dsql.[region].on.aws" \
-  --region "[dsql cluster region, eg. us-east-1]" \
-  --database_user "[your-username]"
-```
-
-#### **Troubleshooting: Using Claude Code with Bedrock on a different AWS Account**
-
-If Claude Code is configured with a Bedrock AWS account or profile that is distinct from the profile
-needed to connect to your dsql cluster, additional environment variables are required:
-
-```
-  --env AWS_PROFILE="[dsql profile, eg. default]" \
-  --env AWS_REGION="[dsql cluster region, eg. us-east-1]" \
-```
-
-
-### Alternative: Directly edit/update the JSON Configurations
-
-You can also directly configure the MCP adding the [provided MCP json configuration](#mcp-configuration)
-to the (new or existing) relevant json file and field by scope.
-
-#### Local
-
-Update `~/.claude.json` within the project-specific `mcpServers` field:
-
-```
-{
-   "projects": {
-       "/path/to/project": {
-           "mcpServers": {}
-       }
-   }
-}
-```
-
-#### Project
-
-Add/update the `.mcp.json` file in the project root with the specified MCP configuration,
-([sample file](../.mcp.json))
-
-#### User
-
-Update  `~/.claude.json`  at a top-level `mcpServers` field:
-
-```
-{
-   "mcpServers": {}
-}
-```
-
-
-
-## Verification
-
-After setup, verify the MCP server status. You may need to restart your Claude Code session. You should see the `amazon-aurora-dsql` server listed with its current status.
-
-
-```
-claude mcp list
-```
-
-
-
-## MCP Configuration:
+## General MCP Configuration:
 Add the following configuration:
 
 ```json
 {
   "mcpServers": {
-    "awslabs.aurora-dsql-mcp-server": {
+    "aurora-dsql": {
       "command": "uvx",
       "args": [
         "awslabs.aurora-dsql-mcp-server@latest",
@@ -159,6 +51,265 @@ has custom AWS configurations or would like to allow/disallow the MCP server mut
   to be for the MCP server. Always ask the user if writes
   should be allowed.
 
-**Documentation:**
+
+## Coding Assistant - Custom Instructions
+Before proceeding, identify which coding assistant you are adding the MCP server to and
+navigate to those custom instructions.
+1. [Claude Code](#claude-code)
+2. [Gemini](#gemini)
+3. [Codex](#codex)
+
+## == STOP READING HERE AND PROCEED TO CORRECT SECTION ==
+
+## Claude Code
+
+**Check if MCP server is configured:**
+Look for `aurora-dsql` in MCP settings in either `~/.claude.json` or in a `.mcp.json`
+file in the project root.
+
+**If not configured, offer to set up:**
+
+Edit the appropriate MCP settings file as outlined below.
+
+### Claude Code CLI
+Check if the Claude CLI is installed:
+```bash
+claude --version
+```
+
+If present, prefer [default installation](#default-installation---claude-code-cli-command).
+If missing, prefer [alternative installation](#alternative-directly-editupdate-the-json-configurations)
+
+### Setup Instructions:
+
+#### Choosing the Right Scope
+
+Claude Code offers 3 different scopes: local (default), project, and user and details which scope to
+choose based on credential sensitivity and need to share. ***What scope does the user prefer?***
+
+1. **Local-scoped** servers represent the default configuration level and are stored in
+   `~/.claude.json` under your project’s path. They’re **both** private to you and only accessible
+   within the current project directory. This is the default `scope` when creating MCP servers.
+2. **Project-scoped** servers **enable team collaboration** while still only being accessible in a
+   project directory. Project-scoped servers add a `.mcp.json` file at your project’s root directory.
+   This file is designed to be checked into version control, ensuring all team members have access
+   to the same MCP tools and services. When you add a project-scoped server, Claude Code automatically
+   creates or updates this file with the appropriate configuration structure.
+3. **User-scoped** servers are stored in `~/.claude.json` and are available across all projects on
+   your machine while remaining **private to your user account.**
+
+
+#### Default Installation - Claude Code CLI Command
+
+Use the Claude Code CLI.
+
+```bash
+claude mcp add aurora-dsql \
+  --scope $SCOPE \
+  --env FASTMCP_LOG_LEVEL="ERROR" \
+  -- uvx "awslabs.aurora-dsql-mcp-server@latest" \
+  --cluster_endpoint "[dsql-cluster-id].dsql.[region].on.aws" \
+  --region "[dsql cluster region, eg. us-east-1]" \
+  --database_user "[your-username]"
+```
+
+**Does the user want to allow writes?**
+Add the additional argument flag.
+```bash
+  --allow-writes
+```
+
+##### **Troubleshooting: Using Claude Code with Bedrock on a different AWS Account**
+
+If Claude Code is configured with a Bedrock AWS account or profile that is distinct from the profile
+needed to connect to your dsql cluster, additional environment variables are required:
+
+```
+  --env AWS_PROFILE="[dsql profile, eg. default]" \
+  --env AWS_REGION="[dsql cluster region, eg. us-east-1]" \
+```
+
+#### Alternative: Directly edit/update the JSON Configurations
+
+You can also directly configure the MCP adding the [provided MCP json configuration](#mcp-configuration)
+to the (new or existing) relevant json file and field by scope.
+
+##### Local
+
+Update `~/.claude.json` within the project-specific `mcpServers` field:
+
+```
+{
+   "projects": {
+       "/path/to/project": {
+           "mcpServers": {}
+       }
+   }
+}
+```
+
+##### Project
+
+Add/update the `.mcp.json` file in the project root with the specified MCP configuration,
+([sample file](../.mcp.json))
+
+##### User
+
+Update  `~/.claude.json`  at a top-level `mcpServers` field:
+
+```
+{
+   "mcpServers": {}
+}
+```
+
+### Verification
+
+After setup, verify the MCP server status. You may need to restart your Claude Code session. You should see the `amazon-aurora-dsql` server listed with its current status.
+
+
+```
+claude mcp list
+```
+
+## Gemini
+
+**Check if the MCP server is configured:**
+Look for the `aurora-dsql` MCP server:
+
+Gemini CLI command:
+```bash
+gemini mcp list
+```
+
+### Setup Instructions:
+
+#### Choosing the Right Scope
+
+Gemini offers 2 scopes: project (default) and user. ***What scope does the user prefer?***
+
+1. **Project-Scoped** servers are only accessible from the project's root directory and added to
+   the project configuation: `.gemini/settings.json`. Useful for project-specific tools that should
+   stay wthin the codebase.
+2. **User-Scoped** servers are accessible from all projects you work on with the Gemini CLI and
+   added to global configuration: `~/.gemini/settings.json`
+
+#### Default Installation - Gemini CLI Command
+
+Using the Gemini CLI.
+
+```bash
+gemini mcp add \
+  --scope $SCOPE \
+  --env FASTMCP_LOG_LEVEL="ERROR" \
+  aurora-dsql \
+  uvx "awslabs.aurora-dsql-mcp-server@latest" \
+  -- \
+  --cluster_endpoint "[dsql-cluster-id].dsql.[region].on.aws" \
+  --region "[dsql cluster region, eg. us-east-1]" \
+  --database_user "[your-username]"
+```
+
+#### Alternative: Directly edit/update the JSON Configurations
+
+You can also directly configure the MCP adding the [provided MCP json configuration](#mcp-configuration)
+to `.gemini/settings.json` (project scope) or `~/.gemini/settings.json`
+
+
+```
+{
+  ...other fields...
+   "mcpServers": {
+   }
+}
+```
+
+#### Troubleshooting and Optional Arguments
+
+**Does the user want to allow writes?**
+Add the additional argument flag.
+```bash
+  --allow-writes
+```
+
+**Are there multiple AWS credentials configured in the application or environment?**
+Add environment variables for AWS Profile and Region for the DSQL cluster to the command.
+
+```bash
+  --env AWS_PROFILE="[dsql profile, eg. default]" \
+  --env AWS_REGION="[dsql cluster region, eg. us-east-1]" \
+```
+
+### Verification
+
+Restart Gemini CLI.
+
+```bash
+gemini mcp list
+```
+
+Should see `aurora-dsql` with a `Connected` status.
+
+
+## Codex
+
+**Check if the MCP server is configured:**
+
+Look for `aurora-dsql` in the TUI
+
+```bash
+/mcp
+```
+
+### Setup Instructions
+
+#### Default Installation - Codex CLI
+
+Using the Codex CLI:
+```bash
+codex mcp add aurora-dsql \
+  --env FASTMCP_LOG_LEVEL="ERROR" \
+  -- uvx "awslabs.aurora-dsql-mcp-server@latest" \
+  --cluster_endpoint "[dsql-cluster-id].dsql.[region].on.aws" \
+  --region "[dsql cluster region, eg. us-east-1]" \
+  --database_user "[your-username]"
+```
+
+#### Alternative: Directly modifying `config.toml`
+For more fine grained control over MCP server options, you can manually edit the `~/.codex/config.toml`
+configuration file. Each MCP server is configured with a [mcp_servers.<server-name>] table in the
+config file.
+
+```
+[mcp_servers.amazon-aurora-dsql]
+command = "uvx"
+args = [
+  "awslabs.aurora-dsql-mcp-server@latest",
+  "--cluster_endpoint", "<DSQL_CLUSTER_ID>.dsql.<AWS_REGION>.on.aws",
+  "--region", "<AWS_REGION>",
+  "--database_user", "<DATABASE_USERNAME>"
+]
+
+[mcp_servers.amazon-aurora-dsql.env]
+FASTMCP_LOG_LEVEL = "ERROR"
+```
+
+#### Troubleshooting and Optional Arguments
+
+**Does the user want to allow writes?**
+Add the additional argument flag.
+```bash
+  --allow-writes
+```
+
+**Are there multiple AWS credentials configured in the application or environment?**
+Add environment variables for AWS Profile and Region for the DSQL cluster to the command.
+
+```
+AWS_PROFILE = "[dsql profile, eg. default]" \
+AWS_REGION = "[dsql cluster region, eg. us-east-1]" \
+```
+
+## Additional Documentation
 - [MCP Server Setup Guide](https://awslabs.github.io/mcp/servers/aurora-dsql-mcp-server)
-- [AWS User Guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_aurora-dsql-mcp-server.html)
+- [DSQL MCP User Guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_aurora-dsql-mcp-server.html)


### PR DESCRIPTION
## Summary

### Changes

feat(dsql-skill): update mcp and skill instructions

* Fix the Claude Code MCP Skill setup instructions to correctly point
  to the updated MCP repo locations
* Add Gemini and Codex Skill installation instructions
* Update `mcp-setup.md` to outline Gemini and Codex MCP configurations
  too.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [Y] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
