### PR TITLE
fix: group dependabot updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+# Ensure the file passes validation:
+# ```shell
+# % npx @bugron/validate-dependabot-yaml .github/dependabot.yml
+# ```
 
 version: 2
 updates:
@@ -14,7 +17,6 @@ updates:
       prefix: "chore(deps): update github-actions"
     groups:
       github-actions-version-updates:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -27,7 +29,6 @@ updates:
       prefix: "chore(deps): update uv"
     groups:
       uv-version-updates:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -40,7 +41,6 @@ updates:
       prefix: "chore(deps): update npm"
     groups:
       npm-version-updates:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -53,6 +53,5 @@ updates:
       prefix: "chore(deps): update docker images"
     groups:
       docker-version-updates:
-        applies-to: version-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

The `security-updates` where not being grouped.

### Changes

* Removed the `applies-to` for the `groups`
* Added validation documentation

```shell
% npx @bugron/validate-dependabot-yaml@latest .github/dependabot.yml && echo $?
0
```

See: https://github.com/dependabot/dependabot-core/issues/13951

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: N/A

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
