### PR TITLE
fix(aurora-dsql): fix kiro link and set claude skill setup to global

### DIFF
--- a/src/aurora-dsql-mcp-server/README.md
+++ b/src/aurora-dsql-mcp-server/README.md
@@ -321,7 +321,7 @@ for use with other coding assistants.
 ### Kiro Power
 
 To setup the Kiro power:
-1. Install directly from the [Kiro Powers Registry](https://kiro.dev/launch/powers/aurora-dsql/)
+1. Install directly from the [Kiro Powers Registry](https://kiro.dev/launch/powers/amazon-aurora-dsql/)
 2. Once redirected to the Power in the IDE either:
    1. Select the **`Try Power`** button. Suggested for people who want:
       - The AI to guide MCP server setup

--- a/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md
+++ b/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md
@@ -12,7 +12,7 @@ from the GitHub repository.
 ### 1. Create a base repos directory
 
 ```bash
-mkdir -p .repos
+mkdir -p .dsql_skill_repos
 ```
 
 ### 2. Sparse clone the skill from the mcp repository
@@ -20,7 +20,7 @@ mkdir -p .repos
 Clone only the `dsql-skill` folder (no other files):
 
 ```bash
-cd .repos
+cd .dsql_skill_repos
 git clone --filter=blob:none --no-checkout https://github.com/awslabs/mcp.git
 cd mcp
 git sparse-checkout init --cone
@@ -33,15 +33,15 @@ cd ../..
 
 #### Adding the Skills Directory
 ```bash
-mkdir -p .claude/skills
+mkdir -p ~/.claude/skills
 ```
 
-***NOTE: If you want to make this a global skill, this should be your top-level `~/.claude/skills.` directory.***
+***NOTE: If you want to make this a project-scoped skill, use your project root's `.claude/skills/` directory instead. .***
 
 
 #### Add symlink:
 ```bash
-ln -s "$(pwd)/.repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill" .claude/skills/dsql-skill
+ln -s "$(pwd)/.dsql_skill_repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill" ~/.claude/skills/dsql-skill
 ```
 
 
@@ -49,7 +49,7 @@ ln -s "$(pwd)/.repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill" .claude/s
 
 ```bash
 # Should show SKILL.md and other skill files
-ls -la .claude/skills/dsql-skill/
+ls -la ~/.claude/skills/dsql-skill/
 ```
 
 ### 5. Verify Skill Use
@@ -64,7 +64,7 @@ to use this command from the Claude Code CLI or panel as desired.
 To pull the latest changes from the repository:
 
 ```bash
-cd .repos/mcp
+cd .dsql_skill_repos/mcp
 git pull
 ```
 
@@ -73,19 +73,18 @@ git pull
 After setup, your project will look like:
 
 ```
-your-project/
-├── .repos/
-│   └── mcp/                              # Sparse git checkout
-│       └── src/
-│           └── aurora-dsql-mcp-server/
-│               └── skills/
-│                   └── dsql-skill/
-│                       ├── SKILL.md
-│                       └── ...
-├── .claude/
-│   └── skills/
-│       └── dsql-skill -> ../../.repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill
-└── ...
+.dsql_skill_repos/
+└── mcp/                              # Sparse git checkout
+    └── src/
+        └── aurora-dsql-mcp-server/
+            └── skills/
+                └── dsql-skill/
+                    ├── SKILL.md
+                    └── ...
+
+~/.claude/
+└── skills/
+    └── dsql-skill -> /path/to/.dsql_skill_repos/mcp/src/aurora-dsql-mcp-server/skills/dsql-skill
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

### Changes

```
fix(dsql-skill): fix kiro link and claude skill as global

Update the Claude Skill defaults to be set up prioritizing a global
skill as the default setup path. Also quickly fix the Kiro Power link
which is out of date and refers to the old link location.

Co-authored-by: anwesham-lab <64298192+anwesham-lab@users.noreply.github.com>
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
