### PR TITLE
fix(core-mcp-server): shorten billing_cost_management prefix to bcm

### DIFF
--- a/src/core-mcp-server/awslabs/core_mcp_server/server.py
+++ b/src/core-mcp-server/awslabs/core_mcp_server/server.py
@@ -393,7 +393,7 @@ async def setup():
         )
         imported_servers = await call_import_server(
             billing_cost_management_server,
-            'billing_cost_management',
+            'bcm',
             'billing_cost_management_server',
             imported_servers,
         )

--- a/src/core-mcp-server/tests/test_server.py
+++ b/src/core-mcp-server/tests/test_server.py
@@ -172,7 +172,7 @@ class TestSetup:
                 'solutions-architect',
                 ['diagram', 'pricing', 'cost_explorer', 'syntheticdata', 'aws_knowledge'],
             ),
-            ('finops', ['cost_explorer', 'pricing', 'cloudwatch', 'billing_cost_management']),
+            ('finops', ['cost_explorer', 'pricing', 'cloudwatch', 'bcm']),
             (
                 'monitoring-observability',
                 ['cloudwatch', 'cloudwatch_appsignals', 'prometheus', 'cloudtrail'],


### PR DESCRIPTION
## Summary
- Shortens the `billing_cost_management` prefix to `bcm` to fix tool names exceeding the 64-character API limit

## Problem
When using `core-mcp-server` with the `finops` role, the `billing_cost_management` prefix (24 chars) combined with Claude Code's MCP prefix causes tool names to exceed the 64-character limit enforced by the Anthropic API.

| Component | Value | Length |
|-----------|-------|--------|
| Claude Code MCP prefix | `mcp__awslabs_core-mcp-server__` | 30 |
| Old prefix | `billing_cost_management_` | **24** |
| **Base total** | | **54** |
| **Remaining for tool name** | | **10** |

This left only 10 characters for tool names, causing 13 of 14 tools to fail.

## Solution
Changed prefix from `billing_cost_management` to `bcm`:
- New base total: 34 chars
- Remaining for tool name: 30 chars ✅

Example: `mcp__awslabs_core-mcp-server__bcm_cost-optimization` = 51 chars ✅

## Test plan
- [x] Updated test expectation in `test_server.py`
- [x] All 65 core-mcp-server tests pass

Fixes #2214

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).