### PR TITLE
feat(postgres): add SSH tunnel support and fix port/user handling

### DIFF
--- a/src/postgres-mcp-server/tests/test_ssh_tunnel_support.py
+++ b/src/postgres-mcp-server/tests/test_ssh_tunnel_support.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for SSH tunnel support and connection parameter handling."""
+
+import pytest
+from awslabs.postgres_mcp_server.connection.db_connection_map import (
+    ConnectionMethod,
+    DatabaseType,
+)
+from awslabs.postgres_mcp_server.server import internal_connect_to_database
+from unittest.mock import MagicMock, patch
+
+
+class TestSSHTunnelSupport:
+    """Test suite for SSH tunnel support features."""
+
+    @pytest.fixture
+    def mock_cluster_properties(self):
+        """Mock cluster properties."""
+        return {
+            'MasterUsername': 'postgres',
+            'Endpoint': 'actual-db.rds.amazonaws.com',
+            'Port': '5432',
+            'HttpEndpointEnabled': False,
+        }
+
+    @pytest.mark.asyncio
+    @patch('awslabs.postgres_mcp_server.server.db_connection_map')
+    @patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection')
+    @patch('awslabs.postgres_mcp_server.server.internal_get_cluster_properties')
+    async def test_connection_host_override(
+        self,
+        mock_get_cluster_properties,
+        mock_psycopg_class,
+        mock_conn_map,
+        mock_cluster_properties,
+    ):
+        """Test connection_host parameter overrides db_endpoint for connection."""
+        mock_get_cluster_properties.return_value = mock_cluster_properties
+        mock_conn = MagicMock()
+        mock_psycopg_class.return_value = mock_conn
+        mock_conn_map.get.return_value = None  # No existing connection
+
+        db_connection, _ = internal_connect_to_database(
+            region='us-west-2',
+            database_type=DatabaseType.APG,
+            connection_method=ConnectionMethod.PG_WIRE_IAM_PROTOCOL,
+            cluster_identifier='test-cluster',
+            db_endpoint='actual-db.rds.amazonaws.com',
+            port=5432,
+            database='postgres',
+            db_user='ops_ro_iam',
+            connection_host='127.0.0.1',
+            connection_port=8192,
+        )
+
+        call_kwargs = mock_psycopg_class.call_args[1]
+        assert call_kwargs['host'] == '127.0.0.1'
+        assert call_kwargs['port'] == 8192
+
+    @pytest.mark.asyncio
+    @patch('awslabs.postgres_mcp_server.server.db_connection_map')
+    @patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection')
+    @patch('awslabs.postgres_mcp_server.server.internal_get_cluster_properties')
+    async def test_iam_endpoint_for_token_generation(
+        self,
+        mock_get_cluster_properties,
+        mock_psycopg_class,
+        mock_conn_map,
+        mock_cluster_properties,
+    ):
+        """Test IAM token uses db_endpoint, not connection_host."""
+        mock_get_cluster_properties.return_value = mock_cluster_properties
+        mock_conn = MagicMock()
+        mock_psycopg_class.return_value = mock_conn
+        mock_conn_map.get.return_value = None  # No existing connection
+
+        db_connection, _ = internal_connect_to_database(
+            region='us-west-2',
+            database_type=DatabaseType.APG,
+            connection_method=ConnectionMethod.PG_WIRE_IAM_PROTOCOL,
+            cluster_identifier='test-cluster',
+            db_endpoint='actual-db.rds.amazonaws.com',
+            port=5432,
+            database='postgres',
+            db_user='ops_ro_iam',
+            connection_host='127.0.0.1',
+            connection_port=8192,
+        )
+
+        call_kwargs = mock_psycopg_class.call_args[1]
+        assert call_kwargs['iam_host'] == 'actual-db.rds.amazonaws.com'
+        assert call_kwargs['iam_port'] == 5432
+
+    @pytest.mark.asyncio
+    @patch('awslabs.postgres_mcp_server.server.db_connection_map')
+    @patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection')
+    @patch('awslabs.postgres_mcp_server.server.internal_get_cluster_properties')
+    async def test_custom_db_user_for_iam_auth(
+        self,
+        mock_get_cluster_properties,
+        mock_psycopg_class,
+        mock_conn_map,
+        mock_cluster_properties,
+    ):
+        """Test db_user parameter is used instead of master username."""
+        mock_get_cluster_properties.return_value = mock_cluster_properties
+        mock_conn = MagicMock()
+        mock_psycopg_class.return_value = mock_conn
+        mock_conn_map.get.return_value = None  # No existing connection
+
+        db_connection, _ = internal_connect_to_database(
+            region='us-west-2',
+            database_type=DatabaseType.APG,
+            connection_method=ConnectionMethod.PG_WIRE_IAM_PROTOCOL,
+            cluster_identifier='test-cluster',
+            db_endpoint='actual-db.rds.amazonaws.com',
+            port=5432,
+            database='postgres',
+            db_user='ops_ro_iam',
+        )
+
+        call_kwargs = mock_psycopg_class.call_args[1]
+        assert call_kwargs['db_user'] == 'ops_ro_iam'


### PR DESCRIPTION
- Add connection_host and connection_port parameters for SSH tunnel support
- Fix port parameter not being passed to connection map
- Add db_user parameter for custom IAM authentication users
- Add SSL requirement for IAM authentication
- Add connection map logging at INFO level
- Add comprehensive test coverage for new features

Fixes issues with IAM authentication through SSH tunnels where the IAM token must be generated for the actual RDS endpoint but connection goes through a local tunnel endpoint.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Support for more Postgres IAM Auth use cases

### Changes
New parameters with safe defaults to enable IAM authentication as users other than dbmaster, to ports other than the default. Also added support for connecting via SSH tunnel. Would like to note that IntelliJ SQL plugin supports tunneled connections with IAM auth.

### User experience
Users experience no change, unless they choose to use the new parameters for Postgres IAM auth.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (end-to-end manual test & new unit tests)
* [x] Changes are documented

Is this a breaking change? (Y/N)
No, the new parameters have safe defaults.

**RFC issue number**:
Did not file an issue

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
