### PR TITLE
chore: release/2026.01.20260121110136

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.11"
+version = "0.0.12"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/__init__.py
+++ b/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 ###awslabs.amazon-keyspaces-mcp-server"""
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'

--- a/src/amazon-keyspaces-mcp-server/pyproject.toml
+++ b/src/amazon-keyspaces-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-keyspaces-mcp-server"
-version = "0.0.11"
+version = "0.0.12"
 description = "An Amazon Keyspaces (for Apache Cassandra) MCP server for interacting with Amazon Keyspaces and Apache Cassandra."
 readme = "README.md"
 requires-python = ">=3.10,<3.12"

--- a/src/amazon-keyspaces-mcp-server/uv.lock
+++ b/src/amazon-keyspaces-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-keyspaces-mcp-server"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/__init__.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aurora-dsql-mcp-server"""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/aurora-dsql-mcp-server/pyproject.toml
+++ b/src/aurora-dsql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aurora-dsql-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for Aurora DSQL"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aurora-dsql-mcp-server/uv.lock
+++ b/src/aurora-dsql-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aurora-dsql-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.3.4'
+__version__ = '1.3.5'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.4"
+version = "1.3.5"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.3.4"
+version = "1.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },

--- a/src/aws-bedrock-custom-model-import-mcp-server/awslabs/aws_bedrock_custom_model_import_mcp_server/__init__.py
+++ b/src/aws-bedrock-custom-model-import-mcp-server/awslabs/aws_bedrock_custom_model_import_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-bedrock-custom-model-import-mcp-server"""
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'

--- a/src/aws-bedrock-custom-model-import-mcp-server/pyproject.toml
+++ b/src/aws-bedrock-custom-model-import-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-bedrock-custom-model-import-mcp-server"
-version = "0.0.10"
+version = "0.0.11"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Custom Model Import"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-bedrock-custom-model-import-mcp-server/uv.lock
+++ b/src/aws-bedrock-custom-model-import-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-bedrock-custom-model-import-mcp-server"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-healthomics-mcp-server"""
 
-__version__ = '0.0.20'
+__version__ = '0.0.21'

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-healthomics-mcp-server"
-version = "0.0.20"
+version = "0.0.21"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-healthomics-mcp-server"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/__init__.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-iac-mcp-server"""
 
-__version__ = '1.0.9'
+__version__ = '1.0.10'

--- a/src/aws-iac-mcp-server/pyproject.toml
+++ b/src/aws-iac-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-iac-mcp-server"
-version = "1.0.9"
+version = "1.0.10"
 description = "An Infrastructure as Code MCP server that provides CloudFormation template validation, compliance checking, and deployment troubleshooting capabilities."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-iac-mcp-server/uv.lock
+++ b/src/aws-iac-mcp-server/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-iac-mcp-server"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/__init__.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-iot-sitewise-mcp-server"""
 
-__version__ = '11.0.9'
+__version__ = '11.0.10'

--- a/src/aws-iot-sitewise-mcp-server/pyproject.toml
+++ b/src/aws-iot-sitewise-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-iot-sitewise-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "11.0.9"
+version = "11.0.10"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-iot-sitewise"
 readme = "README.md"

--- a/src/aws-iot-sitewise-mcp-server/uv.lock
+++ b/src/aws-iot-sitewise-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-iot-sitewise-mcp-server"
-version = "11.0.9"
+version = "11.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-network-mcp-server"""
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/src/aws-network-mcp-server/pyproject.toml
+++ b/src/aws-network-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-network-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.5"
+version = "0.0.6"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-network"
 readme = "README.md"

--- a/src/aws-network-mcp-server/uv.lock
+++ b/src/aws-network-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-network-mcp-server"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/__init__.py
+++ b/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/__init__.py
@@ -26,4 +26,4 @@ logger.add(
 )
 
 # Export version
-__version__ = '0.1.15'
+__version__ = '0.1.16'

--- a/src/aws-support-mcp-server/pyproject.toml
+++ b/src/aws-support-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-support-mcp-server"
-version = "0.1.15"
+version = "0.1.16"
 description = "An Model Context Protocol (MCP) server for AWS SupportAPI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-support-mcp-server/uv.lock
+++ b/src/aws-support-mcp-server/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-support-mcp-server"
-version = "0.1.15"
+version = "0.1.16"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/__init__.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/__init__.py
@@ -19,7 +19,7 @@ This Model Context Protocol (MCP) server provides tools for AWS cost optimizatio
 by wrapping boto3 SDK functions for AWS cost optimization services.
 """
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 
 # We don't import server here to avoid circular imports
 

--- a/src/billing-cost-management-mcp-server/pyproject.toml
+++ b/src/billing-cost-management-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.billing-cost-management-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.11"
+version = "0.0.12"
 
 description = "A Model Context Protocol (MCP) server that provides tools for AWS Billing and Cost Management by wrapping boto3 SDK functions."
 readme = "README.md"

--- a/src/billing-cost-management-mcp-server/uv.lock
+++ b/src/billing-cost-management-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-billing-cost-management-mcp-server"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Application Signals MCP Server."""
 
-__version__ = '0.1.23'
+__version__ = '0.1.24'

--- a/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-applicationsignals-mcp-server"
-version = "0.1.23"
+version = "0.1.24"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Application Signals"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-applicationsignals-mcp-server/uv.lock
+++ b/src/cloudwatch-applicationsignals-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-applicationsignals-mcp-server"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/__init__.py
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Application Signals MCP Server."""
 
-__version__ = '0.1.17'
+__version__ = '0.1.18'

--- a/src/cloudwatch-appsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-appsignals-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-appsignals-mcp-server"
-version = "0.1.17"
+version = "0.1.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Application Signals"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-appsignals-mcp-server/uv.lock
+++ b/src/cloudwatch-appsignals-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-appsignals-mcp-server"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.cloudwatch-mcp-server"""
 
-__version__ = '0.0.17'
+__version__ = '0.0.18'
 MCP_SERVER_VERSION = __version__

--- a/src/cloudwatch-mcp-server/pyproject.toml
+++ b/src/cloudwatch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-mcp-server"
-version = "0.0.17"
+version = "0.0.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudwatch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-mcp-server/uv.lock
+++ b/src/cloudwatch-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-mcp-server"
-version = "0.0.17"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/core-mcp-server/awslabs/core_mcp_server/__init__.py
+++ b/src/core-mcp-server/awslabs/core_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """CORE MCP server package."""
 
-__version__ = '1.0.19'
+__version__ = '1.0.20'

--- a/src/core-mcp-server/pyproject.toml
+++ b/src/core-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.core-mcp-server"
-version = "1.0.19"
+version = "1.0.20"
 description = "An AWS Labs Model Context Protocol (MCP) server for aswlabs Core MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/core-mcp-server/uv.lock
+++ b/src/core-mcp-server/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-core-mcp-server"
-version = "1.0.19"
+version = "1.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-amazon-kendra-index-mcp-server" },

--- a/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
+++ b/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Document Loader MCP Server package"""
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'

--- a/src/document-loader-mcp-server/pyproject.toml
+++ b/src/document-loader-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.document-loader-mcp-server"
-version = "1.0.7"
+version = "1.0.8"
 description = "An AWS Labs Model Context Protocol (MCP) server for document parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/document-loader-mcp-server/uv.lock
+++ b/src/document-loader-mcp-server/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-document-loader-mcp-server"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.dynamodb-mcp-server"""
 
-__version__ = '2.0.10'
+__version__ = '2.0.11'

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.dynamodb-mcp-server"
-version = "2.0.10"
+version = "2.0.11"
 description = "The official MCP Server for interacting with AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-dynamodb-mcp-server"
-version = "2.0.10"
+version = "2.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-aws-api-mcp-server" },

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/__init__.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 # This file makes the ecs_mcp_server directory a Python package
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"

--- a/src/ecs-mcp-server/pyproject.toml
+++ b/src/ecs-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "awslabs.ecs-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 description = "AWS ECS MCP Server for automating containerization and deployment of web applications to AWS ECS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ecs-mcp-server/uv.lock
+++ b/src/ecs-mcp-server/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ecs-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/__init__.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.eks-mcp-server"""
 
-__version__ = '0.1.20'
+__version__ = '0.1.21'

--- a/src/eks-mcp-server/pyproject.toml
+++ b/src/eks-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.eks-mcp-server"
-version = "0.1.20"
+version = "0.1.21"
 description = "An AWS Labs Model Context Protocol (MCP) server for EKS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/eks-mcp-server/uv.lock
+++ b/src/eks-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-eks-mcp-server"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/finch-mcp-server/awslabs/finch_mcp_server/__init__.py
+++ b/src/finch-mcp-server/awslabs/finch_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.finch-mcp-server"""
 
-__version__ = '0.1.12'
+__version__ = '0.1.13'

--- a/src/finch-mcp-server/pyproject.toml
+++ b/src/finch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.finch-mcp-server"
-version = "0.1.12"
+version = "0.1.13"
 description = "A Model Context Protocol server for Finch to build and push container images"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/finch-mcp-server/uv.lock
+++ b/src/finch-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-finch-mcp-server"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/__init__.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/__init__.py
@@ -14,6 +14,6 @@
 
 """awslabs.mcp_lambda_handler: AWS Lambda MCP Server package."""
 
-__version__ = '0.1.11'
+__version__ = '0.1.12'
 
 from .mcp_lambda_handler import MCPLambdaHandler

--- a/src/mcp-lambda-handler/pyproject.toml
+++ b/src/mcp-lambda-handler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "awslabs.mcp-lambda-handler"
-version = "0.1.11"
+version = "0.1.12"
 description = "AWS Lambda MCP Server: A serverless HTTP handler for the Model Context Protocol (MCP) using AWS Lambda."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp-lambda-handler/uv.lock
+++ b/src/mcp-lambda-handler/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "awslabs-mcp-lambda-handler"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.mysql_mcp_server"""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/mysql-mcp-server/pyproject.toml
+++ b/src/mysql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.mysql-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for mysql"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mysql-mcp-server/uv.lock
+++ b/src/mysql-mcp-server/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-mysql-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "asyncmy" },

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
@@ -15,7 +15,7 @@
 OpenAPI MCP Server - A server that dynamically creates MCP tools and resources from OpenAPI specifications.
 """
 
-__version__ = '0.2.11'
+__version__ = '0.2.12'
 
 
 import inspect

--- a/src/openapi-mcp-server/pyproject.toml
+++ b/src/openapi-mcp-server/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "awslabs.openapi-mcp-server"
-version = "0.2.11"
+version = "0.2.12"
 description = "An AWS Labs Model Context Protocol (MCP) server for OpenAPI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/openapi-mcp-server/uv.lock
+++ b/src/openapi-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-openapi-mcp-server"
-version = "0.2.11"
+version = "0.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
+++ b/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """SyntheticData MCP Server package."""
 
-__version__ = '1.0.10'
+__version__ = '1.0.11'

--- a/src/syntheticdata-mcp-server/pyproject.toml
+++ b/src/syntheticdata-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.syntheticdata-mcp-server"
-version = "1.0.10"
+version = "1.0.11"
 description = "An AWS Labs Model Context Protocol (MCP) server for syntheticdata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/syntheticdata-mcp-server/uv.lock
+++ b/src/syntheticdata-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-syntheticdata-mcp-server"
-version = "1.0.10"
+version = "1.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/__init__.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.terraform-mcp-server"""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/terraform-mcp-server/pyproject.toml
+++ b/src/terraform-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.terraform-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for terraform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/terraform-mcp-server/uv.lock
+++ b/src/terraform-mcp-server/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-terraform-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "asteval" },


### PR DESCRIPTION
# release/2026.01.20260121110136

Triggered Release Branch (initiated) by @arnewouters for @arnewouters

## Changes
* amazon-bedrock-agentcore-mcp-server
* amazon-keyspaces-mcp-server
* aurora-dsql-mcp-server
* aws-api-mcp-server
* aws-bedrock-custom-model-import-mcp-server
* aws-healthomics-mcp-server
* aws-iac-mcp-server
* aws-iot-sitewise-mcp-server
* aws-network-mcp-server
* aws-support-mcp-server
* billing-cost-management-mcp-server
* cloudwatch-applicationsignals-mcp-server
* cloudwatch-appsignals-mcp-server
* cloudwatch-mcp-server
* core-mcp-server
* document-loader-mcp-server
* dynamodb-mcp-server
* ecs-mcp-server
* eks-mcp-server
* finch-mcp-server
* mcp-lambda-handler
* mysql-mcp-server
* openapi-mcp-server
* syntheticdata-mcp-server
* terraform-mcp-server

## Checklist
- [ ] Code changes have been reviewed
- [ ] Distribution packages have been built and tested
- [ ] Documentation has been updated if applicable

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).