### PR TITLE
feat(dsql): Add Skills CLI installation instructions

### DIFF
--- a/src/aurora-dsql-mcp-server/README.md
+++ b/src/aurora-dsql-mcp-server/README.md
@@ -312,7 +312,8 @@ context and guidance for best practices and patterns that AI assistants automati
 when generating code to improve the quality of agentic development.
 
 Recommended paths:
-* [Kiro Power](#kiro-power) - simplest installation
+* [Skills CLI for Agent-Agnostic Installation](#skills-cli)
+* [Kiro Power](#kiro-power) - button-click installation
 * [Claude Skill](#claude-skill) - installation instructions in [claude_skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md)
 * [Gemini Skill](#gemini-skill) - use Gemini's github subrepo skill installation with `--path`
 * [Codex Skill](#codex-skill) - use Codex's `$skill-installer` skill.
@@ -320,6 +321,28 @@ Recommended paths:
 Alternative:
 The [dsql-skill](https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server/skills/dsql-skill) can also be cloned into your tool's respective `rules` directory
 for use with other coding assistants.
+
+### Skills CLI
+The [DSQL skill](https://skills.sh/awslabs/mcp/dsql) can also be installed using the [Skills CLI](https://skills.sh/docs/cli).
+
+```bash
+npx skills add awslabs/mcp --skill dsql
+```
+
+The CLI will guide you through:
+* Selecting the agents you'd like to install to (Kiro, Claude Code, Cursor, Copilot, Gemini, Codex, Roo, Cline, OpenCode, Windsurf, etc.)
+* Installation scope
+  - Project: Install in current directory (committed with your project)
+  - Global: Install in home directory (available across all projects)
+*  Installation method
+   - Symlink (Recommended): Single source of truth, easy updates
+   - Copy to all agents: Independent copies for each agent
+
+Check and update skills at any time using:
+```bash
+npx skills check
+npx skills update
+```
 
 ### Kiro Power
 
@@ -336,8 +359,16 @@ To setup the Kiro power:
         the user's task.
 
 ### Claude Skill
+**Simple Setup with the Skills CLI**:
+As outlined, the skill can be installed to Claude Code with the [Skills CLI](#skills-cli). To specify
+only Claude Code as the agent to install to, use:
 
-The recommended setup is outlined in [claude_skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md).
+```bash
+npx skills add awslabs/mcp --skill dsql --agent claude-code
+```
+
+**Direct Setup using a Git Clone**:
+The alternative setup is outlined in [claude_skill_setup.md](https://github.com/awslabs/mcp/blob/main/src/aurora-dsql-mcp-server/skills/claude_skill_setup.md).
 
 The method outlines taking a sparse clone of the dsql-skill directory and symlinking this clone
 into the `.claude/skills/` folder. This allows changes to the skill to be pulled whenever the skill


### PR DESCRIPTION
## Summary

### Changes


feat(dsql): Add Skills CLI installation in README

Added installation instructions for installing the DSQL skill using the
[Skills CLI](skills.sh) for agent-agnostic skill installation and
management.

Also add the Skills CLI installation instructions as a 'Simple Setup'
option for Claude Code reducing the overhead of the sparse git clone
methodology since the CLI manages the same process under the hood.

Co-authored-by: anwesham-lab <64298192+anwesham-lab@users.noreply.github.com>


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
