### PR TITLE
fix(well-architected-security): fix Inspector severity filter and Access Analyzer action field normalization

### DIFF
--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/server.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/server.py
@@ -445,7 +445,7 @@ async def get_security_findings(
                 }
             elif service_name == "inspector":
                 filter_criteria = {
-                    "severities": [{"comparison": "EQUALS", "value": severity_filter.upper()}]
+                    "severity": [{"comparison": "EQUALS", "value": severity_filter.upper()}]
                 }
             elif service_name == "trustedadvisor":
                 # For Trusted Advisor, severity maps to status (error, warning, ok)

--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/util/security_services.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/util/security_services.py
@@ -840,7 +840,7 @@ async def get_inspector_findings(
         if filter_criteria is None:
             # By default, get findings with high or critical severity
             filter_criteria = {
-                "severities": [
+                "severity": [
                     {"comparison": "EQUALS", "value": "HIGH"},
                     {"comparison": "EQUALS", "value": "CRITICAL"},
                 ],
@@ -1150,6 +1150,9 @@ def _summarize_access_analyzer_findings(findings: List[Dict]) -> Dict:
 
         # Count by action
         actions = finding.get("action", [])
+        # Normalize to list (action can sometimes be a string instead of list)
+        if isinstance(actions, str):
+            actions = [actions]
         for action in actions:
             if action in summary["action_counts"]:
                 summary["action_counts"][action] += 1


### PR DESCRIPTION
Fixes #2237

## Summary

This PR fixes two bugs in the Well-Architected Security MCP Server related to `GetSecurityFindings` functionality.

### Changes

1. **Bug #2237**: Fix Inspector severity filter parameter name (`severities` → `severity`)
2. **Bug #2237**: Normalize `action` field to list in Access Analyzer findings summarization

### User experience

**Before**:
- Inspector severity filters are silently ignored (wrong parameter name)
- Access Analyzer findings with string `action` fields cause iteration issues

**After**:
- Severity filters work correctly for Inspector findings
- Action fields are properly normalized to lists

## Technical Details

### Bug #1: Inspector filterCriteria uses wrong key

The AWS Inspector v2 API expects `severity` (singular) but the code uses `severities`:

```python
# Incorrect (current)
"severities": [{"comparison": "EQUALS", "value": sev}]

# Correct (per boto3 docs)
"severity": [{"comparison": "EQUALS", "value": sev}]
```

**Reference**: [boto3 Inspector2.Client.list_findings](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/inspector2/client/list_findings.html)

### Bug #4: action field normalization

The `action` field in Access Analyzer findings is documented as `List[str]`, but defensive normalization ensures edge cases are handled correctly.

```python
actions = finding.get("action", [])
if isinstance(actions, str):
    actions = [actions]
```

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? N

## Testing

- Verified against live AWS environment with Inspector v2 findings
- All existing tests pass (269 tests)
- Manual testing with Claude Code MCP integration

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).