### PR TITLE
feat(aws-documentation-mcp-server): Add streamable-http transport support

### DIFF
--- a/src/aws-api-mcp-server/README.md
+++ b/src/aws-api-mcp-server/README.md
@@ -119,7 +119,7 @@ You can isolate the MCP server by running it in a Docker container. The Docker i
         "--rm",
         "--interactive",
         "--env",
-        "AWS_REGION=us-east-1",
+        "AWS_REGION=cn-northwest-1",
         "--volume",
         "/full/path/to/.aws:/app/.aws",
         "public.ecr.aws/awslabs-mcp/awslabs/aws-api-mcp-server:latest"

--- a/src/aws-api-mcp-server/README.md
+++ b/src/aws-api-mcp-server/README.md
@@ -119,7 +119,7 @@ You can isolate the MCP server by running it in a Docker container. The Docker i
         "--rm",
         "--interactive",
         "--env",
-        "AWS_REGION=cn-northwest-1",
+        "AWS_REGION=us-east-1",
         "--volume",
         "/full/path/to/.aws:/app/.aws",
         "public.ecr.aws/awslabs-mcp/awslabs/aws-api-mcp-server:latest"

--- a/src/aws-documentation-mcp-server/Dockerfile
+++ b/src/aws-documentation-mcp-server/Dockerfile
@@ -60,7 +60,8 @@ FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:50a58a006d3381e38160fc5bb4bbe
 
 # Place executables in the environment at the front of the path and include other binaries
 ENV PATH="/app/.venv/bin:$PATH:/usr/sbin" \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    FASTMCP_HOST=0.0.0.0
 
 # Install other tools as needed for the MCP server
 # Add non-root user and ability to change directory into /root

--- a/src/aws-documentation-mcp-server/README.md
+++ b/src/aws-documentation-mcp-server/README.md
@@ -106,11 +106,64 @@ or docker after a successful `docker build -t mcp/aws-documentation .`:
 }
 ```
 
+### HTTP Transport Mode (for ECS/Container Deployments)
+
+The server supports `streamable-http` transport mode for containerized deployments on platforms like Amazon ECS, Kubernetes, or behind load balancers.
+
+**Environment Variables for HTTP Mode:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FASTMCP_TRANSPORT` | Transport mode (`stdio` or `streamable-http`) | `stdio` |
+| `FASTMCP_HOST` | Host to bind HTTP server | `127.0.0.1` |
+| `FASTMCP_PORT` | Port for HTTP server | `8000` |
+
+**Docker Example with HTTP Mode:**
+
+```bash
+docker run -d \
+  -p 8000:8000 \
+  -e FASTMCP_TRANSPORT=streamable-http \
+  -e FASTMCP_HOST=0.0.0.0 \
+  -e FASTMCP_PORT=8000 \
+  -e AWS_DOCUMENTATION_PARTITION=aws \
+  mcp/aws-documentation:latest
+```
+
+**MCP Client Configuration for HTTP Mode:**
+
+```json
+{
+  "mcpServers": {
+    "aws-doc-remote": {
+      "url": "https://your-domain.com/mcp",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json"
+      },
+      "autoApprove": ["read_documentation", "get_available_services"]
+    }
+  }
+}
+```
+
+**Testing HTTP Endpoint:**
+
+```bash
+curl -X POST http://localhost:8000/mcp \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
+```
+
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|----------|
 | `FASTMCP_LOG_LEVEL` | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | `WARNING` |
+| `FASTMCP_TRANSPORT` | Transport mode (`stdio` or `streamable-http`) | `stdio` |
+| `FASTMCP_HOST` | Host to bind HTTP server (HTTP mode only) | `127.0.0.1` |
+| `FASTMCP_PORT` | Port for HTTP server (HTTP mode only) | `8000` |
 | `AWS_DOCUMENTATION_PARTITION` | AWS partition (`aws` or `aws-cn`) | `aws` |
 | `MCP_USER_AGENT` | Custom User-Agent string for HTTP requests | Chrome-based default |
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -447,8 +447,12 @@ async def recommend(
 
 def main():
     """Run the MCP server with CLI argument support."""
-    logger.info('Starting AWS Documentation MCP Server')
-    mcp.run()
+    import os
+    
+    transport = os.getenv('FASTMCP_TRANSPORT', 'stdio')
+    logger.info(f'Starting AWS Documentation MCP Server with {transport} transport')
+    
+    mcp.run(transport=transport)
 
 
 if __name__ == '__main__':

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -15,6 +15,7 @@
 
 import httpx
 import json
+import os
 import re
 import uuid
 
@@ -55,9 +56,14 @@ SEARCH_TERM_DOMAIN_MODIFIERS = [
     }
 ]
 
+# Read FastMCP settings from environment variables
+FASTMCP_HOST = os.getenv('FASTMCP_HOST', '127.0.0.1')
+FASTMCP_PORT = int(os.getenv('FASTMCP_PORT', '8000'))
 
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
+    host=FASTMCP_HOST,
+    port=FASTMCP_PORT,
     instructions="""
     # AWS Documentation MCP Server
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -459,6 +459,11 @@ def main():
     if transport == "streamable-http":
         mcp.settings.host = FASTMCP_HOST
         mcp.settings.port = FASTMCP_PORT
+        # Only disable DNS rebinding protection for non-localhost deployments
+        # (e.g., ECS behind ALB). Keep it enabled for localhost to prevent
+        # DNS rebinding attacks (CVE-2025-66416).
+        if FASTMCP_HOST not in ("127.0.0.1", "localhost", "::1"):
+            mcp.settings.transport_security = None
     
     mcp.run(transport=transport)
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -62,8 +62,6 @@ FASTMCP_PORT = int(os.getenv('FASTMCP_PORT', '8000'))
 
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
-    host=FASTMCP_HOST,
-    port=FASTMCP_PORT,
     instructions="""
     # AWS Documentation MCP Server
 
@@ -453,10 +451,14 @@ async def recommend(
 
 def main():
     """Run the MCP server with CLI argument support."""
-    import os
     
     transport = os.getenv('FASTMCP_TRANSPORT', 'stdio')
     logger.info(f'Starting AWS Documentation MCP Server with {transport} transport')
+    
+    # Only set host and port for streamable-http transport
+    if transport == "streamable-http":
+        mcp.settings.host = FASTMCP_HOST
+        mcp.settings.port = FASTMCP_PORT
     
     mcp.run(transport=transport)
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -59,6 +59,7 @@ SEARCH_TERM_DOMAIN_MODIFIERS = [
 # Read FastMCP settings from environment variables
 FASTMCP_HOST = os.getenv('FASTMCP_HOST', '127.0.0.1')
 FASTMCP_PORT = int(os.getenv('FASTMCP_PORT', '8000'))
+FASTMCP_STATELESS_HTTP = os.getenv('FASTMCP_STATELESS_HTTP', 'false').lower() == 'true'
 
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
@@ -459,6 +460,7 @@ def main():
     if transport == "streamable-http":
         mcp.settings.host = FASTMCP_HOST
         mcp.settings.port = FASTMCP_PORT
+        mcp.settings.stateless_http = FASTMCP_STATELESS_HTTP
         # Only disable DNS rebinding protection for non-localhost deployments
         # (e.g., ECS behind ALB). Keep it enabled for localhost to prevent
         # DNS rebinding attacks (CVE-2025-66416).

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -31,12 +31,19 @@ from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import AnyUrl, Field
 from typing import Union
+import os
 
 
 SESSION_UUID = str(uuid.uuid4())
 
+# Read FastMCP settings from environment variables
+FASTMCP_HOST = os.getenv('FASTMCP_HOST', '127.0.0.1')
+FASTMCP_PORT = int(os.getenv('FASTMCP_PORT', '8000'))
+
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
+    host=FASTMCP_HOST,
+    port=FASTMCP_PORT,
     instructions="""
     # AWS China Documentation MCP Server
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -241,10 +241,12 @@ async def get_available_services(
 
 def main():
     """Run the MCP server with CLI argument support."""
-    # Log startup information
-    logger.info('Starting AWS China Documentation MCP Server')
-
-    mcp.run()
+    import os
+    
+    transport = os.getenv('FASTMCP_TRANSPORT', 'stdio')
+    logger.info(f'Starting AWS China Documentation MCP Server with {transport} transport')
+    
+    mcp.run(transport=transport)
 
 
 if __name__ == '__main__':

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -254,6 +254,11 @@ def main():
     if transport == "streamable-http":
         mcp.settings.host = FASTMCP_HOST
         mcp.settings.port = FASTMCP_PORT
+        # Only disable DNS rebinding protection for non-localhost deployments
+        # (e.g., ECS behind ALB). Keep it enabled for localhost to prevent
+        # DNS rebinding attacks (CVE-2025-66416).
+        if FASTMCP_HOST not in ("127.0.0.1", "localhost", "::1"):
+            mcp.settings.transport_security = None
     
     mcp.run(transport=transport)
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -39,6 +39,7 @@ SESSION_UUID = str(uuid.uuid4())
 # Read FastMCP settings from environment variables
 FASTMCP_HOST = os.getenv('FASTMCP_HOST', '127.0.0.1')
 FASTMCP_PORT = int(os.getenv('FASTMCP_PORT', '8000'))
+FASTMCP_STATELESS_HTTP = os.getenv('FASTMCP_STATELESS_HTTP', 'false').lower() == 'true'
 
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
@@ -254,6 +255,7 @@ def main():
     if transport == "streamable-http":
         mcp.settings.host = FASTMCP_HOST
         mcp.settings.port = FASTMCP_PORT
+        mcp.settings.stateless_http = FASTMCP_STATELESS_HTTP
         # Only disable DNS rebinding protection for non-localhost deployments
         # (e.g., ECS behind ALB). Keep it enabled for localhost to prevent
         # DNS rebinding attacks (CVE-2025-66416).

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -42,8 +42,6 @@ FASTMCP_PORT = int(os.getenv('FASTMCP_PORT', '8000'))
 
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
-    host=FASTMCP_HOST,
-    port=FASTMCP_PORT,
     instructions="""
     # AWS China Documentation MCP Server
 
@@ -248,10 +246,14 @@ async def get_available_services(
 
 def main():
     """Run the MCP server with CLI argument support."""
-    import os
     
     transport = os.getenv('FASTMCP_TRANSPORT', 'stdio')
     logger.info(f'Starting AWS China Documentation MCP Server with {transport} transport')
+    
+    # Only set host and port for streamable-http transport
+    if transport == "streamable-http":
+        mcp.settings.host = FASTMCP_HOST
+        mcp.settings.port = FASTMCP_PORT
     
     mcp.run(transport=transport)
 

--- a/src/aws-documentation-mcp-server/docker-healthcheck.sh
+++ b/src/aws-documentation-mcp-server/docker-healthcheck.sh
@@ -15,11 +15,23 @@
 
 SERVER="aws-documentation-mcp-server"
 
-# Check if the server process is running
-if pgrep -P 0 -a -l -x -f "/app/.venv/bin/python3? /app/.venv/bin/awslabs.$SERVER" > /dev/null; then
-  echo -n "$SERVER is running";
-  exit 0;
-fi;
-
-# Unhealthy
-exit 1;
+# Check if HTTP transport is enabled
+if [ "$FASTMCP_TRANSPORT" = "streamable-http" ]; then
+  # Check HTTP endpoint
+  PORT="${FASTMCP_PORT:-8000}"
+  if wget -q -O /dev/null "http://localhost:$PORT/health" 2>/dev/null || \
+     wget -q -O /dev/null "http://localhost:$PORT/" 2>/dev/null; then
+    echo "$SERVER HTTP is healthy"
+    exit 0
+  fi
+  echo "$SERVER HTTP is unhealthy"
+  exit 1
+else
+  # Original stdio check
+  if pgrep -P 0 -a -l -x -f "/app/.venv/bin/python3? /app/.venv/bin/awslabs.$SERVER" > /dev/null; then
+    echo "$SERVER is running"
+    exit 0
+  fi
+  echo "$SERVER is not running"
+  exit 1
+fi

--- a/src/aws-documentation-mcp-server/docker-healthcheck.sh
+++ b/src/aws-documentation-mcp-server/docker-healthcheck.sh
@@ -17,14 +17,15 @@ SERVER="aws-documentation-mcp-server"
 
 # Check if HTTP transport is enabled
 if [ "$FASTMCP_TRANSPORT" = "streamable-http" ]; then
-  # Check HTTP endpoint - 406 is acceptable (means server is running but needs proper headers)
+  # Check HTTP endpoint with GET request
+  # 200 = healthy, 406 = server running but needs proper MCP headers (also healthy)
   PORT="${FASTMCP_PORT:-8000}"
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/mcp" --max-time 5)
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/mcp" --max-time 5 2>/dev/null) || HTTP_CODE="000"
   if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "406" ]; then
-    echo "$SERVER HTTP is healthy"
+    echo "$SERVER HTTP is healthy (HTTP $HTTP_CODE)"
     exit 0
   fi
-  echo "$SERVER HTTP is unhealthy"
+  echo "$SERVER HTTP is unhealthy (HTTP $HTTP_CODE)"
   exit 1
 else
   # Original stdio check

--- a/src/aws-documentation-mcp-server/docker-healthcheck.sh
+++ b/src/aws-documentation-mcp-server/docker-healthcheck.sh
@@ -19,17 +19,8 @@ SERVER="aws-documentation-mcp-server"
 if [ "$FASTMCP_TRANSPORT" = "streamable-http" ]; then
   # Check HTTP endpoint - 406 is acceptable (means server is running but needs proper headers)
   PORT="${FASTMCP_PORT:-8000}"
-  if python3 -c "
-import urllib.request
-try:
-    urllib.request.urlopen('http://localhost:$PORT/mcp', timeout=5)
-    exit(0)
-except urllib.error.HTTPError as e:
-    # 406 Not Acceptable means server is running
-    exit(0 if e.code == 406 else 1)
-except Exception:
-    exit(1)
-" 2>/dev/null; then
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/mcp" --max-time 5)
+  if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "406" ]; then
     echo "$SERVER HTTP is healthy"
     exit 0
   fi

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -511,12 +511,22 @@ class TestMain:
 
     def test_main_stdio_transport(self):
         """Test the main function with stdio transport."""
-        with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp.run') as mock_run:
+        with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
             with patch('awslabs.aws_documentation_mcp_server.server_aws.logger.info') as mock_logger:
                 with patch.dict('os.environ', {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+                    mock_mcp.run = MagicMock()
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+
                     main()
+
                     mock_logger.assert_called_once_with('Starting AWS Documentation MCP Server with stdio transport')
-                    mock_run.assert_called_once_with(transport='stdio')
+                    mock_mcp.run.assert_called_once_with(transport='stdio')
+                    # Verify host and port were NOT set on settings
+                    for c in mock_settings._mock_children:
+                        assert c not in ('host', 'port'), (
+                            f'mcp.settings.{c} should not be set for stdio transport'
+                        )
 
     def test_main_streamable_http_transport(self):
         """Test the main function with streamable-http transport."""
@@ -524,12 +534,14 @@ class TestMain:
             with patch('awslabs.aws_documentation_mcp_server.server_aws.logger.info') as mock_logger:
                 with patch.dict('os.environ', {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
                     mock_mcp.run = MagicMock()
-                    mock_mcp.settings = MagicMock()
-                    
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+
                     main()
-                    
+
                     mock_logger.assert_called_once_with('Starting AWS Documentation MCP Server with streamable-http transport')
-                    # Verify host and port were set
-                    assert mock_mcp.settings.host == '127.0.0.1'
-                    assert mock_mcp.settings.port == 8000
+                    # Verify host and port were set (read back the assigned values)
+                    from awslabs.aws_documentation_mcp_server.server_aws import FASTMCP_HOST, FASTMCP_PORT
+                    assert mock_mcp.settings.host == FASTMCP_HOST
+                    assert mock_mcp.settings.port == FASTMCP_PORT
                     mock_mcp.run.assert_called_once_with(transport='streamable-http')

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -509,12 +509,27 @@ class TestRecommend:
 class TestMain:
     """Tests for the main function."""
 
-    def test_main(self):
-        """Test the main function."""
+    def test_main_stdio_transport(self):
+        """Test the main function with stdio transport."""
         with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp.run') as mock_run:
-            with patch(
-                'awslabs.aws_documentation_mcp_server.server_aws.logger.info'
-            ) as mock_logger:
-                main()
-                mock_logger.assert_called_once_with('Starting AWS Documentation MCP Server')
-                mock_run.assert_called_once()
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.logger.info') as mock_logger:
+                with patch.dict('os.environ', {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+                    main()
+                    mock_logger.assert_called_once_with('Starting AWS Documentation MCP Server with stdio transport')
+                    mock_run.assert_called_once_with(transport='stdio')
+
+    def test_main_streamable_http_transport(self):
+        """Test the main function with streamable-http transport."""
+        with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.logger.info') as mock_logger:
+                with patch.dict('os.environ', {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
+                    mock_mcp.run = MagicMock()
+                    mock_mcp.settings = MagicMock()
+                    
+                    main()
+                    
+                    mock_logger.assert_called_once_with('Starting AWS Documentation MCP Server with streamable-http transport')
+                    # Verify host and port were set
+                    assert mock_mcp.settings.host == '127.0.0.1'
+                    assert mock_mcp.settings.port == 8000
+                    mock_mcp.run.assert_called_once_with(transport='streamable-http')

--- a/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
@@ -283,12 +283,36 @@ class TestGetAvailableServices:
 class TestMain:
     """Tests for the main function."""
 
-    def test_main(self):
-        """Test the main function."""
+    def test_main_stdio_transport(self):
+        """Test the main function with stdio transport."""
         with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp.run') as mock_run:
             with patch(
                 'awslabs.aws_documentation_mcp_server.server_aws_cn.logger.info'
             ) as mock_logger:
-                main()
-                mock_logger.assert_called_once_with('Starting AWS China Documentation MCP Server')
-                mock_run.assert_called_once()
+                with patch.dict('os.environ', {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+                    main()
+                    mock_logger.assert_called_once_with(
+                        'Starting AWS China Documentation MCP Server with stdio transport'
+                    )
+                    mock_run.assert_called_once_with(transport='stdio')
+
+    def test_main_streamable_http_transport(self):
+        """Test the main function with streamable-http transport."""
+        with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+            with patch(
+                'awslabs.aws_documentation_mcp_server.server_aws_cn.logger.info'
+            ) as mock_logger:
+                with patch.dict(
+                    'os.environ', {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False
+                ):
+                    mock_mcp.run = MagicMock()
+                    mock_mcp.settings = MagicMock()
+
+                    main()
+
+                    mock_logger.assert_called_once_with(
+                        'Starting AWS China Documentation MCP Server with streamable-http transport'
+                    )
+                    assert mock_mcp.settings.host == '127.0.0.1'
+                    assert mock_mcp.settings.port == 8000
+                    mock_mcp.run.assert_called_once_with(transport='streamable-http')

--- a/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
@@ -285,16 +285,26 @@ class TestMain:
 
     def test_main_stdio_transport(self):
         """Test the main function with stdio transport."""
-        with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp.run') as mock_run:
+        with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
             with patch(
                 'awslabs.aws_documentation_mcp_server.server_aws_cn.logger.info'
             ) as mock_logger:
                 with patch.dict('os.environ', {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+                    mock_mcp.run = MagicMock()
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+
                     main()
+
                     mock_logger.assert_called_once_with(
                         'Starting AWS China Documentation MCP Server with stdio transport'
                     )
-                    mock_run.assert_called_once_with(transport='stdio')
+                    mock_mcp.run.assert_called_once_with(transport='stdio')
+                    # Verify host and port were NOT set on settings
+                    for c in mock_settings._mock_children:
+                        assert c not in ('host', 'port'), (
+                            f'mcp.settings.{c} should not be set for stdio transport'
+                        )
 
     def test_main_streamable_http_transport(self):
         """Test the main function with streamable-http transport."""
@@ -306,13 +316,18 @@ class TestMain:
                     'os.environ', {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False
                 ):
                     mock_mcp.run = MagicMock()
-                    mock_mcp.settings = MagicMock()
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
 
                     main()
 
                     mock_logger.assert_called_once_with(
                         'Starting AWS China Documentation MCP Server with streamable-http transport'
                     )
-                    assert mock_mcp.settings.host == '127.0.0.1'
-                    assert mock_mcp.settings.port == 8000
+                    from awslabs.aws_documentation_mcp_server.server_aws_cn import (
+                        FASTMCP_HOST,
+                        FASTMCP_PORT,
+                    )
+                    assert mock_mcp.settings.host == FASTMCP_HOST
+                    assert mock_mcp.settings.port == FASTMCP_PORT
                     mock_mcp.run.assert_called_once_with(transport='streamable-http')

--- a/src/aws-documentation-mcp-server/tests/test_transport_config.py
+++ b/src/aws-documentation-mcp-server/tests/test_transport_config.py
@@ -1,0 +1,166 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for transport configuration and environment variable handling."""
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestTransportConfiguration:
+    """Tests for transport configuration logic."""
+
+    def test_stdio_transport_does_not_set_host_port(self):
+        """Test that stdio transport does not set host and port."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                mock_mcp.run = MagicMock()
+                mock_mcp.settings = MagicMock()
+                
+                from awslabs.aws_documentation_mcp_server.server_aws import main
+                
+                main()
+                
+                # Verify host and port were not set for stdio transport
+                assert not hasattr(mock_mcp.settings, 'host') or mock_mcp.settings.host != '127.0.0.1'
+                assert not hasattr(mock_mcp.settings, 'port') or mock_mcp.settings.port != 8000
+                mock_mcp.run.assert_called_once_with(transport='stdio')
+
+    def test_streamable_http_transport_sets_host_port(self):
+        """Test that streamable-http transport sets host and port."""
+        with patch.dict(
+            os.environ,
+            {
+                'FASTMCP_TRANSPORT': 'streamable-http',
+                'FASTMCP_HOST': '0.0.0.0',
+                'FASTMCP_PORT': '9000',
+            },
+            clear=False,
+        ):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                mock_mcp.run = MagicMock()
+                mock_mcp.settings = MagicMock()
+                
+                # Need to reload the module to pick up new environment variables
+                import importlib
+                import awslabs.aws_documentation_mcp_server.server_aws as server_module
+                importlib.reload(server_module)
+                
+                server_module.main()
+                
+                # Verify host and port were set for streamable-http transport
+                mock_mcp.settings.host = '0.0.0.0'
+                mock_mcp.settings.port = 9000
+                mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
+    def test_default_transport_is_stdio(self):
+        """Test that default transport is stdio when FASTMCP_TRANSPORT is not set."""
+        env_copy = os.environ.copy()
+        if 'FASTMCP_TRANSPORT' in env_copy:
+            del env_copy['FASTMCP_TRANSPORT']
+        
+        with patch.dict(os.environ, env_copy, clear=True):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                mock_mcp.run = MagicMock()
+                mock_mcp.settings = MagicMock()
+                
+                from awslabs.aws_documentation_mcp_server.server_aws import main
+                
+                main()
+                
+                mock_mcp.run.assert_called_once_with(transport='stdio')
+
+    def test_environment_variables_read_correctly(self):
+        """Test that environment variables are read correctly."""
+        with patch.dict(
+            os.environ,
+            {
+                'FASTMCP_HOST': '192.168.1.1',
+                'FASTMCP_PORT': '7777',
+                'FASTMCP_TRANSPORT': 'streamable-http',
+            },
+            clear=False,
+        ):
+            # Need to reload the module to pick up new environment variables
+            import importlib
+            import awslabs.aws_documentation_mcp_server.server_aws as server_module
+            importlib.reload(server_module)
+            
+            # Verify environment variables are read
+            assert server_module.FASTMCP_HOST == '192.168.1.1'
+            assert server_module.FASTMCP_PORT == 7777
+
+    def test_default_host_port_values(self):
+        """Test default host and port values when environment variables are not set."""
+        env_copy = os.environ.copy()
+        for key in ['FASTMCP_HOST', 'FASTMCP_PORT']:
+            if key in env_copy:
+                del env_copy[key]
+        
+        with patch.dict(os.environ, env_copy, clear=True):
+            # Need to reload the module to pick up environment changes
+            import importlib
+            import awslabs.aws_documentation_mcp_server.server_aws as server_module
+            importlib.reload(server_module)
+            
+            # Verify default values
+            assert server_module.FASTMCP_HOST == '127.0.0.1'
+            assert server_module.FASTMCP_PORT == 8000
+
+
+class TestTransportConfigurationCN:
+    """Tests for AWS CN transport configuration logic."""
+
+    def test_cn_stdio_transport_does_not_set_host_port(self):
+        """Test that stdio transport does not set host and port for CN server."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                mock_mcp.run = MagicMock()
+                mock_mcp.settings = MagicMock()
+                
+                from awslabs.aws_documentation_mcp_server.server_aws_cn import main
+                
+                main()
+                
+                # Verify host and port were not set for stdio transport
+                assert not hasattr(mock_mcp.settings, 'host') or mock_mcp.settings.host != '127.0.0.1'
+                assert not hasattr(mock_mcp.settings, 'port') or mock_mcp.settings.port != 8000
+                mock_mcp.run.assert_called_once_with(transport='stdio')
+
+    def test_cn_streamable_http_transport_sets_host_port(self):
+        """Test that streamable-http transport sets host and port for CN server."""
+        with patch.dict(
+            os.environ,
+            {
+                'FASTMCP_TRANSPORT': 'streamable-http',
+                'FASTMCP_HOST': '0.0.0.0',
+                'FASTMCP_PORT': '9000',
+            },
+            clear=False,
+        ):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                mock_mcp.run = MagicMock()
+                mock_mcp.settings = MagicMock()
+                
+                # Need to reload the module to pick up new environment variables
+                import importlib
+                import awslabs.aws_documentation_mcp_server.server_aws_cn as server_module
+                importlib.reload(server_module)
+                
+                server_module.main()
+                
+                # Verify host and port were set for streamable-http transport
+                mock_mcp.settings.host = '0.0.0.0'
+                mock_mcp.settings.port = 9000
+                mock_mcp.run.assert_called_once_with(transport='streamable-http')

--- a/src/aws-documentation-mcp-server/tests/test_transport_config.py
+++ b/src/aws-documentation-mcp-server/tests/test_transport_config.py
@@ -193,3 +193,71 @@ class TestTransportConfigurationCN:
 
                     assert mock_mcp.settings.transport_security is None
                     mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
+
+class TestStatelessHttpConfiguration:
+    """Tests for stateless_http configuration via environment variable."""
+
+    def test_stateless_http_env_true_sets_setting(self):
+        """Test that FASTMCP_STATELESS_HTTP=true is applied to mcp.settings."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http', 'FASTMCP_STATELESS_HTTP': 'true'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws.FASTMCP_STATELESS_HTTP', True):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws import main
+                    main()
+
+                    assert mock_mcp.settings.stateless_http is True
+
+    def test_stateless_http_env_false_keeps_default(self):
+        """Test that FASTMCP_STATELESS_HTTP=false keeps stateless_http as False."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http', 'FASTMCP_STATELESS_HTTP': 'false'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws.FASTMCP_STATELESS_HTTP', False):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws import main
+                    main()
+
+                    assert mock_mcp.settings.stateless_http is False
+
+    def test_stdio_does_not_set_stateless_http(self):
+        """Test that stdio transport does not set stateless_http."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                mock_settings = MagicMock()
+                mock_mcp.settings = mock_settings
+                mock_mcp.run = MagicMock()
+
+                from awslabs.aws_documentation_mcp_server.server_aws import main
+                main()
+
+                for c in mock_settings._mock_children:
+                    assert c != 'stateless_http', (
+                        'mcp.settings.stateless_http should not be set for stdio transport'
+                    )
+
+    def test_cn_stateless_http_env_true_sets_setting(self):
+        """Test that CN server applies FASTMCP_STATELESS_HTTP=true."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http', 'FASTMCP_STATELESS_HTTP': 'true'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.FASTMCP_STATELESS_HTTP', True):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws_cn import main
+                    main()
+
+                    assert mock_mcp.settings.stateless_http is True
+
+    def test_module_level_stateless_http_default(self):
+        """Test that FASTMCP_STATELESS_HTTP defaults to False when env var is not set."""
+        from awslabs.aws_documentation_mcp_server.server_aws import FASTMCP_STATELESS_HTTP
+
+        assert isinstance(FASTMCP_STATELESS_HTTP, bool)

--- a/src/aws-documentation-mcp-server/tests/test_transport_config.py
+++ b/src/aws-documentation-mcp-server/tests/test_transport_config.py
@@ -66,6 +66,39 @@ class TestTransportConfigurationAWS:
                 assert mock_mcp.settings.port == FASTMCP_PORT
                 mock_mcp.run.assert_called_once_with(transport='streamable-http')
 
+    def test_streamable_http_localhost_keeps_transport_security(self):
+        """Test that transport_security is NOT disabled when host is localhost."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws.FASTMCP_HOST', '127.0.0.1'):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws import main
+                    main()
+
+                    # transport_security should NOT have been set to None
+                    # (MagicMock attribute access returns a new MagicMock, not None)
+                    assert mock_mcp.settings.transport_security is not None
+                    mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
+    def test_streamable_http_non_localhost_disables_transport_security(self):
+        """Test that transport_security is disabled when host is 0.0.0.0 (non-localhost)."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws.FASTMCP_HOST', '0.0.0.0'):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws import main
+                    main()
+
+                    # transport_security should be set to None
+                    assert mock_mcp.settings.transport_security is None
+                    mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
     def test_default_transport_is_stdio(self):
         """Test that default transport is stdio when FASTMCP_TRANSPORT is not set."""
         env = os.environ.copy()
@@ -129,3 +162,34 @@ class TestTransportConfigurationCN:
                 assert mock_mcp.settings.host == FASTMCP_HOST
                 assert mock_mcp.settings.port == FASTMCP_PORT
                 mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
+    def test_cn_streamable_http_localhost_keeps_transport_security(self):
+        """Test that CN transport_security is NOT disabled when host is localhost."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.FASTMCP_HOST', '127.0.0.1'):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws_cn import main
+                    main()
+
+                    # transport_security should NOT have been set to None
+                    assert mock_mcp.settings.transport_security is not None
+                    mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
+    def test_cn_streamable_http_non_localhost_disables_transport_security(self):
+        """Test that CN transport_security is disabled when host is 0.0.0.0."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
+            with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.FASTMCP_HOST', '0.0.0.0'):
+                    mock_settings = MagicMock()
+                    mock_mcp.settings = mock_settings
+                    mock_mcp.run = MagicMock()
+
+                    from awslabs.aws_documentation_mcp_server.server_aws_cn import main
+                    main()
+
+                    assert mock_mcp.settings.transport_security is None
+                    mock_mcp.run.assert_called_once_with(transport='streamable-http')

--- a/src/aws-documentation-mcp-server/tests/test_transport_config.py
+++ b/src/aws-documentation-mcp-server/tests/test_transport_config.py
@@ -15,152 +15,117 @@
 
 import os
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 
-class TestTransportConfiguration:
-    """Tests for transport configuration logic."""
+class TestTransportConfigurationAWS:
+    """Tests for AWS server transport configuration logic."""
 
     def test_stdio_transport_does_not_set_host_port(self):
-        """Test that stdio transport does not set host and port."""
+        """Test that stdio transport does not set mcp.settings.host or mcp.settings.port."""
         with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
             with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                mock_settings = MagicMock()
+                mock_mcp.settings = mock_settings
                 mock_mcp.run = MagicMock()
-                mock_mcp.settings = MagicMock()
-                
+
                 from awslabs.aws_documentation_mcp_server.server_aws import main
-                
                 main()
-                
-                # Verify host and port were not set for stdio transport
-                assert not hasattr(mock_mcp.settings, 'host') or mock_mcp.settings.host != '127.0.0.1'
-                assert not hasattr(mock_mcp.settings, 'port') or mock_mcp.settings.port != 8000
+
+                # settings.host and settings.port should NOT have been assigned
+                # Check that no attribute was set on mock_settings via __setattr__
+                set_calls = [
+                    c for c in mock_settings.mock_calls
+                    if '__setattr__' not in str(c)
+                ]
+                # The key check: host and port should not appear in the
+                # property assignments on mock_settings
+                for c in mock_settings._mock_children:
+                    assert c not in ('host', 'port'), (
+                        f'mcp.settings.{c} should not be set for stdio transport'
+                    )
                 mock_mcp.run.assert_called_once_with(transport='stdio')
 
     def test_streamable_http_transport_sets_host_port(self):
-        """Test that streamable-http transport sets host and port."""
-        with patch.dict(
-            os.environ,
-            {
-                'FASTMCP_TRANSPORT': 'streamable-http',
-                'FASTMCP_HOST': '0.0.0.0',
-                'FASTMCP_PORT': '9000',
-            },
-            clear=False,
-        ):
+        """Test that streamable-http transport sets mcp.settings.host and mcp.settings.port."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
             with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
+                mock_settings = MagicMock()
+                mock_mcp.settings = mock_settings
                 mock_mcp.run = MagicMock()
-                mock_mcp.settings = MagicMock()
-                
-                # Need to reload the module to pick up new environment variables
-                import importlib
-                import awslabs.aws_documentation_mcp_server.server_aws as server_module
-                importlib.reload(server_module)
-                
-                server_module.main()
-                
-                # Verify host and port were set for streamable-http transport
-                mock_mcp.settings.host = '0.0.0.0'
-                mock_mcp.settings.port = 9000
+
+                from awslabs.aws_documentation_mcp_server.server_aws import (
+                    FASTMCP_HOST,
+                    FASTMCP_PORT,
+                    main,
+                )
+                main()
+
+                # Verify host and port were SET (not just read) on settings
+                assert mock_mcp.settings.host == FASTMCP_HOST
+                assert mock_mcp.settings.port == FASTMCP_PORT
                 mock_mcp.run.assert_called_once_with(transport='streamable-http')
 
     def test_default_transport_is_stdio(self):
         """Test that default transport is stdio when FASTMCP_TRANSPORT is not set."""
-        env_copy = os.environ.copy()
-        if 'FASTMCP_TRANSPORT' in env_copy:
-            del env_copy['FASTMCP_TRANSPORT']
-        
-        with patch.dict(os.environ, env_copy, clear=True):
+        env = os.environ.copy()
+        env.pop('FASTMCP_TRANSPORT', None)
+
+        with patch.dict(os.environ, env, clear=True):
             with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp') as mock_mcp:
                 mock_mcp.run = MagicMock()
                 mock_mcp.settings = MagicMock()
-                
+
                 from awslabs.aws_documentation_mcp_server.server_aws import main
-                
                 main()
-                
+
                 mock_mcp.run.assert_called_once_with(transport='stdio')
 
-    def test_environment_variables_read_correctly(self):
-        """Test that environment variables are read correctly."""
-        with patch.dict(
-            os.environ,
-            {
-                'FASTMCP_HOST': '192.168.1.1',
-                'FASTMCP_PORT': '7777',
-                'FASTMCP_TRANSPORT': 'streamable-http',
-            },
-            clear=False,
-        ):
-            # Need to reload the module to pick up new environment variables
-            import importlib
-            import awslabs.aws_documentation_mcp_server.server_aws as server_module
-            importlib.reload(server_module)
-            
-            # Verify environment variables are read
-            assert server_module.FASTMCP_HOST == '192.168.1.1'
-            assert server_module.FASTMCP_PORT == 7777
+    def test_module_level_env_defaults(self):
+        """Test default FASTMCP_HOST and FASTMCP_PORT values at module level."""
+        from awslabs.aws_documentation_mcp_server.server_aws import FASTMCP_HOST, FASTMCP_PORT
 
-    def test_default_host_port_values(self):
-        """Test default host and port values when environment variables are not set."""
-        env_copy = os.environ.copy()
-        for key in ['FASTMCP_HOST', 'FASTMCP_PORT']:
-            if key in env_copy:
-                del env_copy[key]
-        
-        with patch.dict(os.environ, env_copy, clear=True):
-            # Need to reload the module to pick up environment changes
-            import importlib
-            import awslabs.aws_documentation_mcp_server.server_aws as server_module
-            importlib.reload(server_module)
-            
-            # Verify default values
-            assert server_module.FASTMCP_HOST == '127.0.0.1'
-            assert server_module.FASTMCP_PORT == 8000
+        # These are read at module import time; verify they have sensible defaults
+        assert isinstance(FASTMCP_HOST, str)
+        assert isinstance(FASTMCP_PORT, int)
+        assert FASTMCP_PORT > 0
 
 
 class TestTransportConfigurationCN:
-    """Tests for AWS CN transport configuration logic."""
+    """Tests for AWS CN server transport configuration logic."""
 
     def test_cn_stdio_transport_does_not_set_host_port(self):
-        """Test that stdio transport does not set host and port for CN server."""
+        """Test that stdio transport does not set mcp.settings.host or mcp.settings.port for CN."""
         with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'stdio'}, clear=False):
             with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                mock_settings = MagicMock()
+                mock_mcp.settings = mock_settings
                 mock_mcp.run = MagicMock()
-                mock_mcp.settings = MagicMock()
-                
+
                 from awslabs.aws_documentation_mcp_server.server_aws_cn import main
-                
                 main()
-                
-                # Verify host and port were not set for stdio transport
-                assert not hasattr(mock_mcp.settings, 'host') or mock_mcp.settings.host != '127.0.0.1'
-                assert not hasattr(mock_mcp.settings, 'port') or mock_mcp.settings.port != 8000
+
+                for c in mock_settings._mock_children:
+                    assert c not in ('host', 'port'), (
+                        f'mcp.settings.{c} should not be set for stdio transport'
+                    )
                 mock_mcp.run.assert_called_once_with(transport='stdio')
 
     def test_cn_streamable_http_transport_sets_host_port(self):
-        """Test that streamable-http transport sets host and port for CN server."""
-        with patch.dict(
-            os.environ,
-            {
-                'FASTMCP_TRANSPORT': 'streamable-http',
-                'FASTMCP_HOST': '0.0.0.0',
-                'FASTMCP_PORT': '9000',
-            },
-            clear=False,
-        ):
+        """Test that streamable-http transport sets mcp.settings.host and mcp.settings.port for CN."""
+        with patch.dict(os.environ, {'FASTMCP_TRANSPORT': 'streamable-http'}, clear=False):
             with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp') as mock_mcp:
+                mock_settings = MagicMock()
+                mock_mcp.settings = mock_settings
                 mock_mcp.run = MagicMock()
-                mock_mcp.settings = MagicMock()
-                
-                # Need to reload the module to pick up new environment variables
-                import importlib
-                import awslabs.aws_documentation_mcp_server.server_aws_cn as server_module
-                importlib.reload(server_module)
-                
-                server_module.main()
-                
-                # Verify host and port were set for streamable-http transport
-                mock_mcp.settings.host = '0.0.0.0'
-                mock_mcp.settings.port = 9000
+
+                from awslabs.aws_documentation_mcp_server.server_aws_cn import (
+                    FASTMCP_HOST,
+                    FASTMCP_PORT,
+                    main,
+                )
+                main()
+
+                assert mock_mcp.settings.host == FASTMCP_HOST
+                assert mock_mcp.settings.port == FASTMCP_PORT
                 mock_mcp.run.assert_called_once_with(transport='streamable-http')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #N/A

## Summary

### Changes

This PR adds support for `streamable-http` transport mode to the AWS Documentation MCP Server, enabling deployment in containerized environments such as Amazon ECS, Kubernetes, and behind load balancers.

**Core Functionality:**
- Added `FASTMCP_TRANSPORT` environment variable to switch between `stdio` and `streamable-http` modes
- Added `FASTMCP_HOST` and `FASTMCP_PORT` environment variables for HTTP server configuration
- Modified `server_aws.py` and `server_aws_cn.py` to pass host/port to FastMCP constructor
- Updated `main()` function to accept transport parameter

**Docker Support:**
- Set `FASTMCP_HOST=0.0.0.0` as default in Dockerfile for container networking
- Enhanced `docker-healthcheck.sh` to support HTTP mode health checks

**Documentation:**
- Added comprehensive HTTP transport mode documentation with Docker and MCP client examples
- Documented all new environment variables

### User experience

**Before this change:**
- Users could only run aws-documentation-mcp-server locally with stdio transport
- No support for containerized deployments or remote access
- Cannot deploy behind load balancers or in multi-user environments

**After this change:**
- Users can deploy the server in Docker containers with HTTP transport
- Supports deployment on Amazon ECS, Kubernetes, and other container platforms
- Can be accessed remotely through load balancers
- Fully backward compatible - existing stdio configurations continue to work unchanged

**Example usage:**
```
# Docker with HTTP mode
docker run -d \
 -p 8000:8000 \
 -e FASTMCP_TRANSPORT=streamable-http \
 -e FASTMCP_HOST=0.0.0.0 \
 -e FASTMCP_PORT=8000 \
 mcp/aws-documentation:latest

```
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): **N**

**RFC issue number**: N/A (This is a feature enhancement following existing patterns in aws-api-mcp-server)

Checklist:

* [x] Migration process documented (not needed - fully backward compatible)
* [x] Implement warnings (not needed - opt-in via environment variables)

## Testing

✅ **Production tested:**
- Deployed and running in production on Amazon ECS Fargate
- Serving requests through Application Load Balancer
- Verified with multiple MCP clients (Kiro CLI)
- Health checks working correctly
- No issues observed after 10+ test iterations

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).