### PR TITLE
fix: Multiple bugfixes for billing and well-architected-security MCP servers

### DIFF
--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/server.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/server.py
@@ -445,7 +445,7 @@ async def get_security_findings(
                 }
             elif service_name == "inspector":
                 filter_criteria = {
-                    "severities": [{"comparison": "EQUALS", "value": severity_filter.upper()}]
+                    "severity": [{"comparison": "EQUALS", "value": severity_filter.upper()}]
                 }
             elif service_name == "trustedadvisor":
                 # For Trusted Advisor, severity maps to status (error, warning, ok)

--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/util/network_security.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/util/network_security.py
@@ -246,10 +246,14 @@ async def find_network_resources(
 
         default_view = None
         # Find the default view
+        # Note: list_views() returns a list of ARN strings, not dicts
         for view in views.get("Views", []):
-            print(f"[DEBUG:NetworkSecurity] View: {view.get('ViewArn')}")
-            if view.get("Filters", {}).get("FilterString", "") == "":
-                default_view = view.get("ViewArn")
+            # Handle both string ARNs (actual API behavior) and dicts (legacy/mocked)
+            view_arn = view if isinstance(view, str) else view.get("ViewArn")
+            print(f"[DEBUG:NetworkSecurity] View: {view_arn}")
+            # Use the first available view as default
+            if default_view is None:
+                default_view = view_arn
                 print(f"[DEBUG:NetworkSecurity] Found default view: {default_view}")
                 break
 

--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/util/storage_security.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/util/storage_security.py
@@ -216,10 +216,14 @@ async def find_storage_resources(
 
         default_view = None
         # Find the default view
+        # Note: list_views() returns a list of ARN strings, not dicts
         for view in views.get("Views", []):
-            print(f"[DEBUG:StorageSecurity] View: {view.get('ViewArn')}")
-            if view.get("Filters", {}).get("FilterString", "") == "":
-                default_view = view.get("ViewArn")
+            # Handle both string ARNs (actual API behavior) and dicts (legacy/mocked)
+            view_arn = view if isinstance(view, str) else view.get("ViewArn")
+            print(f"[DEBUG:StorageSecurity] View: {view_arn}")
+            # Use the first available view as default
+            if default_view is None:
+                default_view = view_arn
                 print(f"[DEBUG:StorageSecurity] Found default view: {default_view}")
                 break
 


### PR DESCRIPTION
## Summary

This consolidated PR addresses several bugs discovered while using the MCP servers with real AWS accounts. These issues were originally reported in separate PRs (#2241, #2243, #2244, #2245) that were closed when the source fork was deleted.

### billing-cost-management-mcp-server

**sql_utils.py** - Serverless environment compatibility:
- Add `MCP_SESSION_DB_NAME` env var for fixed database name persistence across process restarts
- Add `MCP_SESSION_DB_DIR` env var to override default session directory location
- The default `/var/task/sessions` path in Lambda/ECS environments is read-only

### well-architected-security-mcp-server

**server.py** - Fix Inspector API parameter:
- Change `"severities"` to `"severity"` (correct boto3 Inspector2 filterCriteria parameter name)

**security_services.py** - Multiple fixes:
- Fix Inspector filterCriteria: `"severities"` → `"severity"`
- Add missing `"arn"` field to `analyzer_details` in `check_access_analyzer()`
- Fix `get_access_analyzer_findings()` to properly handle `list_findings()` returning finding objects (not just IDs)
- Extract `"finding"` from `get_finding()` wrapper response `{"finding": {...}}`
- Add `isinstance(finding, dict)` validation before processing findings
- Normalize Access Analyzer `action` field which can be string or list

**network_security.py** & **storage_security.py** - Fix Resource Explorer API:
- `list_views()` returns a list of ARN strings, not dictionaries with `ViewArn`/`Filters` keys
- Updated code handles both string ARNs (real API behavior) and dicts (legacy/mocked behavior)

Fixes #2237

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).