### PR TITLE
feat(dsql): Fix MCP KB query, AI MCP config, skill description

### DIFF
--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
@@ -17,6 +17,7 @@
 import argparse
 import boto3
 import httpx
+import json
 import psycopg
 import psycopg.rows
 import sys
@@ -496,7 +497,13 @@ async def _proxy_to_knowledge_server(
                     await ctx.error(error_msg)
                 raise Exception(error_msg)
 
-            return result.get('result', {})
+            res = result.get('result', {})
+            if not res:
+                content = result.get('content', [])
+                if content and isinstance(content, list) and content[0].get('type') == 'text':
+                    return json.loads(content[0]['text'])
+                return {'content': content}
+            return res
 
     except httpx.HTTPError as e:
         error_msg = 'The DSQL knowledge server is currently unavailable. Please try again later.'

--- a/src/aurora-dsql-mcp-server/kiro_power/mcp.json
+++ b/src/aurora-dsql-mcp-server/kiro_power/mcp.json
@@ -2,18 +2,10 @@
   "mcpServers": {
     "aurora-dsql": {
       "args": [
-        "awslabs.aurora-dsql-mcp-server@latest",
-        "--cluster_endpoint",
-        "${CLUSTER}.dsql.${REGION}.on.aws",
-        "--region",
-        "${REGION}",
-        "--database_user",
-        "admin",
-        "--allow-writes"
+        "awslabs.aurora-dsql-mcp-server@latest"
       ],
       "command": "uvx",
       "env": {
-        "AWS_PROFILE": "${AWS_PROFILE:-default}",
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/mcp-setup.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/mcp-setup.md
@@ -9,17 +9,31 @@ uv --version
 - Install from: [Astral](https://docs.astral.sh/uv/getting-started/installation/)
 
 **Check if MCP server is configured:**
-- Look for `aurora-dsql-mcp-server` in MCP settings
+Look for `aurora-dsql` or `power-amazon-aurora-dsql-aurora-dsql` in MCP settings.
+
+**If configured:**
+The MCP server can be configured in one of 2 ways. The [default documentation-only configuration](#default-documentation-tools-only-configuration) doesn't support database operations.
+
+The MCP server can be updated to support the `readonly_query`, `transact`, and `get_schema` database
+operation tools by connecting the server to the user's DSQL cluster, with the
+[cluster configuration](#cluster-configuration-to-add).
+
+***Ask the user which configuration they prefer and re-configure if needed, editing the appropriate***
+***MCP settings file.***
 
 **If not configured, offer to set up:**
 
-Edit the appropriate MCP settings file.
+Ask the user if they prefer the [documentation-only](#default-documentation-tools-only-configuration)
+functionality or the [database operation](#cluster-configuration-for-database-operations)
+functionality and edit the appropriate MCP settings file.
 
 ## Where to keep the MCP Configuration?
 Would the user like a global MCP configuration or a project-scoped MCP configuration?
 
 **Default:**
-By default, the power has a placeholder MCP configuration globally.
+By default, the power has a placeholder MCP configuration globally. *This MCP configuration does
+not contain any DSQL cluster details. Therefore, it can only be used for documentation tools,
+but can be updated to match the [database operation configuration](#cluster-configuration-for-database-operations) with a DSQL cluster.*
 
 ```bash
 cat ~/.kiro/settings/mcp.json
@@ -66,8 +80,27 @@ the left sidebar (Kiro's ghost icon) and navigating to the bottom "MCP Servers" 
         should be allowed.
 
 ## MCP Configuration:
-Add the following configuration:
+### Default Documentation-Tools-Only Configuration:
 
+```json
+{
+  "mcpServers": {
+    "awslabs.aurora-dsql-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "awslabs.aurora-dsql-mcp-server@latest"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+### Cluster Configuration for Database Operations:
 ```json
 {
   "mcpServers": {

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
@@ -5,7 +5,7 @@ description: Build with Aurora DSQL - manage schemas, execute queries, and handl
 
 # Amazon Aurora DSQL Skill
 
-Aurora DSQL is a serverless, PostgreSQL-compatible distributed SQL database with specific constraints. This skill provides direct database interaction via MCP tools, schema management, migration support, and multi-tenant patterns.
+Aurora DSQL is a serverless, PostgreSQL-compatible distributed SQL database. This skill provides direct database interaction via MCP tools, schema management, migration support, and multi-tenant patterns.
 
 **Key capabilities:**
 - Direct query execution via MCP tools

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/mcp/.mcp.json
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/mcp/.mcp.json
@@ -4,16 +4,25 @@
       "args": [
         "awslabs.aurora-dsql-mcp-server@latest",
         "--cluster_endpoint",
-        "${CLUSTER}.dsql.${REGION}.on.aws",
+        "[dsql cluster id, e.g. abcdefghijklmnopqrst234567].dsql.[dsql cluster region, e.g. us-east-1].on.aws",
         "--region",
-        "${REGION}",
+        "[dsql cluster region, e.g. us-east-1]",
         "--database_user",
         "admin",
         "--allow-writes"
       ],
       "command": "uvx",
       "env": {
-        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_PROFILE": "[aws profile with dsql cluster, e.g. default]",
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    },
+    "aurora-dsql-docs-only": {
+      "args": [
+        "awslabs.aurora-dsql-mcp-server@latest"
+      ],
+      "command": "uvx",
+      "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/mcp/mcp-setup.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/mcp/mcp-setup.md
@@ -9,8 +9,29 @@ uv --version
 - Install from: [Astral](https://docs.astral.sh/uv/getting-started/installation/)
 
 ## General MCP Configuration:
-Add the following configuration:
+Add the following configuration after checking if the user wants documentation-only functionality
+or database operation support too.
 
+### Documentation-Only Configuration
+```json
+{
+  "mcpServers": {
+    "awslabs.aurora-dsql-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "awslabs.aurora-dsql-mcp-server@latest"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+### Database Operation Support Configuration
 ```json
 {
   "mcpServers": {
@@ -50,7 +71,6 @@ has custom AWS configurations or would like to allow/disallow the MCP server mut
 * Arg: `--allow-writes` based on how permissive the user wants
   to be for the MCP server. Always ask the user if writes
   should be allowed.
-
 
 ## Coding Assistant - Custom Instructions
 Before proceeding, identify which coding assistant you are adding the MCP server to and


### PR DESCRIPTION
## Summary

### Changes

feat(dsql): Fix MCP KB query, AI MCP config, skill description
    
1. Fix the knowledge base query return format for the MCP to correctly
   parse out the content.
2. Update the default MCP config in the Kiro Power (and MCP skill) to
   not take the cluster arguments and remove the initial load-in error
   CX where environment variables have to be trusted and the MCP will
   fail to connect.
3. Subsequently update the MCP setup instructions to outline the
   distinct `documentation-only` bare-bones default configuration of
   the MCP server and the cluster-passed configuration of the MCP server
   which supports database operations.
4. Also update the skill description to remove unnecessary phrase.

Co-authored-by: anwesham-lab <64298192+anwesham-lab@users.noreply.github.com>

### User experience

> Please share what the user experience looks like before and after this change
- UX for MCP documentation tools saw transient "success" calls that fail out due to empty responses. This fixes the response in full. 
- Updates the MCP configuration on download of a Kiro Power such that users should no longer experience the untrusted environment variable error or the errno `32000` failure to connect. 
- Updates the onboarding experience with the skill/power so that the MCP can be toggled between the documentation-only mode and supporting DB operations by using the AI assistant to update its own MCP config. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
