### PR TITLE
chore(dynamodb-mcp-server): add license header to ruff.toml

### DIFF
--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/languages/python/ruff.toml
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/languages/python/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/deals/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/deals/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/ecommerce/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/ecommerce/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/elearning/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/elearning/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/gaming_leaderboard/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/gaming_leaderboard/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/saas/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/saas/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/social_media/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/social_media/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/user_analytics/ruff.toml
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/fixtures/expected_outputs/python/user_analytics/ruff.toml
@@ -1,3 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Ruff configuration for generated code
 line-length = 99
 extend-include = ["*.ipynb"]


### PR DESCRIPTION
## Summary

Add license header to ruff.toml configuration file to satisfy CI/CD license checker requirements. The header is added as TOML comments and does not affect the configuration functionality.

### Changes

Updated files:
- Source: awslabs/dynamodb_mcp_server/repo_generation_tool/languages/python/ruff.toml
- Snapshots: All 7 test fixture ruff.toml files regenerated with license header


### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N 

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
