### PR TITLE
chore(ci): add ruff.toml files to license header validation

### DIFF
--- a/.github/workflows/check-license-header.json
+++ b/.github/workflows/check-license-header.json
@@ -28,7 +28,8 @@
       "**/*.py",
       "**/*Dockerfile",
       "**/*.sh",
-      "**/*.guard"
+      "**/*.guard",
+      "**/ruff.toml"
     ],
     "license": "./.github/workflows/check-license-header-hash.txt"
   },


### PR DESCRIPTION
## Summary

### Changes

Include **/ruff.toml in hash-style license validation while excluding pyproject.toml and root .ruff.toml files that don't require headers.

This ensures generated ruff.toml files in repo templates have proper Apache 2.0 license headers.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
