### PR TITLE
docs(mcp): updated Python link in DEVELOPER_GUIDE.md

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -6,7 +6,7 @@ At the moment, there is no dedicated development container, thus you need to con
 
 - [pre-commit](https://pre-commit.com/)
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
-- [Python](Python) 3.10. You can install it through uv using `uv python install 3.10`
+- [Python](https://www.python.org) 3.10. You can install it through uv using `uv python install 3.10`
 - [Git](https://git-scm.com/) (if using code repository)
 - (optional) [AWS CLI](https://aws.amazon.com/cli/). Some servers will require to use your AWS credentials to interact with your AWS account. Configure your credentials:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Updated line 8 in DEVELOPER_GUIDE.md with the correct link to the Python website

### User experience

> Users are now able to navigate directly to the official Python website on click. Before the change, the broken link resulted in an error for users. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) 

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
