### PR TITLE
feat(dsql): Power/Skills: Ensure MCP setup correctness

### DIFF
--- a/src/aurora-dsql-mcp-server/kiro_power/POWER.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/POWER.md
@@ -39,12 +39,15 @@ This power includes the following steering files in [steering](./steering)
 - **troubleshooting**
   - SHOULD Load when debugging errors or unexpected behavior
   - Common pitfalls and errors and how to solve
+- **mcp-setup**
+  - ALWAYS load for MCP server configurations or MCP server operations
+  - Details the options for MCP server configurations AND how to add cluster to MCP
+  - MUST refer to the [Database Operations Configuration](steering/mcp-setup.md#cluster-configuration-for-database-operations)
+    to correctly add DSQL cluster to MCP configuration
+  - Interactive edits when user requests to "Add cluster XYZ to power/mcp" or similar phrase
 - **onboarding**
   - SHOULD load when user requests to try the power, "Get started with DSQL" or similar phrase
   - Interactive "Get Started with DSQL" guide for onboarding users step-by-step
-- **mcp-setup**
-  - SHOULD load when MCP server isn't configured and MCP operation is being invoked
-  - Guides the user through updated MCP server configuration
 - **ddl-migrations**
   - MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
   - Table recreation patterns, batched migration for large tables, data validation
@@ -69,9 +72,14 @@ The `aurora-dsql` MCP server provides these tools:
 
 ## Configuration
 
-Currently the Aurora DSQL MCP Server REQUIRES an existing DSQL cluster which
-all operations are executed atop. If the user requires complete onboarding
-guidance for creating a cluster, refer to the [onboarding guide](steering/onboarding.md).
+To use **Database Operations** MCP tools, the DSQL MCP Server REQUIRES an existing DSQL
+cluster be correctly added to the MCP configuration to execute these operations atop.
+Refer to the provided [MCP Setup Guide](steering/mcp-setup.md), using the
+[Cluster-Added MCP Configuration](steering/mcp-setup.md#cluster-configuration-for-database-operations),
+to update the power's MCP configuration.
+
+If the user requires complete onboarding guidance in creating a cluster, too,
+refere first to the [onboarding guide](steering/onboarding.md).
 
 - **Package:** `awslabs.aurora-dsql-mcp-server@latest`
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
@@ -26,9 +26,11 @@ Load these files as needed for detailed guidance:
 
 ### MCP:
 #### [mcp-setup.md](mcp/mcp-setup.md)
-**When:** Load for guidance adding to the DSQL MCP server
-**Requires:** An existing cluster endpoint
-**Contains:** Instructions for setting up the DSQL MCP server
+**When:** Always load for guidance using or updating the DSQL MCP server
+**Contains:** Instructions for setting up the DSQL MCP server with 2 configuration options as
+sampled in [.mcp.json](mcp/.mcp.json)
+1. Documentation-Tools Only
+2. Database Operations (requires a cluster endpoint)
 
 #### [mcp-tools.md](mcp/mcp-tools.md)
 **When:** Load when you need detailed MCP tool syntax and examples
@@ -72,7 +74,8 @@ The `aurora-dsql` MCP server provides these tools:
 
 **Note:** There is no `list_tables` tool. Use `readonly_query` with information_schema.
 
-See [mcp-tools.md](references/mcp-tools.md) for detailed usage and examples.
+See [mcp-setup.md](mcp/mcp-setup.md) for detailed setup instructions.
+See [mcp-tools.md](mcp/mcp-tools.md) for detailed usage and examples.
 
 ---
 


### PR DESCRIPTION
Fixes

## Summary

### Changes

```
feat(dsql): Firmly require MCP Setup reference

Ensure AI rules more correctly reference the expected MCP setup config
so that the MCP with a cluster is never misconfigured.

Co-authored-by: anwesham-lab <64298192+anwesham-lab@users.noreply.github.com>
```

### User experience

Previously when using prompts that didn't require onboarding assistance like:
`Add Cluster XYZ to the power` for setting up the MCP, the power would not invoke the mcp setup guide
and as a result, just added a `CLUSTER_ID` field to the environment variables causing the MCP configuration 
to fail. The POWER and Skill didn't clearly delineate when the mcp setup was required. 

Cutting over the RFC terms and improving the reference points to the steering on the top level md file seems 
to have fixed this. Tried to reproduce across 10 attempts in Kiro and 10 attempts in Claude and didn't see 
the same error anymore. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
