### PR TITLE
fix: remove unsupported provider from HealthOmics utils

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/codeconnections.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/codeconnections.py
@@ -101,7 +101,7 @@ async def list_codeconnections(
     ctx: Context,
     provider_type_filter: Optional[str] = Field(
         None,
-        description='Filter by provider type: Bitbucket, GitHub, GitHubEnterpriseServer, GitLab, GitLabSelfManaged, AzureDevOps',
+        description='Filter by provider type: Bitbucket, GitHub, GitHubEnterpriseServer, GitLab, GitLabSelfManaged',
     ),
     max_results: int = Field(
         DEFAULT_MAX_RESULTS,
@@ -215,7 +215,7 @@ async def create_codeconnection(
     ),
     provider_type: str = Field(
         ...,
-        description='Git provider type: Bitbucket, GitHub, GitHubEnterpriseServer, GitLab, GitLabSelfManaged, AzureDevOps',
+        description='Git provider type: Bitbucket, GitHub, GitHubEnterpriseServer, GitLab, GitLabSelfManaged',
     ),
     tags: Optional[Dict[str, str]] = Field(
         None,
@@ -233,7 +233,7 @@ async def create_codeconnection(
         ctx: MCP context for error reporting
         connection_name: Name for the new connection
         provider_type: Git provider type (Bitbucket, GitHub, GitHubEnterpriseServer,
-            GitLab, GitLabSelfManaged, AzureDevOps)
+            GitLab, GitLabSelfManaged)
         tags: Optional tags to apply to the connection
 
     Returns:

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/utils/validation_utils.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/utils/validation_utils.py
@@ -40,7 +40,6 @@ class ProviderType(str, Enum):
     GITHUB_ENTERPRISE_SERVER = 'GitHubEnterpriseServer'
     GITLAB = 'GitLab'
     GITLAB_SELF_MANAGED = 'GitLabSelfManaged'
-    AZURE_DEVOPS = 'AzureDevOps'
 
 
 def detect_readme_input_type(readme: str) -> ReadmeInputType:

--- a/src/aws-healthomics-mcp-server/tests/test_validation_utils.py
+++ b/src/aws-healthomics-mcp-server/tests/test_validation_utils.py
@@ -1137,18 +1137,6 @@ class TestValidateProviderType:
         mock_ctx.error.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_validate_provider_type_valid_azure_devops(self):
-        """Test validation with valid AzureDevOps provider type."""
-        from awslabs.aws_healthomics_mcp_server.utils.validation_utils import (
-            validate_provider_type,
-        )
-
-        mock_ctx = AsyncMock()
-        result = await validate_provider_type(mock_ctx, 'AzureDevOps')
-        assert result == 'AzureDevOps'
-        mock_ctx.error.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_validate_provider_type_all_valid_types(self):
         """Test validation with all valid provider types."""
         from awslabs.aws_healthomics_mcp_server.utils.validation_utils import (
@@ -1161,7 +1149,6 @@ class TestValidateProviderType:
             'GitHubEnterpriseServer',
             'GitLab',
             'GitLabSelfManaged',
-            'AzureDevOps',
         ]
 
         for provider_type in valid_types:
@@ -1268,7 +1255,6 @@ class TestValidateProviderType:
         assert 'GitHubEnterpriseServer' in error_message
         assert 'GitLab' in error_message
         assert 'GitLabSelfManaged' in error_message
-        assert 'AzureDevOps' in error_message
 
     @pytest.mark.asyncio
     async def test_validate_provider_type_logs_error(self):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Removes incorrectly-added `AzureDevOps` type from supported repository providers for AWS HealthOmics.

### User experience

Agent receives accurate information on supported repository provider types.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
