### PR TITLE
chore: release/2026.02.20260205000550

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.13"
+version = "0.0.14"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/amazon-kendra-index-mcp-server/awslabs/amazon_kendra_index_mcp_server/__init__.py
+++ b/src/amazon-kendra-index-mcp-server/awslabs/amazon_kendra_index_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-kendra-index-mcp-server"""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/amazon-kendra-index-mcp-server/pyproject.toml
+++ b/src/amazon-kendra-index-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-kendra-index-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for amazon-kendra-index-mcp-server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-kendra-index-mcp-server/uv.lock
+++ b/src/amazon-kendra-index-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-kendra-index-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/__init__.py
+++ b/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 ###awslabs.amazon-keyspaces-mcp-server"""
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'

--- a/src/amazon-keyspaces-mcp-server/pyproject.toml
+++ b/src/amazon-keyspaces-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-keyspaces-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 description = "An Amazon Keyspaces (for Apache Cassandra) MCP server for interacting with Amazon Keyspaces and Apache Cassandra."
 readme = "README.md"
 requires-python = ">=3.10,<3.12"

--- a/src/amazon-keyspaces-mcp-server/uv.lock
+++ b/src/amazon-keyspaces-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-keyspaces-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/__init__.py
+++ b/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
 
-__version__ = '2.0.17'
+__version__ = '2.0.18'

--- a/src/amazon-mq-mcp-server/pyproject.toml
+++ b/src/amazon-mq-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-mq-mcp-server"
-version = "2.0.17"
+version = "2.0.18"
 description = "A Model Context Protocol server for AmazonMQ to provision and manage your AMQ brokers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-mq-mcp-server/uv.lock
+++ b/src/amazon-mq-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-mq-mcp-server"
-version = "2.0.17"
+version = "2.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/__init__.py
+++ b/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.neptune-mcp-server"""
 
-__version__ = '1.0.12'
+__version__ = '1.0.13'

--- a/src/amazon-neptune-mcp-server/pyproject.toml
+++ b/src/amazon-neptune-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-neptune-mcp-server"
-version = "1.0.12"
+version = "1.0.13"
 description = "An Amazon Neptune MCP server that allows for fetching status, schema, and querying using openCypher, Gremlin, and SPARQL for Neptune Database and openCypher for Neptune Analytics."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-neptune-mcp-server/uv.lock
+++ b/src/amazon-neptune-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-neptune-mcp-server"
-version = "1.0.12"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-qbusiness-anonymous-mcp-server/awslabs/amazon_qbusiness_anonymous_mcp_server/__init__.py
+++ b/src/amazon-qbusiness-anonymous-mcp-server/awslabs/amazon_qbusiness_anonymous_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-qbusiness-anonymous-mcp-server"""
 
-__version__ = '0.0.12'
+__version__ = '0.0.13'

--- a/src/amazon-qbusiness-anonymous-mcp-server/pyproject.toml
+++ b/src/amazon-qbusiness-anonymous-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-qbusiness-anonymous-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.12"
+version = "0.0.13"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon Q Business anonymous mode application."
 readme = "README.md"

--- a/src/amazon-qbusiness-anonymous-mcp-server/uv.lock
+++ b/src/amazon-qbusiness-anonymous-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-qbusiness-anonymous-mcp-server"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/__init__.py
+++ b/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-qindex-mcp-server"""
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'

--- a/src/amazon-qindex-mcp-server/pyproject.toml
+++ b/src/amazon-qindex-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-qindex-mcp-server"
-version = "0.0.10"
+version = "0.0.11"
 description = "This is an AWS Labs Model Context Protocol (MCP) server implementation that enables Independent Software Vendors (ISVs) to interact with Amazon Q Business's search capabilities. The server facilitates searching across enterprise customers' Q index using the SearchRelevantContent API."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-qindex-mcp-server/uv.lock
+++ b/src/amazon-qindex-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-qindex-mcp-server"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/__init__.py
+++ b/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-sns-sqs-mcp-server"""
 
-__version__ = '2.0.15'
+__version__ = '2.0.16'

--- a/src/amazon-sns-sqs-mcp-server/pyproject.toml
+++ b/src/amazon-sns-sqs-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-sns-sqs-mcp-server"
-version = "2.0.15"
+version = "2.0.16"
 description = "A Model Context Protocol server for Amazon SNS and SQS to provision and manage your messaging services"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-sns-sqs-mcp-server/uv.lock
+++ b/src/amazon-sns-sqs-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-sns-sqs-mcp-server"
-version = "2.0.15"
+version = "2.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/__init__.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aurora-dsql-mcp-server"""
 
-__version__ = '1.0.17'
+__version__ = '1.0.18'

--- a/src/aurora-dsql-mcp-server/pyproject.toml
+++ b/src/aurora-dsql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aurora-dsql-mcp-server"
-version = "1.0.17"
+version = "1.0.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for Aurora DSQL"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aurora-dsql-mcp-server/uv.lock
+++ b/src/aurora-dsql-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aurora-dsql-mcp-server"
-version = "1.0.17"
+version = "1.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.3.8'
+__version__ = '1.3.9'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.8"
+version = "1.3.9"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.3.8"
+version = "1.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },

--- a/src/aws-appsync-mcp-server/awslabs/aws_appsync_mcp_server/__init__.py
+++ b/src/aws-appsync-mcp-server/awslabs/aws_appsync_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS AppSync MCP Server package."""
 
-__version__ = '0.1.8'
+__version__ = '0.1.9'

--- a/src/aws-appsync-mcp-server/pyproject.toml
+++ b/src/aws-appsync-mcp-server/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "awslabs.aws-appsync-mcp-server"
 
-version = "0.1.8"
+version = "0.1.9"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS AppSync Service capabilities"
 readme = "README.md"

--- a/src/aws-appsync-mcp-server/uv.lock
+++ b/src/aws-appsync-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-appsync-mcp-server"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-bedrock-custom-model-import-mcp-server/awslabs/aws_bedrock_custom_model_import_mcp_server/__init__.py
+++ b/src/aws-bedrock-custom-model-import-mcp-server/awslabs/aws_bedrock_custom_model_import_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-bedrock-custom-model-import-mcp-server"""
 
-__version__ = '0.0.12'
+__version__ = '0.0.13'

--- a/src/aws-bedrock-custom-model-import-mcp-server/pyproject.toml
+++ b/src/aws-bedrock-custom-model-import-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-bedrock-custom-model-import-mcp-server"
-version = "0.0.12"
+version = "0.0.13"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Custom Model Import"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-bedrock-custom-model-import-mcp-server/uv.lock
+++ b/src/aws-bedrock-custom-model-import-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-bedrock-custom-model-import-mcp-server"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-bedrock-data-automation-mcp-server/awslabs/aws_bedrock_data_automation_mcp_server/__init__.py
+++ b/src/aws-bedrock-data-automation-mcp-server/awslabs/aws_bedrock_data_automation_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 
 """awslabs.aws-bedrock-data-automation-mcp-server"""
 
-__version__ = '0.0.15'
+__version__ = '0.0.16'

--- a/src/aws-bedrock-data-automation-mcp-server/pyproject.toml
+++ b/src/aws-bedrock-data-automation-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-bedrock-data-automation-mcp-server"
-version = "0.0.15"
+version = "0.0.16"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Data Automation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-bedrock-data-automation-mcp-server/uv.lock
+++ b/src/aws-bedrock-data-automation-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-bedrock-data-automation-mcp-server"
-version = "0.0.15"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/__init__.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-dataprocessing-mcp-server"""
 
-__version__ = '0.1.22'
+__version__ = '0.1.23'

--- a/src/aws-dataprocessing-mcp-server/pyproject.toml
+++ b/src/aws-dataprocessing-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-dataprocessing-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.22"
+version = "0.1.23"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for dataprocessing"
 readme = "README.md"

--- a/src/aws-dataprocessing-mcp-server/uv.lock
+++ b/src/aws-dataprocessing-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-dataprocessing-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/__init__.py
+++ b/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/__init__.py
@@ -17,4 +17,4 @@
 This package provides an MCP server that creates diagrams using the Python diagrams package DSL.
 """
 
-__version__ = '1.0.18'
+__version__ = '1.0.19'

--- a/src/aws-diagram-mcp-server/pyproject.toml
+++ b/src/aws-diagram-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-diagram-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 description = "An MCP server that seamlessly creates diagrams using the Python diagrams package DSL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aws-diagram-mcp-server/uv.lock
+++ b/src/aws-diagram-mcp-server/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-diagram-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "bandit" },

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/__init__.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-documentation-mcp-server"""
 
-__version__ = '1.1.17'
+__version__ = '1.1.18'

--- a/src/aws-documentation-mcp-server/pyproject.toml
+++ b/src/aws-documentation-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-documentation-mcp-server"
-version = "1.1.17"
+version = "1.1.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-documentation-mcp-server/uv.lock
+++ b/src/aws-documentation-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-documentation-mcp-server"
-version = "1.1.17"
+version = "1.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-healthomics-mcp-server"""
 
-__version__ = '0.0.23'
+__version__ = '0.0.24'

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-healthomics-mcp-server"
-version = "0.0.23"
+version = "0.0.24"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-healthomics-mcp-server"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/__init__.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-iac-mcp-server"""
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'

--- a/src/aws-iac-mcp-server/pyproject.toml
+++ b/src/aws-iac-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-iac-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 description = "An Infrastructure as Code MCP server that provides CloudFormation template validation, compliance checking, and deployment troubleshooting capabilities."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-iac-mcp-server/uv.lock
+++ b/src/aws-iac-mcp-server/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-iac-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/__init__.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-iot-sitewise-mcp-server"""
 
-__version__ = '11.0.11'
+__version__ = '11.0.12'

--- a/src/aws-iot-sitewise-mcp-server/pyproject.toml
+++ b/src/aws-iot-sitewise-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-iot-sitewise-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "11.0.11"
+version = "11.0.12"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-iot-sitewise"
 readme = "README.md"

--- a/src/aws-iot-sitewise-mcp-server/uv.lock
+++ b/src/aws-iot-sitewise-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-iot-sitewise-mcp-server"
-version = "11.0.11"
+version = "11.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-location-mcp-server/pyproject.toml
+++ b/src/aws-location-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-location-mcp-server"
-version = "2.0.14"
+version = "2.0.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Location Service"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-location-mcp-server/uv.lock
+++ b/src/aws-location-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-location-mcp-server"
-version = "2.0.14"
+version = "2.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/__init__.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-msk-mcp-server"""
 
-__version__ = '0.0.14'
+__version__ = '0.0.15'

--- a/src/aws-msk-mcp-server/pyproject.toml
+++ b/src/aws-msk-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-msk-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.14"
+version = "0.0.15"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-msk"
 readme = "README.md"

--- a/src/aws-msk-mcp-server/uv.lock
+++ b/src/aws-msk-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-msk-mcp-server"
-version = "0.0.14"
+version = "0.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-network-mcp-server"""
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'

--- a/src/aws-network-mcp-server/pyproject.toml
+++ b/src/aws-network-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-network-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.7"
+version = "0.0.8"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-network"
 readme = "README.md"

--- a/src/aws-network-mcp-server/uv.lock
+++ b/src/aws-network-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-network-mcp-server"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/__init__.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-pricing-mcp-server"""
 
-__version__ = '1.0.24'
+__version__ = '1.0.25'

--- a/src/aws-pricing-mcp-server/pyproject.toml
+++ b/src/aws-pricing-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-pricing-mcp-server"
-version = "1.0.24"
+version = "1.0.25"
 description = "An AWS Labs Model Context Protocol (MCP) server for official pricing of AWS services"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-pricing-mcp-server/uv.lock
+++ b/src/aws-pricing-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-pricing-mcp-server"
-version = "1.0.24"
+version = "1.0.25"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/__init__.py
+++ b/src/aws-serverless-mcp-server/awslabs/aws_serverless_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-serverless-mcp-server"""
 
-__version__ = '0.1.17'
+__version__ = '0.1.18'

--- a/src/aws-serverless-mcp-server/pyproject.toml
+++ b/src/aws-serverless-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-serverless-mcp-server"
-version = "0.1.17"
+version = "0.1.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Serverless"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-serverless-mcp-server/uv.lock
+++ b/src/aws-serverless-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-serverless-mcp-server"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/__init__.py
+++ b/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/__init__.py
@@ -26,4 +26,4 @@ logger.add(
 )
 
 # Export version
-__version__ = '0.1.17'
+__version__ = '0.1.18'

--- a/src/aws-support-mcp-server/pyproject.toml
+++ b/src/aws-support-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-support-mcp-server"
-version = "0.1.17"
+version = "0.1.18"
 description = "An Model Context Protocol (MCP) server for AWS SupportAPI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-support-mcp-server/uv.lock
+++ b/src/aws-support-mcp-server/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-support-mcp-server"
-version = "0.1.17"
+version = "0.1.18"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/__init__.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs Bedrock Knowledge Base Retrieval MCP Server"""
 
-__version__ = '1.0.16'
+__version__ = '1.0.17'

--- a/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
+++ b/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.bedrock-kb-retrieval-mcp-server"
-version = "1.0.16"
+version = "1.0.17"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Knowledge Base Retrieval"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/bedrock-kb-retrieval-mcp-server/uv.lock
+++ b/src/bedrock-kb-retrieval-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-bedrock-kb-retrieval-mcp-server"
-version = "1.0.16"
+version = "1.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/__init__.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/__init__.py
@@ -19,7 +19,7 @@ This Model Context Protocol (MCP) server provides tools for AWS cost optimizatio
 by wrapping boto3 SDK functions for AWS cost optimization services.
 """
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'
 
 # We don't import server here to avoid circular imports
 

--- a/src/billing-cost-management-mcp-server/pyproject.toml
+++ b/src/billing-cost-management-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.billing-cost-management-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.13"
+version = "0.0.14"
 
 description = "A Model Context Protocol (MCP) server that provides tools for AWS Billing and Cost Management by wrapping boto3 SDK functions."
 readme = "README.md"

--- a/src/billing-cost-management-mcp-server/uv.lock
+++ b/src/billing-cost-management-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-billing-cost-management-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.0.15'
+__version__ = '1.0.16'

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.0.15"
+version = "1.0.16"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/uv.lock
+++ b/src/ccapi-mcp-server/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ccapi-mcp-server"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cdk-mcp-server/awslabs/cdk_mcp_server/__init__.py
+++ b/src/cdk-mcp-server/awslabs/cdk_mcp_server/__init__.py
@@ -18,4 +18,4 @@ from awslabs.cdk_mcp_server.core.server import main, mcp
 
 __all__ = ['main', 'mcp']
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/cdk-mcp-server/pyproject.toml
+++ b/src/cdk-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cdk-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 description = "An AWS CDK MCP server that provides guidance on AWS Cloud Development Kit best practices, infrastructure as code patterns, and security compliance with CDK Nag. This server offers tools to validate infrastructure designs, explain CDK Nag rules, analyze suppressions, generate Bedrock Agent schemas, and discover Solutions Constructs patterns."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cdk-mcp-server/uv.lock
+++ b/src/cdk-mcp-server/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cdk-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "aws-lambda-powertools" },

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/__init__.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.cfn-mcp-server"""
 
-__version__ = '1.0.16'
+__version__ = '1.0.17'

--- a/src/cfn-mcp-server/pyproject.toml
+++ b/src/cfn-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cfn-mcp-server"
-version = "1.0.16"
+version = "1.0.17"
 description = "An AWS Labs Model Context Protocol (MCP) server for doing common cloudformation tasks and for managing your resources in your AWS account"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cfn-mcp-server/uv.lock
+++ b/src/cfn-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cfn-mcp-server"
-version = "1.0.16"
+version = "1.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudtrail-mcp-server/awslabs/cloudtrail_mcp_server/__init__.py
+++ b/src/cloudtrail-mcp-server/awslabs/cloudtrail_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.cloudtrail-mcp-server"""
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'
 MCP_SERVER_VERSION = __version__

--- a/src/cloudtrail-mcp-server/pyproject.toml
+++ b/src/cloudtrail-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.cloudtrail-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.10"
+version = "0.0.11"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudtrail"
 readme = "README.md"

--- a/src/cloudtrail-mcp-server/uv.lock
+++ b/src/cloudtrail-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudtrail-mcp-server"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Application Signals MCP Server."""
 
-__version__ = '0.1.26'
+__version__ = '0.1.27'

--- a/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-applicationsignals-mcp-server"
-version = "0.1.26"
+version = "0.1.27"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Application Signals"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-applicationsignals-mcp-server/uv.lock
+++ b/src/cloudwatch-applicationsignals-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-applicationsignals-mcp-server"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/__init__.py
+++ b/src/cloudwatch-appsignals-mcp-server/awslabs/cloudwatch_appsignals_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Application Signals MCP Server."""
 
-__version__ = '0.1.19'
+__version__ = '0.1.20'

--- a/src/cloudwatch-appsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-appsignals-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-appsignals-mcp-server"
-version = "0.1.19"
+version = "0.1.20"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Application Signals"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-appsignals-mcp-server/uv.lock
+++ b/src/cloudwatch-appsignals-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-appsignals-mcp-server"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.cloudwatch-mcp-server"""
 
-__version__ = '0.0.19'
+__version__ = '0.0.20'
 MCP_SERVER_VERSION = __version__

--- a/src/cloudwatch-mcp-server/pyproject.toml
+++ b/src/cloudwatch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-mcp-server"
-version = "0.0.19"
+version = "0.0.20"
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudwatch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-mcp-server/uv.lock
+++ b/src/cloudwatch-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-mcp-server"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/code-doc-gen-mcp-server/awslabs/code_doc_gen_mcp_server/__init__.py
+++ b/src/code-doc-gen-mcp-server/awslabs/code_doc_gen_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.code-doc-gen-mcp-server"""
 
-__version__ = '1.0.10'
+__version__ = '1.0.11'

--- a/src/code-doc-gen-mcp-server/pyproject.toml
+++ b/src/code-doc-gen-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.code-doc-gen-mcp-server"
-version = "1.0.10"
+version = "1.0.11"
 description = "An AWS Labs Model Context Protocol (MCP) server for code-doc-gen"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/code-doc-gen-mcp-server/uv.lock
+++ b/src/code-doc-gen-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-code-doc-gen-mcp-server"
-version = "1.0.10"
+version = "1.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },

--- a/src/core-mcp-server/awslabs/core_mcp_server/__init__.py
+++ b/src/core-mcp-server/awslabs/core_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """CORE MCP server package."""
 
-__version__ = '1.0.22'
+__version__ = '1.0.23'

--- a/src/core-mcp-server/pyproject.toml
+++ b/src/core-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.core-mcp-server"
-version = "1.0.22"
+version = "1.0.23"
 description = "An AWS Labs Model Context Protocol (MCP) server for aswlabs Core MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/core-mcp-server/uv.lock
+++ b/src/core-mcp-server/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-core-mcp-server"
-version = "1.0.22"
+version = "1.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-amazon-kendra-index-mcp-server" },

--- a/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/__init__.py
+++ b/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/__init__.py
@@ -17,4 +17,4 @@
 This module provides MCP tools for analyzing AWS costs and usage data through the AWS Cost Explorer API.
 """
 
-__version__ = '0.0.18'
+__version__ = '0.0.19'

--- a/src/cost-explorer-mcp-server/pyproject.toml
+++ b/src/cost-explorer-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cost-explorer-mcp-server"
-version = "0.0.18"
+version = "0.0.19"
 description = "MCP server for analyzing AWS costs and usage data through the AWS Cost Explorer API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cost-explorer-mcp-server/uv.lock
+++ b/src/cost-explorer-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cost-explorer-mcp-server"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
+++ b/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Document Loader MCP Server package"""
 
-__version__ = '1.0.9'
+__version__ = '1.0.10'

--- a/src/document-loader-mcp-server/pyproject.toml
+++ b/src/document-loader-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.document-loader-mcp-server"
-version = "1.0.9"
+version = "1.0.10"
 description = "An AWS Labs Model Context Protocol (MCP) server for document parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/document-loader-mcp-server/uv.lock
+++ b/src/document-loader-mcp-server/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-document-loader-mcp-server"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/documentdb-mcp-server/awslabs/documentdb_mcp_server/__init__.py
+++ b/src/documentdb-mcp-server/awslabs/documentdb_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Labs DocumentDB MCP Server package."""
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'

--- a/src/documentdb-mcp-server/pyproject.toml
+++ b/src/documentdb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.documentdb-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 description = "An AWS Labs Model Context Protocol (MCP) server for documentdb"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/documentdb-mcp-server/uv.lock
+++ b/src/documentdb-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-documentdb-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.dynamodb-mcp-server"""
 
-__version__ = '2.0.13'
+__version__ = '2.0.14'

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.dynamodb-mcp-server"
-version = "2.0.13"
+version = "2.0.14"
 description = "The official MCP Server for interacting with AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-dynamodb-mcp-server"
-version = "2.0.13"
+version = "2.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-aws-api-mcp-server" },

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/__init__.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 # This file makes the ecs_mcp_server directory a Python package
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"

--- a/src/ecs-mcp-server/pyproject.toml
+++ b/src/ecs-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "awslabs.ecs-mcp-server"
-version = "0.1.25"
+version = "0.1.26"
 description = "AWS ECS MCP Server for automating containerization and deployment of web applications to AWS ECS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ecs-mcp-server/uv.lock
+++ b/src/ecs-mcp-server/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ecs-mcp-server"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/__init__.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.eks-mcp-server"""
 
-__version__ = '0.1.22'
+__version__ = '0.1.23'

--- a/src/eks-mcp-server/pyproject.toml
+++ b/src/eks-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.eks-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 description = "An AWS Labs Model Context Protocol (MCP) server for EKS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/eks-mcp-server/uv.lock
+++ b/src/eks-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-eks-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/__init__.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.elasticache-mcp-server"""
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'

--- a/src/elasticache-mcp-server/pyproject.toml
+++ b/src/elasticache-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.elasticache-mcp-server"
-version = "0.1.14"
+version = "0.1.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon ElastiCache"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/elasticache-mcp-server/uv.lock
+++ b/src/elasticache-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-elasticache-mcp-server"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/finch-mcp-server/awslabs/finch_mcp_server/__init__.py
+++ b/src/finch-mcp-server/awslabs/finch_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.finch-mcp-server"""
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'

--- a/src/finch-mcp-server/pyproject.toml
+++ b/src/finch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.finch-mcp-server"
-version = "0.1.14"
+version = "0.1.15"
 description = "A Model Context Protocol server for Finch to build and push container images"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/finch-mcp-server/uv.lock
+++ b/src/finch-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-finch-mcp-server"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend-mcp-server/awslabs/frontend_mcp_server/__init__.py
+++ b/src/frontend-mcp-server/awslabs/frontend_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.frontend-mcp-server"""
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'

--- a/src/frontend-mcp-server/pyproject.toml
+++ b/src/frontend-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.frontend-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 description = "An AWS Labs Model Context Protocol (MCP) server for frontend"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/frontend-mcp-server/uv.lock
+++ b/src/frontend-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-frontend-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },

--- a/src/git-repo-research-mcp-server/awslabs/git_repo_research_mcp_server/__init__.py
+++ b/src/git-repo-research-mcp-server/awslabs/git_repo_research_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.git-repo-research-mcp-server"""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/git-repo-research-mcp-server/pyproject.toml
+++ b/src/git-repo-research-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.git-repo-research-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for researching git repositories"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/git-repo-research-mcp-server/uv.lock
+++ b/src/git-repo-research-mcp-server/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-git-repo-research-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },

--- a/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/__init__.py
+++ b/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS HealthLake MCP Server."""
 
-__version__ = '0.0.9'
+__version__ = '0.0.10'

--- a/src/healthlake-mcp-server/pyproject.toml
+++ b/src/healthlake-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.healthlake-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.9"
+version = "0.0.10"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for healthlake"
 readme = "README.md"

--- a/src/healthlake-mcp-server/uv.lock
+++ b/src/healthlake-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-healthlake-mcp-server"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/iam-mcp-server/awslabs/iam_mcp_server/__init__.py
+++ b/src/iam-mcp-server/awslabs/iam_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS IAM MCP Server package."""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/iam-mcp-server/pyproject.toml
+++ b/src/iam-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.iam-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS IAM resources including users, roles, policies, and permissions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/iam-mcp-server/uv.lock
+++ b/src/iam-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-iam-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/__init__.py
+++ b/src/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.lambda-tool-mcp-server"""
 
-__version__ = '2.0.15'
+__version__ = '2.0.16'

--- a/src/lambda-tool-mcp-server/pyproject.toml
+++ b/src/lambda-tool-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.lambda-tool-mcp-server"
-version = "2.0.15"
+version = "2.0.16"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Lambda Tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lambda-tool-mcp-server/uv.lock
+++ b/src/lambda-tool-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-lambda-tool-mcp-server"
-version = "2.0.15"
+version = "2.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/memcached-mcp-server/awslabs/memcached_mcp_server/__init__.py
+++ b/src/memcached-mcp-server/awslabs/memcached_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.memcached-mcp-server"""
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/memcached-mcp-server/pyproject.toml
+++ b/src/memcached-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.memcached-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon ElastiCache Memcached"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/memcached-mcp-server/uv.lock
+++ b/src/memcached-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-memcached-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.mysql_mcp_server"""
 
-__version__ = '1.0.15'
+__version__ = '1.0.16'

--- a/src/mysql-mcp-server/pyproject.toml
+++ b/src/mysql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.mysql-mcp-server"
-version = "1.0.15"
+version = "1.0.16"
 description = "An AWS Labs Model Context Protocol (MCP) server for mysql"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mysql-mcp-server/uv.lock
+++ b/src/mysql-mcp-server/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-mysql-mcp-server"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "asyncmy" },

--- a/src/nova-canvas-mcp-server/awslabs/nova_canvas_mcp_server/__init__.py
+++ b/src/nova-canvas-mcp-server/awslabs/nova_canvas_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.nova-canvas-mcp-server"""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/nova-canvas-mcp-server/pyproject.toml
+++ b/src/nova-canvas-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.nova-canvas-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon Nova Canvas"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/nova-canvas-mcp-server/uv.lock
+++ b/src/nova-canvas-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-nova-canvas-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
@@ -15,7 +15,7 @@
 OpenAPI MCP Server - A server that dynamically creates MCP tools and resources from OpenAPI specifications.
 """
 
-__version__ = '0.2.13'
+__version__ = '0.2.14'
 
 
 import inspect

--- a/src/openapi-mcp-server/pyproject.toml
+++ b/src/openapi-mcp-server/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "awslabs.openapi-mcp-server"
-version = "0.2.13"
+version = "0.2.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for OpenAPI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/openapi-mcp-server/uv.lock
+++ b/src/openapi-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-openapi-mcp-server"
-version = "0.2.13"
+version = "0.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
@@ -19,6 +19,6 @@ from importlib.metadata import version
 try:
     __version__ = version('awslabs.postgres-mcp-server')
 except Exception:
-    __version__ = '1.0.17'
+    __version__ = '1.0.18'
 
 __user_agent__ = f'awslabs/mcp/postgres_mcp_server/{__version__}'

--- a/src/postgres-mcp-server/pyproject.toml
+++ b/src/postgres-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.postgres-mcp-server"
-version = "1.0.17"
+version = "1.0.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for postgres"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/postgres-mcp-server/uv.lock
+++ b/src/postgres-mcp-server/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-postgres-mcp-server"
-version = "1.0.17"
+version = "1.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },

--- a/src/prometheus-mcp-server/awslabs/prometheus_mcp_server/__init__.py
+++ b/src/prometheus-mcp-server/awslabs/prometheus_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs Prometheus MCP Server."""
 
-__version__ = '0.2.12'
+__version__ = '0.2.13'

--- a/src/prometheus-mcp-server/pyproject.toml
+++ b/src/prometheus-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.prometheus-mcp-server"
-version = "0.2.12"
+version = "0.2.13"
 description = "MCP server for interacting with AWS Managed Prometheus"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prometheus-mcp-server/uv.lock
+++ b/src/prometheus-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-prometheus-mcp-server"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/__init__.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.redshift-mcp-server"""
 
-__version__ = '0.0.17'
+__version__ = '0.0.18'

--- a/src/redshift-mcp-server/pyproject.toml
+++ b/src/redshift-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.redshift-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.17"
+version = "0.0.18"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for Redshift"
 readme = "README.md"

--- a/src/redshift-mcp-server/uv.lock
+++ b/src/redshift-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-redshift-mcp-server"
-version = "0.0.17"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/s3-tables-mcp-server/awslabs/s3_tables_mcp_server/__init__.py
+++ b/src/s3-tables-mcp-server/awslabs/s3_tables_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
 
-__version__ = '0.0.19'
+__version__ = '0.0.20'

--- a/src/s3-tables-mcp-server/pyproject.toml
+++ b/src/s3-tables-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.s3-tables-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.19"
+version = "0.0.20"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for awslabs.s3-tables-mcp-server"
 readme = "README.md"

--- a/src/s3-tables-mcp-server/uv.lock
+++ b/src/s3-tables-mcp-server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-s3-tables-mcp-server"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/sagemaker-ai-mcp-server/awslabs/sagemaker_ai_mcp_server/__init__.py
+++ b/src/sagemaker-ai-mcp-server/awslabs/sagemaker_ai_mcp_server/__init__.py
@@ -17,4 +17,4 @@
 
 """awslabs.sagemaker-ai-mcp-server"""
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'

--- a/src/sagemaker-ai-mcp-server/pyproject.toml
+++ b/src/sagemaker-ai-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.sagemaker-ai-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.0.6"
+version = "1.0.7"
 
 description = "MCP server for AWS SageMaker AI"
 readme = "README.md"

--- a/src/sagemaker-ai-mcp-server/uv.lock
+++ b/src/sagemaker-ai-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-sagemaker-ai-mcp-server"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/__init__.py
+++ b/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.stepfunctions-tool-mcp-server"""
 
-__version__ = '0.1.19'
+__version__ = '0.1.20'

--- a/src/stepfunctions-tool-mcp-server/pyproject.toml
+++ b/src/stepfunctions-tool-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.stepfunctions-tool-mcp-server"
-version = "0.1.19"  # When updating this version, also update __version__ in awslabs/stepfunctions_tool_mcp_server/server.py
+version = "0.1.20"  # When updating this version, also update __version__ in awslabs/stepfunctions_tool_mcp_server/server.py
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Step Functions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/stepfunctions-tool-mcp-server/uv.lock
+++ b/src/stepfunctions-tool-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-stepfunctions-tool-mcp-server"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
+++ b/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """SyntheticData MCP Server package."""
 
-__version__ = '1.0.12'
+__version__ = '1.0.13'

--- a/src/syntheticdata-mcp-server/pyproject.toml
+++ b/src/syntheticdata-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.syntheticdata-mcp-server"
-version = "1.0.12"
+version = "1.0.13"
 description = "An AWS Labs Model Context Protocol (MCP) server for syntheticdata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/syntheticdata-mcp-server/uv.lock
+++ b/src/syntheticdata-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-syntheticdata-mcp-server"
-version = "1.0.12"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/__init__.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.terraform-mcp-server"""
 
-__version__ = '1.0.15'
+__version__ = '1.0.16'

--- a/src/terraform-mcp-server/pyproject.toml
+++ b/src/terraform-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.terraform-mcp-server"
-version = "1.0.15"
+version = "1.0.16"
 description = "An AWS Labs Model Context Protocol (MCP) server for terraform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/terraform-mcp-server/uv.lock
+++ b/src/terraform-mcp-server/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-terraform-mcp-server"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "asteval" },

--- a/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/__init__.py
+++ b/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 
 """awslabs.timestream-for-influxdb-mcp-server"""
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'

--- a/src/timestream-for-influxdb-mcp-server/pyproject.toml
+++ b/src/timestream-for-influxdb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.timestream-for-influxdb-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for Timestream for InfluxDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/timestream-for-influxdb-mcp-server/uv.lock
+++ b/src/timestream-for-influxdb-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-timestream-for-influxdb-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/valkey-mcp-server/awslabs/valkey_mcp_server/__init__.py
+++ b/src/valkey-mcp-server/awslabs/valkey_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """Valkey MCP server package."""
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/valkey-mcp-server/pyproject.toml
+++ b/src/valkey-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.valkey-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for valkey"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/valkey-mcp-server/uv.lock
+++ b/src/valkey-mcp-server/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-valkey-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "dotenv" },

--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/__init__.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs AWS Well-Architected Security Assessment Tool MCP Server."""
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/src/well-architected-security-mcp-server/pyproject.toml
+++ b/src/well-architected-security-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.well-architected-security-mcp-server"
-version = "0.1.6"
+version = "0.1.7"
 description = "AWS Well-Architected Security Assessment Tool MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/well-architected-security-mcp-server/uv.lock
+++ b/src/well-architected-security-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-well-architected-security-mcp-server"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# release/2026.02.20260205000550

Triggered Release Branch (initiated) by @okhomin for @okhomin

## Changes
* amazon-bedrock-agentcore-mcp-server
* amazon-kendra-index-mcp-server
* amazon-keyspaces-mcp-server
* amazon-mq-mcp-server
* amazon-neptune-mcp-server
* amazon-qbusiness-anonymous-mcp-server
* amazon-qindex-mcp-server
* amazon-sns-sqs-mcp-server
* aurora-dsql-mcp-server
* aws-api-mcp-server
* aws-appsync-mcp-server
* aws-bedrock-custom-model-import-mcp-server
* aws-bedrock-data-automation-mcp-server
* aws-dataprocessing-mcp-server
* aws-diagram-mcp-server
* aws-documentation-mcp-server
* aws-healthomics-mcp-server
* aws-iac-mcp-server
* aws-iot-sitewise-mcp-server
* aws-location-mcp-server
* aws-msk-mcp-server
* aws-network-mcp-server
* aws-pricing-mcp-server
* aws-serverless-mcp-server
* aws-support-mcp-server
* bedrock-kb-retrieval-mcp-server
* billing-cost-management-mcp-server
* ccapi-mcp-server
* cdk-mcp-server
* cfn-mcp-server
* cloudtrail-mcp-server
* cloudwatch-applicationsignals-mcp-server
* cloudwatch-appsignals-mcp-server
* cloudwatch-mcp-server
* code-doc-gen-mcp-server
* core-mcp-server
* cost-explorer-mcp-server
* document-loader-mcp-server
* documentdb-mcp-server
* dynamodb-mcp-server
* ecs-mcp-server
* eks-mcp-server
* elasticache-mcp-server
* finch-mcp-server
* frontend-mcp-server
* git-repo-research-mcp-server
* healthlake-mcp-server
* iam-mcp-server
* lambda-tool-mcp-server
* memcached-mcp-server
* mysql-mcp-server
* nova-canvas-mcp-server
* openapi-mcp-server
* postgres-mcp-server
* prometheus-mcp-server
* redshift-mcp-server
* s3-tables-mcp-server
* sagemaker-ai-mcp-server
* stepfunctions-tool-mcp-server
* syntheticdata-mcp-server
* terraform-mcp-server
* timestream-for-influxdb-mcp-server
* valkey-mcp-server
* well-architected-security-mcp-server

## Checklist
- [ ] Code changes have been reviewed
- [ ] Distribution packages have been built and tested
- [ ] Documentation has been updated if applicable

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).