### PR TITLE
docs(dsql): Update AI steering links to new mono-repos

### DIFF
--- a/src/aurora-dsql-mcp-server/kiro_power/steering/development-guide.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/development-guide.md
@@ -261,7 +261,7 @@ Low-level libraries that directly connect to the database:
 | **JavaScript** | DSQL Connector for Postgres.js | [Postgres.js samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/javascript/postgres-js) |
 | **Python** | Psycopg | [Python Psycopg samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/psycopg) |
 | **Python** | DSQL Connector for Psycopg2 | [Python Psycopg2 samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/psycopg2 ) |
-| **Python** | DSQL Connector for Asyncpg | [Python Asyncpg samples](https://github.com/awslabs/aurora-dsql-python-connector/tree/main/examples/asyncpg)|
+| **Python** | DSQL Connector for Asyncpg | [Python Asyncpg samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/asyncpg)|
 | **Ruby** | pg | [Ruby pg samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/ruby/ruby-pg) |
 | **Rust** | SQLx | [Rust SQLx samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/rust/sqlx) |
 
@@ -271,8 +271,8 @@ Standalone libraries that provide object-relational mapping functionality:
 
 | Programming Language | ORM Library | Sample Repository |
 |---------------------|-------------|-------------------|
-| **Java** | Hibernate | [Hibernate Pet Clinic App](https://github.com/awslabs/aurora-dsql-hibernate/tree/main/examples/pet-clinic-app) |
-| **Python** | SQLAlchemy | [SQLAlchemy Pet Clinic App](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/examples/pet-clinic-app) |
+| **Java** | Hibernate | [Hibernate Pet Clinic App](https://github.com/awslabs/aurora-dsql-orms/tree/main/java/hibernate/examples/pet-clinic-app) |
+| **Python** | SQLAlchemy | [SQLAlchemy Pet Clinic App](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/examples/pet-clinic-app) |
 | **TypeScript** | Sequelize | [TypeScript Sequelize samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/typescript/sequelize) |
 | **TypeScript** | TypeORM | [TypeScript TypeORM samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/typescript/type-orm) |
 
@@ -282,9 +282,9 @@ Specific extensions that make existing ORMs work with Aurora DSQL:
 
 | Programming Language | ORM/Framework | Repository |
 |---------------------|---------------|------------|
-| **Java** | Hibernate | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-hibernate/) |
-| **Python** | Django | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-django/) |
-| **Python** | SQLAlchemy | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-sqlalchemy/) |
+| **Java** | Hibernate | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/java/hibernate/) |
+| **Python** | Django | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/django/) |
+| **Python** | SQLAlchemy | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/) |
 
 
 ---

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/language.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/language.md
@@ -62,8 +62,8 @@ PREFER using the [DSQL Python Connector](https://docs.aws.amazon.com/aurora-dsql
 
 **SQLAlchemy**
 - Supports `psycopg` and `psycopg2`
-- See [aurora-dsql-samples/python/sqlalchemy](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/sqlalchemy)
-- Dialect Source: [aurora-dsql-sqlalchemy](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/)
+- See [aurora-dsql-orms/python/sqlalchemy](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/)
+- Dialect Source: [aurora-dsql-sqlalchemy](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/)
 
 **JupyterLab**
 - Still SHOULD PREFER using the python connector.

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/development-guide.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/development-guide.md
@@ -261,7 +261,7 @@ Low-level libraries that directly connect to the database:
 | **JavaScript** | DSQL Connector for Postgres.js | [Postgres.js samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/javascript/postgres-js) |
 | **Python** | Psycopg | [Python Psycopg samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/psycopg) |
 | **Python** | DSQL Connector for Psycopg2 | [Python Psycopg2 samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/psycopg2 ) |
-| **Python** | DSQL Connector for Asyncpg | [Python Asyncpg samples](https://github.com/awslabs/aurora-dsql-python-connector/tree/main/examples/asyncpg)|
+| **Python** | DSQL Connector for Asyncpg | [Python Asyncpg samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/asyncpg)|
 | **Ruby** | pg | [Ruby pg samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/ruby/ruby-pg) |
 | **Rust** | SQLx | [Rust SQLx samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/rust/sqlx) |
 
@@ -271,8 +271,8 @@ Standalone libraries that provide object-relational mapping functionality:
 
 | Programming Language | ORM Library | Sample Repository |
 |---------------------|-------------|-------------------|
-| **Java** | Hibernate | [Hibernate Pet Clinic App](https://github.com/awslabs/aurora-dsql-hibernate/tree/main/examples/pet-clinic-app) |
-| **Python** | SQLAlchemy | [SQLAlchemy Pet Clinic App](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/examples/pet-clinic-app) |
+| **Java** | Hibernate | [Hibernate Pet Clinic App](https://github.com/awslabs/aurora-dsql-orms/tree/main/java/hibernate/examples/pet-clinic-app) |
+| **Python** | SQLAlchemy | [SQLAlchemy Pet Clinic App](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/examples/pet-clinic-app) |
 | **TypeScript** | Sequelize | [TypeScript Sequelize samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/typescript/sequelize) |
 | **TypeScript** | TypeORM | [TypeScript TypeORM samples](https://github.com/aws-samples/aurora-dsql-samples/tree/main/typescript/type-orm) |
 
@@ -282,9 +282,9 @@ Specific extensions that make existing ORMs work with Aurora DSQL:
 
 | Programming Language | ORM/Framework | Repository |
 |---------------------|---------------|------------|
-| **Java** | Hibernate | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-hibernate/) |
-| **Python** | Django | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-django/) |
-| **Python** | SQLAlchemy | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-sqlalchemy/) |
+| **Java** | Hibernate | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/java/hibernate/) |
+| **Python** | Django | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/django/) |
+| **Python** | SQLAlchemy | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/) |
 
 
 ---

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/language.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/language.md
@@ -62,8 +62,8 @@ PREFER using the [DSQL Python Connector](https://docs.aws.amazon.com/aurora-dsql
 
 **SQLAlchemy**
 - Supports `psycopg` and `psycopg2`
-- See [aurora-dsql-samples/python/sqlalchemy](https://github.com/aws-samples/aurora-dsql-samples/tree/main/python/sqlalchemy)
-- Dialect Source: [aurora-dsql-sqlalchemy](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/)
+- See [aurora-dsql-orms/python/sqlalchemy](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/)
+- Dialect Source: [aurora-dsql-sqlalchemy](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/)
 
 **JupyterLab**
 - Still SHOULD PREFER using the python connector.


### PR DESCRIPTION
## Summary

Connector and ORM packages have been migrated from individual repos to consolidated mono-repos. This PR updates documentation links to point to the new locations.

### Link Mappings

| Old Repo | New Location |
|----------|--------------|
| `aurora-dsql-python-connector` | `aurora-dsql-connectors/python/connector/` |
| `aurora-dsql-hibernate` | `aurora-dsql-orms/java/hibernate/` |
| `aurora-dsql-sqlalchemy` | `aurora-dsql-orms/python/sqlalchemy/` |
| `aurora-dsql-django` | `aurora-dsql-orms/python/django/` |

### Files Changed

- `kiro_power/steering/development-guide.md` - 6 URL updates
- `kiro_power/steering/language.md` - 1 URL update
- `skills/dsql-skill/references/development-guide.md` - 6 URL updates
- `skills/dsql-skill/references/language.md` - 1 URL update

## Test plan

- [x] All new URLs verified accessible (HTTP 200)
- [x] No old deprecated repo URLs remain (except historical CHANGELOGs)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).