### PR TITLE
feat(dsql): Update to use cloudfront endpint

### DIFF
--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
@@ -67,7 +67,7 @@ read_only = False
 dsql_client: Any = None
 persistent_connection = None
 aws_profile = None
-knowledge_server = 'https://d38p8g9d7yc7ms.cloudfront.net/'
+knowledge_server = 'https://d38p8g9d7yc7ms.cloudfront.net'
 knowledge_timeout = 30.0
 
 mcp = FastMCP(


### PR DESCRIPTION
Fixes

## Summary

Updated the dsql knowledgebase to use cloudfront endpoint.

### Changes

- Update to use cloudfront endpoint for dsql knowledgebase

### User experience

- No change in user experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N - old endpoint is still enabled to allow time for client switchover

**RFC issue number**:

Checklist:

* [x] Migration process documented - new cloudfront is provided via CDK
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
