### PR TITLE
fix(aws_diagram_mcp_server): patch command injection vulnerability

### DIFF
--- a/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/scanner.py
+++ b/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/scanner.py
@@ -239,9 +239,9 @@ def check_dangerous_functions(code: str) -> List[Dict[str, Any]]:
         '__import__',
         'pickle.loads',
         'spawn(',
-         'getattr(',  
-        'setattr(', 
-        '__getattribute__', 
+        'getattr(',
+        'setattr(',
+        '__getattribute__',
         '__getattr__',
     ]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

The scanner's dangerous function detection was vulnerable to bypass
using getattr() and string concatenation. An attacker could execute
arbitrary system commands using patterns like:
  getattr(os, 'syst'+'em')('malicious_command')


The fix blocks the reported exploit while maintaining backward
compatibility with legitimate diagram generation code.
### Changes
Added the following changes to scanner.py
Added  detection for:
- getattr() - prevents dynamic attribute access bypass
- setattr() - prevents attribute manipulation attacks  
- __getattribute__ and __getattr__ - blocks dunder method bypasses
in the check_dangerous_functions

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [x ] Changes have been tested
* [x ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
