### PR TITLE
chore: Updating search endpoint in Docs MCP

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -41,7 +41,7 @@ from pydantic import Field
 from typing import List, Optional
 
 
-SEARCH_API_URL = 'https://proxy.search.docs.aws.amazon.com/search'
+SEARCH_API_URL = 'https://proxy.search.docs.aws.com/search'
 RECOMMENDATIONS_API_URL = 'https://contentrecs-api.docs.aws.amazon.com/v1/recommendations'
 SESSION_UUID = str(uuid.uuid4())
 

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -196,9 +196,7 @@ class TestSearchDocumentation:
                 called_url = args[0]  # args is a tuple, first element is request URL
 
                 assert '?session=' in called_url
-                assert called_url.startswith(
-                    'https://proxy.search.docs.aws.amazon.com/search?session='
-                )
+                assert called_url.startswith('https://proxy.search.docs.aws.com/search?session=')
 
                 request_body = kwargs['json']
                 assert not any(
@@ -250,9 +248,7 @@ class TestSearchDocumentation:
                 called_url = args[0]  # args is a tuple, first element is request URL
 
                 assert '?session=' in called_url
-                assert called_url.startswith(
-                    'https://proxy.search.docs.aws.amazon.com/search?session='
-                )
+                assert called_url.startswith('https://proxy.search.docs.aws.com/search?session=')
 
                 request_body = kwargs['json']
                 assert any(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
- Updating docs search endpoint

### Changes
- New docs search endpoint is being rolled out, need to update Docs MCP + tests accordingly

### User experience

- Experience is unchanged, endpoint behavior is the same

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
