### PR TITLE
feat(terraform-mcp-server): add -target support for plan, apply, and destroy

### DIFF
--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/models/models.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/models/models.py
@@ -25,6 +25,7 @@ class TerraformExecutionRequest(BaseModel):
         variables: Optional dictionary of Terraform variables to pass.
         aws_region: Optional AWS region to use.
         strip_ansi: Whether to strip ANSI color codes from command output.
+        targets: Optional list of resource addresses to target for plan/apply/destroy.
     """
 
     command: Literal['init', 'plan', 'validate', 'apply', 'destroy'] = Field(
@@ -34,6 +35,10 @@ class TerraformExecutionRequest(BaseModel):
     variables: Optional[Dict[str, str]] = Field(None, description='Terraform variables to pass')
     aws_region: Optional[str] = Field(None, description='AWS region to use')
     strip_ansi: bool = Field(True, description='Whether to strip ANSI color codes from output')
+    targets: Optional[List[str]] = Field(
+        default=None,
+        description='List of resource addresses to target. When specified, Terraform will only plan/apply changes for these resources. Example: ["aws_instance.web", "module.vpc"]',
+    )
 
 
 class SubmoduleInfo(BaseModel):
@@ -327,6 +332,7 @@ class TerragruntExecutionRequest(BaseModel):
         variables: Optional dictionary of Terraform variables to pass.
         aws_region: Optional AWS region to use.
         strip_ansi: Whether to strip ANSI color codes from command output.
+        targets: Optional list of resource addresses to target for plan/apply/destroy.
         include_dirs: Optional list of directories to include in a multi-module run.
         exclude_dirs: Optional list of directories to exclude from a multi-module run.
         run_all: Whether to run the command in all subdirectories with terragrunt.hcl files.
@@ -339,6 +345,10 @@ class TerragruntExecutionRequest(BaseModel):
     variables: Optional[Dict[str, str]] = Field(None, description='Terraform variables to pass')
     aws_region: Optional[str] = Field(None, description='AWS region to use')
     strip_ansi: bool = Field(True, description='Whether to strip ANSI color codes from output')
+    targets: Optional[List[str]] = Field(
+        default=None,
+        description='List of resource addresses to target. When specified, Terragrunt will only plan/apply changes for these resources. Example: ["aws_instance.web", "module.vpc"]',
+    )
     include_dirs: Optional[List[str]] = Field(
         None, description='Directories to include in a multi-module run'
     )

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/server.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/server.py
@@ -74,6 +74,10 @@ async def execute_terraform_command(
     variables: Optional[Dict[str, str]] = Field(None, description='Terraform variables to pass'),
     aws_region: Optional[str] = Field(None, description='AWS region to use'),
     strip_ansi: bool = Field(True, description='Whether to strip ANSI color codes from output'),
+    targets: Optional[List[str]] = Field(
+        None,
+        description='List of resource addresses to target (e.g. ["aws_instance.web", "module.vpc"]). Only applicable to plan, apply, and destroy commands.',
+    ),
 ) -> TerraformExecutionResult:
     """Execute Terraform workflow commands against an AWS account.
 
@@ -86,6 +90,7 @@ async def execute_terraform_command(
         variables: Terraform variables to pass
         aws_region: AWS region to use
         strip_ansi: Whether to strip ANSI color codes from output
+        targets: List of resource addresses to target
 
     Returns:
         A TerraformExecutionResult object containing command output and status
@@ -96,6 +101,7 @@ async def execute_terraform_command(
         variables=variables,
         aws_region=aws_region,
         strip_ansi=strip_ansi,
+        targets=targets,
     )
     return await execute_terraform_command_impl(request)
 
@@ -109,6 +115,10 @@ async def execute_terragrunt_command(
     variables: Optional[Dict[str, str]] = Field(None, description='Terraform variables to pass'),
     aws_region: Optional[str] = Field(None, description='AWS region to use'),
     strip_ansi: bool = Field(True, description='Whether to strip ANSI color codes from output'),
+    targets: Optional[List[str]] = Field(
+        None,
+        description='List of resource addresses to target (e.g. ["aws_instance.web", "module.vpc"]). Only applicable to plan, apply, destroy, and run-all commands.',
+    ),
     include_dirs: Optional[List[str]] = Field(
         None, description='Directories to include in a multi-module run'
     ),
@@ -133,6 +143,7 @@ async def execute_terragrunt_command(
         variables: Terraform variables to pass
         aws_region: AWS region to use
         strip_ansi: Whether to strip ANSI color codes from output
+        targets: List of resource addresses to target
         include_dirs: Directories to include in a multi-module run
         exclude_dirs: Directories to exclude from a multi-module run
         run_all: Run command on all modules in subdirectories
@@ -147,6 +158,7 @@ async def execute_terragrunt_command(
         variables=variables,
         aws_region=aws_region,
         strip_ansi=strip_ansi,
+        targets=targets,
         include_dirs=include_dirs,
         exclude_dirs=exclude_dirs,
         run_all=run_all,

--- a/src/terraform-mcp-server/tests/test_models.py
+++ b/src/terraform-mcp-server/tests/test_models.py
@@ -64,6 +64,22 @@ class TestTerraformExecutionRequest:
         assert request.variables is None
         assert request.aws_region is None
         assert request.strip_ansi is True
+        assert request.targets is None
+
+    def test_terraform_execution_request_with_targets(self, temp_terraform_dir):
+        """Test TerraformExecutionRequest with targets field."""
+        targets = ['aws_instance.web', 'module.vpc']
+        request = TerraformExecutionRequest(
+            command='plan',
+            working_directory=temp_terraform_dir,
+            variables=None,
+            aws_region=None,
+            strip_ansi=True,
+            targets=targets,
+        )
+
+        assert request.command == 'plan'
+        assert request.targets == targets
 
 
 class TestTerraformExecutionResult:

--- a/src/terraform-mcp-server/tests/test_server.py
+++ b/src/terraform-mcp-server/tests/test_server.py
@@ -104,6 +104,7 @@ class TestTools:
             variables={'foo': 'bar'},
             aws_region='us-west-2',
             strip_ansi=True,
+            targets=['aws_instance.web', 'module.vpc'],
         )
 
         # Verify the result
@@ -118,6 +119,7 @@ class TestTools:
         assert request.variables == {'foo': 'bar'}
         assert request.aws_region == 'us-west-2'
         assert request.strip_ansi is True
+        assert request.targets == ['aws_instance.web', 'module.vpc']
 
     def test_search_aws_provider_docs_registration(self):
         """Test that the search_aws_provider_docs tool is registered correctly."""
@@ -418,6 +420,7 @@ class TestTools:
             variables={'foo': 'bar'},
             aws_region='us-west-2',
             strip_ansi=True,
+            targets=['aws_instance.web'],
             include_dirs=['/path/to/module1'],
             exclude_dirs=['/path/to/excluded'],
             run_all=False,
@@ -436,6 +439,7 @@ class TestTools:
         assert request.variables == {'foo': 'bar'}
         assert request.aws_region == 'us-west-2'
         assert request.strip_ansi is True
+        assert request.targets == ['aws_instance.web']
         assert request.include_dirs == ['/path/to/module1']
         assert request.exclude_dirs == ['/path/to/excluded']
         assert request.run_all is False


### PR DESCRIPTION
## Summary

Adds `-target` flag support to Terraform and Terragrunt MCP tools, addressing #2013.

- Adds `targets: Optional[List[str]]` field to `TerraformExecutionRequest` and `TerragruntExecutionRequest` models
- Appends `-target=<resource>` flags to `plan`, `apply`, and `destroy` commands (and `run-all` for Terragrunt)
- Validates target values against dangerous patterns (command injection prevention)
- Exposes `targets` parameter on both `ExecuteTerraformCommand` and `ExecuteTerragruntCommand` MCP tools

When unset (`None`), behavior is unchanged — no `-target` flags are added.

## Motivation

On large infrastructure, full `terraform plan` output consumes enormous context window space. Restricting to specific resources via `-target` produces focused output, making MCP interactions more efficient.

## Files changed

- `models/models.py` — new `targets` field on both request models
- `impl/tools/execute_terraform_command.py` — security check + command building
- `impl/tools/execute_terragrunt_command.py` — security check + command building
- `server.py` — `targets` parameter on tool functions
- 5 test files — 7 new tests covering targets, init exclusion, and dangerous pattern detection

## Test plan

- [x] All 148 existing + new tests pass
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Targets appended correctly for plan/apply/destroy
- [x] Targets ignored for init/validate
- [x] Dangerous patterns in targets detected and rejected

Closes #2013