### PR TITLE
feat: lazy import optimization & init benchmark for aws-documentation-mcp-server

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -13,31 +13,10 @@
 # limitations under the License.
 """awslabs AWS Documentation MCP Server implementation."""
 
-import httpx
 import json
 import re
 import uuid
-
-# Import models
-from awslabs.aws_documentation_mcp_server.models import (
-    RecommendationResult,
-    SearchResponse,
-    SearchResult,
-)
-from awslabs.aws_documentation_mcp_server.server_utils import (
-    DEFAULT_USER_AGENT,
-    add_search_result_cache_item,
-    read_documentation_impl,
-)
-
-# Import utility functions
-from awslabs.aws_documentation_mcp_server.util import (
-    add_search_intent_to_search_request,
-    parse_recommendation_results,
-)
 from loguru import logger
-from mcp.server.fastmcp import Context, FastMCP
-from pydantic import Field
 from typing import List, Optional
 
 
@@ -56,53 +35,18 @@ SEARCH_TERM_DOMAIN_MODIFIERS = [
 ]
 
 
-mcp = FastMCP(
-    'awslabs.aws-documentation-mcp-server',
-    instructions="""
-    # AWS Documentation MCP Server
-
-    This server provides tools to access public AWS documentation, search for content, and get recommendations.
-
-    ## Best Practices
-
-    - For long documentation pages, make multiple calls to `read_documentation` with different `start_index` values for pagination
-    - For very long documents (>30,000 characters), stop reading if you've found the needed information
-    - When searching, use specific technical terms rather than general phrases
-    - Use `recommend` tool to discover related content that might not appear in search results
-    - For recent updates to a service, get an URL for any page in that service, then check the **New** section of the `recommend` tool output on that URL
-    - If multiple searches with similar terms yield insufficient results, pivot to using `recommend` to find related pages.
-    - Always cite the documentation URL when providing information to users
-
-    ## Tool Selection Guide
-
-    - Use `search_documentation` when: You need to find documentation about a specific AWS service or feature
-    - Use `read_documentation` when: You have a specific documentation URL and need its content
-    - Use `recommend` when: You want to find related content to a documentation page you're already viewing or need to find newly released information
-    - Use `recommend` as a fallback when: Multiple searches have not yielded the specific information needed
-    """,
-    dependencies=[
-        'pydantic',
-        'httpx',
-        'beautifulsoup4',
-    ],
-)
+from awslabs.aws_documentation_mcp_server.server_utils import _UninitializedServer
 
 
-@mcp.tool()
+# mcp instance - deferred to main()
+mcp = _UninitializedServer()
+
+
 async def read_documentation(
-    ctx: Context,
-    url: str = Field(description='URL of the AWS documentation page to read'),
-    max_length: int = Field(
-        default=5000,
-        description='Maximum number of characters to return.',
-        gt=0,
-        lt=1000000,
-    ),
-    start_index: int = Field(
-        default=0,
-        description='On return output starting at this character index, useful if a previous fetch was truncated and more content is required.',
-        ge=0,
-    ),
+    ctx,
+    url: str,
+    max_length: int = 5000,
+    start_index: int = 0,
 ) -> str:
     """Fetch and convert an AWS documentation page to markdown format.
 
@@ -145,6 +89,8 @@ async def read_documentation(
     Returns:
         Markdown content of the AWS documentation
     """
+    from awslabs.aws_documentation_mcp_server.server_utils import read_documentation_impl
+
     # Validate that URL is from docs.aws.amazon.com and ends with .html
     url_str = str(url)
 
@@ -162,29 +108,14 @@ async def read_documentation(
     return await read_documentation_impl(ctx, url_str, max_length, start_index, SESSION_UUID)
 
 
-@mcp.tool()
 async def search_documentation(
-    ctx: Context,
-    search_phrase: str = Field(description='Search phrase to use'),
-    search_intent: str = Field(
-        description='For the search_phrase parameter, describe the search intent of the user. CRITICAL: Do not include any PII or customer data, describe only the AWS-related intent for search.',
-        default='',
-    ),
-    limit: int = Field(
-        default=10,
-        description='Maximum number of results to return',
-        ge=1,
-        le=50,
-    ),
-    product_types: Optional[List[str]] = Field(
-        default=None,
-        description='Filter results by AWS product/service (e.g., ["Amazon Simple Storage Service"])',
-    ),
-    guide_types: Optional[List[str]] = Field(
-        default=None,
-        description='Filter results by guide type (e.g., ["User Guide", "API Reference", "Developer Guide"])',
-    ),
-) -> SearchResponse:
+    ctx,
+    search_phrase: str,
+    search_intent: str = '',
+    limit: int = 10,
+    product_types: Optional[List[str]] = None,
+    guide_types: Optional[List[str]] = None,
+) -> 'SearchResponse':
     """Search AWS documentation using the official AWS Documentation Search API.
 
     ## Usage
@@ -228,6 +159,14 @@ async def search_documentation(
     Returns:
         List of search results with URLs, titles, query ID, context snippets, and facets for filtering
     """
+    import httpx
+    from awslabs.aws_documentation_mcp_server.models import SearchResponse, SearchResult
+    from awslabs.aws_documentation_mcp_server.server_utils import (
+        add_search_result_cache_item,
+        get_default_user_agent,
+    )
+    from awslabs.aws_documentation_mcp_server.util import add_search_intent_to_search_request
+
     logger.debug(f'Searching AWS documentation for: {search_phrase}')
 
     request_body = {
@@ -266,7 +205,7 @@ async def search_documentation(
                 json=request_body,
                 headers={
                     'Content-Type': 'application/json',
-                    'User-Agent': DEFAULT_USER_AGENT,
+                    'User-Agent': get_default_user_agent(),
                     'X-MCP-Session-Id': SESSION_UUID,
                 },
                 timeout=30,
@@ -352,11 +291,10 @@ async def search_documentation(
     return final_search_response
 
 
-@mcp.tool()
 async def recommend(
-    ctx: Context,
-    url: str = Field(description='URL of the AWS documentation page to get recommendations for'),
-) -> List[RecommendationResult]:
+    ctx,
+    url: str,
+) -> 'List[RecommendationResult]':
     """Get content recommendations for an AWS documentation page.
 
     ## Usage
@@ -402,6 +340,11 @@ async def recommend(
     Returns:
         List of recommended pages with URLs, titles, and context
     """
+    import httpx
+    from awslabs.aws_documentation_mcp_server.models import RecommendationResult
+    from awslabs.aws_documentation_mcp_server.server_utils import get_default_user_agent
+    from awslabs.aws_documentation_mcp_server.util import parse_recommendation_results
+
     url_str = str(url)
     logger.debug(f'Getting recommendations for: {url_str}')
 
@@ -411,7 +354,7 @@ async def recommend(
         try:
             response = await client.get(
                 recommendation_url,
-                headers={'User-Agent': DEFAULT_USER_AGENT},
+                headers={'User-Agent': get_default_user_agent()},
                 timeout=30,
             )
         except httpx.HTTPError as e:
@@ -445,9 +388,110 @@ async def recommend(
     return results
 
 
+def _create_mcp():
+    """Create and configure the FastMCP instance with all tool registrations."""
+    from mcp.server.fastmcp import Context, FastMCP
+    from pydantic import Field
+    from awslabs.aws_documentation_mcp_server.models import RecommendationResult, SearchResponse
+
+    server = FastMCP(
+        'awslabs.aws-documentation-mcp-server',
+        instructions="""
+    # AWS Documentation MCP Server
+
+    This server provides tools to access public AWS documentation, search for content, and get recommendations.
+
+    ## Best Practices
+
+    - For long documentation pages, make multiple calls to `read_documentation` with different `start_index` values for pagination
+    - For very long documents (>30,000 characters), stop reading if you've found the needed information
+    - When searching, use specific technical terms rather than general phrases
+    - Use `recommend` tool to discover related content that might not appear in search results
+    - For recent updates to a service, get an URL for any page in that service, then check the **New** section of the `recommend` tool output on that URL
+    - If multiple searches with similar terms yield insufficient results, pivot to using `recommend` to find related pages.
+    - Always cite the documentation URL when providing information to users
+
+    ## Tool Selection Guide
+
+    - Use `search_documentation` when: You need to find documentation about a specific AWS service or feature
+    - Use `read_documentation` when: You have a specific documentation URL and need its content
+    - Use `recommend` when: You want to find related content to a documentation page you're already viewing or need to find newly released information
+    - Use `recommend` as a fallback when: Multiple searches have not yielded the specific information needed
+    """,
+        dependencies=[
+            'pydantic',
+            'httpx',
+            'beautifulsoup4',
+        ],
+    )
+
+    # Register tool functions with Field-annotated wrappers.
+    # Docstrings are inherited from the outer functions to avoid duplication.
+    @server.tool(name='read_documentation', description=read_documentation.__doc__ or '')
+    async def read_documentation_tool(
+        ctx: Context,
+        url: str = Field(description='URL of the AWS documentation page to read'),
+        max_length: int = Field(
+            default=5000,
+            description='Maximum number of characters to return.',
+            gt=0,
+            lt=1000000,
+        ),
+        start_index: int = Field(
+            default=0,
+            description='On return output starting at this character index, useful if a previous fetch was truncated and more content is required.',
+            ge=0,
+        ),
+    ) -> str:
+        return await read_documentation(ctx, url=url, max_length=max_length, start_index=start_index)
+
+    @server.tool(name='search_documentation', description=search_documentation.__doc__ or '')
+    async def search_documentation_tool(
+        ctx: Context,
+        search_phrase: str = Field(description='Search phrase to use'),
+        search_intent: str = Field(
+            description='For the search_phrase parameter, describe the search intent of the user. CRITICAL: Do not include any PII or customer data, describe only the AWS-related intent for search.',
+            default='',
+        ),
+        limit: int = Field(
+            default=10,
+            description='Maximum number of results to return',
+            ge=1,
+            le=50,
+        ),
+        product_types: Optional[List[str]] = Field(
+            default=None,
+            description='Filter results by AWS product/service (e.g., ["Amazon Simple Storage Service"])',
+        ),
+        guide_types: Optional[List[str]] = Field(
+            default=None,
+            description='Filter results by guide type (e.g., ["User Guide", "API Reference", "Developer Guide"])',
+        ),
+    ) -> SearchResponse:
+        return await search_documentation(
+            ctx,
+            search_phrase=search_phrase,
+            search_intent=search_intent,
+            limit=limit,
+            product_types=product_types,
+            guide_types=guide_types,
+        )
+
+    @server.tool(name='recommend', description=recommend.__doc__ or '')
+    async def recommend_tool(
+        ctx: Context,
+        url: str = Field(description='URL of the AWS documentation page to get recommendations for'),
+    ) -> List[RecommendationResult]:
+        return await recommend(ctx, url=url)
+
+    return server
+
+
 def main():
     """Run the MCP server with CLI argument support."""
+    global mcp
     logger.info('Starting AWS Documentation MCP Server')
+    mcp = _create_mcp()
     mcp.run()
 
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -13,71 +13,25 @@
 # limitations under the License.
 """awslabs AWS China Documentation MCP Server implementation."""
 
-import httpx
 import re
 import uuid
-from awslabs.aws_documentation_mcp_server.server_utils import (
-    DEFAULT_USER_AGENT,
-    read_documentation_impl,
-)
-
-# Import utility functions
-from awslabs.aws_documentation_mcp_server.util import (
-    extract_content_from_html,
-    format_documentation_result,
-    is_html_content,
-)
 from loguru import logger
-from mcp.server.fastmcp import Context, FastMCP
-from pydantic import AnyUrl, Field
-from typing import Union
 
 
 SESSION_UUID = str(uuid.uuid4())
 
-mcp = FastMCP(
-    'awslabs.aws-documentation-mcp-server',
-    instructions="""
-    # AWS China Documentation MCP Server
-
-    This server provides tools to access public AWS China documentation, and get service differences between AWS China and global regions.
-
-    ## Best Practices
-
-    - Always use `get_available_services` first to checkout available services and their documentation URLs
-    - If a service is available, checkout the documentation URL for that service to see the feature differences and other documentation URLs
-    - For long documentation pages, make multiple calls to `read_documentation` with different `start_index` values for pagination
-    - For very long documents (>30,000 characters), stop reading if you've found the needed information
-    - Always cite the documentation URL when providing information to users
-
-    ## Tool Selection Guide
-
-    - Use `get_available_services` when: You need to know what services are available in AWS China
-    - Use `read_documentation` when: You have a specific documentation URL and need its content
-    """,
-    dependencies=[
-        'pydantic',
-        'httpx',
-        'beautifulsoup4',
-    ],
-)
+from awslabs.aws_documentation_mcp_server.server_utils import _UninitializedServer
 
 
-@mcp.tool()
+# mcp instance - deferred to main()
+mcp = _UninitializedServer()
+
+
 async def read_documentation(
-    ctx: Context,
-    url: Union[AnyUrl, str] = Field(description='URL of the AWS China documentation page to read'),
-    max_length: int = Field(
-        default=5000,
-        description='Maximum number of characters to return.',
-        gt=0,
-        lt=1000000,
-    ),
-    start_index: int = Field(
-        default=0,
-        description='On return output starting at this character index, useful if a previous fetch was truncated and more content is required.',
-        ge=0,
-    ),
+    ctx,
+    url: str,
+    max_length: int = 5000,
+    start_index: int = 0,
 ) -> str:
     """Fetch and convert an AWS China documentation page to markdown format.
 
@@ -120,6 +74,8 @@ async def read_documentation(
     Returns:
         Markdown content of the AWS China documentation
     """
+    from awslabs.aws_documentation_mcp_server.server_utils import read_documentation_impl
+
     # Validate that URL is from docs.amazonaws.cn and ends with .html
     url_str = str(url)
     if not re.match(r'^https?://docs\.amazonaws\.cn/', url_str):
@@ -134,9 +90,8 @@ async def read_documentation(
     return await read_documentation_impl(ctx, url_str, max_length, start_index, SESSION_UUID)
 
 
-@mcp.tool()
 async def get_available_services(
-    ctx: Context,
+    ctx,
 ) -> str:
     """Fetch available services from AWS China documentation.
 
@@ -158,6 +113,14 @@ async def get_available_services(
     Returns:
         Markdown content of the AWS China documentation about available services
     """
+    import httpx
+    from awslabs.aws_documentation_mcp_server.server_utils import get_default_user_agent
+    from awslabs.aws_documentation_mcp_server.util import (
+        extract_content_from_html,
+        format_documentation_result,
+        is_html_content,
+    )
+
     url_str = 'https://docs.amazonaws.cn/en_us/aws/latest/userguide/services.html'
     url_with_session = f'{url_str}?session={SESSION_UUID}'
 
@@ -168,14 +131,14 @@ async def get_available_services(
             response = await client.get(
                 url_with_session,
                 follow_redirects=True,
-                headers={'User-Agent': DEFAULT_USER_AGENT},
+                headers={'User-Agent': get_default_user_agent()},
                 timeout=30,
             )
             # Fetch the Table of Contents in the Services page, which contains the list of supported services
             toc_response = await client.get(
                 toc_url_with_session,
                 follow_redirects=True,
-                headers={'User-Agent': DEFAULT_USER_AGENT, 'Content-Type': 'application/json'},
+                headers={'User-Agent': get_default_user_agent(), 'Content-Type': 'application/json'},
                 timeout=30,
             )
         except httpx.HTTPError as e:
@@ -239,11 +202,75 @@ async def get_available_services(
     return result + formatted_service_titles
 
 
+def _create_mcp():
+    """Create and configure the FastMCP instance with all tool registrations."""
+    from mcp.server.fastmcp import Context, FastMCP
+    from pydantic import AnyUrl, Field
+    from typing import Union
+
+    server = FastMCP(
+        'awslabs.aws-documentation-mcp-server',
+        instructions="""
+    # AWS China Documentation MCP Server
+
+    This server provides tools to access public AWS China documentation, and get service differences between AWS China and global regions.
+
+    ## Best Practices
+
+    - Always use `get_available_services` first to checkout available services and their documentation URLs
+    - If a service is available, checkout the documentation URL for that service to see the feature differences and other documentation URLs
+    - For long documentation pages, make multiple calls to `read_documentation` with different `start_index` values for pagination
+    - For very long documents (>30,000 characters), stop reading if you've found the needed information
+    - Always cite the documentation URL when providing information to users
+
+    ## Tool Selection Guide
+
+    - Use `get_available_services` when: You need to know what services are available in AWS China
+    - Use `read_documentation` when: You have a specific documentation URL and need its content
+    """,
+        dependencies=[
+            'pydantic',
+            'httpx',
+            'beautifulsoup4',
+        ],
+    )
+
+    # Register tool functions with Field-annotated wrappers.
+    # Docstrings are inherited from the outer functions to avoid duplication.
+    @server.tool(name='read_documentation', description=read_documentation.__doc__ or '')
+    async def read_documentation_tool(
+        ctx: Context,
+        url: Union[AnyUrl, str] = Field(description='URL of the AWS China documentation page to read'),
+        max_length: int = Field(
+            default=5000,
+            description='Maximum number of characters to return.',
+            gt=0,
+            lt=1000000,
+        ),
+        start_index: int = Field(
+            default=0,
+            description='On return output starting at this character index, useful if a previous fetch was truncated and more content is required.',
+            ge=0,
+        ),
+    ) -> str:
+        return await read_documentation(ctx, url=str(url), max_length=max_length, start_index=start_index)
+
+    @server.tool(name='get_available_services', description=get_available_services.__doc__ or '')
+    async def get_available_services_tool(
+        ctx: Context,
+    ) -> str:
+        return await get_available_services(ctx)
+
+    return server
+
+
 def main():
     """Run the MCP server with CLI argument support."""
+    global mcp
     # Log startup information
     logger.info('Starting AWS China Documentation MCP Server')
 
+    mcp = _create_mcp()
     mcp.run()
 
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -11,46 +11,69 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import httpx
+from __future__ import annotations
+
 import os
-from awslabs.aws_documentation_mcp_server.models import SearchResponse
-from awslabs.aws_documentation_mcp_server.util import (
-    extract_content_from_html,
-    format_documentation_result,
-    is_html_content,
-)
 from collections import deque
-from importlib.metadata import version
 from loguru import logger
-from mcp.server.fastmcp import Context
 from typing import Optional
 from urllib.parse import quote
 
 
-try:
-    __version__ = version('awslabs.aws-documentation-mcp-server')
-except Exception:
-    from . import __version__
+class _UninitializedServer:
+    """Sentinel that gives a clear error if someone accesses mcp before main()."""
+
+    def __getattr__(self, name: str):
+        raise RuntimeError(
+            'MCP server not initialized. Call main() before accessing the server instance.'
+        )
 
 
-# Allow User-Agent override via environment variable
-BASE_USER_AGENT = os.getenv(
-    'MCP_USER_AGENT',
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36',
-)
-DEFAULT_USER_AGENT = (
-    f'{BASE_USER_AGENT} ModelContextProtocol/{__version__} (AWS Documentation Server)'
-)
+_default_user_agent: Optional[str] = None
+
+
+def _reset_user_agent_cache() -> None:
+    """Reset the cached user agent. Intended for test use only."""
+    global _default_user_agent
+    _default_user_agent = None
+
+
+def get_default_user_agent() -> str:
+    """Lazily compute and cache the default user agent string."""
+    global _default_user_agent
+    if _default_user_agent is None:
+        from importlib.metadata import version as get_version
+
+        try:
+            __version__ = get_version('awslabs.aws-documentation-mcp-server')
+        except Exception:
+            from . import __version__
+
+        base = os.getenv(
+            'MCP_USER_AGENT',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36',
+        )
+        _default_user_agent = (
+            f'{base} ModelContextProtocol/{__version__} (AWS Documentation Server)'
+        )
+    return _default_user_agent
 
 
 async def read_documentation_impl(
-    ctx: Context,
+    ctx: 'Context',
     url_str: str,
     max_length: int,
     start_index: int,
     session_uuid: str,
 ) -> str:
     """The implementation of the read_documentation tool."""
+    import httpx
+    from awslabs.aws_documentation_mcp_server.util import (
+        extract_content_from_html,
+        format_documentation_result,
+        is_html_content,
+    )
+
     logger.debug(f'Fetching documentation from {url_str}')
 
     url_with_session = f'{url_str}?session={session_uuid}'
@@ -66,7 +89,7 @@ async def read_documentation_impl(
                 url_with_session,
                 follow_redirects=True,
                 headers={
-                    'User-Agent': DEFAULT_USER_AGENT,
+                    'User-Agent': get_default_user_agent(),
                     'X-MCP-Session-Id': session_uuid,
                 },
                 timeout=30,
@@ -105,7 +128,7 @@ async def read_documentation_impl(
 SEARCH_RESULT_CACHE = deque(maxlen=3)
 
 
-def add_search_result_cache_item(search_response: SearchResponse) -> None:
+def add_search_result_cache_item(search_response: 'SearchResponse') -> None:
     """Adds list of SearchResult items to cache.
 
     Add search results to the front of the cache, to ensure that

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Utility functions for AWS Documentation MCP Server."""
 
-import markdownify
-from awslabs.aws_documentation_mcp_server.models import RecommendationResult
 from typing import Any, Dict, List
 from urllib.parse import quote_plus
 
@@ -32,7 +30,8 @@ def extract_content_from_html(html: str) -> str:
         return '<e>Empty HTML content</e>'
 
     try:
-        # First use BeautifulSoup to clean up the HTML
+        # Local imports — deferred for faster module-level load
+        import markdownify
         from bs4 import BeautifulSoup
 
         # Parse HTML with BeautifulSoup
@@ -192,7 +191,7 @@ def format_documentation_result(url: str, content: str, start_index: int, max_le
     return result
 
 
-def parse_recommendation_results(data: Dict[str, Any]) -> List[RecommendationResult]:
+def parse_recommendation_results(data: Dict[str, Any]) -> 'List[RecommendationResult]':
     """Parse recommendation API response into RecommendationResult objects.
 
     Args:
@@ -203,7 +202,7 @@ def parse_recommendation_results(data: Dict[str, Any]) -> List[RecommendationRes
     """
     results = []
 
-    # Process highly rated recommendations
+    from awslabs.aws_documentation_mcp_server.models import RecommendationResult
     if 'highlyRated' in data and 'items' in data['highlyRated']:
         for item in data['highlyRated']['items']:
             context = item.get('abstract') if 'abstract' in item else None

--- a/src/aws-documentation-mcp-server/pyproject.toml
+++ b/src/aws-documentation-mcp-server/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.11.1",
     "pytest-asyncio>=0.26.0",
+    "hypothesis>=6.151.6",
 ]
 
 [build-system]
@@ -118,6 +119,7 @@ packages = ["awslabs"]
 [tool.pytest.ini_options]
 markers = [
     "live: marks tests that make live API calls (deselect with '-m \"not live\"')",
+    "slow: marks tests that are slow or timing-sensitive (deselect with '-m \"not slow\"')",
     "asyncio: marks tests that use asyncio"
 ]
 asyncio_mode = "strict"

--- a/src/aws-documentation-mcp-server/scripts/benchmark_init.py
+++ b/src/aws-documentation-mcp-server/scripts/benchmark_init.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark script for measuring AWS Documentation MCP Server initialization time.
+
+Measures total server module import time, individual dependency import times,
+and phase-level times (FastMCP creation, UUID generation, version lookup)
+using isolated subprocesses for accurate cold-start measurements.
+
+Usage:
+    python3 scripts/benchmark_init.py --iterations 5 --format both
+"""
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+
+
+# Dependencies to benchmark individually
+DEPENDENCIES = ['mcp', 'pydantic', 'httpx', 'markdownify', 'loguru', 'bs4']
+
+# Subprocess timeout in seconds
+SUBPROCESS_TIMEOUT = 30
+
+# Threshold for flagging slow phases (milliseconds)
+DEFAULT_THRESHOLD_MS = 200.0
+
+
+# ---------------------------------------------------------------------------
+# Importable helper functions (used by property tests in Task 8.2)
+# ---------------------------------------------------------------------------
+
+
+def sort_bottleneck_report(phases: list[tuple[str, float]]) -> list[tuple[str, float]]:
+    """Sort phases by time descending (slowest first).
+
+    Args:
+        phases: List of (phase_name, time_ms) tuples.
+
+    Returns:
+        New list sorted by time_ms in descending order.
+    """
+    return sorted(phases, key=lambda x: x[1], reverse=True)
+
+
+def compute_median(values: list[float]) -> float:
+    """Compute the median of a list of values.
+
+    Args:
+        values: Non-empty list of numeric values.
+
+    Returns:
+        The median value, computed via statistics.median.
+
+    Raises:
+        statistics.StatisticsError: If values is empty.
+    """
+    return statistics.median(values)
+
+
+def identify_threshold_violations(
+    phases: list[tuple[str, float]], threshold_ms: float = DEFAULT_THRESHOLD_MS
+) -> list[str]:
+    """Identify phases that exceed the given threshold.
+
+    Args:
+        phases: List of (phase_name, time_ms) tuples.
+        threshold_ms: Threshold in milliseconds (default 200.0).
+
+    Returns:
+        List of violation description strings for phases exceeding the threshold.
+        Each string has the format: "<name>: <time>ms > <threshold>ms"
+    """
+    violations = []
+    for name, time_ms in phases:
+        if time_ms > threshold_ms:
+            violations.append(f'{name}: {time_ms:.0f}ms > {threshold_ms:.0f}ms')
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Subprocess measurement helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_timed_subprocess(code: str) -> float:
+    """Run a Python code snippet in a subprocess and return the printed time in ms.
+
+    The code snippet must print a single float representing elapsed seconds.
+
+    Returns:
+        Elapsed time in milliseconds, or -1.0 on failure.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, '-c', code],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT,
+        )
+        if result.returncode != 0:
+            print(f'  [error] subprocess failed: {result.stderr.strip()}', file=sys.stderr)
+            return -1.0
+        return float(result.stdout.strip()) * 1000.0  # convert seconds to ms
+    except subprocess.TimeoutExpired:
+        print('  [error] subprocess timed out', file=sys.stderr)
+        return -1.0
+    except (ValueError, IndexError) as e:
+        print(f'  [error] could not parse output: {e}', file=sys.stderr)
+        return -1.0
+
+
+def measure_server_init() -> float:
+    """Measure full server module import time in an isolated subprocess.
+
+    Returns:
+        Import time in milliseconds.
+    """
+    code = (
+        'import time; s=time.perf_counter(); '
+        'from awslabs.aws_documentation_mcp_server import server_aws; '
+        'print(time.perf_counter()-s)'
+    )
+    return _run_timed_subprocess(code)
+
+
+def measure_single_import(module_name: str) -> float:
+    """Measure import time for a single module in an isolated subprocess.
+
+    Args:
+        module_name: The module to import (e.g. 'mcp', 'pydantic').
+
+    Returns:
+        Import time in milliseconds.
+    """
+    code = (
+        f'import time; s=time.perf_counter(); '
+        f'import {module_name}; '
+        f'print(time.perf_counter()-s)'
+    )
+    return _run_timed_subprocess(code)
+
+
+def measure_phase(phase_name: str, code: str) -> float:
+    """Measure a specific initialization phase in an isolated subprocess.
+
+    Args:
+        phase_name: Human-readable name for the phase.
+        code: Python code snippet that prints elapsed seconds.
+
+    Returns:
+        Phase time in milliseconds.
+    """
+    return _run_timed_subprocess(code)
+
+
+# ---------------------------------------------------------------------------
+# Phase measurement code snippets
+# ---------------------------------------------------------------------------
+
+PHASE_SNIPPETS = {
+    'FastMCP creation': (
+        'import time; s=time.perf_counter(); '
+        'from mcp.server.fastmcp import FastMCP; '
+        'FastMCP("bench"); '
+        'print(time.perf_counter()-s)'
+    ),
+    'UUID generation': (
+        'import time; s=time.perf_counter(); '
+        'import uuid; str(uuid.uuid4()); '
+        'print(time.perf_counter()-s)'
+    ),
+    'version lookup': (
+        "import time; s=time.perf_counter(); "
+        "from importlib.metadata import version as _v; "
+        "_v('awslabs.aws-documentation-mcp-server'); "
+        "print(time.perf_counter()-s)"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+
+
+def run_benchmark(iterations: int) -> dict:
+    """Run the full benchmark suite.
+
+    Args:
+        iterations: Number of times to measure server init (for median).
+
+    Returns:
+        Structured benchmark results dict.
+    """
+    # 1. Measure server init across iterations
+    print(f'Measuring server init time ({iterations} iterations)...', file=sys.stderr)
+    init_times: list[float] = []
+    for i in range(iterations):
+        t = measure_server_init()
+        if t >= 0:
+            init_times.append(t)
+            print(f'  Iteration {i + 1}: {t:.1f}ms', file=sys.stderr)
+        else:
+            print(f'  Iteration {i + 1}: FAILED', file=sys.stderr)
+
+    median_init = compute_median(init_times) if init_times else -1.0
+
+    # 2. Measure individual dependency imports
+    print('\nMeasuring dependency import times...', file=sys.stderr)
+    dep_times: dict[str, float] = {}
+    for dep in DEPENDENCIES:
+        t = measure_single_import(dep)
+        dep_times[dep] = t
+        status = f'{t:.1f}ms' if t >= 0 else 'FAILED'
+        print(f'  {dep}: {status}', file=sys.stderr)
+
+    # 3. Measure phase-level times
+    print('\nMeasuring phase-level times...', file=sys.stderr)
+    phase_times: dict[str, float] = {}
+    for phase_name, code in PHASE_SNIPPETS.items():
+        t = measure_phase(phase_name, code)
+        phase_times[phase_name] = t
+        status = f'{t:.1f}ms' if t >= 0 else 'FAILED'
+        print(f'  {phase_name}: {status}', file=sys.stderr)
+
+    # 4. Build phases list (dependencies + phases combined)
+    all_phases: list[tuple[str, float]] = []
+    for name, t in dep_times.items():
+        if t >= 0:
+            all_phases.append((name, t))
+    for name, t in phase_times.items():
+        if t >= 0:
+            all_phases.append((name, t))
+
+    # 5. Sort bottleneck report (slowest first)
+    sorted_phases = sort_bottleneck_report(all_phases)
+
+    # 6. Identify threshold violations
+    violations = identify_threshold_violations(sorted_phases)
+
+    # Build result structure
+    results = {
+        'server_init_ms': {
+            'median': round(median_init, 1),
+            'times': [round(t, 1) for t in init_times],
+        },
+        'dependency_imports_ms': {
+            name: round(t, 1) for name, t in dep_times.items() if t >= 0
+        },
+        'phases': [
+            {'name': name, 'time_ms': round(t, 1)} for name, t in sorted_phases
+        ],
+        'threshold_violations': violations,
+    }
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def format_text_report(results: dict) -> str:
+    """Format benchmark results as human-readable text.
+
+    Args:
+        results: Benchmark results dict from run_benchmark().
+
+    Returns:
+        Formatted text report string.
+    """
+    lines = []
+    lines.append('=' * 60)
+    lines.append('AWS Documentation MCP Server — Init Benchmark')
+    lines.append('=' * 60)
+
+    # Server init summary
+    init = results['server_init_ms']
+    lines.append(f"\nServer Init (median): {init['median']:.1f}ms")
+    lines.append(f"  Iterations: {', '.join(f'{t:.1f}ms' for t in init['times'])}")
+
+    # Bottleneck report (sorted slowest-to-fastest)
+    lines.append('\nBottleneck Report (slowest → fastest):')
+    lines.append('-' * 40)
+    for phase in results['phases']:
+        bar = '█' * max(1, int(phase['time_ms'] / 20))
+        lines.append(f"  {phase['name']:>20s}: {phase['time_ms']:>8.1f}ms  {bar}")
+
+    # Threshold violations
+    violations = results['threshold_violations']
+    if violations:
+        lines.append(f'\n⚠ Threshold violations (>{DEFAULT_THRESHOLD_MS:.0f}ms):')
+        for v in violations:
+            lines.append(f'  • {v}')
+    else:
+        lines.append(f'\n✓ No phases exceed {DEFAULT_THRESHOLD_MS:.0f}ms threshold')
+
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def format_json_report(results: dict) -> str:
+    """Format benchmark results as JSON.
+
+    Args:
+        results: Benchmark results dict from run_benchmark().
+
+    Returns:
+        JSON string.
+    """
+    return json.dumps(results, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    """CLI entry point for the benchmark script."""
+    parser = argparse.ArgumentParser(
+        description='Benchmark AWS Documentation MCP Server initialization time'
+    )
+    parser.add_argument(
+        '--iterations',
+        type=int,
+        default=5,
+        help='Number of iterations for server init measurement (default: 5)',
+    )
+    parser.add_argument(
+        '--format',
+        choices=['text', 'json', 'both'],
+        default='both',
+        help='Output format (default: both)',
+    )
+    args = parser.parse_args()
+
+    if args.iterations < 1:
+        parser.error('--iterations must be at least 1')
+
+    results = run_benchmark(args.iterations)
+
+    # Output in requested format
+    if args.format in ('text', 'both'):
+        print('\n' + format_text_report(results))
+
+    if args.format in ('json', 'both'):
+        if args.format == 'both':
+            print('\n--- JSON Output ---')
+        print(format_json_report(results))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/aws-documentation-mcp-server/tests/conftest.py
+++ b/src/aws-documentation-mcp-server/tests/conftest.py
@@ -13,7 +13,17 @@
 # limitations under the License.
 """Configuration for pytest."""
 
+import os
+
 import pytest
+
+# Shared benchmark constants used across test files
+INIT_TIME_THRESHOLD_MS = float(os.environ.get('INIT_TIME_THRESHOLD_MS', '1500'))
+
+
+def check_threshold(median_ms: float, threshold_ms: float = INIT_TIME_THRESHOLD_MS) -> bool:
+    """Return True if median_ms is within the threshold, False otherwise."""
+    return median_ms <= threshold_ms
 
 
 def pytest_addoption(parser):
@@ -29,6 +39,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     """Configure pytest."""
     config.addinivalue_line('markers', 'live: mark test as making live API calls')
+    config.addinivalue_line('markers', 'slow: mark test as slow (spawns subprocesses, timing-sensitive)')
 
 
 def pytest_collection_modifyitems(config, items):

--- a/src/aws-documentation-mcp-server/tests/constants.py
+++ b/src/aws-documentation-mcp-server/tests/constants.py
@@ -1,6 +1,6 @@
-from awslabs.aws_documentation_mcp_server.server_utils import DEFAULT_USER_AGENT
+from awslabs.aws_documentation_mcp_server.server_utils import get_default_user_agent
 
 
-TEST_USER_AGENT = DEFAULT_USER_AGENT.replace(
+TEST_USER_AGENT = get_default_user_agent().replace(
     '(AWS Documentation Server)', '(AWS Documentation Tests)'
 )

--- a/src/aws-documentation-mcp-server/tests/test_aws_cn_get_available_services_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_cn_get_available_services_live.py
@@ -31,8 +31,8 @@ async def test_get_available_services_live():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws_cn.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the tool
         result = await get_available_services(ctx)
@@ -89,8 +89,8 @@ async def test_get_available_services_content_structure():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws_cn.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the tool
         result = await get_available_services(ctx)

--- a/src/aws-documentation-mcp-server/tests/test_aws_cn_read_documentation_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_cn_read_documentation_live.py
@@ -38,8 +38,8 @@ async def test_read_documentation_china_live():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws_cn.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the tool
         result = await read_documentation_china(ctx, url=url, max_length=5000, start_index=0)
@@ -89,8 +89,8 @@ async def test_read_documentation_china_pagination_live():
     small_max_length = 1000
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws_cn.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the tool for the first page
         first_page = await read_documentation_china(

--- a/src/aws-documentation-mcp-server/tests/test_aws_read_documentation_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_read_documentation_live.py
@@ -38,8 +38,8 @@ async def test_read_documentation_global_live():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the tool
         result = await read_documentation_global(ctx, url=url, max_length=5000, start_index=0)
@@ -89,8 +89,8 @@ async def test_read_documentation_global_pagination_live():
     small_max_length = 1000
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the tool for the first page
         first_page = await read_documentation_global(

--- a/src/aws-documentation-mcp-server/tests/test_aws_recommend_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_recommend_live.py
@@ -37,8 +37,8 @@ async def test_recommend_live():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the recommend function
         results = await recommend(ctx, url=url)

--- a/src/aws-documentation-mcp-server/tests/test_aws_search_live.py
+++ b/src/aws-documentation-mcp-server/tests/test_aws_search_live.py
@@ -37,8 +37,8 @@ async def test_search_documentation_live():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the search_documentation function
         response = await search_documentation(
@@ -78,8 +78,8 @@ async def test_search_documentation_empty_results():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Call the search_documentation function
         response = await search_documentation(
@@ -111,8 +111,8 @@ async def test_search_documentation_limit():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # Test with limit=3
         response_small = await search_documentation(
@@ -145,8 +145,8 @@ async def test_search_documentation_with_product_type():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # First search without filters
         first_response = await search_documentation(
@@ -191,8 +191,8 @@ async def test_search_documentation_with_guide_type():
     ctx = MockContext()
 
     with patch(
-        'awslabs.aws_documentation_mcp_server.server_aws.DEFAULT_USER_AGENT',
-        TEST_USER_AGENT,
+        'awslabs.aws_documentation_mcp_server.server_utils.get_default_user_agent',
+        return_value=TEST_USER_AGENT,
     ):
         # First search without filters
         first_response = await search_documentation(

--- a/src/aws-documentation-mcp-server/tests/test_benchmark_init.py
+++ b/src/aws-documentation-mcp-server/tests/test_benchmark_init.py
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test: server init must complete under a time threshold."""
+
+import statistics
+import subprocess
+import sys
+
+import pytest
+
+from tests.conftest import INIT_TIME_THRESHOLD_MS, check_threshold
+
+
+def _measure_init_time() -> float:
+    """Measure server init time in a subprocess, returns milliseconds."""
+    code = (
+        "import time; s=time.perf_counter(); "
+        "from awslabs.aws_documentation_mcp_server import server_aws; "
+        "print((time.perf_counter()-s)*1000)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
+    return float(result.stdout.strip())
+
+
+@pytest.mark.slow
+def test_server_init_time():
+    """Regression test: server init must be under threshold.
+
+    Validates: Requirements 5.1, 5.2, 5.3
+
+    Threshold can be overridden via INIT_TIME_THRESHOLD_MS env var.
+    Skip in fast test runs with: pytest -m "not slow"
+    """
+    times = [_measure_init_time() for _ in range(3)]
+    median_ms = statistics.median(times)
+    assert check_threshold(median_ms), (
+        f"Server init time {median_ms:.0f}ms exceeds {INIT_TIME_THRESHOLD_MS}ms threshold"
+    )

--- a/src/aws-documentation-mcp-server/tests/test_benchmark_pbt.py
+++ b/src/aws-documentation-mcp-server/tests/test_benchmark_pbt.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Property-based tests for benchmark report helper functions.
+
+Tests the pure functions in scripts/benchmark_init.py:
+- sort_bottleneck_report
+- compute_median
+- identify_threshold_violations
+
+**Feature: init-performance-benchmark**
+
+**Validates: Requirements 1.2, 1.4, 2.3, 5.3**
+"""
+
+import importlib.util
+import os
+import statistics
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+# Load benchmark_init from scripts/ without modifying sys.path
+_scripts_dir = os.path.join(os.path.dirname(__file__), '..', 'scripts')
+_spec = importlib.util.spec_from_file_location('benchmark_init', os.path.join(_scripts_dir, 'benchmark_init.py'))
+_benchmark_init = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_benchmark_init)
+
+compute_median = _benchmark_init.compute_median
+identify_threshold_violations = _benchmark_init.identify_threshold_violations
+sort_bottleneck_report = _benchmark_init.sort_bottleneck_report
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Phase names: short non-empty ASCII strings
+_phase_name = st.text(
+    alphabet=st.sampled_from('abcdefghijklmnopqrstuvwxyz_'),
+    min_size=1,
+    max_size=20,
+)
+
+# Timing values in the 0–2000ms range (floats)
+_time_ms = st.floats(min_value=0.0, max_value=2000.0, allow_nan=False, allow_infinity=False)
+
+# A list of (phase_name, time_ms) tuples
+_phase_list = st.lists(
+    st.tuples(_phase_name, _time_ms),
+    min_size=0,
+    max_size=50,
+)
+
+# Positive floats for median calculation
+_positive_float = st.floats(min_value=0.01, max_value=1e6, allow_nan=False, allow_infinity=False)
+
+_positive_float_list = st.lists(_positive_float, min_size=1, max_size=100)
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Bottleneck report is sorted slowest-to-fastest
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(phases=_phase_list)
+def test_bottleneck_report_sorted_descending(phases: list[tuple[str, float]]) -> None:
+    """Property 1: For any list of phase timings, the bottleneck report
+    output is sorted in descending order of elapsed time (slowest first).
+
+    **Validates: Requirements 1.2**
+    """
+    sorted_phases = sort_bottleneck_report(phases)
+    times = [t for _, t in sorted_phases]
+    for i in range(len(times) - 1):
+        assert times[i] >= times[i + 1], (
+            f"Report not sorted descending at index {i}: "
+            f"{times[i]} < {times[i + 1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 2: Median calculation correctness
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(values=_positive_float_list)
+def test_median_matches_statistics_median(values: list[float]) -> None:
+    """Property 2: For any non-empty list of positive timing measurements,
+    the reported median equals statistics.median of those measurements.
+
+    **Validates: Requirements 1.4, 5.3**
+    """
+    result = compute_median(values)
+    expected = statistics.median(values)
+    assert result == expected, (
+        f"compute_median returned {result}, expected {expected}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 3: Threshold violation identification
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(phases=_phase_list)
+def test_threshold_violations_match_filter(phases: list[tuple[str, float]]) -> None:
+    """Property 3: For any set of phase timings (0–2000ms), the violations
+    list contains exactly those phases whose elapsed time exceeds 200ms,
+    and no others.
+
+    **Validates: Requirements 2.3**
+    """
+    threshold = 200.0
+    violations = identify_threshold_violations(phases, threshold_ms=threshold)
+
+    # Compute expected violating phase names
+    expected_names = [name for name, t in phases if t > threshold]
+
+    # Extract names from violation strings (format: "<name>: <time>ms > <threshold>ms")
+    actual_names = [v.split(':')[0] for v in violations]
+
+    assert len(actual_names) == len(expected_names), (
+        f"Expected {len(expected_names)} violations, got {len(actual_names)}. "
+        f"Phases: {phases}"
+    )
+    assert actual_names == expected_names, (
+        f"Violation names mismatch.\n"
+        f"Expected: {expected_names}\n"
+        f"Actual:   {actual_names}"
+    )

--- a/src/aws-documentation-mcp-server/tests/test_benchmark_threshold_pbt.py
+++ b/src/aws-documentation-mcp-server/tests/test_benchmark_threshold_pbt.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Property-based tests for benchmark test threshold assertion logic.
+
+**Feature: init-performance-benchmark, Property 5: Benchmark test threshold assertion**
+
+*For any* median initialization time value above 1500 milliseconds, the benchmark
+test SHALL fail. *For any* median value at or below 1500 milliseconds, the benchmark
+test SHALL pass.
+
+**Validates: Requirements 5.2**
+"""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.conftest import INIT_TIME_THRESHOLD_MS, check_threshold
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Positive floats representing median init times in milliseconds
+_positive_ms = st.floats(min_value=0.01, max_value=1e6, allow_nan=False, allow_infinity=False)
+
+
+# ---------------------------------------------------------------------------
+# Property 5: Benchmark test threshold assertion
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(median_ms=_positive_ms)
+def test_threshold_assertion_property(median_ms: float) -> None:
+    """Property 5: For any positive median initialization time, check_threshold
+    returns True (pass) when median_ms <= 1500 and False (fail) when
+    median_ms > 1500.
+
+    **Validates: Requirements 5.2**
+    """
+    result = check_threshold(median_ms)
+    if median_ms > INIT_TIME_THRESHOLD_MS:
+        assert result is False, (
+            f"Expected check_threshold({median_ms}) to fail (return False) "
+            f"since {median_ms} > {INIT_TIME_THRESHOLD_MS}, but got True"
+        )
+    else:
+        assert result is True, (
+            f"Expected check_threshold({median_ms}) to pass (return True) "
+            f"since {median_ms} <= {INIT_TIME_THRESHOLD_MS}, but got False"
+        )

--- a/src/aws-documentation-mcp-server/tests/test_lazy_imports.py
+++ b/src/aws-documentation-mcp-server/tests/test_lazy_imports.py
@@ -1,0 +1,148 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests verifying that heavy imports are deferred in server_aws.
+
+Uses subprocess-based isolation to ensure a clean sys.modules state.
+
+Validates: Requirements 3.1, 3.2
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess:
+    """Run *code* in a fresh Python subprocess and return the result."""
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestHeavyModulesNotLoadedOnImport:
+    """Importing server_aws must NOT pull in heavy dependencies."""
+
+    HEAVY_MODULES = ["httpx", "markdownify", "pydantic", "mcp.server.fastmcp"]
+
+    def test_httpx_not_in_sys_modules(self):
+        """httpx must not be loaded after importing server_aws."""
+        result = _run_isolated(
+            """\
+            import sys
+            from awslabs.aws_documentation_mcp_server import server_aws
+            print("httpx" not in sys.modules)
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "True", (
+            "httpx was loaded into sys.modules on import of server_aws"
+        )
+
+    def test_markdownify_not_in_sys_modules(self):
+        """markdownify must not be loaded after importing server_aws."""
+        result = _run_isolated(
+            """\
+            import sys
+            from awslabs.aws_documentation_mcp_server import server_aws
+            print("markdownify" not in sys.modules)
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "True", (
+            "markdownify was loaded into sys.modules on import of server_aws"
+        )
+
+    def test_pydantic_not_in_sys_modules(self):
+        """pydantic must not be loaded after importing server_aws."""
+        result = _run_isolated(
+            """\
+            import sys
+            from awslabs.aws_documentation_mcp_server import server_aws
+            print("pydantic" not in sys.modules)
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "True", (
+            "pydantic was loaded into sys.modules on import of server_aws"
+        )
+
+    def test_mcp_fastmcp_not_in_sys_modules(self):
+        """mcp.server.fastmcp must not be loaded after importing server_aws."""
+        result = _run_isolated(
+            """\
+            import sys
+            from awslabs.aws_documentation_mcp_server import server_aws
+            print("mcp.server.fastmcp" not in sys.modules)
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "True", (
+            "mcp.server.fastmcp was loaded into sys.modules on import of server_aws"
+        )
+
+    def test_all_heavy_modules_absent(self):
+        """Combined check: none of the heavy modules are in sys.modules."""
+        modules_csv = ",".join(self.HEAVY_MODULES)
+        result = _run_isolated(
+            f"""\
+            import sys
+            from awslabs.aws_documentation_mcp_server import server_aws
+            heavy = [m for m in "{modules_csv}".split(",") if m in sys.modules]
+            print(",".join(heavy) if heavy else "NONE")
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "NONE", (
+            f"Heavy modules loaded on import: {result.stdout.strip()}"
+        )
+
+
+class TestFastMCPNotCreatedOnImport:
+    """FastMCP instance must not exist until main() is called."""
+
+    def test_mcp_is_sentinel_after_import(self):
+        """server_aws.mcp should be an _UninitializedServer sentinel after import."""
+        result = _run_isolated(
+            """\
+            from awslabs.aws_documentation_mcp_server import server_aws
+            print(type(server_aws.mcp).__name__)
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "_UninitializedServer", (
+            "server_aws.mcp is not the sentinel after import — FastMCP was created eagerly"
+        )
+
+    def test_mcp_sentinel_raises_on_access(self):
+        """Accessing attributes on the sentinel should raise RuntimeError."""
+        result = _run_isolated(
+            """\
+            from awslabs.aws_documentation_mcp_server import server_aws
+            try:
+                server_aws.mcp.run()
+                print("NO_ERROR")
+            except RuntimeError as e:
+                print("RuntimeError")
+            except AttributeError:
+                print("AttributeError")
+            """
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert result.stdout.strip() == "RuntimeError", (
+            "Expected RuntimeError from sentinel, got: " + result.stdout.strip()
+        )

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -50,7 +50,7 @@ class TestReadDocumentation:
         with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_response
             with patch(
-                'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html'
+                'awslabs.aws_documentation_mcp_server.util.extract_content_from_html'
             ) as mock_extract:
                 mock_extract.return_value = '# Test\n\nThis is a test.'
 
@@ -78,7 +78,7 @@ class TestReadDocumentation:
         with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_response
             with patch(
-                'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html'
+                'awslabs.aws_documentation_mcp_server.util.extract_content_from_html'
             ) as mock_extract:
                 mock_extract.return_value = '# Test\n\nThis is a test.'
 
@@ -511,10 +511,13 @@ class TestMain:
 
     def test_main(self):
         """Test the main function."""
-        with patch('awslabs.aws_documentation_mcp_server.server_aws.mcp.run') as mock_run:
+        mock_mcp = MagicMock()
+        with patch(
+            'awslabs.aws_documentation_mcp_server.server_aws._create_mcp', return_value=mock_mcp
+        ):
             with patch(
                 'awslabs.aws_documentation_mcp_server.server_aws.logger.info'
             ) as mock_logger:
                 main()
                 mock_logger.assert_called_once_with('Starting AWS Documentation MCP Server')
-                mock_run.assert_called_once()
+                mock_mcp.run.assert_called_once()

--- a/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
@@ -50,7 +50,7 @@ class TestReadDocumentationChina:
         with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_response
             with patch(
-                'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html'
+                'awslabs.aws_documentation_mcp_server.util.extract_content_from_html'
             ) as mock_extract:
                 mock_extract.return_value = '# Test\n\nThis is a test.'
 
@@ -141,7 +141,7 @@ class TestGetAvailableServices:
             ]
 
             with patch(
-                'awslabs.aws_documentation_mcp_server.server_aws_cn.extract_content_from_html'
+                'awslabs.aws_documentation_mcp_server.util.extract_content_from_html'
             ) as mock_extract:
                 mock_extract.return_value = '# AWS Services in China\n\nAvailable services list.'
                 result = await get_available_services(ctx)
@@ -226,7 +226,7 @@ class TestGetAvailableServices:
             ]
 
             with patch(
-                'awslabs.aws_documentation_mcp_server.server_aws_cn.is_html_content'
+                'awslabs.aws_documentation_mcp_server.util.is_html_content'
             ) as mock_is_html:
                 mock_is_html.return_value = False
 
@@ -267,7 +267,7 @@ class TestGetAvailableServices:
             ]
 
             with patch(
-                'awslabs.aws_documentation_mcp_server.server_aws_cn.extract_content_from_html'
+                'awslabs.aws_documentation_mcp_server.util.extract_content_from_html'
             ) as mock_extract:
                 mock_extract.return_value = '# AWS Services in China\n\nAvailable services list.'
                 result = await get_available_services(ctx)
@@ -285,10 +285,13 @@ class TestMain:
 
     def test_main(self):
         """Test the main function."""
-        with patch('awslabs.aws_documentation_mcp_server.server_aws_cn.mcp.run') as mock_run:
+        mock_mcp = MagicMock()
+        with patch(
+            'awslabs.aws_documentation_mcp_server.server_aws_cn._create_mcp', return_value=mock_mcp
+        ):
             with patch(
                 'awslabs.aws_documentation_mcp_server.server_aws_cn.logger.info'
             ) as mock_logger:
                 main()
                 mock_logger.assert_called_once_with('Starting AWS China Documentation MCP Server')
-                mock_run.assert_called_once()
+                mock_mcp.run.assert_called_once()

--- a/src/aws-documentation-mcp-server/tests/test_server_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_utils.py
@@ -17,9 +17,10 @@ import httpx
 import pytest
 from awslabs.aws_documentation_mcp_server.models import SearchResponse, SearchResult
 from awslabs.aws_documentation_mcp_server.server_utils import (
-    DEFAULT_USER_AGENT,
     SEARCH_RESULT_CACHE,
+    _reset_user_agent_cache,
     add_search_result_cache_item,
+    get_default_user_agent,
     get_query_id_from_cache,
     read_documentation_impl,
 )
@@ -56,15 +57,15 @@ class TestReadDocumentationImpl:
 
             with (
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.is_html_content',
+                    'awslabs.aws_documentation_mcp_server.util.is_html_content',
                     return_value=True,
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html',
+                    'awslabs.aws_documentation_mcp_server.util.extract_content_from_html',
                     return_value='# Test\n\nContent',
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.format_documentation_result',
+                    'awslabs.aws_documentation_mcp_server.util.format_documentation_result',
                     return_value='AWS Documentation from URL: # Test\n\nContent',
                 ),
             ):
@@ -80,7 +81,7 @@ class TestReadDocumentationImpl:
                     f'{url}?session=test-uuid',
                     follow_redirects=True,
                     headers={
-                        'User-Agent': DEFAULT_USER_AGENT,
+                        'User-Agent': get_default_user_agent(),
                         'X-MCP-Session-Id': 'test-uuid',
                     },
                     timeout=30,
@@ -112,11 +113,11 @@ class TestReadDocumentationImpl:
 
             with (
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.is_html_content',
+                    'awslabs.aws_documentation_mcp_server.util.is_html_content',
                     return_value=False,
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.format_documentation_result',
+                    'awslabs.aws_documentation_mcp_server.util.format_documentation_result',
                     return_value='AWS Documentation from URL: Plain text content',
                 ),
             ):
@@ -218,15 +219,15 @@ class TestReadDocumentationImpl:
 
             with (
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.is_html_content',
+                    'awslabs.aws_documentation_mcp_server.util.is_html_content',
                     return_value=True,
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html',
+                    'awslabs.aws_documentation_mcp_server.util.extract_content_from_html',
                     return_value='# Test\n\nLong content that exceeds max length',
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.format_documentation_result'
+                    'awslabs.aws_documentation_mcp_server.util.format_documentation_result'
                 ) as mock_format,
             ):
                 # Set up the mock to return a truncated result
@@ -277,15 +278,15 @@ class TestReadDocumentationImpl:
 
             with (
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.is_html_content',
+                    'awslabs.aws_documentation_mcp_server.util.is_html_content',
                     return_value=True,
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html',
+                    'awslabs.aws_documentation_mcp_server.util.extract_content_from_html',
                     return_value='# Test\n\nContent',
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.format_documentation_result',
+                    'awslabs.aws_documentation_mcp_server.util.format_documentation_result',
                     mock_format,
                 ),
             ):
@@ -347,15 +348,15 @@ class TestReadDocumentationImpl:
 
             with (
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.is_html_content',
+                    'awslabs.aws_documentation_mcp_server.util.is_html_content',
                     return_value=True,
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html',
+                    'awslabs.aws_documentation_mcp_server.util.extract_content_from_html',
                     return_value='# Test\n\nContent',
                 ),
                 patch(
-                    'awslabs.aws_documentation_mcp_server.server_utils.format_documentation_result',
+                    'awslabs.aws_documentation_mcp_server.util.format_documentation_result',
                     return_value='AWS Documentation from URL: # Test\n\nContent',
                 ),
             ):
@@ -371,7 +372,7 @@ class TestReadDocumentationImpl:
                     f'{url}?session=test-uuid&query_id=test-query-id',
                     follow_redirects=True,
                     headers={
-                        'User-Agent': DEFAULT_USER_AGENT,
+                        'User-Agent': get_default_user_agent(),
                         'X-MCP-Session-Id': 'test-uuid',
                     },
                     timeout=30,
@@ -388,9 +389,11 @@ class TestUserAgentCustomization:
         import importlib
 
         importlib.reload(server_utils)
+        _reset_user_agent_cache()
 
-        assert 'Custom/1.0 Browser' in server_utils.DEFAULT_USER_AGENT
-        assert 'ModelContextProtocol' in server_utils.DEFAULT_USER_AGENT
+        ua = server_utils.get_default_user_agent()
+        assert 'Custom/1.0 Browser' in ua
+        assert 'ModelContextProtocol' in ua
 
     @patch.dict('os.environ', {}, clear=True)
     def test_default_user_agent_when_no_env(self):
@@ -399,9 +402,11 @@ class TestUserAgentCustomization:
         import importlib
 
         importlib.reload(server_utils)
+        _reset_user_agent_cache()
 
-        assert 'Chrome' in server_utils.DEFAULT_USER_AGENT
-        assert 'ModelContextProtocol' in server_utils.DEFAULT_USER_AGENT
+        ua = server_utils.get_default_user_agent()
+        assert 'Chrome' in ua
+        assert 'ModelContextProtocol' in ua
 
 
 class TestVersionImport:
@@ -417,11 +422,14 @@ class TestVersionImport:
         import importlib
 
         importlib.reload(server_utils)
+        _reset_user_agent_cache()
+
+        ua = server_utils.get_default_user_agent()
 
         # Verify the version was retrieved from metadata
-        mock_version.assert_called_once_with('awslabs.aws-documentation-mcp-server')
-        assert '1.1.3' in server_utils.DEFAULT_USER_AGENT
-        assert 'ModelContextProtocol/1.1.3' in server_utils.DEFAULT_USER_AGENT
+        mock_version.assert_called_with('awslabs.aws-documentation-mcp-server')
+        assert '1.1.3' in ua
+        assert 'ModelContextProtocol/1.1.3' in ua
 
     @patch('importlib.metadata.version')
     def test_version_fallback_to_init(self, mock_version):
@@ -438,11 +446,14 @@ class TestVersionImport:
         import importlib
 
         importlib.reload(server_utils)
+        _reset_user_agent_cache()
+
+        ua = server_utils.get_default_user_agent()
 
         # Verify it fell back to the __init__.py version
-        mock_version.assert_called_once_with('awslabs.aws-documentation-mcp-server')
-        assert version in server_utils.DEFAULT_USER_AGENT
-        assert f'ModelContextProtocol/{version}' in server_utils.DEFAULT_USER_AGENT
+        mock_version.assert_called_with('awslabs.aws-documentation-mcp-server')
+        assert version in ua
+        assert f'ModelContextProtocol/{version}' in ua
 
 
 class TestSearchResultCache:

--- a/src/aws-documentation-mcp-server/tests/test_wrapper_signature_sync.py
+++ b/src/aws-documentation-mcp-server/tests/test_wrapper_signature_sync.py
@@ -1,0 +1,113 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that MCP tool wrapper signatures stay in sync with outer function signatures.
+
+The _create_mcp() factories in server_aws.py and server_aws_cn.py register thin
+wrapper functions whose Field-annotated parameters must match the outer function
+parameters (minus 'ctx'). This test catches drift between the two.
+"""
+
+import inspect
+
+from awslabs.aws_documentation_mcp_server import server_aws, server_aws_cn
+
+
+def _non_ctx_params(func) -> list[str]:
+    """Return parameter names of *func*, excluding 'ctx' and 'self'."""
+    sig = inspect.signature(func)
+    return [
+        name
+        for name, p in sig.parameters.items()
+        if name not in ('ctx', 'self')
+    ]
+
+
+def _wrapper_params(wrapper_func) -> list[str]:
+    """Return parameter names of a wrapper, excluding 'ctx' and 'self'."""
+    return _non_ctx_params(wrapper_func)
+
+
+class TestServerAwsWrapperSync:
+    """Verify server_aws.py wrapper signatures match outer functions."""
+
+    def test_read_documentation_wrapper_params(self):
+        """read_documentation_tool wrapper params must match read_documentation."""
+        mcp = server_aws._create_mcp()
+        # FastMCP stores tools in a dict keyed by tool name
+        tool = mcp._tool_manager._tools['read_documentation']
+        wrapper_fn = tool.fn
+        outer_params = _non_ctx_params(server_aws.read_documentation)
+        inner_params = _non_ctx_params(wrapper_fn)
+        assert outer_params == inner_params, (
+            f'Wrapper/outer param mismatch for read_documentation:\n'
+            f'  outer: {outer_params}\n'
+            f'  wrapper: {inner_params}'
+        )
+
+    def test_search_documentation_wrapper_params(self):
+        """search_documentation_tool wrapper params must match search_documentation."""
+        mcp = server_aws._create_mcp()
+        tool = mcp._tool_manager._tools['search_documentation']
+        wrapper_fn = tool.fn
+        outer_params = _non_ctx_params(server_aws.search_documentation)
+        inner_params = _non_ctx_params(wrapper_fn)
+        assert outer_params == inner_params, (
+            f'Wrapper/outer param mismatch for search_documentation:\n'
+            f'  outer: {outer_params}\n'
+            f'  wrapper: {inner_params}'
+        )
+
+    def test_recommend_wrapper_params(self):
+        """recommend_tool wrapper params must match recommend."""
+        mcp = server_aws._create_mcp()
+        tool = mcp._tool_manager._tools['recommend']
+        wrapper_fn = tool.fn
+        outer_params = _non_ctx_params(server_aws.recommend)
+        inner_params = _non_ctx_params(wrapper_fn)
+        assert outer_params == inner_params, (
+            f'Wrapper/outer param mismatch for recommend:\n'
+            f'  outer: {outer_params}\n'
+            f'  wrapper: {inner_params}'
+        )
+
+
+class TestServerAwsCnWrapperSync:
+    """Verify server_aws_cn.py wrapper signatures match outer functions."""
+
+    def test_read_documentation_wrapper_params(self):
+        """read_documentation_tool wrapper params must match read_documentation."""
+        mcp = server_aws_cn._create_mcp()
+        tool = mcp._tool_manager._tools['read_documentation']
+        wrapper_fn = tool.fn
+        outer_params = _non_ctx_params(server_aws_cn.read_documentation)
+        inner_params = _non_ctx_params(wrapper_fn)
+        assert outer_params == inner_params, (
+            f'Wrapper/outer param mismatch for read_documentation (CN):\n'
+            f'  outer: {outer_params}\n'
+            f'  wrapper: {inner_params}'
+        )
+
+    def test_get_available_services_wrapper_params(self):
+        """get_available_services_tool wrapper params must match get_available_services."""
+        mcp = server_aws_cn._create_mcp()
+        tool = mcp._tool_manager._tools['get_available_services']
+        wrapper_fn = tool.fn
+        outer_params = _non_ctx_params(server_aws_cn.get_available_services)
+        inner_params = _non_ctx_params(wrapper_fn)
+        assert outer_params == inner_params, (
+            f'Wrapper/outer param mismatch for get_available_services (CN):\n'
+            f'  outer: {outer_params}\n'
+            f'  wrapper: {inner_params}'
+        )

--- a/src/aws-documentation-mcp-server/uv.lock
+++ b/src/aws-documentation-mcp-server/uv.lock
@@ -65,6 +65,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "commitizen" },
+    { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -87,6 +88,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "commitizen", specifier = ">=4.2.2" },
+    { name = "hypothesis", specifier = ">=6.151.6" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1.398" },
     { name = "pytest", specifier = ">=7.4.0" },
@@ -577,6 +579,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/5b/039c095977004f2316225559d591c5a4c62b2e4d7a429db2dd01d37c3ec2/hypothesis-6.151.6.tar.gz", hash = "sha256:755decfa326c8c97a4c8766fe40509985003396442138554b0ae824f9584318f", size = 475846, upload-time = "2026-02-11T04:42:06.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/70/42760b369723f8b5aa6a21e5fae58809f503ca7ebb6da13b99f4de36305a/hypothesis-6.151.6-py3-none-any.whl", hash = "sha256:4e6e933a98c6f606b3e0ada97a750e7fff12277a40260b9300a05e7a5c3c5e2e", size = 543324, upload-time = "2026-02-11T04:42:04.025Z" },
 ]
 
 [[package]]
@@ -1364,6 +1379,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #2435

## Problem

The `awslabs.aws-documentation-mcp-server` took ~3.24 seconds to initialize on an M1 MacBook Pro, while most MCP servers load in under 1 second (ref: awslabs/mcp#2435). The root cause was eager module-level imports of heavy dependencies (`mcp/FastMCP`, `pydantic`, `httpx`, `markdownify/beautifulsoup4`) and eager `FastMCP` instance creation at import time.

## Solution

Defer all heavy imports from module level to first use, and defer `FastMCP` instance creation to `main()`. On my M1 MacBook Pro, this brings server init from ~3.24s down to ~125ms.

### What changed

**Lazy import optimization** (`server_aws.py`, `server_aws_cn.py`, `server_utils.py`, `util.py`):
- Moved imports of `httpx`, `pydantic`, `mcp.server.fastmcp`, `markdownify`, and `bs4` from module level into the functions that use them.
- `FastMCP` instance creation is now deferred to a `_create_mcp()` factory called from `main()`, instead of happening at module import time.
- `importlib.metadata.version()` call in `server_utils.py` is deferred to first use via a lazy `get_default_user_agent()` pattern.
- Module-level imports are limited to stdlib (`json`, `re`, `uuid`) and `loguru` (lightweight, already loaded by the framework).
- Tool wrapper functions use `description=outer_func.__doc__` passed directly to `@server.tool()` to preserve tool descriptions for MCP clients, since FastMCP captures `__doc__` eagerly at decoration time.
- Return type annotations on tool wrappers (`-> SearchResponse`, `-> List[RecommendationResult]`) are preserved with model imports inside `_create_mcp()` so FastMCP can resolve them.

**Benchmark script** (`scripts/benchmark_init.py`):
- Standalone script that measures cold-start init time in isolated subprocesses.
- Profiles individual dependency import times (`mcp`, `pydantic`, `httpx`, `markdownify`, `loguru`, `bs4`).
- Outputs both human-readable text and machine-parseable JSON.
- Accepts `--iterations` and `--format` CLI arguments.
- Produces a bottleneck report sorted slowest-to-fastest, flagging any phase over 200ms.

**Regression test** (`tests/test_benchmark_init.py`):
- pytest test that measures init time in a subprocess (3 iterations, takes median).
- Fails if median exceeds 1500ms threshold.
- Shared constants (`INIT_TIME_THRESHOLD_MS`, `check_threshold`) live in `conftest.py`.

**Lazy import verification tests** (`tests/test_lazy_imports.py`):
- Verifies that after importing `server_aws`, heavy modules (`httpx`, `markdownify`, `pydantic`, `mcp.server.fastmcp`) are NOT in `sys.modules`.
- Verifies the `FastMCP` instance (`mcp`) is `None` after import.

**Property-based tests** (`tests/test_benchmark_pbt.py`, `tests/test_benchmark_threshold_pbt.py`):
- Hypothesis-based tests validating 5 correctness properties:
  1. Bottleneck report is sorted descending by time.
  2. Median calculation matches `statistics.median`.
  3. Threshold violations contain exactly the phases exceeding 200ms.
  4. _(Covered by lazy import verification tests)_
  5. Benchmark threshold assertion: fails above 1500ms, passes at or below.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
