### PR TITLE
feat(k8s-apis): add proxy configuration support for NO_PROXY environm…

### DIFF
--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_apis.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_apis.py
@@ -91,6 +91,9 @@ class K8sApis:
 
     def _configure_proxy_settings(self, config):
         """Configure proxy settings for Kubernetes client from environment variables."""
+        from urllib.parse import urlparse
+        from urllib.request import proxy_bypass_environment
+
         # Get proxy URL (HTTPS proxy takes precedence over HTTP proxy)
         proxy_url = (
             os.environ.get('HTTPS_PROXY')
@@ -100,6 +103,12 @@ class K8sApis:
         )
 
         if not proxy_url:
+            return
+
+        # Check NO_PROXY/no_proxy before configuring proxy
+        hostname = urlparse(config.host).hostname
+        if hostname and proxy_bypass_environment(hostname):
+            logger.debug(f'Skipping proxy for {hostname} (matches NO_PROXY)')
             return
 
         logger.debug(f'Configuring proxy: {proxy_url}')


### PR DESCRIPTION
Fixes https://github.com/awslabs/mcp/issues/2438

## Summary

### Changes

The `_configure_proxy_settings` method in `k8s_apis.py` now checks the `NO_PROXY/no_proxy` environment variable before configuring a proxy on the Kubernetes client. If the K8s API server hostname matches a `NO_PROXY` entry, the proxy is skipped.

- Uses `urllib.request.proxy_bypass_environment()` to evaluate the target hostname against `NO_PROXY/no_proxy`
- Extracts the hostname from `config.host` using `urllib.parse.urlparse`
- Adds a debug log message when proxy is skipped due to `NO_PROXY` match
- Adds 4 new tests covering: endpoint match, no match, wildcard (`*`), and lowercase `no_proxy`

### User experience

**Before:** When `HTTP_PROXY/HTTPS_PROXY` was set globally, the EKS MCP server would always route requests through the proxy: even for EKS API endpoints reachable via Direct Connect. Users had no way to bypass the proxy for specific endpoints.

**After:** Users can set `NO_PROXY=.eks.amazonaws.com` (or any matching pattern) to bypass the proxy for EKS API endpoints, following standard proxy environment variable conventions.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? **N**

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
