### PR TITLE
chore(aws-api-mcp-server): expose AWS_MAX_ATTEMPTS

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
@@ -193,6 +193,7 @@ ENDPOINT_SUGGEST_AWS_COMMANDS = os.getenv(
 )
 CONNECT_TIMEOUT_SECONDS = 10
 READ_TIMEOUT_SECONDS = 60
+AWS_MAX_ATTEMPTS = int(os.getenv('AWS_MAX_ATTEMPTS', 3))
 
 # Authentication Configuration
 AUTH_TYPE = os.getenv('AUTH_TYPE')

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
@@ -14,13 +14,17 @@
 
 import boto3
 import json
-import os
 from ..aws.pagination import build_result
 from ..aws.services import (
     extract_pagination_config,
 )
 from ..common.command import IRCommand, OutputFile
-from ..common.config import CONNECT_TIMEOUT_SECONDS, READ_TIMEOUT_SECONDS, get_user_agent_extra
+from ..common.config import (
+    AWS_MAX_ATTEMPTS,
+    CONNECT_TIMEOUT_SECONDS,
+    READ_TIMEOUT_SECONDS,
+    get_user_agent_extra,
+)
 from ..common.file_system_controls import validate_file_path
 from ..common.helpers import Boto3Encoder, operation_timer
 from botocore.config import Config
@@ -55,7 +59,7 @@ def interpret(
         region_name=region,
         connect_timeout=CONNECT_TIMEOUT_SECONDS,
         read_timeout=READ_TIMEOUT_SECONDS,
-        retries={'max_attempts': int(os.environ.get('AWS_MAX_ATTEMPTS') or 3), 'mode': 'adaptive'},
+        retries={'total_max_attempts': AWS_MAX_ATTEMPTS, 'mode': 'standard'},
         user_agent_extra=get_user_agent_extra(),
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Expose environment variable `AWS_MAX_ATTEMPTS` to set retries on boto3

`AWS_MAX_ATTEMPTS=3`: 1 initial request + 2 retries = 3 total attempts ([boto3](https://docs.aws.amazon.com/boto3/latest/guide/retries.html#available-configuration-options), [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#cli-config-max_attempts))

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
