### PR TITLE
Add Topics Management API Module

### DIFF
--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/server.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/server.py
@@ -27,10 +27,12 @@ from awslabs.aws_msk_mcp_server.tools import (
     logs_and_telemetry,
     mutate_cluster,
     mutate_config,
+    mutate_topics,
     mutate_vpc,
     read_cluster,
     read_config,
     read_global,
+    read_topics,
     read_vpc,
     static_tools,
 )
@@ -78,6 +80,7 @@ async def run_server():
     read_global.register_module(mcp)
     read_vpc.register_module(mcp)
     read_config.register_module(mcp)
+    read_topics.register_module(mcp)
     logs_and_telemetry.register_module(mcp)
     static_tools.register_module(mcp)
 
@@ -86,6 +89,7 @@ async def run_server():
         logger.info('Write operations are enabled')
         mutate_cluster.register_module(mcp)
         mutate_config.register_module(mcp)
+        mutate_topics.register_module(mcp)
         mutate_vpc.register_module(mcp)
     else:
         logger.info('Server running in read-only mode. Write operations are disabled.')

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/__init__.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/__init__.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Topics Management API Module
+
+This module provides functions to manage topics in MSK clusters.
+"""
+
+import boto3
+from botocore.config import Config
+from awslabs.aws_msk_mcp_server import __version__
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from .create_topic import create_topic
+from .delete_topic import delete_topic
+from .update_topic import update_topic
+
+
+def register_module(mcp: FastMCP) -> None:
+    @mcp.tool(name="create_topic", description="Creates a topic in the specified MSK cluster.")
+    def create_topic_tool(
+        region: str = Field(..., description="AWS region"),
+        cluster_arn: str = Field(
+            ..., description="The Amazon Resource Name (ARN) that uniquely identifies the cluster"
+        ),
+        topic_name: str = Field(..., description="The name of the topic to create"),
+        partition_count: int = Field(..., description="The number of partitions for the topic"),
+        replication_factor: int = Field(..., description="The replication factor for the topic"),
+        configs: str = Field(None, description="Topic configurations encoded as a Base64 string"),
+    ):
+        """
+        Creates a topic in the specified MSK cluster.
+
+        Args:
+            region (str): AWS region
+            cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+            topic_name (str): The name of the topic to create
+            partition_count (int): The number of partitions for the topic
+            replication_factor (int): The replication factor for the topic
+            configs (str, optional): Topic configurations encoded as a Base64 string
+
+        Returns:
+            dict: Response containing topic creation result:
+                - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+                - TopicName (str): The name of the topic that was created
+                - Status (str): The status of the topic creation (CREATING, UPDATING, DELETING, ACTIVE)
+        """
+        # Create a boto3 client
+        client = boto3.client(
+            "kafka",
+            region_name=region,
+            config=Config(user_agent_extra=f"awslabs/mcp/aws-msk-mcp-server/{__version__}"),
+        )
+        return create_topic(
+            cluster_arn, topic_name, partition_count, replication_factor, client, configs
+        )
+
+    @mcp.tool(
+        name="update_topic",
+        description="Updates the configuration of the specified topic.",
+    )
+    def update_topic_tool(
+        region: str = Field(..., description="AWS region"),
+        cluster_arn: str = Field(
+            ..., description="The Amazon Resource Name (ARN) that uniquely identifies the cluster"
+        ),
+        topic_name: str = Field(..., description="The name of the topic to update configuration for"),
+        configs: str = Field(
+            None, description="The new topic configurations encoded as a Base64 string"
+        ),
+        partition_count: int = Field(
+            None, description="The new total number of partitions for the topic"
+        ),
+    ):
+        """
+        Updates the configuration of the specified topic.
+
+        Args:
+            region (str): AWS region
+            cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+            topic_name (str): The name of the topic to update configuration for
+            configs (str, optional): The new topic configurations encoded as a Base64 string
+            partition_count (int, optional): The new total number of partitions for the topic
+
+        Returns:
+            dict: Response containing topic update result:
+                - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+                - TopicName (str): The name of the topic whose configuration was updated
+                - Status (str): The status of the topic update (CREATING, UPDATING, DELETING, ACTIVE)
+        """
+        # Create a boto3 client
+        client = boto3.client(
+            "kafka",
+            region_name=region,
+            config=Config(user_agent_extra=f"awslabs/mcp/aws-msk-mcp-server/{__version__}"),
+        )
+        return update_topic(cluster_arn, topic_name, client, configs, partition_count)
+
+    @mcp.tool(
+        name="delete_topic", description="Deletes a topic in the specified MSK cluster."
+    )
+    def delete_topic_tool(
+        region: str = Field(..., description="AWS region"),
+        cluster_arn: str = Field(
+            ..., description="The Amazon Resource Name (ARN) that uniquely identifies the cluster"
+        ),
+        topic_name: str = Field(..., description="The name of the topic to delete"),
+        confirm_delete: str = Field(
+            ..., description='Must be exactly "DELETE" to confirm the destructive operation'
+        ),
+    ):
+        """
+        Deletes a topic in the specified MSK cluster.
+
+        SAFETY REQUIREMENTS:
+        1. confirm_delete parameter must be exactly "DELETE" (case-sensitive)
+        2. Topics with system prefixes (__*, _internal*, _confluent*, _kafka*, _schema*) are protected
+
+        WARNING: This is a destructive operation that permanently deletes the topic and all its data.
+
+        Args:
+            region (str): AWS region
+            cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+            topic_name (str): The name of the topic to delete
+            confirm_delete (str): Must be exactly "DELETE" to confirm the destructive operation
+
+        Returns:
+            dict: Response containing topic deletion result:
+                - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+                - TopicName (str): The name of the topic that was deleted
+                - Status (str): The status of the topic deletion (CREATING, UPDATING, DELETING, ACTIVE)
+
+        Raises:
+            ValueError: If confirm_delete is not "DELETE" or if topic has protected system prefix
+        """
+        # Create a boto3 client
+        client = boto3.client(
+            "kafka",
+            region_name=region,
+            config=Config(user_agent_extra=f"awslabs/mcp/aws-msk-mcp-server/{__version__}"),
+        )
+        return delete_topic(cluster_arn, topic_name, client, confirm_delete)

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/create_topic.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/create_topic.py
@@ -1,0 +1,61 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function to create a topic in an MSK cluster.
+Maps to AWS MSK API: create_topic
+"""
+
+
+def create_topic(
+    cluster_arn, topic_name, partition_count, replication_factor, client, configs=None
+):
+    """
+    Creates a topic in the specified MSK cluster.
+
+    Args:
+        cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+        topic_name (str): The name of the topic to create
+        partition_count (int): The number of partitions for the topic
+        replication_factor (int): The replication factor for the topic
+        client (boto3.client): Boto3 client for Kafka. Must be provided by create_topic_tool.
+        configs (str, optional): Topic configurations encoded as a Base64 string
+
+    Returns:
+        dict: Response containing topic creation result:
+            - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+            - TopicName (str): The name of the topic that was created
+            - Status (str): The status of the topic creation (CREATING, UPDATING, DELETING, ACTIVE)
+    """
+    if client is None:
+        raise ValueError(
+            "Client must be provided. This function should only be called from create_topic_tool."
+        )
+
+    # Build parameters for the API call
+    params = {
+        "ClusterArn": cluster_arn,
+        "TopicName": topic_name,
+        "PartitionCount": partition_count,
+        "ReplicationFactor": replication_factor,
+    }
+
+    # Add optional configs parameter if provided
+    if configs is not None:
+        params["Configs"] = configs
+
+    # Make the API call using the MSK create_topic API
+    response = client.create_topic(**params)
+
+    return response

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/delete_topic.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/delete_topic.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function to delete a topic in an MSK cluster.
+Maps to AWS MSK API: delete_topic
+"""
+
+
+def delete_topic(cluster_arn, topic_name, client, confirm_delete=None):
+    """
+    Deletes a topic in the specified MSK cluster.
+
+    Args:
+        cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+        topic_name (str): The name of the topic to delete
+        client (boto3.client): Boto3 client for Kafka. Must be provided by delete_topic_tool.
+        confirm_delete (str, optional): Must be exactly "DELETE" to confirm the destructive operation
+
+    Returns:
+        dict: Response containing topic deletion result:
+            - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+            - TopicName (str): The name of the topic that was deleted
+            - Status (str): The status of the topic deletion (CREATING, UPDATING, DELETING, ACTIVE)
+    """
+    if client is None:
+        raise ValueError(
+            "Client must be provided. This function should only be called from delete_topic_tool."
+        )
+
+    # Safety check: require explicit confirmation
+    if confirm_delete != "DELETE":
+        raise ValueError(
+            f"Safety confirmation required: To delete topic '{topic_name}', you must set "
+            f"confirm_delete parameter to exactly 'DELETE' (case-sensitive). "
+            f"This is a destructive operation that will permanently delete the topic and all its data. "
+            f"Current confirm_delete value: '{confirm_delete}'"
+        )
+
+    # Additional safety: prevent deletion of topics with system-like names
+    system_prefixes = ["__", "_internal", "_confluent", "_kafka", "_schema"]
+    if any(topic_name.startswith(prefix) for prefix in system_prefixes):
+        raise ValueError(
+            f"Cannot delete topic '{topic_name}': Topics starting with system prefixes "
+            f"{system_prefixes} are protected from deletion for safety."
+        )
+
+    # Make the API call using the MSK delete_topic API
+    response = client.delete_topic(ClusterArn=cluster_arn, TopicName=topic_name)
+
+    return response

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/update_topic.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/mutate_topics/update_topic.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function to update the configuration of a topic in an MSK cluster.
+Maps to AWS MSK API: update_topic
+"""
+
+
+def update_topic(cluster_arn, topic_name, client, configs=None, partition_count=None):
+    """
+    Updates the configuration of the specified topic.
+
+    Args:
+        cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+        topic_name (str): The name of the topic to update configuration for
+        client (boto3.client): Boto3 client for Kafka. Must be provided by update_topic_tool.
+        configs (str, optional): The new topic configurations encoded as a Base64 string
+        partition_count (int, optional): The new total number of partitions for the topic
+
+    Returns:
+        dict: Response containing topic update result:
+            - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+            - TopicName (str): The name of the topic whose configuration was updated
+            - Status (str): The status of the topic update (CREATING, UPDATING, DELETING, ACTIVE)
+    """
+    if client is None:
+        raise ValueError(
+            "Client must be provided. This function should only be called from update_topic_tool."
+        )
+
+    # Build parameters for the API call
+    params = {
+        "ClusterArn": cluster_arn,
+        "TopicName": topic_name,
+    }
+
+    # Add optional parameters if provided
+    if configs is not None:
+        params["Configs"] = configs
+
+    if partition_count is not None:
+        params["PartitionCount"] = partition_count
+
+    # Make the API call using the MSK update_topic API
+    response = client.update_topic(**params)
+
+    return response

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/__init__.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/__init__.py
@@ -1,0 +1,154 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Topics Information API Module
+
+This module provides functions to retrieve information about topics in MSK clusters.
+"""
+
+import boto3
+from botocore.config import Config
+from awslabs.aws_msk_mcp_server import __version__
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from .describe_topic import describe_topic
+from .describe_topic_partitions import describe_topic_partitions
+from .list_topics import list_topics
+
+
+def register_module(mcp: FastMCP) -> None:
+    @mcp.tool(name="list_topics", description="Returns all topics in an MSK cluster.")
+    def list_topics_tool(
+        region: str = Field(..., description="AWS region"),
+        cluster_arn: str = Field(
+            ..., description="The Amazon Resource Name (ARN) that uniquely identifies the cluster"
+        ),
+        topic_name_filter: str = Field(
+            None, description="Returns topics starting with given name"
+        ),
+        max_results: int = Field(
+            None,
+            description="The maximum number of results to return in the response (default maximum 100 results per API call)",
+        ),
+        next_token: str = Field(
+            None,
+            description="The paginated results marker. When the result of the operation is truncated, the call returns NextToken in the response",
+        ),
+    ):
+        """
+        Returns all topics in an MSK cluster.
+
+        Args:
+            region (str): AWS region
+            cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+            topic_name_filter (str, optional): Returns topics starting with given name
+            max_results (int, optional): The maximum number of results to return in the response
+                                       (default maximum 100 results per API call)
+            next_token (str, optional): The paginated results marker. When the result of the operation
+                                      is truncated, the call returns NextToken in the response
+
+        Returns:
+            dict: Response containing:
+                - topics (list): List of topic objects containing:
+                    - topicArn (str): ARN of the topic
+                    - topicName (str): Name of the topic
+                    - partitionCount (int): Number of partitions in the topic
+                    - replicationFactor (int): Replication factor for the topic
+                    - outOfSyncReplicaCount (int): Number of out-of-sync replicas
+                - nextToken (str, optional): The token for the next set of results, if there are more results
+        """
+        # Create a boto3 client
+        client = boto3.client(
+            "kafka",
+            region_name=region,
+            config=Config(user_agent_extra=f"awslabs/mcp/aws-msk-mcp-server/{__version__}"),
+        )
+        return list_topics(cluster_arn, client, topic_name_filter, max_results, next_token)
+
+    @mcp.tool(
+        name="describe_topic", description="Returns details for a specific topic on an MSK cluster."
+    )
+    def describe_topic_tool(
+        region: str = Field(..., description="AWS region"),
+        cluster_arn: str = Field(
+            ..., description="The Amazon Resource Name (ARN) that uniquely identifies the cluster"
+        ),
+        topic_name: str = Field(..., description="The name of the topic to describe"),
+    ):
+        """
+        Returns details for a specific topic on an MSK cluster.
+
+        Args:
+            region (str): AWS region
+            cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+            topic_name (str): The name of the topic to describe
+
+        Returns:
+            dict: Response containing topic details:
+                - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+                - TopicName (str): The Kafka topic name of the topic
+                - ReplicationFactor (int): The replication factor of the topic
+                - PartitionCount (int): The partition count of the topic
+                - Configs (str): Topic configurations encoded as a Base64 string
+                - Status (str): The status of the topic (CREATING, UPDATING, DELETING, ACTIVE)
+        """
+        # Create a boto3 client
+        client = boto3.client(
+            "kafka",
+            region_name=region,
+            config=Config(user_agent_extra=f"awslabs/mcp/aws-msk-mcp-server/{__version__}"),
+        )
+        return describe_topic(cluster_arn, topic_name, client)
+
+    @mcp.tool(
+        name="describe_topic_partitions",
+        description="Returns partition information for a specific topic on an MSK cluster.",
+    )
+    def describe_topic_partitions_tool(
+        region: str = Field(..., description="AWS region"),
+        cluster_arn: str = Field(
+            ..., description="The Amazon Resource Name (ARN) that uniquely identifies the cluster"
+        ),
+        topic_name: str = Field(..., description="The name of the topic to describe partitions for"),
+        max_results: int = Field(None, description="Maximum number of partitions to return"),
+        next_token: str = Field(None, description="Token for pagination"),
+    ):
+        """
+        Returns partition information for a specific topic on an MSK cluster.
+
+        Args:
+            region (str): AWS region
+            cluster_arn (str): The Amazon Resource Name (ARN) that uniquely identifies the cluster
+            topic_name (str): The name of the topic to describe partitions for
+            max_results (int, optional): Maximum number of partitions to return
+            next_token (str, optional): Token for pagination
+
+        Returns:
+            dict: Response containing partition information:
+                - Partitions (list): List of partition objects containing:
+                    - Partition (int): The partition ID
+                    - Leader (int): The leader broker ID for the partition
+                    - Replicas (list): List of replica broker IDs for the partition
+                    - Isr (list): List of in-sync replica broker IDs for the partition
+                - NextToken (str, optional): Token for next page if there are more results
+        """
+        # Create a boto3 client
+        client = boto3.client(
+            "kafka",
+            region_name=region,
+            config=Config(user_agent_extra=f"awslabs/mcp/aws-msk-mcp-server/{__version__}"),
+        )
+        return describe_topic_partitions(cluster_arn, topic_name, client, max_results, next_token)

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/describe_topic.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/describe_topic.py
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function to describe a specific topic in an MSK cluster.
+Maps to AWS MSK API: GET /v1/clusters/{clusterArn}/topics/{topicName}
+"""
+
+
+def describe_topic(cluster_arn, topic_name, client):
+    """
+    Returns details for a topic on an MSK cluster.
+
+    Args:
+        cluster_arn (str): The ARN of the cluster containing the topic
+        topic_name (str): The name of the topic to describe
+        client (boto3.client): Boto3 client for Kafka. Must be provided by describe_topic_tool.
+
+    Returns:
+        dict: Response containing topic details:
+            - TopicArn (str): The Amazon Resource Name (ARN) of the topic
+            - TopicName (str): The Kafka topic name of the topic
+            - ReplicationFactor (int): The replication factor of the topic
+            - PartitionCount (int): The partition count of the topic
+            - Configs (str): Topic configurations encoded as a Base64 string
+            - Status (str): The status of the topic (CREATING, UPDATING, DELETING, ACTIVE)
+    """
+    if client is None:
+        raise ValueError(
+            "Client must be provided. This function should only be called from describe_topic_tool."
+        )
+
+    # Make the API call using the MSK describe_topic API
+    response = client.describe_topic(ClusterArn=cluster_arn, TopicName=topic_name)
+
+    return response

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/describe_topic_partitions.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/describe_topic_partitions.py
@@ -1,0 +1,58 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function to describe partitions of a specific topic in an MSK cluster.
+Maps to AWS MSK API: describe_topic_partitions
+"""
+
+
+def describe_topic_partitions(cluster_arn, topic_name, client, max_results=None, next_token=None):
+    """
+    Returns partition information for a topic on an MSK cluster.
+
+    Args:
+        cluster_arn (str): The ARN of the cluster containing the topic
+        topic_name (str): The name of the topic to describe partitions for
+        client (boto3.client): Boto3 client for Kafka. Must be provided by describe_topic_partitions_tool.
+        max_results (int, optional): Maximum number of partitions to return
+        next_token (str, optional): Token for pagination
+
+    Returns:
+        dict: Response containing partition information:
+            - Partitions (list): List of partition objects containing:
+                - Partition (int): The partition ID
+                - Leader (int): The leader broker ID for the partition
+                - Replicas (list): List of replica broker IDs for the partition
+                - Isr (list): List of in-sync replica broker IDs for the partition
+            - NextToken (str, optional): Token for next page if there are more results
+    """
+    if client is None:
+        raise ValueError(
+            "Client must be provided. This function should only be called from describe_topic_partitions_tool."
+        )
+
+    # Build parameters for the API call
+    params = {"ClusterArn": cluster_arn, "TopicName": topic_name}
+
+    if max_results is not None:
+        params["MaxResults"] = max_results
+
+    if next_token is not None:
+        params["NextToken"] = next_token
+
+    # Make the API call using the MSK describe_topic_partitions API
+    response = client.describe_topic_partitions(**params)
+
+    return response

--- a/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/list_topics.py
+++ b/src/aws-msk-mcp-server/awslabs/aws_msk_mcp_server/tools/read_topics/list_topics.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function to list topics in an MSK cluster.
+Maps to AWS MSK API: GET /clusters/{clusterArn}/topics
+"""
+
+
+def list_topics(cluster_arn, client, topic_name_filter=None, max_results=None, next_token=None):
+    """
+    Returns all topics in an MSK cluster.
+
+    Args:
+        cluster_arn (str): The ARN of the cluster to list topics for
+        client (boto3.client): Boto3 client for Kafka. Must be provided by list_topics_tool.
+        topic_name_filter (str, optional): Returns topics starting with given name
+        max_results (int, optional): Maximum number of results to return (default maximum 100 per API call)
+        next_token (str, optional): Token for pagination
+
+    Returns:
+        dict: Response containing topics information:
+            - topics (list): List of topic objects with:
+                - partitionCount (int): Number of partitions in the topic
+                - replicationFactor (int): Replication factor for the topic
+                - topicName (str): Name of the topic
+                - outOfSyncReplicaCount (int): Number of out-of-sync replicas
+                - topicArn (str): ARN of the topic
+            - nextToken (str, optional): Token for next page if there are more results
+    """
+    if client is None:
+        raise ValueError(
+            "Client must be provided. This function should only be called from list_topics_tool."
+        )
+
+    # Build parameters for the API call
+    params = {"ClusterArn": cluster_arn}
+
+    if topic_name_filter is not None:
+        params["TopicNameFilter"] = topic_name_filter
+
+    if max_results is not None:
+        params["MaxResults"] = max_results
+
+    if next_token is not None:
+        params["NextToken"] = next_token
+
+    # Make the API call using the new MSK Topics API
+    response = client.list_topics(**params)
+
+    return response


### PR DESCRIPTION
Implemented topic APIs MCP tools for ListTopics, DescribeTopic, DescribeTopicPartitions, CreateTopic, UpdateTopic and DeleteTopic.

This implementation follows the open source repository's pattern of separating read and mutate operations:
- read_topics module: Contains list_topics, describe_topic, and describe_topic_partitions (always available)
- mutate_topics module: Contains create_topic, update_topic, and delete_topic (only available with --allow-writes flag)

Key Features:
- Safety checks for destructive operations (delete requires 'DELETE' confirmation)
- Protection for system topics (prefixes: __, _internal, _confluent, _kafka, _schema)
- Base64 encoded topic configurations
- Comprehensive error handling and parameter validation
- Respects read-only/write mode separation



<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
