### PR TITLE
feat(dsql): Add AI agent telemetry, fix query guidance

### DIFF
--- a/src/aurora-dsql-mcp-server/kiro_power/steering/dsql-examples.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/dsql-examples.md
@@ -18,6 +18,7 @@ For additional samples, including in alternative language and driver support, re
 PGPASSWORD="$(aws dsql generate-db-connect-admin-auth-token \
   --hostname ${CLUSTER}.dsql.${REGION}.on.aws \
   --region ${REGION})" \
+PGAPPNAME="<app-name>/<model-id>" \
 psql -h ${CLUSTER}.dsql.${REGION}.on.aws -U admin -d postgres \
   -c "SELECT COUNT(*) FROM objectives WHERE tenant_id = 'tenant-123';"
 ```
@@ -37,6 +38,7 @@ function createPool(clusterEndpoint, user) {
   return new AuroraDSQLPool({
     host: clusterEndpoint,
     user: user,
+    application_name: "<app-name>/<model-id>",
     max: 10,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 10000,

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/language.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/language.md
@@ -73,11 +73,19 @@ PREFER using the [DSQL Python Connector](https://docs.aws.amazon.com/aurora-dsql
 - See [aurora-dsql-samples/python/jupyter](https://github.com/aws-samples/aurora-dsql-samples/blob/main/python/jupyter/)
 
 ### Go
-**pgx** (recommended)
+PREFER using the [DSQL Go Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/go/pgx) for automatic IAM auth with token caching:
+- `import "github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql"`
+- `pool, err := dsql.NewPool(ctx, dsql.Config{Host: "<endpoint>"})`
+- Automatic token refresh at 80% of token lifetime
+- SSL/TLS with `verify-full` enabled by default
+- Set `application_name` in connection string to `<app-name>/<model-id>`
+- See [aurora-dsql-connectors/go/pgx](https://github.com/awslabs/aurora-dsql-connectors/tree/main/go/pgx)
+
+**pgx** (manual token management)
 - Use `aws-sdk-go-v2/feature/dsql/auth` for token generation
 - Implement `BeforeConnect` hook: `config.BeforeConnect = func() { cfg.Password = token }`
 - Use `pgxpool` for connection pooling with max lifetime < 1 hour
-- Set `sslmode=verify-full` in connection string
+- Set `sslmode=verify-full&application_name=<app-name>/<model-id>` in connection string
 - See [aurora-dsql-samples/go/pgx](https://github.com/aws-samples/aurora-dsql-samples/tree/main/go/pgx)
 
 ### JavaScript/TypeScript
@@ -127,7 +135,7 @@ PREFER using JDBC with the [DSQL JDBC Connector](https://docs.aws.amazon.com/aur
 
 **SQLx** (async)
 - Use `aws-sdk-dsql` for token generation
-- Connection format: `postgres://admin:{token}@{endpoint}:5432/postgres?sslmode=verify-full`
+- Connection format: `postgres://admin:{token}@{endpoint}:5432/postgres?sslmode=verify-full&application_name=<app-name>/<model-id>`
 - Use `after_connect` hook: `.after_connect(|conn, _| conn.execute("SET search_path = public"))`
 - Implement periodic token refresh with `tokio::spawn`
 - See [aurora-dsql-samples/rust/sqlx](https://github.com/aws-samples/aurora-dsql-samples/tree/main/rust/sqlx)

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/onboarding.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/onboarding.md
@@ -105,7 +105,7 @@ aws dsql list-clusters --region $REGION
 **Create cluster command (if needed):**
 
 ```bash
-aws dsql create-cluster --region $REGION --tags Key=Name,Value=my-dsql-cluster
+aws dsql create-cluster --region $REGION --tags '{"Name":"my-dsql-cluster","created_by":"<model-id>"}'
 ```
 
 **Wait for ACTIVE status** (takes ~60 seconds):
@@ -153,6 +153,7 @@ export PGPASSWORD=$(aws dsql generate-db-connect-admin-auth-token \
   --expires-in 3600)
 
 export PGSSLMODE=require
+export PGAPPNAME="<app-name>/<model-id>"
 
 psql --quiet -h $CLUSTER_ENDPOINT -U admin -d postgres
 ```

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
@@ -255,7 +255,7 @@ Always use CREATE INDEX ASYNC in separate transaction
 - **ALWAYS use ASYNC indexes** - `CREATE INDEX ASYNC` is mandatory
 - **MUST Serialize arrays/JSON as TEXT** - Store arrays/JSON as TEXT (comma separated, JSON.stringify)
 - **ALWAYS Batch under 3,000 rows** - maintain transaction limits
-- **REQUIRED: Use parameterized queries** - Prevent SQL injection with $1, $2 placeholders
+- **REQUIRED: Sanitize SQL inputs with allowlists, regex, and quote escaping** - See [Input Validation](mcp/mcp-tools.md#input-validation-critical)
 - **MUST follow correct Application Layer Patterns** - when multi-tenant isolation or application referential itegrity are required; refer to [Application Layer Patterns](references/development-guide.md#application-layer-patterns)
 - **REQUIRED use DELETE for truncation** - DELETE is the only supported operation for truncation
 - **SHOULD test any migrations** - Verify DDL on dev clusters before production

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/development-guide.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/development-guide.md
@@ -16,7 +16,7 @@ effortless scaling, multi-region viability, among other advantages.
 - **ALWAYS use ASYNC indexes** - `CREATE INDEX ASYNC` is mandatory
 - **MUST Serialize arrays/JSON as TEXT** - Store arrays/JSON as TEXT (comma separated, JSON.stringify)
 - **ALWAYS Batch under 3,000 rows** - maintain transaction limits
-- **REQUIRED: Use parameterized queries** - Prevent SQL injection with $1, $2 placeholders
+- **REQUIRED: Sanitize SQL inputs with allowlists, regex, and quote escaping** - See [Input Validation](../mcp/mcp-tools.md#input-validation-critical)
 - **MUST follow correct Application Layer Patterns** - when multi-tenant isolation or application referential itegrity are required; refer to [Application Layer Patterns](#application-layer-patterns)
 - **REQUIRED use DELETE for truncation** - DELETE is the only supported operation for truncation
 - **SHOULD test any migrations** - Verify DDL on dev clusters before production

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/dsql-examples.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/dsql-examples.md
@@ -18,6 +18,7 @@ For additional samples, including in alternative language and driver support, re
 PGPASSWORD="$(aws dsql generate-db-connect-admin-auth-token \
   --hostname ${CLUSTER}.dsql.${REGION}.on.aws \
   --region ${REGION})" \
+PGAPPNAME="<app-name>/<model-id>" \
 psql -h ${CLUSTER}.dsql.${REGION}.on.aws -U admin -d postgres \
   -c "SELECT COUNT(*) FROM objectives WHERE tenant_id = 'tenant-123';"
 ```
@@ -37,6 +38,7 @@ function createPool(clusterEndpoint, user) {
   return new AuroraDSQLPool({
     host: clusterEndpoint,
     user: user,
+    application_name: "<app-name>/<model-id>",
     max: 10,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 10000,

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/language.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/language.md
@@ -73,11 +73,19 @@ PREFER using the [DSQL Python Connector](https://docs.aws.amazon.com/aurora-dsql
 - See [aurora-dsql-samples/python/jupyter](https://github.com/aws-samples/aurora-dsql-samples/blob/main/python/jupyter/)
 
 ### Go
-**pgx** (recommended)
+PREFER using the [DSQL Go Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/go/pgx) for automatic IAM auth with token caching:
+- `import "github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql"`
+- `pool, err := dsql.NewPool(ctx, dsql.Config{Host: "<endpoint>"})`
+- Automatic token refresh at 80% of token lifetime
+- SSL/TLS with `verify-full` enabled by default
+- Set `application_name` in connection string to `<app-name>/<model-id>`
+- See [aurora-dsql-connectors/go/pgx](https://github.com/awslabs/aurora-dsql-connectors/tree/main/go/pgx)
+
+**pgx** (manual token management)
 - Use `aws-sdk-go-v2/feature/dsql/auth` for token generation
 - Implement `BeforeConnect` hook: `config.BeforeConnect = func() { cfg.Password = token }`
 - Use `pgxpool` for connection pooling with max lifetime < 1 hour
-- Set `sslmode=verify-full` in connection string
+- Set `sslmode=verify-full&application_name=<app-name>/<model-id>` in connection string
 - See [aurora-dsql-samples/go/pgx](https://github.com/aws-samples/aurora-dsql-samples/tree/main/go/pgx)
 
 ### JavaScript/TypeScript
@@ -127,7 +135,7 @@ PREFER using JDBC with the [DSQL JDBC Connector](https://docs.aws.amazon.com/aur
 
 **SQLx** (async)
 - Use `aws-sdk-dsql` for token generation
-- Connection format: `postgres://admin:{token}@{endpoint}:5432/postgres?sslmode=verify-full`
+- Connection format: `postgres://admin:{token}@{endpoint}:5432/postgres?sslmode=verify-full&application_name=<app-name>/<model-id>`
 - Use `after_connect` hook: `.after_connect(|conn, _| conn.execute("SET search_path = public"))`
 - Implement periodic token refresh with `tokio::spawn`
 - See [aurora-dsql-samples/rust/sqlx](https://github.com/aws-samples/aurora-dsql-samples/tree/main/rust/sqlx)

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/onboarding.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/onboarding.md
@@ -105,7 +105,7 @@ aws dsql list-clusters --region $REGION
 **Create cluster command (if needed):**
 
 ```bash
-aws dsql create-cluster --region $REGION --tags Key=Name,Value=my-dsql-cluster
+aws dsql create-cluster --region $REGION --tags '{"Name":"my-dsql-cluster","created_by":"<model-id>"}'
 ```
 
 **Wait for ACTIVE status** (takes ~60 seconds):
@@ -153,6 +153,7 @@ export PGPASSWORD=$(aws dsql generate-db-connect-admin-auth-token \
   --expires-in 3600)
 
 export PGSSLMODE=require
+export PGAPPNAME="<app-name>/<model-id>"
 
 psql --quiet -h $CLUSTER_ENDPOINT -U admin -d postgres
 ```


### PR DESCRIPTION
Fixes

## Summary

### Changes

```
Add --created-by to create-cluster.sh for cluster tagging and
--ai-model to psql-connect.sh for application_name tracking.
Update code snippets in docs with application_name patterns.
Fix contradictory parameterized query guidance.

Co-authored-by: anwesham-lab <64298192+anwesham-lab@users.noreply.github.com>
```

### User experience

Tested with skill locally, user experience won't change, but tags and app name will for tracking.

```
# Aurora DSQL Cluster Lifecycle Test — us-east-2

## 1. Create Cluster

**Command:**
```bash
bash scripts/create-cluster.sh --region us-east-2 --created-by claude-opus-4-6
```

**Output:**
```
Creating Aurora DSQL cluster in us-east-2...

✓ Cluster created successfully!

Cluster Identifier: uftsiohkrh5gndmmvn2nj6dqy4
Cluster Endpoint:   uftsiohkrh5gndmmvn2nj6dqy4.dsql.us-east-2.on.aws
Cluster ARN:        arn:aws:dsql:us-east-2:603014702751:cluster/uftsiohkrh5gndmmvn2nj6dqy4
Region:             us-east-2
```

---

## 2. Test psql Connectivity

**Command:**
```bash
export CLUSTER=uftsiohkrh5gndmmvn2nj6dqy4
export REGION=us-east-2
bash scripts/psql-connect.sh --ai-model claude-opus-4-6 --admin --command "SELECT 1 AS connection_test"
```

**Output:**
```
Generating IAM auth token for uftsiohkrh5gndmmvn2nj6dqy4.dsql.us-east-2.on.aws...
Connecting to uftsiohkrh5gndmmvn2nj6dqy4.dsql.us-east-2.on.aws as admin...

 connection_test
-----------------
               1
(1 row)
```

---

## 3. Check Tags

**Command:**
```bash
aws dsql list-tags-for-resource \
  --resource-arn "arn:aws:dsql:us-east-2:603014702751:cluster/uftsiohkrh5gndmmvn2nj6dqy4" \
  --region us-east-2 --output json
```

**Output:**
```json
{
    "tags": {
        "created_by": "claude-opus-4-6"
    }
}
```

---

## 4. Check Application Name

**Command:**
```bash
bash scripts/psql-connect.sh --ai-model claude-opus-4-6 --admin --command "SHOW application_name"
```

**Output:**
```
      application_name
----------------------------
 dsql-skill/claude-opus-4-6
(1 row)
```

---

## 5. Delete Cluster

Deletion protection is enabled by default on new DSQL clusters, so it must be disabled first.

**Command (disable deletion protection):**
```bash
aws dsql update-cluster \
  --identifier uftsiohkrh5gndmmvn2nj6dqy4 \
  --region us-east-2 \
  --no-deletion-protection-enabled
```

**Output:**
```json
{
    "identifier": "uftsiohkrh5gndmmvn2nj6dqy4",
    "arn": "arn:aws:dsql:us-east-2:603014702751:cluster/uftsiohkrh5gndmmvn2nj6dqy4",
    "status": "UPDATING",
    "creationTime": "2026-02-24T18:37:32.532000+00:00"
}
```

**Command (delete):**
```bash
bash scripts/delete-cluster.sh uftsiohkrh5gndmmvn2nj6dqy4 --region us-east-2 --force
```

**Output:**
```
Deleting Aurora DSQL cluster: uftsiohkrh5gndmmvn2nj6dqy4 in us-east-2...
{
    "identifier": "uftsiohkrh5gndmmvn2nj6dqy4",
    "arn": "arn:aws:dsql:us-east-2:603014702751:cluster/uftsiohkrh5gndmmvn2nj6dqy4",
    "status": "DELETING",
    "creationTime": "2026-02-24T18:37:32.532000+00:00"
}

✓ Cluster deletion initiated!
```

---

## Summary

| Step | Result |
|------|--------|
| Create cluster | Cluster `uftsiohkrh5gndmmvn2nj6dqy4` created in `us-east-2` |
| psql connectivity | `SELECT 1` returned successfully via IAM auth as `admin` |
| Tags | `created_by: claude-opus-4-6` (set via `--created-by` flag) |
| Application name | `dsql-skill/claude-opus-4-6` (set via `PGAPPNAME` env var from `--ai-model` flag) |
| Delete cluster | Disabled deletion protection, then deleted successfully (status: `DELETING`) |

```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
