### PR TITLE
docs: add AdaL CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ For macOS/Linux:
 
 # Add core AWS services
 /mcp add aws-api --command uvx --args "awslabs.aws-api-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR"
-/mcp add aws-cdk --command uvx --args "awslabs.cdk-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR"
+/mcp add aws-iac --command uvx --args "awslabs.aws-iac-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR"
 /mcp add aws-docs --command uvx --args "awslabs.aws-documentation-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR,AWS_DOCUMENTATION_PARTITION=aws"
 
 # Add AI/ML and Bedrock services

--- a/docusaurus/docs/installation.md
+++ b/docusaurus/docs/installation.md
@@ -332,7 +332,7 @@ Configure MCP servers in VS Code settings or in `.vscode/mcp.json` (see [VS Code
 
 # Add core AWS services
 /mcp add aws-api --command uvx --args "awslabs.aws-api-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR"
-/mcp add aws-cdk --command uvx --args "awslabs.cdk-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR"
+/mcp add aws-iac --command uvx --args "awslabs.aws-iac-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR"
 /mcp add aws-docs --command uvx --args "awslabs.aws-documentation-mcp-server@latest" --env "FASTMCP_LOG_LEVEL=ERROR,AWS_DOCUMENTATION_PARTITION=aws"
 
 # Add AI/ML and Bedrock services


### PR DESCRIPTION
## Summary

Add [AdaL CLI](https://sylph.ai/) as an MCP client option in the installation documentation. AdaL CLI is a unified AI agent for software engineering with built-in [MCP support](https://docs.sylph.ai/features/mcp-support-proposed).

## Changes

- **`README.md`**: Added "Getting Started with AdaL CLI" section (with `<details>` collapsible) after the existing Claude Code section, including example `/mcp add` commands for core AWS services, AI/ML, and data/analytics servers.
- **`docusaurus/docs/installation.md`**: Added the same AdaL CLI section after the VS Code section for consistency across the root README and Docusaurus site.

## Why

AdaL CLI provides a streamlined way to add MCP servers via its `/mcp add` command, making it easy for developers to integrate AWS MCP servers into their workflow. This follows the existing pattern of documenting multiple MCP client options.

## Formatting

- Uses `text` code fences (not `bash`) since the commands run inside the AdaL CLI prompt, not a shell.
- AdaL CLI is placed last, following the convention of appending new clients after existing ones.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🌸 Generated with [AdaL](https://github.com/adal-cli/)
