### PR TITLE
fix(dsql): add skill symlinks to license header config

### DIFF
--- a/.github/workflows/check-license-header.json
+++ b/.github/workflows/check-license-header.json
@@ -78,7 +78,10 @@
       "**/*.template",
       "**/*.properties",
       "**/*.xml",
-      "**/dist/**"
+      "**/dist/**",
+      "**/skills/*/scripts",
+      "**/skills/*/references",
+      "**/skills/*/mcp"
     ]
   }
 ]


### PR DESCRIPTION
Fixes

See: https://github.com/awslabs/mcp/actions/runs/22413520598/job/64892991834

## Summary

### Changes

```
The check-license-header CI step treats symlinks (scripts, references,
mcp) in skill alias directories as uncovered files. Add patterns to the
no-license-required rule so these symlinks are recognized.

Co-authored-by: anwesham-lab <64298192+anwesham-lab@users.noreply.github.com>
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [y] I have performed a self-review of this change
* [y] Changes have been tested
* [y] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
