### PR TITLE
fix(aws-api-mcp-server): deprecation warnings when running pytest

### DIFF
--- a/src/aws-api-mcp-server/tests/parser/test_parser.py
+++ b/src/aws-api-mcp-server/tests/parser/test_parser.py
@@ -372,7 +372,7 @@ def test_plural_singular_params(command):
     'command',
     [
         'aws s3api get-bucket-location --bucket=deploymentloggingbucke-9c88ebe0707be65d2518510c64917283d761bf03',
-        "aws ec2 describe-availability-zones --query='AvailabilityZones[?ZoneName==`us-east-1a`]'",
+        'aws ec2 describe-availability-zones --query=\'AvailabilityZones[?ZoneName=="us-east-1a"]\'',
         'aws s3api get-bucket-lifecycle --bucket my-s3-bucket',
         'aws --region=us-east-1 ec2 get-subnet-cidr-reservations --subnet-id subnet-012 --color=on',
         "aws apigateway get-export --parameters extensions='postman' --rest-api-id a1b2c3d4e5 --stage-name dev --export-type swagger -",
@@ -573,7 +573,8 @@ def test_client_side_filter_error():
     """Test that a malformed client-side filter raises an error."""
     command = 'aws ec2 describe-instances --query "Reservations[[]"'
     with pytest.raises(
-        ClientSideFilterError, match="Error parsing client-side filter 'Reservations[[]'*"
+        ClientSideFilterError,
+        match=re.escape("Error parsing client-side filter 'Reservations[[]'") + '.*',
     ):
         parse(command)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Fixes the following warnings:

```txt
tests/parser/test_parser.py::test_should_pass_for_valid_equal_sign_params[aws ec2 describe-availability-zones --query='AvailabilityZones[?ZoneName==`us-east-1a`]']
  /Volumes/workplace/mcp-dev/src/aws-api-mcp-server/.venv/lib/python3.12/site-packages/jmespath/lexer.py:169: PendingDeprecationWarning: deprecated string literal syntax
    warnings.warn("deprecated string literal syntax",

tests/parser/test_parser.py::test_client_side_filter_error
  /Volumes/workplace/mcp-dev/src/aws-api-mcp-server/.venv/lib/python3.12/site-packages/_pytest/raises.py:395: FutureWarning: Possible nested set at position 47
    self.match: Pattern[str] | None = re.compile(match)
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
