### PR TITLE
fix(aws-api-mcp-server): remove duplicate assignments in tests

### DIFF
--- a/src/aws-api-mcp-server/tests/test_server.py
+++ b/src/aws-api-mcp-server/tests/test_server.py
@@ -325,7 +325,6 @@ async def test_call_aws_with_consent_and_reject(
     mock_interpret,
 ):
     """Test call_aws with mutating action and consent enabled."""
-    mock_response = InterpretationResponse(error=None, json='{"Buckets": []}', status_code=200)
     mock_is_operation_read_only.return_value = False
 
     # Mock IR with command metadata


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Remove duplicate assignment

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
