### PR TITLE
fix(ccapi-mcp-server): support configurable schema cache directory

### DIFF
--- a/src/ccapi-mcp-server/README.md
+++ b/src/ccapi-mcp-server/README.md
@@ -139,6 +139,7 @@ The server uses boto3's standard credential chain automatically:
 | ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `FASTMCP_LOG_LEVEL` | _(not set)_ | Logging level (ERROR, WARN, INFO, DEBUG)                                                                                                    |
 | `SECURITY_SCANNING` | `enabled`   | Enable/disable Checkov security scanning (`enabled` or `disabled`). When disabled, shows warning but allows resource operations to proceed. |
+| `CCAPI_SCHEMA_CACHE_DIR` | _(auto)_ | Override the schema cache directory. Defaults to `.schemas` relative to the package, with a temp directory fallback for read-only filesystems. |
 
 ### Default Tagging
 

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/schema_manager.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/schema_manager.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import tempfile
 from awslabs.ccapi_mcp_server.aws_client import get_aws_client
 from awslabs.ccapi_mcp_server.errors import ClientError
 from datetime import datetime, timedelta
@@ -31,8 +32,21 @@ class SchemaManager:
     """Responsible for keeping track of schemas, cacheing them locally, and updating them if they are outdated."""
 
     def __init__(self):
-        """Initialize the schema manager with the cache directory."""
-        cache_dir = os.path.join(os.path.dirname(__file__), '.schemas')
+        """Initialize the schema manager with the cache directory.
+
+        The cache directory is resolved in the following order:
+        1. CCAPI_SCHEMA_CACHE_DIR environment variable (if set)
+        2. .schemas directory relative to this file (original default)
+        3. A temp directory fallback if the default is not writable
+        """
+        cache_dir = os.environ.get('CCAPI_SCHEMA_CACHE_DIR')
+        if cache_dir is None:
+            default_dir = os.path.join(os.path.dirname(__file__), '.schemas')
+            try:
+                Path(default_dir).mkdir(exist_ok=True)
+                cache_dir = default_dir
+            except OSError:
+                cache_dir = os.path.join(tempfile.gettempdir(), '.ccapi_schemas')
         self.cache_dir = Path(cache_dir)
         self.metadata_file = self.cache_dir / SCHEMA_METADATA_FILE
         self.schema_registry: Dict[str, dict] = {}


### PR DESCRIPTION
Fixes #2425

## Summary

Allow the schema cache directory to be configured via environment variable, with a fallback to a temp directory for read-only filesystems.

### Changes

- Added `CCAPI_SCHEMA_CACHE_DIR` environment variable support in `SchemaManager.__init__()`. Resolution order:
  1. `CCAPI_SCHEMA_CACHE_DIR` env var (if set)
  2. `.schemas` directory relative to the package (original default)
  3. Temp directory fallback (`/tmp/.ccapi_schemas`) if the default is not writable
- Documented the new env var in `README.md` under Server Configuration

### User experience

**Before:** Server crashes with `PermissionError` on startup when installed to a read-only filesystem (AWS Lambda `/var/task/`, read-only container images).

**After:** Server automatically falls back to a writable temp directory, or users can explicitly set `CCAPI_SCHEMA_CACHE_DIR=/tmp/.ccapi_schemas`. Existing installations are unaffected — the default `.schemas` path is tried first.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).