### PR TITLE
fix(aws-iac-mcp-server): shorten tool names to fit 64-char limit

### DIFF
--- a/src/aws-iac-mcp-server/README.md
+++ b/src/aws-iac-mcp-server/README.md
@@ -75,7 +75,7 @@ Validates CloudFormation template syntax, schema, and resource properties using 
 - `regions` (optional): List of AWS regions to validate against
 - `ignore_checks` (optional): List of cfn-lint check IDs to ignore
 
-#### check_cloudformation_template_compliance
+#### check_cfn_template_compliance
 Validates CloudFormation templates against security and compliance rules using cfn-guard.
 
 **Use this tool to:**
@@ -101,7 +101,7 @@ Analyzes failed CloudFormation stacks and provides resolution guidance.
 #### search_cloudformation_documentation
 Searches AWS CloudFormation documentation knowledge bases and returns relevant best practices.
 
-#### get_cloudformation_pre_deploy_validation_instructions
+#### get_cfn_predeploy_validation_guide
 Returns instructions for CloudFormation's pre-deployment validation feature that validates templates during change set creation.
 
 **Parameters:**

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py
@@ -47,8 +47,8 @@ mcp = FastMCP(
                 ## Tool Selection Guide
 
                 - Use `validate_cloudformation_template` when: You need to validate CloudFormation template syntax, schema, and resource properties using cfn-lint
-                - Use `check_cloudformation_template_compliance` when: You need to validate templates against security and compliance rules using cfn-guard
-                - Use `cloudformation_pre_deploy_validation` when: You need instructions for pre-deployment validation using CloudFormation change sets to catch account-level issues
+                - Use `check_cfn_template_compliance` when: You need to validate templates against security and compliance rules using cfn-guard
+                - Use `get_cfn_predeploy_validation_guide` when: You need instructions for pre-deployment validation using CloudFormation change sets to catch account-level issues
                 - Use `troubleshoot_cloudformation_deployment` when: You need to diagnose CloudFormation deployment failures with root cause analysis and CloudTrail integration
                 - Use `search_cdk_documentation` when: You need specific CDK construct APIs, properties, or official documentation from AWS CDK knowledge bases
                 - Use `search_cdk_samples_and_constructs` when: You need working code examples, implementation patterns, or community constructs
@@ -142,7 +142,7 @@ def validate_cloudformation_template(
 
 
 @mcp.tool()
-def check_cloudformation_template_compliance(
+def check_cfn_template_compliance(
     template_content: str, rules_file_path: str = 'default_guard_rules.guard'
 ) -> str:
     """Validate CloudFormation template against security and compliance rules using cfn-guard.
@@ -261,7 +261,7 @@ def troubleshoot_cloudformation_deployment(
 
 
 @mcp.tool()
-def get_cloudformation_pre_deploy_validation_instructions() -> str:
+def get_cfn_predeploy_validation_guide() -> str:
     """Get instructions for CloudFormation pre-deployment validation.
 
     Returns structured JSON guidance for using CloudFormation's pre-deployment validation feature

--- a/src/aws-iac-mcp-server/tests/test_server.py
+++ b/src/aws-iac-mcp-server/tests/test_server.py
@@ -23,10 +23,10 @@ from unittest.mock import patch
 
 # Access underlying functions from FastMCP decorated tools
 validate_cloudformation_template = server.validate_cloudformation_template.fn
-check_cloudformation_template_compliance = server.check_cloudformation_template_compliance.fn
+check_cfn_template_compliance = server.check_cfn_template_compliance.fn
 troubleshoot_cloudformation_deployment = server.troubleshoot_cloudformation_deployment.fn
-get_cloudformation_pre_deploy_validation_instructions = (
-    server.get_cloudformation_pre_deploy_validation_instructions.fn
+get_cfn_predeploy_validation_guide = (
+    server.get_cfn_predeploy_validation_guide.fn
 )
 search_cdk_documentation = server.search_cdk_documentation.fn
 search_cloudformation_documentation = server.search_cloudformation_documentation.fn
@@ -81,7 +81,7 @@ class TestValidateCloudFormationTemplate:
 
 
 class TestCheckTemplateCompliance:
-    """Test check_cloudformation_template_compliance tool."""
+    """Test check_cfn_template_compliance tool."""
 
     @patch('awslabs.aws_iac_mcp_server.server.check_compliance')
     @patch('awslabs.aws_iac_mcp_server.server.sanitize_tool_response')
@@ -91,7 +91,7 @@ class TestCheckTemplateCompliance:
         mock_sanitize.return_value = 'sanitized response'
 
         template = json.dumps({'Resources': {}})
-        result = check_cloudformation_template_compliance(template)
+        result = check_cfn_template_compliance(template)
 
         assert result == 'sanitized response'
         mock_check.assert_called_once()
@@ -104,7 +104,7 @@ class TestCheckTemplateCompliance:
         mock_sanitize.return_value = 'sanitized response'
 
         template = json.dumps({'Resources': {}})
-        check_cloudformation_template_compliance(template, rules_file_path='/custom/rules.guard')
+        check_cfn_template_compliance(template, rules_file_path='/custom/rules.guard')
 
         mock_check.assert_called_once_with(
             template_content=template, rules_file_path='/custom/rules.guard'
@@ -278,7 +278,7 @@ class TestSearchCdkSamplesAndConstructs:
 
 
 class TestPreDeployValidation:
-    """Test get_cloudformation_pre_deploy_validation_instructions tool."""
+    """Test get_cfn_predeploy_validation_guide tool."""
 
     @patch('awslabs.aws_iac_mcp_server.server.cloudformation_pre_deploy_validation')
     @patch('awslabs.aws_iac_mcp_server.server.sanitize_tool_response')
@@ -287,7 +287,7 @@ class TestPreDeployValidation:
         mock_validation.return_value = '{"instructions": "test"}'
         mock_sanitize.return_value = 'sanitized response'
 
-        result = get_cloudformation_pre_deploy_validation_instructions()
+        result = get_cfn_predeploy_validation_guide()
 
         assert result == 'sanitized response'
         mock_validation.assert_called_once()


### PR DESCRIPTION
Fixes #2395

## Summary

Shorten two tool names in `aws-iac-mcp-server` that exceed Bedrock's 64-character tool name limit when MCP clients append server name suffixes (e.g., `_mcp_aws-iac-mcp-server`).

### Changes

| Before | After | Length |
|--------|-------|--------|
| `check_cloudformation_template_compliance` (41) | `check_cfn_template_compliance` (29) | -12 |
| `get_cloudformation_pre_deploy_validation_instructions` (53) | `get_cfn_predeploy_validation_guide` (35) | -18 |

Uses the `cfn` abbreviation pattern already established elsewhere in the repo.

Files changed:
- `src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py` — rename tool functions and update instructions text
- `src/aws-iac-mcp-server/tests/test_server.py` — update all references to renamed tools
- `src/aws-iac-mcp-server/README.md` — update tool name headings

### User experience

**Before:** MCP clients that namespace tool names (e.g., LibreChat with `_mcp_aws-iac-mcp-server` suffix) hit Bedrock's 64-char limit, causing the entire agent session to fail.

**After:** Both tool names are well under the 64-char limit even with long client suffixes (max 58 chars with LibreChat suffix).

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? Y — Tool names are changed, which is a breaking change for clients that reference tools by name. However, since the old names are broken for many clients anyway (Bedrock rejects them), the rename restores usability.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).