### PR TITLE
fix(core-mcp-server): shorten billing_cost_management prefix to bcm

### DIFF
--- a/src/core-mcp-server/awslabs/core_mcp_server/server.py
+++ b/src/core-mcp-server/awslabs/core_mcp_server/server.py
@@ -393,7 +393,7 @@ async def setup():
         )
         imported_servers = await call_import_server(
             billing_cost_management_server,
-            'billing_cost_management',
+            'bcm',
             'billing_cost_management_server',
             imported_servers,
         )

--- a/src/core-mcp-server/tests/test_server.py
+++ b/src/core-mcp-server/tests/test_server.py
@@ -172,7 +172,7 @@ class TestSetup:
                 'solutions-architect',
                 ['diagram', 'pricing', 'cost_explorer', 'syntheticdata', 'aws_knowledge'],
             ),
-            ('finops', ['cost_explorer', 'pricing', 'cloudwatch', 'billing_cost_management']),
+            ('finops', ['cost_explorer', 'pricing', 'cloudwatch', 'bcm']),
             (
                 'monitoring-observability',
                 ['cloudwatch', 'cloudwatch_appsignals', 'prometheus', 'cloudtrail'],


### PR DESCRIPTION
Fixes #2214

## Summary

Shorten the `billing_cost_management` import prefix (24 chars) to `bcm` (3 chars) in core-mcp-server, fixing the 64-character tool name limit violation.

### Changes

- `src/core-mcp-server/awslabs/core_mcp_server/server.py` — change prefix from `billing_cost_management` to `bcm`
- `src/core-mcp-server/tests/test_server.py` — update expected prefix in role test

### User experience

**Before:** 13 out of 14 billing-cost-management tools exceed the 64-char limit when used with Claude Code (`mcp__awslabs_core-mcp-server__billing_cost_management_*`), causing the entire session to fail.

**After:** All tool names fit within the limit. The longest tool name with Claude Code prefix is 51 chars (`mcp__awslabs_core-mcp-server__bcm_compute-optimizer`).

| Component | Before | After |
|-----------|--------|-------|
| Import prefix | `billing_cost_management_` (24 chars) | `bcm_` (4 chars) |
| Longest full name | 71 chars ❌ | 51 chars ✅ |
| Tools over limit | 13/14 | 0/14 |

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? Y — Tool names change from `billing_cost_management_*` to `bcm_*`. However, the old names are broken for most MCP clients anyway, so this is a fix rather than a regression.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).