### PR TITLE
fix: update trivy-action to v0.34.2

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: hashFiles(format('{0}/trivy-results.sarif', matrix.dockerfile)) == ''
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 #v0.34.1
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 #v0.34.2
         with:
           image-ref: 'docker.io/${{ matrix.dockerfile }}:${{ github.sha }}'
           format: 'sarif'


### PR DESCRIPTION
## Summary
Updates aquasecurity/trivy-action from v0.34.1 to v0.34.2 to resolve failing trivy workflow checks.

## Problem
Version 0.34.1 (introduced in PR #2518) is causing all trivy builds to fail with exit code 1 across all MCP server builds.

## Solution
Update to v0.34.2 which was released on March 2, 2026, and should contain fixes for the issues in v0.34.1.

## Testing
This will resolve the failing trivy checks that are blocking PRs from being merged.

## Related
- Addresses trivy workflow failures mentioned in context of other PRs
- Related to PR #2518 which introduced the broken v0.34.1

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).