### PR TITLE
fix(mcp-lambda-handler): resolve Optional[T] to correct JSON Schema type instead of defaulting to string

### DIFF
--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -216,6 +216,18 @@ class MCPLambdaHandler:
 
                 # Get origin type (e.g., Dict from Dict[str, int])
                 origin = get_origin(type_hint)
+
+                # Handle Union types (including Optional[T] which is Union[T, None])
+                if origin is Union:
+                    args = get_args(type_hint)
+                    non_none_args = [arg for arg in args if arg is not type(None)]
+                    if len(non_none_args) == 1:
+                        return get_type_schema(non_none_args[0])
+                    # For Union with multiple non-None types, use first type
+                    return (
+                        get_type_schema(non_none_args[0]) if non_none_args else {'type': 'string'}
+                    )
+
                 if origin is None:
                     return {'type': 'string'}  # Default for unknown types
 

--- a/src/mcp-lambda-handler/tests/test_lambda_handler.py
+++ b/src/mcp-lambda-handler/tests/test_lambda_handler.py
@@ -584,18 +584,66 @@ def test_tool_decorator_with_no_origin_type_hints():
     handler = MCPLambdaHandler('test-server')
 
     @handler.tool()
-    def foo(a: typing.Any, b: Optional[str]) -> str:
+    def foo(a: typing.Any) -> str:
         """Test tool.
 
         Args:
             a: Any (get_origin returns None)
-            b: Optional (get_origin returns Optional, but it is unsupported)
         """
         return a
 
     schema = handler.tools['foo']
     assert schema['inputSchema']['properties']['a']['type'] == 'string'
-    assert schema['inputSchema']['properties']['b']['type'] == 'string'
+
+
+def test_tool_decorator_optional_type_hints():
+    """Test tool decorator correctly resolves Optional[T] to the underlying type T."""
+    handler = MCPLambdaHandler('test-server')
+
+    @handler.tool()
+    def foo(
+        a: Optional[int],
+        b: Optional[str],
+        c: Optional[float],
+        d: Optional[bool],
+        e: Optional[List[str]],
+    ) -> str:
+        """Test tool.
+
+        Args:
+            a: An optional integer
+            b: An optional string
+            c: An optional float
+            d: An optional boolean
+            e: An optional list of strings
+        """
+        return 'ok'
+
+    schema = handler.tools['foo']
+    props = schema['inputSchema']['properties']
+    assert props['a']['type'] == 'integer'
+    assert props['b']['type'] == 'string'
+    assert props['c']['type'] == 'number'
+    assert props['d']['type'] == 'boolean'
+    assert props['e']['type'] == 'array'
+    assert props['e']['items'] == {'type': 'string'}
+
+
+def test_tool_decorator_union_type_hints():
+    """Test tool decorator correctly resolves Union[T1, T2] to the first non-None type."""
+    handler = MCPLambdaHandler('test-server')
+
+    @handler.tool()
+    def foo(a: typing.Union[int, str]) -> str:
+        """Test tool.
+
+        Args:
+            a: A union of int and str
+        """
+        return 'ok'
+
+    schema = handler.tools['foo']
+    assert schema['inputSchema']['properties']['a']['type'] == 'integer'
 
 
 def test_tool_decorator_dictionary_type_hints():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

The `get_type_schema` function had no handler for `Union` types, so `Optional[int]` (which is Union[int, None]) fell through to the default case and was incorrectly mapped to `"string"`. The fix adds a Union handler that strips NoneType and recursively resolves the actual inner type, so `Optional[int]` now correctly produces `"integer"`.

### User experience

When a user defines a tool with `Optional[int]` parameters like:

`@mcp.tool()
def test_int_param(days: Optional[int] = 30, status: Optional[str] = "new") -> str:
`
Before this change, the generated JSON Schema showed `days` as a string:
`
"days": {
  "type": "string",
  "description": "Number of days, default 30"
}
`
After this change, it correctly reflects the integer type:
`
"days": {
  "type": "integer",
  "description": "Number of days, default 30"
}
`
This matters because MCP clients validate parameter types against the schema. With the old behavior, a client sending `days: 30` as an integer would see a type mismatch against the `"string"` schema, causing confusion or requiring workarounds.



## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: #2354

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
