### PR TITLE
fix(terraform-mcp-server): harden working_directory and terragrunt_config path validation

### DIFF
--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/execute_terraform_command.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/execute_terraform_command.py
@@ -18,7 +18,10 @@ import json
 import os
 import re
 import subprocess
-from awslabs.terraform_mcp_server.impl.tools.utils import get_dangerous_patterns
+from awslabs.terraform_mcp_server.impl.tools.utils import (
+    get_dangerous_patterns,
+    validate_working_directory,
+)
 from awslabs.terraform_mcp_server.models import TerraformExecutionRequest, TerraformExecutionResult
 from loguru import logger
 
@@ -132,6 +135,19 @@ async def execute_terraform_command_impl(
                         outputs=None,
                     )
 
+    # Validate and resolve working_directory
+    try:
+        validated_working_dir = validate_working_directory(request.working_directory)
+    except ValueError as e:
+        logger.error(str(e))
+        return TerraformExecutionResult(
+            command=f'terraform {request.command}',
+            status='error',
+            error_message=str(e),
+            working_directory=request.working_directory,
+            outputs=None,
+        )
+
     # Build the command
     cmd = ['terraform', request.command]
 
@@ -152,7 +168,7 @@ async def execute_terraform_command_impl(
         # Safe: Command is validated against allowlist, variables are checked for dangerous patterns,
         # working_directory is user-controlled but subprocess uses cwd parameter (not shell injection)
         process = subprocess.run(  # noqa: B603 - Safe: allowlisted commands, validated variables, no shell injection
-            cmd, cwd=request.working_directory, capture_output=True, text=True, env=env
+            cmd, cwd=validated_working_dir, capture_output=True, text=True, env=env
         )
 
         # Prepare the result
@@ -181,7 +197,7 @@ async def execute_terraform_command_impl(
                 logger.info('Getting Terraform outputs')
                 output_process = subprocess.run(  # noqa: B603 - Safe: hardcoded terraform output command with no user input
                     ['terraform', 'output', '-json'],
-                    cwd=request.working_directory,
+                    cwd=validated_working_dir,
                     capture_output=True,
                     text=True,
                     env=env,

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/execute_terragrunt_command.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/execute_terragrunt_command.py
@@ -18,7 +18,10 @@ import json
 import os
 import re
 import subprocess
-from awslabs.terraform_mcp_server.impl.tools.utils import get_dangerous_patterns
+from awslabs.terraform_mcp_server.impl.tools.utils import (
+    get_dangerous_patterns,
+    validate_working_directory,
+)
 from awslabs.terraform_mcp_server.models import (
     TerragruntExecutionRequest,
     TerragruntExecutionResult,
@@ -192,6 +195,20 @@ async def execute_terragrunt_command_impl(
                         affected_dirs=None,
                     )
 
+    # Validate and resolve working_directory
+    try:
+        validated_working_dir = validate_working_directory(request.working_directory)
+    except ValueError as e:
+        logger.error(str(e))
+        return TerragruntExecutionResult(
+            command=f'terragrunt {request.command}',
+            status='error',
+            error_message=str(e),
+            working_directory=request.working_directory,
+            outputs=None,
+            affected_dirs=None,
+        )
+
     # Build the command
     base_cmd = ['terragrunt']
 
@@ -211,8 +228,20 @@ async def execute_terragrunt_command_impl(
 
     # Add terragrunt_config if specified and not using run-all
     if request.terragrunt_config:
-        logger.info(f'Using custom terragrunt config file: {request.terragrunt_config}')
-        base_cmd.append(f'--terragrunt-config={request.terragrunt_config}')
+        try:
+            validated_config = validate_working_directory(request.terragrunt_config)
+        except ValueError as e:
+            logger.error(str(e))
+            return TerragruntExecutionResult(
+                command=f'terragrunt {request.command}',
+                status='error',
+                error_message=f'Security violation: terragrunt_config path is invalid. {e}',
+                working_directory=request.working_directory,
+                outputs=None,
+                affected_dirs=None,
+            )
+        logger.info(f'Using custom terragrunt config file: {validated_config}')
+        base_cmd.append(f'--terragrunt-config={validated_config}')
 
     # Add variables only for commands that accept them (plan, apply, destroy, output)
     if request.command in ['plan', 'apply', 'destroy', 'output', 'run-all'] and request.variables:
@@ -236,7 +265,7 @@ async def execute_terragrunt_command_impl(
         # Safe: Command is validated against allowlist, variables are checked for dangerous patterns,
         # working_directory is user-controlled but subprocess uses cwd parameter (not shell injection)
         process = subprocess.run(  # noqa: B603 - Safe: allowlisted commands, validated variables, no shell injection
-            base_cmd, cwd=request.working_directory, capture_output=True, text=True, env=env
+            base_cmd, cwd=validated_working_dir, capture_output=True, text=True, env=env
         )
 
         # Prepare the result
@@ -277,7 +306,7 @@ async def execute_terragrunt_command_impl(
                 logger.info('Getting Terragrunt outputs')
                 output_process = subprocess.run(  # noqa: B603 - Safe: hardcoded terragrunt output command with no user input
                     ['terragrunt', 'output', '-json'],
-                    cwd=request.working_directory,
+                    cwd=validated_working_dir,
                     capture_output=True,
                     text=True,
                     env=env,

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/run_checkov_scan.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/run_checkov_scan.py
@@ -15,10 +15,12 @@
 """Implementation of Checkov scan tools."""
 
 import json
-import os
 import re
 import subprocess
-from awslabs.terraform_mcp_server.impl.tools.utils import get_dangerous_patterns
+from awslabs.terraform_mcp_server.impl.tools.utils import (
+    get_dangerous_patterns,
+    validate_working_directory,
+)
 from awslabs.terraform_mcp_server.models import (
     CheckovScanRequest,
     CheckovScanResult,
@@ -262,17 +264,21 @@ async def run_checkov_scan_impl(request: CheckovScanRequest) -> CheckovScanResul
                     )
 
     # Build the command
-    # Convert working_directory to absolute path if it's not already
-    working_dir = request.working_directory
-    if not os.path.isabs(working_dir):
-        # Get the current working directory of the MCP server
-        current_dir = os.getcwd()
-        # Go up to the project root directory (assuming we're in src/terraform-mcp-server/awslabs/terraform_mcp_server)
-        project_root = os.path.abspath(os.path.join(current_dir, '..', '..', '..', '..'))
-        # Join with the requested working directory
-        working_dir = os.path.abspath(os.path.join(project_root, working_dir))
+    # Validate and resolve working_directory
+    try:
+        working_dir = validate_working_directory(request.working_directory)
+    except ValueError as e:
+        logger.error(str(e))
+        return CheckovScanResult(
+            status='error',
+            working_directory=request.working_directory,
+            error_message=str(e),
+            vulnerabilities=[],
+            summary={},
+            raw_output=None,
+        )
 
-    logger.info(f'Using absolute working directory: {working_dir}')
+    logger.info(f'Using validated working directory: {working_dir}')
     cmd = ['checkov', '--quiet', '-d', working_dir]
 
     # Add framework if specified

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/utils.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/impl/tools/utils.py
@@ -15,6 +15,7 @@
 """Utility functions for Terraform MCP server tools."""
 
 import asyncio
+import os
 import re
 import requests
 import time
@@ -501,6 +502,40 @@ def parse_variables_tf(content: str) -> List[TerraformVariable]:
         variables.append(variable)
 
     return variables
+
+
+def validate_working_directory(working_dir: str, allowed_base: Optional[str] = None) -> str:
+    """Validate and resolve a working directory path.
+
+    Ensures the resolved path is within an allowed base directory. If no base
+    directory is provided, the current working directory is used.
+
+    Args:
+        working_dir: User-supplied working directory (relative or absolute).
+        allowed_base: Optional base directory that the path must reside under.
+                      Defaults to the current working directory.
+
+    Returns:
+        The validated, resolved absolute path.
+
+    Raises:
+        ValueError: If the resolved path is outside the allowed base directory.
+    """
+    if allowed_base is None:
+        allowed_base = os.getcwd()
+
+    resolved_base = os.path.realpath(allowed_base)
+    resolved_path = os.path.realpath(os.path.join(resolved_base, working_dir))
+
+    # Ensure the resolved path is the base itself or a child of it
+    if resolved_path != resolved_base and not resolved_path.startswith(resolved_base + os.sep):
+        raise ValueError(
+            f"Security: working_directory '{working_dir}' resolves to "
+            f"'{resolved_path}' which is outside the allowed base directory "
+            f"'{resolved_base}'. Only paths within the base directory are permitted."
+        )
+
+    return resolved_path
 
 
 # Security-related constants and utilities

--- a/src/terraform-mcp-server/tests/test_command_impl.py
+++ b/src/terraform-mcp-server/tests/test_command_impl.py
@@ -23,6 +23,26 @@ from unittest.mock import MagicMock, patch
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def mock_path_validation(temp_terraform_dir):
+    """Bypass path validation for tests that use temp dirs outside cwd."""
+    with (
+        patch(
+            'awslabs.terraform_mcp_server.impl.tools.execute_terraform_command.validate_working_directory',
+            return_value=temp_terraform_dir,
+        ),
+        patch(
+            'awslabs.terraform_mcp_server.impl.tools.execute_terragrunt_command.validate_working_directory',
+            return_value=temp_terraform_dir,
+        ),
+        patch(
+            'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan.validate_working_directory',
+            return_value=temp_terraform_dir,
+        ),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_execute_terraform_command_success(temp_terraform_dir):
     """Test the Terraform command execution function with successful mocks."""

--- a/src/terraform-mcp-server/tests/test_execute_terraform_command.py
+++ b/src/terraform-mcp-server/tests/test_execute_terraform_command.py
@@ -12,6 +12,16 @@ from unittest.mock import MagicMock, patch
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def mock_path_validation(temp_terraform_dir):
+    """Bypass path validation for tests that use temp dirs outside cwd."""
+    with patch(
+        'awslabs.terraform_mcp_server.impl.tools.execute_terraform_command.validate_working_directory',
+        return_value=temp_terraform_dir,
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_clean_output_text_helper(temp_terraform_dir):
     """Test the clean_output_text helper function indirectly."""
@@ -226,3 +236,25 @@ async def test_execute_terraform_command_complex_outputs(temp_terraform_dir):
         assert result.outputs['vpc_config']['vpc_id'] == 'vpc-1234'
         assert result.outputs['vpc_config']['subnet_ids'] == ['subnet-1', 'subnet-2']
         assert result.outputs['simple_output'] == 'direct_value'
+
+
+@pytest.mark.asyncio
+async def test_execute_terraform_command_rejects_invalid_path(temp_terraform_dir):
+    """Test that terraform command rejects paths outside the allowed base."""
+    request = TerraformExecutionRequest(
+        command='init',
+        working_directory='/etc',
+        variables={},
+        aws_region=None,
+        strip_ansi=True,
+    )
+
+    with patch(
+        'awslabs.terraform_mcp_server.impl.tools.execute_terraform_command.validate_working_directory',
+        side_effect=ValueError('path outside allowed base'),
+    ):
+        result = await execute_terraform_command_impl(request)
+
+        assert result.status == 'error'
+        assert result.error_message is not None
+        assert 'path outside allowed base' in result.error_message

--- a/src/terraform-mcp-server/tests/test_execute_terragrunt_command.py
+++ b/src/terraform-mcp-server/tests/test_execute_terragrunt_command.py
@@ -14,6 +14,16 @@ from unittest.mock import MagicMock, patch
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def mock_path_validation(temp_terraform_dir):
+    """Bypass path validation for tests that use temp dirs outside cwd."""
+    with patch(
+        'awslabs.terraform_mcp_server.impl.tools.execute_terragrunt_command.validate_working_directory',
+        side_effect=lambda path, **kwargs: temp_terraform_dir,
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_execute_terragrunt_command_success(temp_terraform_dir):
     """Test the Terragrunt command execution function with successful mocks."""
@@ -488,6 +498,68 @@ async def test_execute_terragrunt_command_with_custom_config(temp_terraform_dir)
         assert result.status == 'success'
         assert result.stdout == 'Terragrunt initialized with custom config!'
 
-        # Verify the command included the custom config flag
+        # Verify the command included a --terragrunt-config flag (path is validated/resolved)
         cmd_args = mock_run.call_args[0][0]
-        assert f'--terragrunt-config={custom_config}' in cmd_args
+        assert any(arg.startswith('--terragrunt-config=') for arg in cmd_args)
+
+
+@pytest.mark.asyncio
+async def test_execute_terragrunt_command_rejects_invalid_path(temp_terraform_dir):
+    """Test that terragrunt command rejects paths outside the allowed base."""
+    request = TerragruntExecutionRequest(
+        command='init',
+        working_directory='/etc',
+        variables={},
+        aws_region=None,
+        strip_ansi=True,
+        include_dirs=None,
+        exclude_dirs=None,
+        run_all=False,
+        terragrunt_config=None,
+    )
+
+    with patch(
+        'awslabs.terraform_mcp_server.impl.tools.execute_terragrunt_command.validate_working_directory',
+        side_effect=ValueError('path outside allowed base'),
+    ):
+        result = await execute_terragrunt_command_impl(request)
+
+        assert result.status == 'error'
+        assert result.error_message is not None
+        assert 'path outside allowed base' in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_execute_terragrunt_command_rejects_invalid_config_path(temp_terraform_dir):
+    """Test that terragrunt command rejects config paths outside the allowed base."""
+    request = TerragruntExecutionRequest(
+        command='init',
+        working_directory=temp_terraform_dir,
+        variables={},
+        aws_region=None,
+        strip_ansi=True,
+        include_dirs=None,
+        exclude_dirs=None,
+        run_all=False,
+        terragrunt_config='/etc/malicious.hcl',
+    )
+
+    # First call (working_dir) succeeds, second call (config) raises
+    call_count = 0
+
+    def side_effect(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return temp_terraform_dir
+        raise ValueError('config path outside allowed base')
+
+    with patch(
+        'awslabs.terraform_mcp_server.impl.tools.execute_terragrunt_command.validate_working_directory',
+        side_effect=side_effect,
+    ):
+        result = await execute_terragrunt_command_impl(request)
+
+        assert result.status == 'error'
+        assert result.error_message is not None
+        assert 'config path outside allowed base' in result.error_message

--- a/src/terraform-mcp-server/tests/test_run_checkov_scan.py
+++ b/src/terraform-mcp-server/tests/test_run_checkov_scan.py
@@ -132,81 +132,115 @@ async def test_parse_checkov_json_output_invalid():
 
 
 @pytest.mark.asyncio
-async def test_run_checkov_scan_with_absolute_path(temp_terraform_dir):
-    """Test running Checkov scan with an absolute path."""
-    # Create the request with an absolute path and all required parameters
-    absolute_path = os.path.abspath(temp_terraform_dir)
+async def test_run_checkov_scan_with_absolute_path_outside_cwd(temp_terraform_dir):
+    """Test that absolute paths outside cwd are rejected."""
     request = CheckovScanRequest(
-        working_directory=absolute_path,
+        working_directory='/etc',
         framework='terraform',
         output_format='json',
         check_ids=None,
         skip_check_ids=None,
     )
 
-    # Create a mock subprocess.run result
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = json.dumps(
-        {'results': {'failed_checks': []}, 'summary': {'passed': 5, 'failed': 0, 'skipped': 0}}
-    )
-    mock_result.stderr = ''
+    result = await run_checkov_scan_impl(request)
 
-    # Mock subprocess.run and _ensure_checkov_installed
-    with patch('subprocess.run', return_value=mock_result):
-        with patch(
-            'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
-            return_value=True,
-        ):
-            # Call the function
-            result = await run_checkov_scan_impl(request)
-
-            # Check the result
-            assert result.status == 'success'
-            assert result.working_directory == absolute_path
-            assert result.summary['passed'] == 5
-            assert result.summary['failed'] == 0
+    assert result.status == 'error'
+    assert result.error_message is not None
+    assert 'Security' in result.error_message
+    assert 'outside' in result.error_message
 
 
 @pytest.mark.asyncio
-async def test_run_checkov_scan_with_relative_path(temp_terraform_dir):
-    """Test running Checkov scan with a relative path."""
-    # Create a relative path (just the directory name)
-    relative_path = os.path.basename(temp_terraform_dir)
-
-    # Create the request with a relative path and all required parameters
+async def test_run_checkov_scan_with_parent_traversal(temp_terraform_dir):
+    """Test that parent directory traversal is rejected."""
     request = CheckovScanRequest(
-        working_directory=relative_path,
+        working_directory='../../etc/passwd',
         framework='terraform',
         output_format='json',
         check_ids=None,
         skip_check_ids=None,
     )
 
-    # Create a mock subprocess.run result
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = json.dumps(
-        {'results': {'failed_checks': []}, 'summary': {'passed': 3, 'failed': 0, 'skipped': 0}}
-    )
-    mock_result.stderr = ''
+    result = await run_checkov_scan_impl(request)
 
-    # Mock subprocess.run, _ensure_checkov_installed, and os.path.isabs
-    with patch('subprocess.run', return_value=mock_result):
-        with patch(
-            'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
-            return_value=True,
-        ):
-            with patch('os.path.isabs', return_value=False):
-                with patch('os.getcwd', return_value='/fake/cwd'):
-                    with patch('os.path.abspath', return_value='/fake/absolute/path'):
-                        # Call the function
-                        result = await run_checkov_scan_impl(request)
+    assert result.status == 'error'
+    assert result.error_message is not None
+    assert 'Security' in result.error_message
 
-                        # Check the result
-                        assert result.status == 'success'
-                        assert result.working_directory == relative_path
-                        assert result.summary['passed'] == 3
+
+@pytest.mark.asyncio
+async def test_run_checkov_scan_with_valid_subdirectory(temp_terraform_dir):
+    """Test running Checkov scan with a valid subdirectory within cwd."""
+    # Create a subdirectory within cwd
+    subdir = os.path.join(os.getcwd(), 'test_subdir')
+    os.makedirs(subdir, exist_ok=True)
+
+    try:
+        request = CheckovScanRequest(
+            working_directory='test_subdir',
+            framework='terraform',
+            output_format='json',
+            check_ids=None,
+            skip_check_ids=None,
+        )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(
+            {'results': {'failed_checks': []}, 'summary': {'passed': 5, 'failed': 0, 'skipped': 0}}
+        )
+        mock_result.stderr = ''
+
+        with patch('subprocess.run', return_value=mock_result):
+            with patch(
+                'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
+                return_value=True,
+            ):
+                result = await run_checkov_scan_impl(request)
+
+                assert result.status == 'success'
+                assert result.summary['passed'] == 5
+                assert result.summary['failed'] == 0
+    finally:
+        os.rmdir(subdir)
+
+
+@pytest.mark.asyncio
+async def test_run_checkov_scan_with_relative_path_in_cwd(temp_terraform_dir):
+    """Test running Checkov scan with a relative path that resolves within cwd."""
+    # Create a subdirectory in cwd for this test
+    subdir_name = 'tf_test_relative'
+    subdir = os.path.join(os.getcwd(), subdir_name)
+    os.makedirs(subdir, exist_ok=True)
+
+    try:
+        request = CheckovScanRequest(
+            working_directory=subdir_name,
+            framework='terraform',
+            output_format='json',
+            check_ids=None,
+            skip_check_ids=None,
+        )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(
+            {'results': {'failed_checks': []}, 'summary': {'passed': 3, 'failed': 0, 'skipped': 0}}
+        )
+        mock_result.stderr = ''
+
+        with patch('subprocess.run', return_value=mock_result):
+            with patch(
+                'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
+                return_value=True,
+            ):
+                result = await run_checkov_scan_impl(request)
+
+                assert result.status == 'success'
+                assert result.working_directory == subdir_name
+                assert result.summary['passed'] == 3
+    finally:
+        os.rmdir(subdir)
 
 
 @pytest.mark.asyncio
@@ -234,7 +268,6 @@ async def test_run_checkov_scan_with_skip_check_ids_dangerous_pattern(temp_terra
 @pytest.mark.asyncio
 async def test_run_checkov_scan_cli_output_parsing(temp_terraform_dir):
     """Test running Checkov scan with CLI output format and parsing the results."""
-    # Create the request with all required parameters
     request = CheckovScanRequest(
         working_directory=temp_terraform_dir,
         framework='terraform',
@@ -243,11 +276,9 @@ async def test_run_checkov_scan_cli_output_parsing(temp_terraform_dir):
         skip_check_ids=None,
     )
 
-    # Create a mock subprocess.run result with CLI output
     mock_result = MagicMock()
     mock_result.returncode = 1  # Vulnerabilities found
 
-    # Create CLI output with multiple checks
     cli_output = f"""
     Check: CKV_AWS_1: "Ensure S3 bucket has encryption enabled"
     FAILED for resource: aws_s3_bucket.my_bucket
@@ -267,28 +298,28 @@ async def test_run_checkov_scan_cli_output_parsing(temp_terraform_dir):
     mock_result.stdout = cli_output
     mock_result.stderr = ''
 
-    # Mock subprocess.run and _ensure_checkov_installed
     with patch('subprocess.run', return_value=mock_result):
         with patch(
             'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
             return_value=True,
         ):
-            # Call the function
-            result = await run_checkov_scan_impl(request)
+            with patch(
+                'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan.validate_working_directory',
+                return_value=temp_terraform_dir,
+            ):
+                result = await run_checkov_scan_impl(request)
 
-            # Check the result
-            assert result.status == 'success'
-            assert result.return_code == 1
-            assert len(result.vulnerabilities) == 3
-            assert result.summary['passed'] == 2
-            assert result.summary['failed'] == 3
-            assert result.summary['skipped'] == 1
+                assert result.status == 'success'
+                assert result.return_code == 1
+                assert len(result.vulnerabilities) == 3
+                assert result.summary['passed'] == 2
+                assert result.summary['failed'] == 3
+                assert result.summary['skipped'] == 1
 
 
 @pytest.mark.asyncio
 async def test_run_checkov_scan_with_return_code_2(temp_terraform_dir):
     """Test running Checkov scan with return code 2 (error)."""
-    # Create the request with all required parameters
     request = CheckovScanRequest(
         working_directory=temp_terraform_dir,
         framework='terraform',
@@ -297,31 +328,30 @@ async def test_run_checkov_scan_with_return_code_2(temp_terraform_dir):
         skip_check_ids=None,
     )
 
-    # Create a mock subprocess.run result with error
     mock_result = MagicMock()
     mock_result.returncode = 2  # Error code
     mock_result.stdout = 'Error running checkov'
     mock_result.stderr = 'Failed to parse Terraform files'
 
-    # Mock subprocess.run and _ensure_checkov_installed
     with patch('subprocess.run', return_value=mock_result):
         with patch(
             'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
             return_value=True,
         ):
-            # Call the function
-            result = await run_checkov_scan_impl(request)
+            with patch(
+                'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan.validate_working_directory',
+                return_value=temp_terraform_dir,
+            ):
+                result = await run_checkov_scan_impl(request)
 
-            # Check the result
-            assert result.status == 'error'
-            assert result.return_code == 2
-            assert len(result.vulnerabilities) == 0
+                assert result.status == 'error'
+                assert result.return_code == 2
+                assert len(result.vulnerabilities) == 0
 
 
 @pytest.mark.asyncio
 async def test_run_checkov_scan_exception_handling(temp_terraform_dir):
     """Test running Checkov scan with exception handling."""
-    # Create the request with all required parameters
     request = CheckovScanRequest(
         working_directory=temp_terraform_dir,
         framework='terraform',
@@ -330,25 +360,25 @@ async def test_run_checkov_scan_exception_handling(temp_terraform_dir):
         skip_check_ids=None,
     )
 
-    # Mock subprocess.run to raise an exception
     with patch('subprocess.run', side_effect=Exception('Command execution failed')):
         with patch(
             'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan._ensure_checkov_installed',
             return_value=True,
         ):
-            # Call the function
-            result = await run_checkov_scan_impl(request)
+            with patch(
+                'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan.validate_working_directory',
+                return_value=temp_terraform_dir,
+            ):
+                result = await run_checkov_scan_impl(request)
 
-            # Check the result
-            assert result.status == 'error'
-            assert result.error_message == 'Command execution failed'
-            assert result.working_directory == temp_terraform_dir
+                assert result.status == 'error'
+                assert result.error_message == 'Command execution failed'
+                assert result.working_directory == temp_terraform_dir
 
 
 @pytest.mark.asyncio
 async def test_run_checkov_scan_checkov_not_found_install_success(temp_terraform_dir):
     """Test running Checkov scan when checkov is not found but install succeeds."""
-    # Create the request with all required parameters
     request = CheckovScanRequest(
         working_directory=temp_terraform_dir,
         framework='terraform',
@@ -357,7 +387,6 @@ async def test_run_checkov_scan_checkov_not_found_install_success(temp_terraform
         skip_check_ids=None,
     )
 
-    # Create a mock subprocess.run result for the actual scan
     mock_scan_result = MagicMock()
     mock_scan_result.returncode = 0
     mock_scan_result.stdout = json.dumps(
@@ -365,34 +394,29 @@ async def test_run_checkov_scan_checkov_not_found_install_success(temp_terraform
     )
     mock_scan_result.stderr = ''
 
-    # Create a mock subprocess.run result for pip install
     mock_install_result = MagicMock()
     mock_install_result.returncode = 0
 
-    # Mock subprocess.run with side_effect to handle multiple calls
     with patch('subprocess.run') as mock_run:
-        # First call (checkov --version) raises FileNotFoundError
-        # Second call (pip install) succeeds
-        # Third call (actual scan) succeeds
         mock_run.side_effect = [
             FileNotFoundError(),
             mock_install_result,  # pip install success
             mock_scan_result,  # checkov scan
         ]
+        with patch(
+            'awslabs.terraform_mcp_server.impl.tools.run_checkov_scan.validate_working_directory',
+            return_value=temp_terraform_dir,
+        ):
+            result = await run_checkov_scan_impl(request)
 
-        # Call the function
-        result = await run_checkov_scan_impl(request)
-
-        # Check the result
-        assert result.status == 'success'
-        assert result.summary['passed'] == 1
-        assert mock_run.call_count == 3
+            assert result.status == 'success'
+            assert result.summary['passed'] == 1
+            assert mock_run.call_count == 3
 
 
 @pytest.mark.asyncio
 async def test_run_checkov_scan_checkov_not_found_install_fails(temp_terraform_dir):
     """Test running Checkov scan when checkov is not found and install fails."""
-    # Create the request with all required parameters
     request = CheckovScanRequest(
         working_directory=temp_terraform_dir,
         framework='terraform',
@@ -401,19 +425,14 @@ async def test_run_checkov_scan_checkov_not_found_install_fails(temp_terraform_d
         skip_check_ids=None,
     )
 
-    # Mock subprocess.run with side_effect to handle multiple calls
     with patch('subprocess.run') as mock_run:
-        # First call (checkov --version) raises FileNotFoundError
-        # Second call (pip install) raises CalledProcessError
         mock_run.side_effect = [
             FileNotFoundError(),
             subprocess.CalledProcessError(1, 'pip install checkov'),
         ]
 
-        # Call the function
         result = await run_checkov_scan_impl(request)
 
-        # Check the result
         assert result.status == 'error'
         assert result.error_message is not None
         assert 'Failed to install Checkov' in result.error_message

--- a/src/terraform-mcp-server/tests/test_utils.py
+++ b/src/terraform-mcp-server/tests/test_utils.py
@@ -1,11 +1,15 @@
 """Tests for the utils module of the terraform-mcp-server."""
 
+import os
+import pytest
+import tempfile
 from awslabs.terraform_mcp_server.impl.tools.utils import (
     clean_description,
     extract_description_from_readme,
     extract_outputs_from_readme,
     get_dangerous_patterns,
     parse_variables_tf,
+    validate_working_directory,
 )
 from awslabs.terraform_mcp_server.models import TerraformVariable
 from unittest.mock import patch
@@ -300,3 +304,56 @@ class TestGetDangerousPatterns:
         assert '--' in patterns
         assert 'rm' in patterns
         assert 'sudo' in patterns
+
+
+class TestValidateWorkingDirectory:
+    """Tests for the validate_working_directory function."""
+
+    def test_relative_path_within_base(self):
+        """Test that a relative subdirectory within base is accepted."""
+        with tempfile.TemporaryDirectory() as base:
+            subdir = os.path.join(base, 'child')
+            os.makedirs(subdir)
+            result = validate_working_directory('child', allowed_base=base)
+            assert result == os.path.realpath(subdir)
+
+    def test_absolute_path_outside_base_rejected(self):
+        """Test that an absolute path outside the base raises ValueError."""
+        with tempfile.TemporaryDirectory() as base:
+            with pytest.raises(ValueError, match='Security'):
+                validate_working_directory('/etc', allowed_base=base)
+
+    def test_parent_traversal_rejected(self):
+        """Test that ../ traversal outside the base raises ValueError."""
+        with tempfile.TemporaryDirectory() as base:
+            with pytest.raises(ValueError, match='Security'):
+                validate_working_directory('../../etc', allowed_base=base)
+
+    def test_dot_path_accepted(self):
+        """Test that '.' (the base itself) is accepted."""
+        with tempfile.TemporaryDirectory() as base:
+            result = validate_working_directory('.', allowed_base=base)
+            assert result == os.path.realpath(base)
+
+    def test_nested_subdirectory_accepted(self):
+        """Test that a nested subdirectory within base is accepted."""
+        with tempfile.TemporaryDirectory() as base:
+            nested = os.path.join(base, 'a', 'b', 'c')
+            os.makedirs(nested)
+            result = validate_working_directory('a/b/c', allowed_base=base)
+            assert result == os.path.realpath(nested)
+
+    def test_symlink_escape_rejected(self):
+        """Test that a symlink pointing outside the base is rejected."""
+        with tempfile.TemporaryDirectory() as base:
+            link_path = os.path.join(base, 'escape')
+            os.symlink('/etc', link_path)
+            with pytest.raises(ValueError, match='Security'):
+                validate_working_directory('escape', allowed_base=base)
+
+    def test_defaults_to_cwd(self):
+        """Test that allowed_base defaults to os.getcwd() when not specified."""
+        cwd = os.getcwd()
+        # A relative path that stays within cwd should work
+        result = validate_working_directory('.', allowed_base=None)
+        assert result == os.path.realpath(cwd)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #N/A

## Summary

### Changes

Adds `validate_working_directory()` to `utils.py` that resolves user-supplied paths via `os.path.realpath()` and ensures they stay within the server's working directory. This hardening is applied to:

- `run_checkov_scan.py` — `working_directory` parameter
- `execute_terraform_command.py` — `working_directory` parameter
- `execute_terragrunt_command.py` — `working_directory` and `terragrunt_config` parameters

Previously, the `working_directory` parameter accepted arbitrary absolute paths without boundary checks. With this change, all paths are resolved and validated against the server's current working directory before being passed to subprocess calls.

| File | Change |
|------|--------|
| `impl/tools/utils.py` | New `validate_working_directory()` utility |
| `impl/tools/run_checkov_scan.py` | Replace raw path handling with validation |
| `impl/tools/execute_terraform_command.py` | Add path validation before subprocess call |
| `impl/tools/execute_terragrunt_command.py` | Add path validation for both `working_directory` and `terragrunt_config` |
| `tests/test_utils.py` | 7 new tests for path validation |
| `tests/test_run_checkov_scan.py` | 3 new path boundary tests, updated existing tests |
| `tests/test_execute_terraform_command.py` | Updated test fixtures |
| `tests/test_execute_terragrunt_command.py` | Updated test fixtures |
| `tests/test_command_impl.py` | Updated test fixtures |

### User experience

Before: Users could pass any absolute path (e.g., `/etc`) as `working_directory` and it would be accepted.

After: Paths that resolve outside the server's working directory are rejected with a clear error message. Relative paths within the project continue to work as before.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).