### PR TITLE
feat(aws-diagram-mcp-server): add diagram Claude Code agent skill

### DIFF
--- a/src/aws-diagram-mcp-server/skills/README.md
+++ b/src/aws-diagram-mcp-server/skills/README.md
@@ -1,0 +1,67 @@
+# Diagram Skills
+
+## Skill Aliases
+
+The following folders are aliases for `diagram-skill` for more accurate domain representation.
+
+| Folder | Skill Name |
+|--------|-----------|
+| `diagram-skill` | `diagram` (source of truth) |
+| `aws-diagram-skill` | `aws diagram` |
+| `architecture-diagram-skill` | `architecture diagram` |
+
+Each alias folder contains:
+- Its own `SKILL.md` with only the `name` field changed
+- Symlinks for `references/`, `examples/`, and `scripts/` pointing back to `diagram-skill/`
+
+## Installation
+
+### Skills CLI
+
+```bash
+npx skills add awslabs/mcp --skill diagram
+```
+
+### Manual (Claude Code)
+
+```bash
+# Sparse clone the skill
+mkdir -p .diagram_skill_repos
+cd .diagram_skill_repos
+git clone --filter=blob:none --no-checkout https://github.com/awslabs/mcp.git
+cd mcp
+git sparse-checkout init --cone
+git sparse-checkout set src/aws-diagram-mcp-server/skills/diagram-skill
+git checkout
+cd ../..
+
+# Symlink into Claude Code skills directory
+mkdir -p ~/.claude/skills
+ln -s "$(pwd)/.diagram_skill_repos/mcp/src/aws-diagram-mcp-server/skills/diagram-skill" ~/.claude/skills/diagram-skill
+```
+
+For project-scoped installation, use `.claude/skills/` in your project root instead of `~/.claude/skills/`.
+
+### Verify
+
+```bash
+ls -la ~/.claude/skills/diagram-skill/
+# Should show SKILL.md and other skill files
+```
+
+In Claude Code, type `/diagram` -- it should appear in autocomplete.
+
+## Prerequisites
+
+The skill requires:
+1. **GraphViz**: `brew install graphviz` (macOS) or `apt-get install graphviz` (Linux)
+2. **Python diagrams package**: `pip install diagrams`
+
+Run `scripts/setup.sh` inside the skill directory to check prerequisites.
+
+## Updating
+
+```bash
+cd .diagram_skill_repos/mcp
+git pull
+```

--- a/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/SKILL.md
+++ b/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: architecture diagram
+description: >
+  Generate architecture diagrams using the Python diagrams DSL. Use when
+  user requests architecture diagrams, system design visuals, or
+  infrastructure diagrams for AWS, Kubernetes, or on-premises systems.
+allowed-tools: Bash, Read, Write
+---
+
+# Architecture Diagram Skill
+
+Generate professional architecture diagrams using the Python [diagrams](https://diagrams.mingrammer.com/) package. Supports AWS (29 service categories), Kubernetes, on-premises, GCP, SaaS, and more.
+
+**Output:** PNG images saved to `generated-diagrams/` in the workspace.
+
+---
+
+## Reference Files
+
+Load these files as needed for detailed guidance:
+
+### [dsl-guide.md](references/dsl-guide.md)
+**When:** ALWAYS load before writing diagram code
+**Contains:** Full DSL reference -- imports, Diagram/Cluster/Edge syntax, provider import paths, all AWS service categories
+
+### [icon-reference.md](references/icon-reference.md)
+**When:** Load when you need to find the correct class name for a specific service or icon
+**Contains:** Complete listing of all providers, services, and icon class names
+
+### [aws-examples.md](examples/aws-examples.md)
+**When:** Load when generating AWS architecture diagrams
+**Contains:** 5 AWS examples -- basic, grouped workers, clustered services, event processing, Bedrock
+
+### [general-examples.md](examples/general-examples.md)
+**When:** Load when generating non-AWS diagrams (K8s, on-prem, sequence, flow, class, custom icons)
+**Contains:** 7 examples -- sequence, flow, class, K8s, on-prem, colored edges, custom icons
+
+---
+
+## Prerequisites
+
+Requires two dependencies installed locally:
+
+1. **GraphViz** (system package -- provides the `dot` renderer):
+   - macOS: `brew install graphviz`
+   - Ubuntu/Debian: `sudo apt-get install graphviz`
+   - Amazon Linux: `sudo yum install graphviz`
+2. **Python `diagrams` package**: `pip install diagrams`
+
+Run `scripts/setup.sh` to check and guide installation.
+
+---
+
+## Quick Start
+
+### 1. Generate a simple diagram
+
+```python
+from diagrams import Diagram
+from diagrams.aws.compute import EC2
+from diagrams.aws.database import RDS
+from diagrams.aws.network import ELB
+
+with Diagram("Web Service", show=False, filename="generated-diagrams/web-service"):
+    ELB("lb") >> EC2("web") >> RDS("db")
+```
+
+### 2. Run it
+
+```bash
+mkdir -p generated-diagrams
+python diagram.py
+# Output: generated-diagrams/web-service.png
+```
+
+---
+
+## Best Practices
+
+- **ALWAYS use `show=False`** -- prevents diagram from opening in a viewer
+- **ALWAYS set `filename=`** -- save to `generated-diagrams/` subdirectory
+- **MUST use explicit imports** -- `from diagrams.aws.compute import EC2`, not `import *`
+- **SHOULD use `Cluster` for grouping** -- VPCs, subnets, service groups, namespaces
+- **MUST create output directory** -- `mkdir -p generated-diagrams` before running

--- a/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/examples
+++ b/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/examples
@@ -1,0 +1,1 @@
+../diagram-skill/examples

--- a/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/references
+++ b/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/references
@@ -1,0 +1,1 @@
+../diagram-skill/references

--- a/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/scripts
+++ b/src/aws-diagram-mcp-server/skills/architecture-diagram-skill/scripts
@@ -1,0 +1,1 @@
+../diagram-skill/scripts

--- a/src/aws-diagram-mcp-server/skills/aws-diagram-skill/SKILL.md
+++ b/src/aws-diagram-mcp-server/skills/aws-diagram-skill/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: aws diagram
+description: >
+  Generate architecture diagrams using the Python diagrams DSL. Use when
+  user requests architecture diagrams, system design visuals, or
+  infrastructure diagrams for AWS, Kubernetes, or on-premises systems.
+allowed-tools: Bash, Read, Write
+---
+
+# Architecture Diagram Skill
+
+Generate professional architecture diagrams using the Python [diagrams](https://diagrams.mingrammer.com/) package. Supports AWS (29 service categories), Kubernetes, on-premises, GCP, SaaS, and more.
+
+**Output:** PNG images saved to `generated-diagrams/` in the workspace.
+
+---
+
+## Reference Files
+
+Load these files as needed for detailed guidance:
+
+### [dsl-guide.md](references/dsl-guide.md)
+**When:** ALWAYS load before writing diagram code
+**Contains:** Full DSL reference -- imports, Diagram/Cluster/Edge syntax, provider import paths, all AWS service categories
+
+### [icon-reference.md](references/icon-reference.md)
+**When:** Load when you need to find the correct class name for a specific service or icon
+**Contains:** Complete listing of all providers, services, and icon class names
+
+### [aws-examples.md](examples/aws-examples.md)
+**When:** Load when generating AWS architecture diagrams
+**Contains:** 5 AWS examples -- basic, grouped workers, clustered services, event processing, Bedrock
+
+### [general-examples.md](examples/general-examples.md)
+**When:** Load when generating non-AWS diagrams (K8s, on-prem, sequence, flow, class, custom icons)
+**Contains:** 7 examples -- sequence, flow, class, K8s, on-prem, colored edges, custom icons
+
+---
+
+## Prerequisites
+
+Requires two dependencies installed locally:
+
+1. **GraphViz** (system package -- provides the `dot` renderer):
+   - macOS: `brew install graphviz`
+   - Ubuntu/Debian: `sudo apt-get install graphviz`
+   - Amazon Linux: `sudo yum install graphviz`
+2. **Python `diagrams` package**: `pip install diagrams`
+
+Run `scripts/setup.sh` to check and guide installation.
+
+---
+
+## Quick Start
+
+### 1. Generate a simple diagram
+
+```python
+from diagrams import Diagram
+from diagrams.aws.compute import EC2
+from diagrams.aws.database import RDS
+from diagrams.aws.network import ELB
+
+with Diagram("Web Service", show=False, filename="generated-diagrams/web-service"):
+    ELB("lb") >> EC2("web") >> RDS("db")
+```
+
+### 2. Run it
+
+```bash
+mkdir -p generated-diagrams
+python diagram.py
+# Output: generated-diagrams/web-service.png
+```
+
+---
+
+## Best Practices
+
+- **ALWAYS use `show=False`** -- prevents diagram from opening in a viewer
+- **ALWAYS set `filename=`** -- save to `generated-diagrams/` subdirectory
+- **MUST use explicit imports** -- `from diagrams.aws.compute import EC2`, not `import *`
+- **SHOULD use `Cluster` for grouping** -- VPCs, subnets, service groups, namespaces
+- **MUST create output directory** -- `mkdir -p generated-diagrams` before running

--- a/src/aws-diagram-mcp-server/skills/aws-diagram-skill/examples
+++ b/src/aws-diagram-mcp-server/skills/aws-diagram-skill/examples
@@ -1,0 +1,1 @@
+../diagram-skill/examples

--- a/src/aws-diagram-mcp-server/skills/aws-diagram-skill/references
+++ b/src/aws-diagram-mcp-server/skills/aws-diagram-skill/references
@@ -1,0 +1,1 @@
+../diagram-skill/references

--- a/src/aws-diagram-mcp-server/skills/aws-diagram-skill/scripts
+++ b/src/aws-diagram-mcp-server/skills/aws-diagram-skill/scripts
@@ -1,0 +1,1 @@
+../diagram-skill/scripts

--- a/src/aws-diagram-mcp-server/skills/diagram-skill/SKILL.md
+++ b/src/aws-diagram-mcp-server/skills/diagram-skill/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: diagram
+description: >
+  Generate architecture diagrams using the Python diagrams DSL. Use when
+  user requests architecture diagrams, system design visuals, or
+  infrastructure diagrams for AWS, Kubernetes, or on-premises systems.
+allowed-tools: Bash, Read, Write
+---
+
+# Architecture Diagram Skill
+
+Generate professional architecture diagrams using the Python [diagrams](https://diagrams.mingrammer.com/) package. Supports AWS (29 service categories), Kubernetes, on-premises, GCP, SaaS, and more.
+
+**Output:** PNG images saved to `generated-diagrams/` in the workspace.
+
+---
+
+## Reference Files
+
+Load these files as needed for detailed guidance:
+
+### [dsl-guide.md](references/dsl-guide.md)
+**When:** ALWAYS load before writing diagram code
+**Contains:** Full DSL reference -- imports, Diagram/Cluster/Edge syntax, provider import paths, all AWS service categories
+
+### [icon-reference.md](references/icon-reference.md)
+**When:** Load when you need to find the correct class name for a specific service or icon
+**Contains:** Complete listing of all providers, services, and icon class names
+
+### [aws-examples.md](examples/aws-examples.md)
+**When:** Load when generating AWS architecture diagrams
+**Contains:** 5 AWS examples -- basic, grouped workers, clustered services, event processing, Bedrock
+
+### [general-examples.md](examples/general-examples.md)
+**When:** Load when generating non-AWS diagrams (K8s, on-prem, sequence, flow, class, custom icons)
+**Contains:** 7 examples -- sequence, flow, class, K8s, on-prem, colored edges, custom icons
+
+---
+
+## Prerequisites
+
+Requires two dependencies installed locally:
+
+1. **GraphViz** (system package -- provides the `dot` renderer):
+   - macOS: `brew install graphviz`
+   - Ubuntu/Debian: `sudo apt-get install graphviz`
+   - Amazon Linux: `sudo yum install graphviz`
+2. **Python `diagrams` package**: `pip install diagrams`
+
+Run `scripts/setup.sh` to check and guide installation.
+
+---
+
+## Quick Start
+
+### 1. Generate a simple diagram
+
+```python
+from diagrams import Diagram
+from diagrams.aws.compute import EC2
+from diagrams.aws.database import RDS
+from diagrams.aws.network import ELB
+
+with Diagram("Web Service", show=False, filename="generated-diagrams/web-service"):
+    ELB("lb") >> EC2("web") >> RDS("db")
+```
+
+### 2. Run it
+
+```bash
+mkdir -p generated-diagrams
+python diagram.py
+# Output: generated-diagrams/web-service.png
+```
+
+---
+
+## Common Workflows
+
+### Workflow 1: AWS Architecture Diagram
+
+**Goal:** Generate an AWS architecture diagram from a description.
+
+**Steps:**
+1. Load [dsl-guide.md](references/dsl-guide.md) for syntax reference
+2. Load [aws-examples.md](examples/aws-examples.md) for patterns
+3. Write a Python script using the `diagrams` DSL
+4. Run via Bash: `mkdir -p generated-diagrams && python diagram.py`
+5. Verify the PNG was created
+
+**Critical rules:**
+- ALWAYS set `show=False` in the `Diagram()` constructor
+- ALWAYS set `filename="generated-diagrams/<name>"` (no `.png` extension)
+- Use `with Cluster("name"):` to group related resources
+- Use explicit imports: `from diagrams.aws.<service> import <Icon>`
+
+### Workflow 2: Kubernetes Diagram
+
+**Goal:** Generate a K8s architecture diagram.
+
+**Steps:**
+1. Load [dsl-guide.md](references/dsl-guide.md) for syntax
+2. Load [general-examples.md](examples/general-examples.md) for K8s patterns
+3. Write script using `diagrams.k8s.*` imports
+4. Run via Bash
+
+**Critical rules:**
+- K8s imports: `from diagrams.k8s.compute import Pod, Deployment, StatefulSet`
+- K8s networking: `from diagrams.k8s.network import Ingress, Service`
+- Use `Cluster` for namespaces or logical groups
+
+### Workflow 3: Sequence or Flow Diagram
+
+**Goal:** Generate a process flow or interaction diagram.
+
+**Steps:**
+1. Load [general-examples.md](examples/general-examples.md) for flow/sequence patterns
+2. Use `diagrams.programming.flowchart` for flow shapes (Decision, Action, InputOutput, etc.)
+3. Run via Bash
+
+### Workflow 4: Custom Styling
+
+**Goal:** Customize colors, labels, and edge styles.
+
+**Steps:**
+1. Use `Edge(label="text", color="darkgreen", style="dashed")` for styled connections
+2. Use `direction="TB"` or `direction="LR"` in `Diagram()` for layout direction
+3. Use `Cluster` with nested `Cluster` for hierarchical grouping
+
+**Edge styles:** `"solid"`, `"dashed"`, `"dotted"`, `"bold"`
+**Common colors:** `"darkgreen"`, `"firebrick"`, `"brown"`, `"darkorange"`, `"black"`
+
+---
+
+## Best Practices
+
+- **ALWAYS use `show=False`** -- prevents diagram from opening in a viewer
+- **ALWAYS set `filename=`** -- save to `generated-diagrams/` subdirectory
+- **MUST use explicit imports** -- `from diagrams.aws.compute import EC2`, not `import *`
+- **SHOULD use `Cluster` for grouping** -- VPCs, subnets, service groups, namespaces
+- **SHOULD set `direction=`** -- `"TB"` (top-to-bottom) or `"LR"` (left-to-right) for clarity
+- **MUST create output directory** -- `mkdir -p generated-diagrams` before running
+- **SHOULD use `Edge` for labeled connections** -- `>> Edge(label="HTTPS") >>` for clarity
+
+---
+
+## Additional Resources
+
+- [diagrams documentation](https://diagrams.mingrammer.com/)
+- [diagrams GitHub](https://github.com/mingrammer/diagrams)
+- [GraphViz download](https://graphviz.org/download/)
+- [Diagram node list](https://diagrams.mingrammer.com/docs/nodes/aws)

--- a/src/aws-diagram-mcp-server/skills/diagram-skill/examples/aws-examples.md
+++ b/src/aws-diagram-mcp-server/skills/diagram-skill/examples/aws-examples.md
@@ -1,0 +1,127 @@
+# AWS Architecture Diagram Examples
+
+## 1. Basic Web Service
+
+Simple three-tier architecture.
+
+```python
+from diagrams import Diagram
+from diagrams.aws.compute import EC2
+from diagrams.aws.database import RDS
+from diagrams.aws.network import ELB
+
+with Diagram("Web Service Architecture", show=False, filename="generated-diagrams/aws-basic"):
+    ELB("lb") >> EC2("web") >> RDS("userdb")
+```
+
+## 2. Grouped Workers
+
+Load balancer distributing to multiple EC2 workers.
+
+```python
+from diagrams import Diagram
+from diagrams.aws.compute import EC2
+from diagrams.aws.database import RDS
+from diagrams.aws.network import ELB
+
+with Diagram("Grouped Workers", show=False, direction="TB", filename="generated-diagrams/aws-workers"):
+    ELB("lb") >> [EC2("worker1"),
+                  EC2("worker2"),
+                  EC2("worker3"),
+                  EC2("worker4"),
+                  EC2("worker5")] >> RDS("events")
+```
+
+## 3. Clustered Web Services
+
+DNS, load balancer, service cluster with DB replication and caching.
+
+```python
+from diagrams import Diagram, Cluster
+from diagrams.aws.compute import ECS
+from diagrams.aws.database import RDS, ElastiCache
+from diagrams.aws.network import ELB, Route53
+
+with Diagram("Clustered Web Services", show=False, filename="generated-diagrams/aws-clustered"):
+    dns = Route53("dns")
+    lb = ELB("lb")
+
+    with Cluster("Services"):
+        svc_group = [ECS("web1"),
+                     ECS("web2"),
+                     ECS("web3")]
+
+    with Cluster("DB Cluster"):
+        db_primary = RDS("userdb")
+        db_primary - [RDS("userdb ro")]
+
+    memcached = ElastiCache("memcached")
+
+    dns >> lb >> svc_group
+    svc_group >> db_primary
+    svc_group >> memcached
+```
+
+## 4. Event Processing
+
+EKS source, SQS queue, Lambda processors, S3 storage, Redshift analytics.
+
+```python
+from diagrams import Diagram, Cluster
+from diagrams.aws.compute import ECS, EKS, Lambda
+from diagrams.aws.analytics import Redshift
+from diagrams.aws.integration import SQS
+from diagrams.aws.storage import S3
+
+with Diagram("Event Processing", show=False, filename="generated-diagrams/aws-events"):
+    source = EKS("k8s source")
+
+    with Cluster("Event Flows"):
+        with Cluster("Event Workers"):
+            workers = [ECS("worker1"),
+                       ECS("worker2"),
+                       ECS("worker3")]
+
+        queue = SQS("event queue")
+
+        with Cluster("Processing"):
+            handlers = [Lambda("proc1"),
+                        Lambda("proc2"),
+                        Lambda("proc3")]
+
+    store = S3("events store")
+    dw = Redshift("analytics")
+
+    source >> workers >> queue >> handlers
+    handlers >> store
+    handlers >> dw
+```
+
+## 5. S3 Image Processing with Bedrock
+
+Serverless image processing pipeline using Bedrock.
+
+```python
+from diagrams import Diagram, Cluster, Edge
+from diagrams.aws.compute import Lambda
+from diagrams.aws.general import User
+from diagrams.aws.ml import Bedrock
+from diagrams.aws.storage import S3
+
+with Diagram("S3 Image Processing with Bedrock", show=False, direction="LR", filename="generated-diagrams/aws-bedrock"):
+    user = User("User")
+
+    with Cluster("Amazon S3 Bucket"):
+        input_folder = S3("Input Folder")
+        output_folder = S3("Output Folder")
+
+    lambda_function = Lambda("Image Processor Function")
+    bedrock = Bedrock("Claude Sonnet 3.7")
+
+    user >> Edge(label="Upload Image") >> input_folder
+    input_folder >> Edge(label="Trigger") >> lambda_function
+    lambda_function >> Edge(label="Process Image") >> bedrock
+    bedrock >> Edge(label="Return Bounding Box") >> lambda_function
+    lambda_function >> Edge(label="Upload Processed Image") >> output_folder
+    output_folder >> Edge(label="Download Result") >> user
+```

--- a/src/aws-diagram-mcp-server/skills/diagram-skill/examples/general-examples.md
+++ b/src/aws-diagram-mcp-server/skills/diagram-skill/examples/general-examples.md
@@ -1,0 +1,173 @@
+# General Diagram Examples
+
+## 1. Sequence / Authentication Flow
+
+Using flowchart shapes for process flows.
+
+```python
+from diagrams import Diagram
+from diagrams.aws.general import User
+from diagrams.programming.flowchart import Action, Decision, InputOutput
+
+with Diagram("User Authentication Flow", show=False, filename="generated-diagrams/sequence"):
+    user = User("User")
+    login = InputOutput("Login Form")
+    auth = Decision("Authenticated?")
+    success = Action("Access Granted")
+    failure = Action("Access Denied")
+
+    user >> login >> auth
+    auth >> success
+    auth >> failure
+```
+
+## 2. Order Processing Flow
+
+Decision trees and branching workflows.
+
+```python
+from diagrams import Diagram
+from diagrams.programming.flowchart import Action, Decision, Delay, InputOutput, Predefined
+
+with Diagram("Order Processing Flow", show=False, filename="generated-diagrams/flow"):
+    start = Predefined("Start")
+    order = InputOutput("Order Received")
+    check = Decision("In Stock?")
+    process = Action("Process Order")
+    wait = Delay("Backorder")
+    ship = Action("Ship Order")
+    end = Predefined("End")
+
+    start >> order >> check
+    check >> process >> ship >> end
+    check >> wait >> process
+```
+
+## 3. Class Diagram
+
+Object relationship / inheritance diagram.
+
+```python
+from diagrams import Diagram
+from diagrams.programming.language import Python
+
+with Diagram("Simple Class Diagram", show=False, filename="generated-diagrams/class"):
+    base = Python("BaseClass")
+    child1 = Python("ChildClass1")
+    child2 = Python("ChildClass2")
+
+    base >> child1
+    base >> child2
+```
+
+## 4. Kubernetes Exposed Pod
+
+Ingress to service to pod replicas with HPA.
+
+```python
+from diagrams import Diagram
+from diagrams.k8s.compute import Deployment, Pod, ReplicaSet
+from diagrams.k8s.clusterconfig import HPA
+from diagrams.k8s.network import Ingress, Service
+
+with Diagram("Exposed Pod with 3 Replicas", show=False, filename="generated-diagrams/k8s-exposed"):
+    net = Ingress("domain.com") >> Service("svc")
+    net >> [Pod("pod1"),
+            Pod("pod2"),
+            Pod("pod3")] << ReplicaSet("rs") << Deployment("dp") << HPA("hpa")
+```
+
+## 5. Kubernetes Stateful Architecture
+
+StatefulSet with PVCs and storage classes.
+
+```python
+from diagrams import Diagram, Cluster
+from diagrams.k8s.compute import Pod, StatefulSet
+from diagrams.k8s.network import Service
+from diagrams.k8s.storage import PV, PVC, StorageClass
+
+with Diagram("Stateful Architecture", show=False, filename="generated-diagrams/k8s-stateful"):
+    with Cluster("Apps"):
+        svc = Service("svc")
+        sts = StatefulSet("sts")
+
+        apps = []
+        for _ in range(3):
+            pod = Pod("pod")
+            pvc = PVC("pvc")
+            pod - sts - pvc
+            apps.append(svc >> pod >> pvc)
+
+    apps << PV("pv") << StorageClass("sc")
+```
+
+## 6. On-Premises Web Service (with colored edges)
+
+Full on-prem stack with monitoring, logging, and styled edges.
+
+```python
+from diagrams import Diagram, Cluster, Edge
+from diagrams.onprem.analytics import Spark
+from diagrams.onprem.compute import Server
+from diagrams.onprem.database import PostgreSQL
+from diagrams.onprem.inmemory import Redis
+from diagrams.onprem.logging import Fluentd
+from diagrams.onprem.monitoring import Grafana, Prometheus
+from diagrams.onprem.network import Nginx
+from diagrams.onprem.queue import Kafka
+
+with Diagram("Advanced Web Service with On-Premise (colored)", show=False, filename="generated-diagrams/onprem-colored"):
+    ingress = Nginx("ingress")
+
+    metrics = Prometheus("metric")
+    metrics << Edge(color="firebrick", style="dashed") << Grafana("monitoring")
+
+    with Cluster("Service Cluster"):
+        grpcsvc = [
+            Server("grpc1"),
+            Server("grpc2"),
+            Server("grpc3")]
+
+    with Cluster("Sessions HA"):
+        primary = Redis("session")
+        primary - Edge(color="brown", style="dashed") - Redis("replica") << Edge(label="collect") << metrics
+        grpcsvc >> Edge(color="brown") >> primary
+
+    with Cluster("Database HA"):
+        primary = PostgreSQL("users")
+        primary - Edge(color="brown", style="dotted") - PostgreSQL("replica") << Edge(label="collect") << metrics
+        grpcsvc >> Edge(color="black") >> primary
+
+    aggregator = Fluentd("logging")
+    aggregator >> Edge(label="parse") >> Kafka("stream") >> Edge(color="black", style="bold") >> Spark("analytics")
+
+    ingress >> Edge(color="darkgreen") << grpcsvc >> Edge(color="darkorange") >> aggregator
+```
+
+## 7. Custom Icons
+
+Using external images as diagram nodes.
+
+```python
+from diagrams import Diagram, Cluster
+from diagrams.aws.database import Aurora
+from diagrams.custom import Custom
+from diagrams.k8s.compute import Pod
+from urllib.request import urlretrieve
+
+# Download an image to be used into a Custom Node class
+rabbitmq_url = "https://jpadilla.github.io/rabbitmqapp/assets/img/icon.png"
+rabbitmq_icon, _ = urlretrieve(rabbitmq_url, "rabbitmq.png")
+
+with Diagram("Broker Consumers", show=False, filename="generated-diagrams/custom"):
+    with Cluster("Consumers"):
+        consumers = [
+            Pod("worker"),
+            Pod("worker"),
+            Pod("worker")]
+
+    queue = Custom("Message queue", rabbitmq_icon)
+
+    queue >> consumers >> Aurora("Database")
+```

--- a/src/aws-diagram-mcp-server/skills/diagram-skill/references/dsl-guide.md
+++ b/src/aws-diagram-mcp-server/skills/diagram-skill/references/dsl-guide.md
@@ -1,0 +1,198 @@
+# Diagrams DSL Reference
+
+## Installation
+
+```bash
+# Python package
+pip install diagrams
+
+# GraphViz (required renderer)
+# macOS:
+brew install graphviz
+# Ubuntu/Debian:
+sudo apt-get install graphviz
+# Amazon Linux:
+sudo yum install graphviz
+```
+
+## Basic Structure
+
+```python
+from diagrams import Diagram, Cluster, Edge
+from diagrams.aws.compute import EC2, Lambda
+from diagrams.aws.database import RDS, DynamoDB
+from diagrams.aws.network import ELB, CloudFront
+
+with Diagram("My Architecture", show=False, filename="generated-diagrams/my-arch"):
+    with Cluster("VPC"):
+        lb = ELB("ALB")
+        with Cluster("Private Subnet"):
+            servers = [EC2("web1"), EC2("web2")]
+        db = RDS("PostgreSQL")
+
+    CloudFront("CDN") >> lb >> servers >> db
+```
+
+## Diagram Constructor
+
+```python
+Diagram(
+    name="Diagram Title",     # Title shown on the diagram
+    show=False,                # ALWAYS False -- don't open viewer
+    filename="path/name",      # Output path (no .png extension)
+    direction="TB",            # TB (top-bottom), LR (left-right), BT, RL
+    outformat="png",           # png (default), jpg, svg, pdf
+)
+```
+
+## Connections
+
+```python
+# Left to right flow
+node1 >> node2 >> node3
+
+# Right to left flow
+node1 << node2
+
+# Bidirectional
+node1 - node2
+
+# Fan out to multiple
+node1 >> [node2, node3, node4]
+
+# Labeled/styled edge
+node1 >> Edge(label="HTTPS", color="darkgreen", style="dashed") >> node2
+```
+
+## Clusters (Grouping)
+
+```python
+with Cluster("VPC"):
+    with Cluster("Public Subnet"):
+        lb = ELB("ALB")
+    with Cluster("Private Subnet"):
+        app = EC2("App")
+        db = RDS("DB")
+```
+
+## Edge Styles
+
+| Parameter | Values |
+|-----------|--------|
+| `color` | `"darkgreen"`, `"firebrick"`, `"brown"`, `"darkorange"`, `"black"`, any CSS color |
+| `style` | `"solid"`, `"dashed"`, `"dotted"`, `"bold"` |
+| `label` | Any string |
+
+## Provider Import Paths
+
+| Provider | Import Pattern | Example |
+|----------|---------------|---------|
+| AWS | `diagrams.aws.<service>` | `from diagrams.aws.compute import EC2` |
+| GCP | `diagrams.gcp.<service>` | `from diagrams.gcp.storage import GCS` |
+| Kubernetes | `diagrams.k8s.<service>` | `from diagrams.k8s.compute import Pod` |
+| On-premises | `diagrams.onprem.<service>` | `from diagrams.onprem.database import PostgreSQL` |
+| SaaS | `diagrams.saas.<service>` | `from diagrams.saas.chat import Slack` |
+| Elastic | `diagrams.elastic.<service>` | `from diagrams.elastic.elasticsearch import Elasticsearch` |
+| Programming | `diagrams.programming.<service>` | `from diagrams.programming.language import Python` |
+| Generic | `diagrams.generic.<service>` | `from diagrams.generic.compute import Rack` |
+| Custom | `diagrams.custom.Custom` | `Custom("name", "icon.png")` |
+
+## AWS Service Categories (29 total)
+
+| Category | Import Path | Common Icons |
+|----------|------------|--------------|
+| `analytics` | `diagrams.aws.analytics` | Athena, EMR, Glue, Kinesis, Redshift, Quicksight |
+| `compute` | `diagrams.aws.compute` | EC2, Lambda, ECS, EKS, Fargate, Batch |
+| `cost` | `diagrams.aws.cost` | Budgets, CostExplorer |
+| `database` | `diagrams.aws.database` | RDS, DynamoDB, ElastiCache, Aurora, Redshift |
+| `devtools` | `diagrams.aws.devtools` | CodeBuild, CodeDeploy, CodePipeline |
+| `general` | `diagrams.aws.general` | User, Users, Client, InternetGateway |
+| `integration` | `diagrams.aws.integration` | SQS, SNS, StepFunctions, EventBridge, APIGateway |
+| `iot` | `diagrams.aws.iot` | IotCore, IotAnalytics |
+| `management` | `diagrams.aws.management` | CloudWatch, CloudFormation, SystemsManager |
+| `ml` | `diagrams.aws.ml` | Sagemaker, Rekognition, Comprehend, Bedrock |
+| `network` | `diagrams.aws.network` | VPC, ELB, CloudFront, Route53, APIGateway |
+| `security` | `diagrams.aws.security` | IAM, Cognito, WAF, KMS, Shield |
+| `storage` | `diagrams.aws.storage` | S3, EBS, EFS, FSx |
+
+Other categories: `ar`, `blockchain`, `business`, `enablement`, `enduser`, `engagement`, `game`, `media`, `migration`, `mobile`, `quantum`, `robotics`, `satellite`.
+
+## Kubernetes Service Categories
+
+| Category | Import Path | Common Icons |
+|----------|------------|--------------|
+| `compute` | `diagrams.k8s.compute` | Pod, Deployment, StatefulSet, ReplicaSet, DaemonSet, Job |
+| `network` | `diagrams.k8s.network` | Service, Ingress, NetworkPolicy |
+| `storage` | `diagrams.k8s.storage` | PV, PVC, StorageClass |
+| `controlplane` | `diagrams.k8s.controlplane` | APIServer, Scheduler, ControllerManager |
+| `clusterconfig` | `diagrams.k8s.clusterconfig` | HPA, Namespace, Quota |
+| `rbac` | `diagrams.k8s.rbac` | Role, RoleBinding, ClusterRole |
+| `infra` | `diagrams.k8s.infra` | Node, Master |
+| `group` | `diagrams.k8s.group` | NS |
+
+## On-Premises Service Categories
+
+| Category | Common Icons |
+|----------|-------------|
+| `compute` | Server |
+| `database` | PostgreSQL, MySQL, MongoDB, Cassandra, InfluxDB |
+| `container` | Docker |
+| `ci` | Jenkins, GitlabCI, GithubActions |
+| `cd` | ArgoCD, FluxCD |
+| `monitoring` | Prometheus, Grafana, Datadog |
+| `logging` | Fluentd, Loki |
+| `queue` | Kafka, RabbitMQ, Celery |
+| `network` | Nginx, HAProxy, Traefik |
+| `inmemory` | Redis, Memcached |
+| `search` | Elasticsearch |
+| `vcs` | Git, Github, Gitlab |
+| `iac` | Terraform, Ansible |
+| `storage` | Ceph |
+
+## Flowchart Shapes (for sequence/flow diagrams)
+
+```python
+from diagrams.programming.flowchart import (
+    Action,          # Rectangle -- process step
+    Decision,        # Diamond -- yes/no branch
+    InputOutput,     # Parallelogram -- data input/output
+    Predefined,      # Double-border rectangle -- predefined process
+    Delay,           # Half-oval -- wait/delay
+)
+```
+
+## Custom Nodes (external icons)
+
+```python
+from diagrams.custom import Custom
+
+# Download an icon and use it
+from urllib.request import urlretrieve
+icon_path, _ = urlretrieve("https://example.com/icon.png", "icon.png")
+custom_node = Custom("My Service", icon_path)
+```
+
+## Common Patterns
+
+### Fan-out / Fan-in
+```python
+source >> [worker1, worker2, worker3] >> sink
+```
+
+### Bidirectional with Replica
+```python
+primary = RDS("primary")
+primary - RDS("replica")  # bidirectional dash
+```
+
+### Nested Clusters
+```python
+with Cluster("VPC"):
+    with Cluster("Public"):
+        lb = ELB("ALB")
+    with Cluster("Private"):
+        app = [EC2("app1"), EC2("app2")]
+    with Cluster("Data"):
+        db = RDS("db")
+    lb >> app >> db
+```

--- a/src/aws-diagram-mcp-server/skills/diagram-skill/references/icon-reference.md
+++ b/src/aws-diagram-mcp-server/skills/diagram-skill/references/icon-reference.md
@@ -1,0 +1,140 @@
+# Diagram Icon Reference
+
+Complete listing of all available providers and service categories. For the full list of icons within each category, see the [diagrams node documentation](https://diagrams.mingrammer.com/docs/nodes/aws).
+
+## AWS (29 categories)
+
+| Category | Import Path |
+|----------|------------|
+| analytics | `from diagrams.aws.analytics import ...` |
+| ar | `from diagrams.aws.ar import ...` |
+| blockchain | `from diagrams.aws.blockchain import ...` |
+| business | `from diagrams.aws.business import ...` |
+| compute | `from diagrams.aws.compute import ...` |
+| cost | `from diagrams.aws.cost import ...` |
+| database | `from diagrams.aws.database import ...` |
+| devtools | `from diagrams.aws.devtools import ...` |
+| enablement | `from diagrams.aws.enablement import ...` |
+| enduser | `from diagrams.aws.enduser import ...` |
+| engagement | `from diagrams.aws.engagement import ...` |
+| game | `from diagrams.aws.game import ...` |
+| general | `from diagrams.aws.general import ...` |
+| integration | `from diagrams.aws.integration import ...` |
+| iot | `from diagrams.aws.iot import ...` |
+| management | `from diagrams.aws.management import ...` |
+| media | `from diagrams.aws.media import ...` |
+| migration | `from diagrams.aws.migration import ...` |
+| ml | `from diagrams.aws.ml import ...` |
+| mobile | `from diagrams.aws.mobile import ...` |
+| network | `from diagrams.aws.network import ...` |
+| quantum | `from diagrams.aws.quantum import ...` |
+| robotics | `from diagrams.aws.robotics import ...` |
+| satellite | `from diagrams.aws.satellite import ...` |
+| security | `from diagrams.aws.security import ...` |
+| storage | `from diagrams.aws.storage import ...` |
+
+### Commonly Used AWS Icons
+
+| Category | Icons |
+|----------|-------|
+| compute | `EC2`, `Lambda`, `ECS`, `EKS`, `Fargate`, `Batch`, `LightsailContainer` |
+| database | `RDS`, `Aurora`, `DynamoDB`, `ElastiCache`, `Redshift`, `Neptune`, `DocumentDB` |
+| network | `VPC`, `ELB`, `ALB`, `NLB`, `CloudFront`, `Route53`, `APIGateway`, `DirectConnect` |
+| storage | `S3`, `EBS`, `EFS`, `FSx`, `Backup` |
+| integration | `SQS`, `SNS`, `StepFunctions`, `EventBridge`, `MQ` |
+| security | `IAM`, `Cognito`, `WAF`, `KMS`, `Shield`, `SecretsManager` |
+| ml | `Sagemaker`, `Rekognition`, `Comprehend`, `Bedrock`, `Lex`, `Polly` |
+| analytics | `Athena`, `EMR`, `Glue`, `Kinesis`, `Redshift`, `Quicksight`, `LakeFormation` |
+| management | `CloudWatch`, `CloudFormation`, `SystemsManager`, `Config`, `CloudTrail` |
+| general | `User`, `Users`, `Client`, `InternetGateway` |
+
+## Kubernetes (12 categories)
+
+| Category | Import Path |
+|----------|------------|
+| chaos | `from diagrams.k8s.chaos import ...` |
+| clusterconfig | `from diagrams.k8s.clusterconfig import ...` |
+| compute | `from diagrams.k8s.compute import ...` |
+| controlplane | `from diagrams.k8s.controlplane import ...` |
+| ecosystem | `from diagrams.k8s.ecosystem import ...` |
+| group | `from diagrams.k8s.group import ...` |
+| infra | `from diagrams.k8s.infra import ...` |
+| network | `from diagrams.k8s.network import ...` |
+| others | `from diagrams.k8s.others import ...` |
+| podconfig | `from diagrams.k8s.podconfig import ...` |
+| rbac | `from diagrams.k8s.rbac import ...` |
+| storage | `from diagrams.k8s.storage import ...` |
+
+## On-Premises (27 categories)
+
+| Category | Import Path |
+|----------|------------|
+| aggregator | `from diagrams.onprem.aggregator import ...` |
+| analytics | `from diagrams.onprem.analytics import ...` |
+| auth | `from diagrams.onprem.auth import ...` |
+| cd | `from diagrams.onprem.cd import ...` |
+| certificates | `from diagrams.onprem.certificates import ...` |
+| ci | `from diagrams.onprem.ci import ...` |
+| client | `from diagrams.onprem.client import ...` |
+| compute | `from diagrams.onprem.compute import ...` |
+| container | `from diagrams.onprem.container import ...` |
+| database | `from diagrams.onprem.database import ...` |
+| dns | `from diagrams.onprem.dns import ...` |
+| etl | `from diagrams.onprem.etl import ...` |
+| gitops | `from diagrams.onprem.gitops import ...` |
+| groupware | `from diagrams.onprem.groupware import ...` |
+| iac | `from diagrams.onprem.iac import ...` |
+| identity | `from diagrams.onprem.identity import ...` |
+| inmemory | `from diagrams.onprem.inmemory import ...` |
+| logging | `from diagrams.onprem.logging import ...` |
+| messaging | `from diagrams.onprem.messaging import ...` |
+| mlops | `from diagrams.onprem.mlops import ...` |
+| monitoring | `from diagrams.onprem.monitoring import ...` |
+| network | `from diagrams.onprem.network import ...` |
+| proxmox | `from diagrams.onprem.proxmox import ...` |
+| queue | `from diagrams.onprem.queue import ...` |
+| registry | `from diagrams.onprem.registry import ...` |
+| search | `from diagrams.onprem.search import ...` |
+| security | `from diagrams.onprem.security import ...` |
+| storage | `from diagrams.onprem.storage import ...` |
+| tracing | `from diagrams.onprem.tracing import ...` |
+| vcs | `from diagrams.onprem.vcs import ...` |
+| workflow | `from diagrams.onprem.workflow import ...` |
+
+## SaaS (14 categories)
+
+| Category | Import Path |
+|----------|------------|
+| alerting | `from diagrams.saas.alerting import ...` |
+| analytics | `from diagrams.saas.analytics import ...` |
+| automation | `from diagrams.saas.automation import ...` |
+| cdn | `from diagrams.saas.cdn import ...` |
+| chat | `from diagrams.saas.chat import ...` |
+| communication | `from diagrams.saas.communication import ...` |
+| crm | `from diagrams.saas.crm import ...` |
+| filesharing | `from diagrams.saas.filesharing import ...` |
+| identity | `from diagrams.saas.identity import ...` |
+| logging | `from diagrams.saas.logging import ...` |
+| media | `from diagrams.saas.media import ...` |
+| recommendation | `from diagrams.saas.recommendation import ...` |
+| security | `from diagrams.saas.security import ...` |
+| social | `from diagrams.saas.social import ...` |
+
+## Other Providers
+
+| Provider | Categories |
+|----------|-----------|
+| GCP | `storage` |
+| Elastic | `agent`, `beats`, `elasticsearch`, `enterprisesearch`, `observability`, `orchestration`, `saas`, `security` |
+| Programming | `flowchart`, `framework`, `language`, `runtime` |
+| Generic | `blank`, `compute`, `database`, `device`, `network`, `os`, `place`, `storage`, `virtualization` |
+| GIS | `cli`, `cplusplus`, `data`, `database`, `desktop`, `format`, `geocoding`, `java`, `javascript`, `mobile`, `ogc`, `organization`, `python`, `routing`, `server` |
+
+## Custom Nodes
+
+For services not in the built-in icon set:
+
+```python
+from diagrams.custom import Custom
+my_node = Custom("Service Name", "/path/to/icon.png")
+```

--- a/src/aws-diagram-mcp-server/skills/diagram-skill/scripts/setup.sh
+++ b/src/aws-diagram-mcp-server/skills/diagram-skill/scripts/setup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Diagram skill prerequisite checker
+# Checks for GraphViz and Python diagrams package
+
+set -e
+
+echo "Checking diagram skill prerequisites..."
+echo ""
+
+# Check GraphViz
+if command -v dot &> /dev/null; then
+    DOT_VERSION=$(dot -V 2>&1)
+    echo "[OK] GraphViz installed: $DOT_VERSION"
+else
+    echo "[MISSING] GraphViz not found."
+    echo ""
+    echo "  Install GraphViz:"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "    brew install graphviz"
+    elif [[ -f /etc/debian_version ]]; then
+        echo "    sudo apt-get install graphviz"
+    elif [[ -f /etc/redhat-release ]] || [[ -f /etc/system-release ]]; then
+        echo "    sudo yum install graphviz"
+    else
+        echo "    See https://graphviz.org/download/"
+    fi
+    echo ""
+fi
+
+# Check Python diagrams package
+if python3 -c "import diagrams" 2>/dev/null; then
+    DIAG_VERSION=$(python3 -c "import diagrams; print(diagrams.__version__)" 2>/dev/null || echo "unknown")
+    echo "[OK] Python diagrams package installed: v$DIAG_VERSION"
+else
+    echo "[MISSING] Python diagrams package not found."
+    echo ""
+    echo "  Install:"
+    echo "    pip install diagrams"
+    echo ""
+fi
+
+# Summary
+echo ""
+if command -v dot &> /dev/null && python3 -c "import diagrams" 2>/dev/null; then
+    echo "All prerequisites met. Ready to generate diagrams."
+else
+    echo "Some prerequisites are missing. Install them and re-run this script."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Converts diagram generation capabilities from the AWS Diagram MCP server into a Claude Code agent skill following the [Agent Skills open standard](https://agentskills.io)
- Covers stories 3.1–3.8 from the deprecation plan: directory structure, core SKILL.md, DSL reference, examples, icon reference, setup script, alias skills, and installation docs
- Follows the alias pattern established by the DSQL skill (symlinked `references/`, `examples/`, `scripts/` across `diagram`, `aws diagram`, and `architecture diagram` skill names)

### What's included

| File | Purpose |
|------|---------|
| `skills/diagram-skill/SKILL.md` | Core skill definition with workflows and best practices |
| `skills/diagram-skill/references/dsl-guide.md` | Full DSL reference (Diagram, Cluster, Edge, all providers) |
| `skills/diagram-skill/references/icon-reference.md` | All providers and service categories |
| `skills/diagram-skill/examples/aws-examples.md` | 5 AWS architecture examples |
| `skills/diagram-skill/examples/general-examples.md` | 7 general examples (K8s, on-prem, sequence, flow, etc.) |
| `skills/diagram-skill/scripts/setup.sh` | Prerequisite checker (GraphViz + diagrams package) |
| `skills/aws-diagram-skill/` | Alias skill (`name: aws diagram`) with symlinks |
| `skills/architecture-diagram-skill/` | Alias skill (`name: architecture diagram`) with symlinks |
| `skills/README.md` | Installation and usage documentation |

### Prerequisites

The skill requires users to have GraphViz and the Python `diagrams` package installed locally. This was confirmed as acceptable by the team (GraphViz is a standard system package, similar to other skill prerequisites).

### Related PRs

- #2597 — Terraform server deprecation notices
- #2598 — Terraform README deprecation banner
- #2599 — Terraform migration guide

## Test plan

- [ ] Install skill via `npx skills add awslabs/mcp --skill diagram` or manual sparse clone
- [ ] Verify `/diagram` appears in Claude Code autocomplete
- [ ] Run `scripts/setup.sh` to check prerequisites
- [ ] Generate at least 3 diagrams (1 AWS, 1 K8s, 1 general) from the examples
- [ ] Verify alias skills (`/aws diagram`, `/architecture diagram`) resolve correctly
- [ ] Confirm symlinks work (alias skills reference the same examples/references/scripts)