### PR TITLE
fix(terraform-mcp-server): remove unused loguru import

### DIFF
--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/server.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/server.py
@@ -46,7 +46,6 @@ from awslabs.terraform_mcp_server.static import (
     MCP_INSTRUCTIONS,
     TERRAFORM_WORKFLOW_GUIDE,
 )
-from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 from typing import Any, Dict, List, Literal, Optional


### PR DESCRIPTION
## Summary
- Remove unused `from loguru import logger` import that was left behind when `logger.warning()` was replaced with `warnings.warn()` in #2597
- Fixes ruff F401 lint error

## Test plan
- [ ] Verify `ruff check` passes on `src/terraform-mcp-server/`
- [ ] Verify existing tests still pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).