### PR TITLE
fix: healthomics mcp create workflow registry mapping model to be in s…

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/models/core.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/models/core.py
@@ -233,8 +233,8 @@ class RegistryMapping(BaseModel):
 
     upstreamRegistryUrl: str
     ecrRepositoryPrefix: str
-    upstreamRepositoryPrefix: Optional[str]
-    ecrAccountId: Optional[str]
+    upstreamRepositoryPrefix: Optional[str] = None
+    ecrAccountId: Optional[str] = None
 
 
 class ImageMapping(BaseModel):

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_management.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_management.py
@@ -180,7 +180,7 @@ async def create_workflow(
         ) = await validate_definition_sources(
             ctx, definition_zip_base64, definition_uri, definition_repository
         )
-        await validate_container_registry_params(
+        validated_container_registry_map = await validate_container_registry_params(
             ctx, container_registry_map, container_registry_map_uri
         )
 
@@ -218,8 +218,8 @@ async def create_workflow(
         if parameter_template:
             params['parameterTemplate'] = parameter_template
 
-        if container_registry_map:
-            params['containerRegistryMap'] = container_registry_map
+        if validated_container_registry_map is not None:
+            params['containerRegistryMap'] = validated_container_registry_map
 
         if container_registry_map_uri:
             params['containerRegistryMapUri'] = container_registry_map_uri
@@ -414,7 +414,7 @@ async def create_workflow_version(
         ) = await validate_definition_sources(
             ctx, definition_zip_base64, definition_uri, definition_repository
         )
-        await validate_container_registry_params(
+        validated_container_registry_map = await validate_container_registry_params(
             ctx, container_registry_map, container_registry_map_uri
         )
 
@@ -465,8 +465,8 @@ async def create_workflow_version(
         if storage_type == 'STATIC':
             params['storageCapacity'] = storage_capacity
 
-        if container_registry_map:
-            params['containerRegistryMap'] = container_registry_map
+        if validated_container_registry_map is not None:
+            params['containerRegistryMap'] = validated_container_registry_map
 
         if container_registry_map_uri:
             params['containerRegistryMapUri'] = container_registry_map_uri

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/utils/validation_utils.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/utils/validation_utils.py
@@ -303,13 +303,21 @@ async def validate_container_registry_params(
     ctx: Context,
     container_registry_map: Optional[Dict[str, Any]],
     container_registry_map_uri: Optional[str],
-) -> None:
+) -> Optional[Dict[str, Any]]:
     """Validate container registry parameters.
+
+    When a container_registry_map is provided, upstreamRepositoryPrefix and ecrAccountId
+    are not required in each registryMapping. If they are present (explicitly provided or
+    inferred), they will be included in the returned map; otherwise they are omitted.
 
     Args:
         ctx: MCP context for error reporting
         container_registry_map: Container registry map dictionary
         container_registry_map_uri: S3 URI pointing to container registry mappings
+
+    Returns:
+        Cleaned container registry map with optional fields omitted when None, or None if
+        no map was provided.
 
     Raises:
         ValueError: If validation fails
@@ -334,15 +342,41 @@ async def validate_container_registry_params(
         await ctx.error(error_message)
         raise ValueError(error_message)
 
-    # Validate container registry map structure if provided
+    # Validate container registry map structure if provided and return cleaned version
     if container_registry_map is not None:
         try:
-            ContainerRegistryMap(**container_registry_map)
+            validated = ContainerRegistryMap(**container_registry_map)
         except ValidationError as e:
             error_message = f'Invalid container registry map structure: {str(e)}'
             logger.error(error_message)
             await ctx.error(error_message)
             raise ValueError(error_message)
+
+        # Build cleaned registry mappings, including upstreamRepositoryPrefix and ecrAccountId
+        # only when they are present (not None)
+        cleaned_registry_mappings = []
+        for rm in validated.registryMappings:
+            entry: Dict[str, Any] = {
+                'upstreamRegistryUrl': rm.upstreamRegistryUrl,
+                'ecrRepositoryPrefix': rm.ecrRepositoryPrefix,
+            }
+            if rm.upstreamRepositoryPrefix is not None:
+                entry['upstreamRepositoryPrefix'] = rm.upstreamRepositoryPrefix
+            if rm.ecrAccountId is not None:
+                entry['ecrAccountId'] = rm.ecrAccountId
+            cleaned_registry_mappings.append(entry)
+
+        cleaned_image_mappings = [
+            {'sourceImage': im.sourceImage, 'destinationImage': im.destinationImage}
+            for im in validated.imageMappings
+        ]
+
+        return {
+            'registryMappings': cleaned_registry_mappings,
+            'imageMappings': cleaned_image_mappings,
+        }
+
+    return None
 
 
 async def validate_adhoc_s3_buckets(adhoc_buckets: Optional[List[str]]) -> List[str]:

--- a/src/aws-healthomics-mcp-server/tests/test_workflow_management.py
+++ b/src/aws-healthomics-mcp-server/tests/test_workflow_management.py
@@ -901,6 +901,25 @@ async def test_create_workflow_with_container_registry_map():
         ]
     }
 
+    # Expected cleaned map after validation (imageMappings normalized to empty list)
+    expected_registry_map = {
+        'registryMappings': [
+            {
+                'upstreamRegistryUrl': 'registry-1.docker.io',
+                'ecrRepositoryPrefix': 'docker-hub',
+                'upstreamRepositoryPrefix': 'library',
+                'ecrAccountId': '123456789012',
+            },
+            {
+                'upstreamRegistryUrl': 'quay.io',
+                'ecrRepositoryPrefix': 'quay',
+                'upstreamRepositoryPrefix': 'biocontainers',
+                'ecrAccountId': '123456789012',
+            },
+        ],
+        'imageMappings': [],
+    }
+
     with patch(
         'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
         return_value=mock_client,
@@ -921,7 +940,7 @@ async def test_create_workflow_with_container_registry_map():
     assert expected_call.kwargs['definitionZip'] == b'test workflow content'
     assert expected_call.kwargs['description'] == 'Test workflow with container registry map'
     assert expected_call.kwargs['parameterTemplate'] == {'param1': {'type': 'string'}}
-    assert expected_call.kwargs['containerRegistryMap'] == container_registry_map
+    assert expected_call.kwargs['containerRegistryMap'] == expected_registry_map
     # path_to_main should not be passed when None
     assert 'main' not in expected_call.kwargs
 
@@ -1320,6 +1339,25 @@ async def test_create_workflow_version_with_container_registry_map():
         ]
     }
 
+    # Expected cleaned map after validation (imageMappings normalized to empty list)
+    expected_registry_map = {
+        'registryMappings': [
+            {
+                'upstreamRegistryUrl': 'registry-1.docker.io',
+                'ecrRepositoryPrefix': 'docker-hub',
+                'upstreamRepositoryPrefix': 'library',
+                'ecrAccountId': '123456789012',
+            },
+            {
+                'upstreamRegistryUrl': 'quay.io',
+                'ecrRepositoryPrefix': 'quay',
+                'upstreamRepositoryPrefix': 'biocontainers',
+                'ecrAccountId': '123456789012',
+            },
+        ],
+        'imageMappings': [],
+    }
+
     with patch(
         'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
         return_value=mock_client,
@@ -1345,7 +1383,7 @@ async def test_create_workflow_version_with_container_registry_map():
     assert expected_call.kwargs['description'] == 'Version 2.0 with container registry map'
     assert expected_call.kwargs['parameterTemplate'] == {'param1': {'type': 'string'}}
     assert expected_call.kwargs['storageType'] == 'DYNAMIC'
-    assert expected_call.kwargs['containerRegistryMap'] == container_registry_map
+    assert expected_call.kwargs['containerRegistryMap'] == expected_registry_map
     # path_to_main should not be passed when None
     assert 'main' not in expected_call.kwargs
 
@@ -1441,6 +1479,19 @@ async def test_create_workflow_version_with_static_storage_and_container_registr
         ]
     }
 
+    # Expected cleaned map after validation (imageMappings normalized to empty list)
+    expected_registry_map = {
+        'registryMappings': [
+            {
+                'upstreamRegistryUrl': 'registry-1.docker.io',
+                'ecrRepositoryPrefix': 'docker-hub',
+                'upstreamRepositoryPrefix': 'library',
+                'ecrAccountId': '123456789012',
+            }
+        ],
+        'imageMappings': [],
+    }
+
     with patch(
         'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
         return_value=mock_client,
@@ -1469,7 +1520,7 @@ async def test_create_workflow_version_with_static_storage_and_container_registr
     )
     assert expected_call.kwargs['storageType'] == 'STATIC'
     assert expected_call.kwargs['storageCapacity'] == 2000
-    assert expected_call.kwargs['containerRegistryMap'] == container_registry_map
+    assert expected_call.kwargs['containerRegistryMap'] == expected_registry_map
     # path_to_main should not be passed when None
     assert 'main' not in expected_call.kwargs
 
@@ -2351,6 +2402,19 @@ async def test_create_workflow_version_with_path_to_main_and_container_registry(
         ]
     }
 
+    # Expected cleaned map after validation (imageMappings normalized to empty list)
+    expected_registry_map = {
+        'registryMappings': [
+            {
+                'upstreamRegistryUrl': 'registry-1.docker.io',
+                'ecrRepositoryPrefix': 'docker-hub',
+                'upstreamRepositoryPrefix': 'library',
+                'ecrAccountId': '123456789012',
+            }
+        ],
+        'imageMappings': [],
+    }
+
     with patch(
         'awslabs.aws_healthomics_mcp_server.tools.workflow_management.get_omics_client',
         return_value=mock_client,
@@ -2380,7 +2444,7 @@ async def test_create_workflow_version_with_path_to_main_and_container_registry(
         == 'Version 2.0 with path_to_main and container registry'
     )
     assert expected_call.kwargs['storageType'] == 'DYNAMIC'
-    assert expected_call.kwargs['containerRegistryMap'] == container_registry_map
+    assert expected_call.kwargs['containerRegistryMap'] == expected_registry_map
     assert expected_call.kwargs['main'] == 'workflows/containerized/main.wdl'
 
     # Verify result contains expected fields


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

fix: healthomics mcp create workflow registry mapping model to be in sync with API spec

## Summary

### Changes

The `container_registry_map` parameter for `CreateAHOWorkflow` and `CreateAHOWorkflowVersion` required `upstreamRepositoryPrefix` and `ecrAccountId` in each `registryMapping` entry, even though the HealthOmics API treats these as optional fields. This change aligns the MCP server's validation with the API spec:

- `validate_container_registry_params` now returns a cleaned/normalized `Dict` instead of `None`, omitting `upstreamRepositoryPrefix` and `ecrAccountId` from registry mappings when they are not provided, and including them only when explicitly set.
- Both `create_workflow` and `create_workflow_version` use the validated map returned from the validator rather than passing the raw input directly.
- The `imageMappings` key is always normalized to an empty list when not provided by the caller.
- Tests updated to assert against the normalized map structure.

### User experience

Before: Providing a `container_registry_map` without `upstreamRepositoryPrefix` or `ecrAccountId` in a registry mapping would fail validation, even though the HealthOmics API accepts those fields as optional.

After: Users can provide registry mappings with only the required `upstreamRegistryUrl` and `ecrRepositoryPrefix`. The optional `upstreamRepositoryPrefix` and `ecrAccountId` are included in the API call only when explicitly provided.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: 2625

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
