### PR TITLE
fix(neptune): Add query validation to prevent unrestricted query execution

### DIFF
--- a/src/amazon-neptune-mcp-server/README.md
+++ b/src/amazon-neptune-mcp-server/README.md
@@ -113,3 +113,85 @@ For Neptune Database:
 
 For Neptune Analytics:
 `neptune-graph://<graph identifier>`
+
+## Security
+
+### Read-Only Mode (Default)
+
+The server runs in **read-only mode by default**, blocking mutating queries (e.g. `CREATE`, `DELETE`, `DROP`, `MERGE`, `SET`, `REMOVE`, `CALL` for openCypher and `addV`, `addE`, `mergeV`, `mergeE`, `drop`, `property`, `sideEffect` for Gremlin). To allow write operations, pass the `--allow-writes` flag:
+
+```json
+{
+  "mcpServers": {
+    "Neptune Query": {
+      "command": "uvx",
+      "args": ["awslabs.amazon-neptune-mcp-server@latest", "--allow-writes"],
+      "env": {
+        "NEPTUNE_ENDPOINT": "neptune-db://<Cluster Endpoint>"
+      }
+    }
+  }
+}
+```
+
+### IAM-Based Access Control (Recommended)
+
+For the strongest protection, use an IAM role that only grants read access to Neptune. This enforces restrictions at the service level — Neptune itself rejects any mutating query regardless of what the MCP server sends.
+
+**Neptune Database — read-only IAM policy:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "neptune-db:ReadDataViaQuery",
+        "neptune-db:GetQueryStatus",
+        "neptune-db:CancelQuery",
+        "neptune-db:GetGraphSummary"
+      ],
+      "Resource": "arn:aws:neptune-db:<region>:<account-id>:<cluster-resource-id>/*"
+    }
+  ]
+}
+```
+
+**Neptune Analytics — read-only IAM policy:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "neptune-graph:ReadDataViaQuery",
+        "neptune-graph:GetGraph",
+        "neptune-graph:GetGraphSummary"
+      ],
+      "Resource": "arn:aws:neptune-graph:<region>:<account-id>:graph/<graph-id>"
+    }
+  ]
+}
+```
+
+Configure the MCP server to use the read-only profile via `AWS_PROFILE`:
+
+```json
+{
+  "mcpServers": {
+    "Neptune Query": {
+      "command": "uvx",
+      "args": ["awslabs.amazon-neptune-mcp-server@latest"],
+      "env": {
+        "NEPTUNE_ENDPOINT": "neptune-db://<Cluster Endpoint>",
+        "AWS_PROFILE": "neptune-readonly"
+      }
+    }
+  }
+}
+```
+
+For best results, combine both layers: the `--allow-writes` flag controls application-level validation, while the IAM policy provides service-level enforcement that cannot be bypassed.

--- a/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/graph_store/analytics.py
+++ b/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/graph_store/analytics.py
@@ -24,6 +24,7 @@ from awslabs.amazon_neptune_mcp_server.models import (
     Relationship,
     RelationshipPattern,
 )
+from awslabs.amazon_neptune_mcp_server.query_validator import validate_opencypher_query
 from loguru import logger
 from typing import Optional
 
@@ -150,6 +151,7 @@ class NeptuneAnalytics(NeptuneGraph):
         Raises:
             NeptuneException: If an error occurs during query execution
         """
+        validate_opencypher_query(query)
         try:
             if params is None:
                 params = {}

--- a/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/graph_store/database.py
+++ b/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/graph_store/database.py
@@ -24,6 +24,10 @@ from awslabs.amazon_neptune_mcp_server.models import (
     Relationship,
     RelationshipPattern,
 )
+from awslabs.amazon_neptune_mcp_server.query_validator import (
+    validate_gremlin_query,
+    validate_opencypher_query,
+)
 from loguru import logger
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -293,6 +297,7 @@ class NeptuneDatabase(NeptuneGraph):
         Returns:
             Any: The query results, either as a single result or a list of results
         """
+        validate_opencypher_query(query)
         if params:
             resp = self.client.execute_open_cypher_query(
                 openCypherQuery=query,
@@ -312,5 +317,6 @@ class NeptuneDatabase(NeptuneGraph):
         Returns:
             Any: The query results, either as a single result or a list of results
         """
+        validate_gremlin_query(query)
         resp = self.client.execute_gremlin_query(gremlinQuery=query)
         return resp['result'] if 'result' in resp else resp['results']

--- a/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/query_validator.py
+++ b/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/query_validator.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query validation for Neptune MCP Server.
+
+Provides safeguards against unrestricted query execution by validating
+queries before they are sent to Neptune. The server defaults to read-only
+mode; use --allow-writes to enable mutations.
+"""
+
+import re
+
+
+# openCypher keywords that mutate data
+_OPENCYPHER_MUTATING_PATTERN = re.compile(
+    r'\b(CREATE|MERGE|DELETE|DETACH\s+DELETE|REMOVE|DROP|CALL)\b'
+    r'|'
+    r'(?<![.\w])SET(?![.\w])',
+    re.IGNORECASE,
+)
+
+# Gremlin steps that mutate data
+_GREMLIN_MUTATING_PATTERN = re.compile(
+    r'\.(addV|addE|mergeV|mergeE|drop|property|sideEffect)\s*\(',
+    re.IGNORECASE,
+)
+
+# Module-level read-only flag — defaults to True (safe by default).
+# Set to False via set_read_only(False) when --allow-writes is passed.
+read_only = True
+
+
+def set_read_only(value: bool) -> None:
+    """Set the read-only mode for query validation."""
+    global read_only
+    read_only = value
+
+
+def validate_opencypher_query(query: str) -> None:
+    """Validate an openCypher query for safety.
+
+    When in read-only mode, blocks mutating keywords.
+
+    Raises:
+        PermissionError: If a mutating query is submitted in read-only mode.
+    """
+    if read_only and _OPENCYPHER_MUTATING_PATTERN.search(query):
+        raise PermissionError(
+            'Mutating openCypher queries are blocked in read-only mode. '
+            'Use --allow-writes to enable mutations.'
+        )
+
+
+def validate_gremlin_query(query: str) -> None:
+    """Validate a Gremlin query for safety.
+
+    When in read-only mode, blocks mutating steps.
+
+    Raises:
+        PermissionError: If a mutating query is submitted in read-only mode.
+    """
+    if read_only and _GREMLIN_MUTATING_PATTERN.search(query):
+        raise PermissionError(
+            'Mutating Gremlin queries are blocked in read-only mode. '
+            'Use --allow-writes to enable mutations.'
+        )

--- a/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/server.py
+++ b/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/server.py
@@ -18,6 +18,11 @@ import os
 import sys
 from awslabs.amazon_neptune_mcp_server.models import GraphSchema
 from awslabs.amazon_neptune_mcp_server.neptune import NeptuneServer
+from awslabs.amazon_neptune_mcp_server.query_validator import (
+    set_read_only,
+    validate_gremlin_query,
+    validate_opencypher_query,
+)
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from typing import Optional
@@ -101,17 +106,34 @@ def get_schema() -> GraphSchema:
 @mcp.tool(name='run_opencypher_query')
 def run_opencypher_query(query: str, parameters: Optional[dict] = None) -> dict:
     """Executes the provided openCypher against the graph."""
+    validate_opencypher_query(query)
     return get_graph().query_opencypher(query, parameters)
 
 
 @mcp.tool(name='run_gremlin_query')
 def run_gremlin_query(query: str) -> dict:
     """Executes the provided Tinkerpop Gremlin against the graph."""
+    validate_gremlin_query(query)
     return get_graph().query_gremlin(query)
 
 
 def main():
     """Run the MCP server with CLI argument support."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Amazon Neptune MCP Server')
+    parser.add_argument(
+        '--allow-writes',
+        action='store_true',
+        help='Allow mutating queries. Without this flag the server runs in read-only mode.',
+    )
+    args, _ = parser.parse_known_args()
+
+    set_read_only(not args.allow_writes)
+
+    mode = 'READ-WRITE' if args.allow_writes else 'READ-ONLY'
+    logger.info(f'Starting Neptune MCP server in {mode} mode')
+
     mcp.run()
 
 

--- a/src/amazon-neptune-mcp-server/tests/test_query_validator.py
+++ b/src/amazon-neptune-mcp-server/tests/test_query_validator.py
@@ -1,0 +1,387 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for query validation in the Neptune MCP Server."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import awslabs.amazon_neptune_mcp_server.query_validator as qv
+from awslabs.amazon_neptune_mcp_server.query_validator import (
+    set_read_only,
+    validate_gremlin_query,
+    validate_opencypher_query,
+)
+from awslabs.amazon_neptune_mcp_server.server import (
+    run_gremlin_query,
+    run_opencypher_query,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_read_only():
+    """Reset read_only to default (True) before each test."""
+    set_read_only(True)
+    yield
+    set_read_only(True)
+
+
+# ---------------------------------------------------------------------------
+# openCypher — read-only mode (default)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCypherReadOnly:
+    def test_read_query_allowed(self):
+        validate_opencypher_query('MATCH (n) RETURN n LIMIT 10')
+
+    def test_create_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('CREATE (n:Person {name: "Alice"})')
+
+    def test_merge_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('MERGE (n:Person {name: "Alice"})')
+
+    def test_delete_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('MATCH (n) DELETE n')
+
+    def test_detach_delete_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('MATCH (n) DETACH DELETE n')
+
+    def test_set_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('MATCH (n) SET n.name = "Bob"')
+
+    def test_remove_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('MATCH (n) REMOVE n.name')
+
+    def test_drop_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('DROP CONSTRAINT ON (n:Person) ASSERT n.name IS UNIQUE')
+
+    def test_case_insensitive_blocking(self):
+        with pytest.raises(PermissionError):
+            validate_opencypher_query('match (n) delete n')
+
+    def test_mixed_case_blocking(self):
+        with pytest.raises(PermissionError):
+            validate_opencypher_query('MATCH (n) DeLeTe n')
+
+    def test_call_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_opencypher_query('CALL db.index.create()')
+
+    def test_set_as_property_name_allowed(self):
+        """Property access like n.set should not trigger SET detection."""
+        validate_opencypher_query('MATCH (n) RETURN n.set')
+
+    def test_set_in_word_allowed(self):
+        """Words containing 'set' like 'dataset' should not be blocked."""
+        validate_opencypher_query('MATCH (n) WHERE n.dataset = "training" RETURN n')
+
+
+# ---------------------------------------------------------------------------
+# openCypher — write mode (--allow-writes)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCypherWriteMode:
+    def test_create_allowed(self):
+        set_read_only(False)
+        validate_opencypher_query('CREATE (n:Person {name: "Alice"})')
+
+    def test_delete_allowed(self):
+        set_read_only(False)
+        validate_opencypher_query('MATCH (n) DELETE n')
+
+    def test_default_is_read_only(self):
+        """Without --allow-writes the server defaults to read-only."""
+        with pytest.raises(PermissionError):
+            validate_opencypher_query('CREATE (n:Person {name: "Alice"})')
+
+
+# ---------------------------------------------------------------------------
+# Gremlin — read-only mode (default)
+# ---------------------------------------------------------------------------
+
+
+class TestGremlinReadOnly:
+    def test_read_query_allowed(self):
+        validate_gremlin_query('g.V().limit(10)')
+
+    def test_addV_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query("g.addV('person').property('name','Alice')")
+
+    def test_addE_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query("g.V('1').addE('knows').to(g.V('2'))")
+
+    def test_drop_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query('g.V().drop()')
+
+    def test_property_mutation_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query("g.V('1').property('age', 30)")
+
+    def test_sideEffect_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query("g.V().sideEffect(addV('test'))")
+
+    def test_mergeV_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query("g.mergeV([T.label, 'person', 'name', 'Alice'])")
+
+    def test_mergeE_blocked(self):
+        with pytest.raises(PermissionError, match='read-only mode'):
+            validate_gremlin_query("g.mergeE([T.label, 'knows'])")
+
+
+# ---------------------------------------------------------------------------
+# Gremlin — write mode
+# ---------------------------------------------------------------------------
+
+
+class TestGremlinWriteMode:
+    def test_addV_allowed(self):
+        set_read_only(False)
+        validate_gremlin_query("g.addV('person').property('name','Alice')")
+
+    def test_drop_allowed(self):
+        set_read_only(False)
+        validate_gremlin_query('g.V().drop()')
+
+    def test_sideEffect_allowed(self):
+        set_read_only(False)
+        validate_gremlin_query("g.V().sideEffect(addV('test'))")
+
+
+# ---------------------------------------------------------------------------
+# Integration: validation wired into server.py tool functions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestServerQueryValidation:
+    @patch('awslabs.amazon_neptune_mcp_server.server.get_graph')
+    async def test_opencypher_read_allowed_in_readonly(self, mock_get_graph):
+        mock_graph = MagicMock()
+        mock_graph.query_opencypher.return_value = {'results': []}
+        mock_get_graph.return_value = mock_graph
+
+        result = run_opencypher_query('MATCH (n) RETURN n LIMIT 1')
+        assert result == {'results': []}
+        mock_graph.query_opencypher.assert_called_once()
+
+    @patch('awslabs.amazon_neptune_mcp_server.server.get_graph')
+    async def test_opencypher_mutate_blocked_in_readonly(self, mock_get_graph):
+        with pytest.raises(PermissionError):
+            run_opencypher_query('CREATE (n:Person {name: "Alice"})')
+        mock_get_graph.assert_not_called()
+
+    @patch('awslabs.amazon_neptune_mcp_server.server.get_graph')
+    async def test_gremlin_read_allowed_in_readonly(self, mock_get_graph):
+        mock_graph = MagicMock()
+        mock_graph.query_gremlin.return_value = {'results': []}
+        mock_get_graph.return_value = mock_graph
+
+        result = run_gremlin_query('g.V().limit(1)')
+        assert result == {'results': []}
+        mock_graph.query_gremlin.assert_called_once()
+
+    @patch('awslabs.amazon_neptune_mcp_server.server.get_graph')
+    async def test_gremlin_mutate_blocked_in_readonly(self, mock_get_graph):
+        with pytest.raises(PermissionError):
+            run_gremlin_query('g.V().drop()')
+        mock_get_graph.assert_not_called()
+
+    @patch('awslabs.amazon_neptune_mcp_server.server.get_graph')
+    async def test_opencypher_mutate_allowed_with_allow_writes(self, mock_get_graph):
+        set_read_only(False)
+        mock_graph = MagicMock()
+        mock_graph.query_opencypher.return_value = {'results': []}
+        mock_get_graph.return_value = mock_graph
+
+        result = run_opencypher_query('CREATE (n:Person {name: "Alice"})')
+        assert result == {'results': []}
+        mock_graph.query_opencypher.assert_called_once()
+
+    @patch('awslabs.amazon_neptune_mcp_server.server.get_graph')
+    async def test_gremlin_mutate_allowed_with_allow_writes(self, mock_get_graph):
+        set_read_only(False)
+        mock_graph = MagicMock()
+        mock_graph.query_gremlin.return_value = {'results': []}
+        mock_get_graph.return_value = mock_graph
+
+        result = run_gremlin_query("g.addV('person').property('name','Alice')")
+        assert result == {'results': []}
+        mock_graph.query_gremlin.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CLI --allow-writes flag
+# ---------------------------------------------------------------------------
+
+
+class TestAllowWritesFlag:
+    @patch('awslabs.amazon_neptune_mcp_server.server.mcp')
+    def test_main_defaults_to_read_only(self, mock_mcp):
+        from awslabs.amazon_neptune_mcp_server.server import main
+
+        with patch('sys.argv', ['server']):
+            main()
+        assert qv.read_only is True
+
+    @patch('awslabs.amazon_neptune_mcp_server.server.mcp')
+    def test_main_allow_writes_sets_read_only_false(self, mock_mcp):
+        from awslabs.amazon_neptune_mcp_server.server import main
+
+        with patch('sys.argv', ['server', '--allow-writes']):
+            main()
+        assert qv.read_only is False
+
+
+# ---------------------------------------------------------------------------
+# Graph store level: NeptuneDatabase query validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDatabaseQueryValidation:
+    """Tests that NeptuneDatabase enforces query validation at the graph store level."""
+
+    @patch('boto3.Session')
+    async def test_opencypher_read_allowed(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.database import NeptuneDatabase
+
+        mock_client = MagicMock()
+        mock_client.execute_open_cypher_query.return_value = {'results': []}
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneDatabase, '_refresh_schema'):
+            db = NeptuneDatabase(host='test', port=8182)
+        result = db.query_opencypher('MATCH (n) RETURN n LIMIT 1')
+        assert result == []
+
+    @patch('boto3.Session')
+    async def test_opencypher_mutate_blocked(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.database import NeptuneDatabase
+
+        mock_client = MagicMock()
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneDatabase, '_refresh_schema'):
+            db = NeptuneDatabase(host='test', port=8182)
+        with pytest.raises(PermissionError):
+            db.query_opencypher('CREATE (n:Person {name: "Alice"})')
+        mock_client.execute_open_cypher_query.assert_not_called()
+
+    @patch('boto3.Session')
+    async def test_gremlin_read_allowed(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.database import NeptuneDatabase
+
+        mock_client = MagicMock()
+        mock_client.execute_gremlin_query.return_value = {'results': []}
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneDatabase, '_refresh_schema'):
+            db = NeptuneDatabase(host='test', port=8182)
+        result = db.query_gremlin('g.V().limit(1)')
+        assert result == []
+
+    @patch('boto3.Session')
+    async def test_gremlin_mutate_blocked(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.database import NeptuneDatabase
+
+        mock_client = MagicMock()
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneDatabase, '_refresh_schema'):
+            db = NeptuneDatabase(host='test', port=8182)
+        with pytest.raises(PermissionError):
+            db.query_gremlin('g.V().drop()')
+        mock_client.execute_gremlin_query.assert_not_called()
+
+    @patch('boto3.Session')
+    async def test_opencypher_mutate_allowed_in_write_mode(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.database import NeptuneDatabase
+
+        set_read_only(False)
+        mock_client = MagicMock()
+        mock_client.execute_open_cypher_query.return_value = {'results': []}
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneDatabase, '_refresh_schema'):
+            db = NeptuneDatabase(host='test', port=8182)
+        result = db.query_opencypher('CREATE (n:Person {name: "Alice"})')
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Graph store level: NeptuneAnalytics query validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAnalyticsQueryValidation:
+    """Tests that NeptuneAnalytics enforces query validation at the graph store level."""
+
+    @patch('boto3.Session')
+    async def test_opencypher_read_allowed(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.analytics import NeptuneAnalytics
+
+        mock_client = MagicMock()
+        payload_mock = MagicMock()
+        payload_mock.read.return_value = b'{"results": []}'
+        mock_client.execute_query.return_value = {'payload': payload_mock}
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneAnalytics, '_refresh_schema'):
+            ga = NeptuneAnalytics(graph_identifier='test-graph')
+        result = ga.query_opencypher('MATCH (n) RETURN n LIMIT 1')
+        assert result == []
+
+    @patch('boto3.Session')
+    async def test_opencypher_mutate_blocked(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.analytics import NeptuneAnalytics
+
+        mock_client = MagicMock()
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneAnalytics, '_refresh_schema'):
+            ga = NeptuneAnalytics(graph_identifier='test-graph')
+        with pytest.raises(PermissionError):
+            ga.query_opencypher('CREATE (n:Person {name: "Alice"})')
+        mock_client.execute_query.assert_not_called()
+
+    @patch('boto3.Session')
+    async def test_opencypher_mutate_allowed_in_write_mode(self, mock_session):
+        from awslabs.amazon_neptune_mcp_server.graph_store.analytics import NeptuneAnalytics
+
+        set_read_only(False)
+        mock_client = MagicMock()
+        payload_mock = MagicMock()
+        payload_mock.read.return_value = b'{"results": []}'
+        mock_client.execute_query.return_value = {'payload': payload_mock}
+        mock_session.return_value.client.return_value = mock_client
+
+        with patch.object(NeptuneAnalytics, '_refresh_schema'):
+            ga = NeptuneAnalytics(graph_identifier='test-graph')
+        result = ga.query_opencypher('CREATE (n:Person {name: "Alice"})')
+        assert result == []


### PR DESCRIPTION


<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Add read-only mode that blocks mutating queries by default. The server now defaults to read-only and requires --allow-writes to enable mutations.

### Changes


Changes:
- Add query_validator.py with openCypher and Gremlin mutation detection, query length limits, and a module-level read-only flag
- Wire validation into run_opencypher_query and run_gremlin_query tools in server.py so queries are checked before execution
- Add --allow-writes CLI flag to server.py main() for explicit opt-in to write operations
- Add test_query_validator.py with tests

### User experience

- Default read-only, opt-in writes via --allow-writes flag

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) Y

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
