### PR TITLE
fix(dynamodb-mcp-server): use cdk@latest in generate-resource tooling

### DIFF
--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/cdk_generator/generator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/cdk_generator/generator.py
@@ -109,7 +109,7 @@ class CdkGenerator:
         """
         try:
             subprocess.run(  # nosec B603, B607 - user local env, hardcoded cmd, no shell, timeout
-                ['npx', 'cdk', 'init', 'app', '--language', 'typescript'],
+                ['npx', 'cdk@latest', 'init', 'app', '--language', 'typescript'],
                 cwd=target_dir,
                 capture_output=True,
                 text=True,

--- a/src/dynamodb-mcp-server/tests/cdk_generator/test_generator.py
+++ b/src/dynamodb-mcp-server/tests/cdk_generator/test_generator.py
@@ -200,7 +200,7 @@ class TestRunCdkInit:
 
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
-        assert args == ['npx', 'cdk', 'init', 'app', '--language', 'typescript']
+        assert args == ['npx', 'cdk@latest', 'init', 'app', '--language', 'typescript']
         assert mock_run.call_args[1]['check'] is True
 
     @patch('awslabs.dynamodb_mcp_server.cdk_generator.generator.subprocess.run')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes: CDK generator scaffolds projects with existing cdk version at host which could be outdated aws-cdk-lib that lacks multi-attribute composite key support (partitionKeys/sortKeys)

## Summary

### Changes
The CDK generator runs npx cdk init to scaffold TypeScript projects. Without a version specifier, npx uses whatever CDK CLI version is cached locally. If the cached version predates v2.177.0, the scaffolded package.json pins aws-cdk-lib to that old version.

The Jinja template (stack.ts.j2) generates partitionKeys and sortKeys (plural arrays) for multi-attribute composite key GSIs — a feature added to GlobalSecondaryIndexPropsV2 in aws-cdk-lib v2.177.0. With an older pinned version, cdk synth fails:
```
error TS2561: Object literal may only specify known properties, but 'partitionKeys' does not exist in type 'GlobalSecondaryIndexPropsV2'.
```
Fix: Change npx cdk to npx cdk@latest in _run_cdk_init, forcing npx to always resolve the latest published CDK CLI from npm.

### User experience
Before: Scenarios with multi-attribute key GSIs generate CDK projects that fail TypeScript compilation. Users see error TS2561 when running cdk synth or cdk deploy.

After: All generated CDK projects use the latest aws-cdk-lib with full partitionKeys/sortKeys support. cdk synth and cdk deploy succeed for all scenarios.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
