### PR TITLE
feat(cfn-mcp-server): add deprecation notices

### DIFF
--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -430,7 +430,7 @@ async def create_template(
 
 def main():
     """Run the MCP server with CLI argument support."""
-    warnings.warn(DEPRECATION_NOTICE, DeprecationWarning, stacklevel=1)
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
     parser = argparse.ArgumentParser(
         description='An AWS Labs Model Context Protocol (MCP) server for doing common cloudformation tasks and for managing your resources in your AWS account'
     )

--- a/src/cfn-mcp-server/tests/test_main.py
+++ b/src/cfn-mcp-server/tests/test_main.py
@@ -25,8 +25,9 @@ class TestMain:
     @patch('sys.argv', ['awslabs.cfn-mcp-server'])
     def test_main_default(self, mock_run):
         """Test main function with default arguments."""
-        # Call the main function
-        main()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            main()
 
         # Check that mcp.run was called with the correct arguments
         mock_run.assert_called_once()
@@ -34,13 +35,13 @@ class TestMain:
     @patch('awslabs.cfn_mcp_server.server.mcp.run')
     @patch('sys.argv', ['awslabs.cfn-mcp-server'])
     def test_main_emits_deprecation_warning(self, mock_run):
-        """Test that main() emits a DeprecationWarning."""
+        """Test that main() emits a FutureWarning."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             main()
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert DEPRECATION_NOTICE in str(w[0].message)
+            future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+            assert len(future_warnings) == 1
+            assert DEPRECATION_NOTICE in str(future_warnings[0].message)
         mock_run.assert_called_once()
 
     def test_module_execution(self):


### PR DESCRIPTION
## Summary
- Add `DEPRECATION_NOTICE` constant pointing users to the AWS IAC MCP Server
- Prepend deprecation notice to FastMCP `instructions`
- Add `[DEPRECATED]` prefix to all 8 tool docstrings
- Add `warnings.warn(DEPRECATION_NOTICE, DeprecationWarning, stacklevel=1)` in `main()`
- Add test coverage for deprecation warning in `main()`

Users should migrate to `aws-iac-mcp-server` for CloudFormation and infrastructure-as-code capabilities.

## Test plan
- [x] `warnings.warn()` test passes
- [x] All 8 tool docstrings prefixed with `[DEPRECATED]`
- [x] ruff check/format passes
- [x] Existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
