### PR TITLE
docs: add deprecation notices to Tier 1 server READMEs

### DIFF
--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. Please migrate to the [AWS Knowledge Base MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server), which provides expanded knowledge base retrieval capabilities.
+
 # Amazon Bedrock Knowledge Base Retrieval MCP Server
 
 MCP server for accessing Amazon Bedrock Knowledge Bases

--- a/src/ccapi-mcp-server/README.md
+++ b/src/ccapi-mcp-server/README.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. The original owner has departed and no service team has taken ownership. For Cloud Control API access, consider using the [AWS IAC MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-iac-mcp-server), which provides a unified infrastructure-as-code experience covering CloudFormation, CDK, and Terraform.
+
 # AWS Cloud Control API (CCAPI) MCP Server
 
 Model Context Protocol (MCP) server that enables LLMs to directly create and manage over 1,100 AWS resources through natural language using AWS Cloud Control API and IaC Generator with Infrastructure as Code best practices.

--- a/src/cfn-mcp-server/README.md
+++ b/src/cfn-mcp-server/README.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. Please migrate to the [AWS IAC MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-iac-mcp-server), which provides a unified infrastructure-as-code experience covering CloudFormation, CDK, and Terraform.
+
 # CloudFormation MCP Server
 
 Model Context Protocol (MCP) server that enables LLMs to directly create and manage over 1,100 AWS resources through natural language using AWS Cloud Control API and Iac Generator with Infrastructure as Code best practices.

--- a/src/cost-explorer-mcp-server/README.md
+++ b/src/cost-explorer-mcp-server/README.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. Please migrate to the [Billing and Cost Management MCP Server](https://github.com/awslabs/mcp/tree/main/src/billing-cost-management-mcp-server), which provides broader cost analysis capabilities including Cost Explorer, Budgets, and Cost Anomaly Detection.
+
 # Cost Explorer MCP Server
 
 MCP server for analyzing AWS costs and usage data through the AWS Cost Explorer API.


### PR DESCRIPTION
## Summary
Add deprecation banners to the READMEs for all 4 Tier 1 deprecated servers:

- **ccapi-mcp-server** → [aws-iac-mcp-server](https://github.com/awslabs/mcp/tree/main/src/aws-iac-mcp-server) (owner departed, no service team ownership)
- **cost-explorer-mcp-server** → [billing-cost-management-mcp-server](https://github.com/awslabs/mcp/tree/main/src/billing-cost-management-mcp-server)
- **bedrock-kb-retrieval-mcp-server** → [aws-knowledge-mcp-server](https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server)
- **cfn-mcp-server** → [aws-iac-mcp-server](https://github.com/awslabs/mcp/tree/main/src/aws-iac-mcp-server)

Format matches the existing deprecation banner on terraform-mcp-server and aws-diagram-mcp-server.

## Test plan
- [x] Banner format matches existing deprecated server READMEs
- [x] All migration links point to correct replacement servers
- [x] No other content modified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.