### PR TITLE
feat(redshift): add REDSHIFT_DB_USER env var for provisioned clusters

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -108,6 +108,7 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 - `AWS_REGION`: AWS region to use (overrides all other region settings)
 - `AWS_DEFAULT_REGION`: Default AWS region (used if AWS_REGION not set and no region in profile)
 - `AWS_PROFILE`: AWS profile to use (optional, uses default if not specified)
+- `REDSHIFT_DB_USER`: Database user name for provisioned clusters. When set, passed as `DbUser` to the Data API's `ExecuteStatement`, authenticating via `GetClusterCredentials` as the specified user instead of the IAM-mapped temporary user. Only applies to provisioned clusters (not serverless).
 - `FASTMCP_LOG_LEVEL`: Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
 - `LOG_FILE`: Path to log file (optional, logs to stdout if not specified)
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -348,6 +348,9 @@ async def _execute_statement(
         request_params['Database'] = database_name
         if cluster_info['type'] == 'provisioned':
             request_params['ClusterIdentifier'] = cluster_identifier
+            db_user = os.environ.get('REDSHIFT_DB_USER')
+            if db_user:
+                request_params['DbUser'] = db_user
         elif cluster_info['type'] == 'serverless':
             request_params['WorkgroupName'] = cluster_identifier
         else:


### PR DESCRIPTION

## Summary
Add support for the REDSHIFT_DB_USER environment variable to specify the DbUser parameter when executing statements on provisioned Redshift clusters. Without this, the Data API uses GetClusterCredentialsWithIAM which creates a temporary user that may lack schema grants.

This follows the existing pattern of AWS_PROFILE and AWS_REGION env vars. Only applies to provisioned clusters (serverless uses IAM auth directly).

### User experience

Developers can set an environment variable to explicitly set the db user for the MCP server

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
