### PR TITLE
fix(ccapi): Remove save_to_file from create_template

### DIFF
--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/iac_generator.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/iac_generator.py
@@ -14,7 +14,6 @@
 
 """CloudFormation IaC Generator tool implementation."""
 
-import os
 from awslabs.ccapi_mcp_server.aws_client import get_aws_client
 from awslabs.ccapi_mcp_server.errors import ClientError, handle_aws_api_error
 from typing import Dict, List, Optional
@@ -27,7 +26,6 @@ async def create_template(
     deletion_policy: str = 'RETAIN',
     update_replace_policy: str = 'RETAIN',
     template_id: Optional[str] = None,
-    save_to_file: Optional[str] = None,
     region_name: Optional[str] = None,
 ) -> Dict:
     """Create a CloudFormation template from existing resources using the IaC Generator API.
@@ -44,7 +42,6 @@ async def create_template(
         deletion_policy: Default DeletionPolicy for resources in the template (RETAIN, DELETE, or SNAPSHOT)
         update_replace_policy: Default UpdateReplacePolicy for resources in the template (RETAIN, DELETE, or SNAPSHOT)
         template_id: ID of an existing template generation process to check status or retrieve template
-        save_to_file: Path to save the generated template to a file
         region_name: AWS region name
 
     Returns:
@@ -68,9 +65,7 @@ async def create_template(
 
     # Case 1: Check status or retrieve template for an existing template generation process
     if template_id:
-        return await _handle_existing_template(
-            cfn_client, template_id, save_to_file, output_format
-        )
+        return await _handle_existing_template(cfn_client, template_id, output_format)
 
     # Case 2: Start a new template generation process
     return await _start_template_generation(
@@ -136,14 +131,13 @@ async def _start_template_generation(
 
 
 async def _handle_existing_template(
-    cfn_client, template_id: str, save_to_file: Optional[str], output_format: str = 'YAML'
+    cfn_client, template_id: str, output_format: str = 'YAML'
 ) -> Dict:
     """Handle an existing template generation process - check status or retrieve template.
 
     Args:
         cfn_client: Boto3 CloudFormation client
         template_id: ID of the template generation process
-        save_to_file: Path to save the generated template to a file
         output_format: Format of generated template. Either JSON or YAML
 
     Returns:
@@ -171,20 +165,6 @@ async def _handle_existing_template(
         template_content = template_response['TemplateBody']
         resources = status_response.get('ResourceIdentifiers', [])
 
-        # Save the template to a file if requested
-        file_path = None
-        if save_to_file:
-            try:
-                # Ensure the directory exists
-                os.makedirs(os.path.dirname(os.path.abspath(save_to_file)), exist_ok=True)
-
-                # Write the template to the file
-                with open(save_to_file, 'w') as f:
-                    f.write(template_content)
-                file_path = save_to_file
-            except Exception as e:
-                raise ClientError(f'Failed to save template to file: {str(e)}')
-
         # Return the template and related information
         result = {
             'status': 'COMPLETED',
@@ -193,9 +173,6 @@ async def _handle_existing_template(
             'resources': resources,
             'message': 'Template generation completed.',
         }
-
-        if file_path:
-            result['file_path'] = file_path
 
         return result
 

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/server.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/server.py
@@ -540,9 +540,6 @@ async def create_template(
         None,
         description='ID of an existing template generation process to check status or retrieve template',
     ),
-    save_to_file: str | None = Field(
-        None, description='Path to save the generated template to a file'
-    ),
     region: str | None = Field(
         description='The AWS region that the operation should be performed in', default=None
     ),
@@ -582,10 +579,9 @@ async def create_template(
     2. Check status of template generation:
        create_template(template_id="arn:aws:cloudformation:us-east-1:123456789012:generatedtemplate/abcdef12-3456-7890-abcd-ef1234567890")
 
-    3. Retrieve and save generated template:
+    3. Retrieve generated template:
        create_template(
            template_id="arn:aws:cloudformation:us-east-1:123456789012:generatedtemplate/abcdef12-3456-7890-abcd-ef1234567890",
-           save_to_file="/path/to/template.yaml",
            output_format="YAML"
        )
     """
@@ -596,23 +592,8 @@ async def create_template(
         deletion_policy=deletion_policy,
         update_replace_policy=update_replace_policy,
         template_id=template_id,
-        save_to_file=save_to_file,
         region_name=region,
     )
-
-    # Handle FieldInfo objects for save_to_file
-    save_path = save_to_file
-    if (
-        save_to_file is not None
-        and not isinstance(save_to_file, str)
-        and hasattr(save_to_file, 'default')
-    ):
-        save_path = save_to_file.default
-
-    # If save_to_file is specified and we have template_body, write it to file
-    if save_path and result.get('template_body'):
-        with open(save_path, 'w') as f:
-            f.write(result['template_body'])
 
     return result
 

--- a/src/ccapi-mcp-server/tests/test_iac_generator.py
+++ b/src/ccapi-mcp-server/tests/test_iac_generator.py
@@ -14,7 +14,6 @@
 
 """Tests for the CloudFormation IaC Generator tool."""
 
-import os
 import pytest
 from awslabs.ccapi_mcp_server.errors import ClientError
 from awslabs.ccapi_mcp_server.iac_generator import create_template
@@ -163,32 +162,6 @@ async def test_create_template_retrieve_json_template(mock_get_aws_client, mock_
 
 
 @pytest.mark.asyncio
-async def test_create_template_save_to_file(mock_get_aws_client, mock_cfn_client, tmpdir):
-    """Test saving a generated template to a file."""
-    mock_get_aws_client.return_value = mock_cfn_client
-    mock_cfn_client.describe_generated_template.return_value = {
-        'Status': 'COMPLETE',
-        'ResourceIdentifiers': [],
-    }
-    mock_cfn_client.get_generated_template.return_value = {'TemplateBody': 'template-content'}
-
-    file_path = os.path.join(tmpdir, 'template.yaml')
-
-    result = await create_template(template_id='test-template-id', save_to_file=file_path)
-
-    assert os.path.exists(file_path)
-    with open(file_path, 'r') as f:
-        assert f.read() == 'template-content'
-
-    mock_cfn_client.get_generated_template.assert_called_once_with(
-        GeneratedTemplateName='test-template-id', Format='YAML'
-    )
-
-    assert result['status'] == 'COMPLETED'
-    assert result['file_path'] == file_path
-
-
-@pytest.mark.asyncio
 async def test_create_template_resource_validation_error(mock_get_aws_client, mock_cfn_client):
     """Test validation error when resources are invalid."""
     mock_get_aws_client.return_value = mock_cfn_client
@@ -235,16 +208,3 @@ async def test_create_template_failed_status(mock_get_aws_client, mock_cfn_clien
 
     assert result['status'] == 'FAILED'
     assert 'Template generation failed' in result['message']
-
-
-@pytest.mark.asyncio
-async def test_create_template_file_write_error(mock_get_aws_client, mock_cfn_client):
-    """Test handling of file write errors."""
-    mock_get_aws_client.return_value = mock_cfn_client
-    mock_cfn_client.describe_generated_template.return_value = {'Status': 'COMPLETE'}
-    mock_cfn_client.get_generated_template.return_value = {'TemplateBody': 'content'}
-
-    with pytest.raises(ClientError):
-        await create_template(
-            template_id='test-template-id', save_to_file='/invalid/path/template.yaml'
-        )

--- a/src/ccapi-mcp-server/tests/test_server.py
+++ b/src/ccapi-mcp-server/tests/test_server.py
@@ -389,7 +389,6 @@ class TestTools:
         from awslabs.ccapi_mcp_server.server import (
             _workflow_store,
             check_environment_variables,
-            create_template,
             delete_resource,
             get_aws_account_info,
             get_aws_session_info,
@@ -557,15 +556,6 @@ class TestTools:
                 )
                 assert not result['passed']
 
-        # Test lines 1130-1131 - create_template with save_to_file
-        with patch('awslabs.ccapi_mcp_server.iac_generator.create_template') as mock_impl:
-            mock_impl.return_value = {'template_body': '{}'}
-            with patch('builtins.open', create=True):
-                try:
-                    await create_template(template_id='test', save_to_file='/tmp/test.yaml')
-                except Exception:
-                    pass
-
         # Test lines 1243, 1247 - get_aws_profile_info exception handling
         with patch('awslabs.ccapi_mcp_server.server.get_aws_client') as mock_client:
             mock_client.side_effect = Exception('AWS Error')
@@ -649,7 +639,6 @@ class TestTools:
         from awslabs.ccapi_mcp_server.impl.tools.security_scanning import _check_checkov_installed
         from awslabs.ccapi_mcp_server.server import (
             _workflow_store,
-            create_template,
             delete_resource,
             explain,
             generate_infrastructure_code,
@@ -833,17 +822,6 @@ class TestTools:
                     explained_token=explained_token, framework='cloudformation'
                 )
                 assert not result['passed']
-
-        # Test create_template with FieldInfo save_to_file
-        with patch('awslabs.ccapi_mcp_server.iac_generator.create_template') as mock_impl:
-            mock_impl.return_value = {'template_body': '{}'}
-            field_info = MagicMock()
-            field_info.default = '/tmp/test.yaml'
-            with patch('builtins.open', create=True):
-                try:
-                    await create_template(template_id='test', save_to_file=field_info)
-                except Exception:
-                    pass
 
         # Test get_aws_session_info with invalid environment token
         try:


### PR DESCRIPTION
## Summary

### Changes

Remove the `save_to_file` parameter and all associated file-writing logic from `create_template` in both `server.py` and `iac_generator.py`. The template content is already returned in the tool response, so the MCP client can write it to disk using its own file tools with appropriate user approval flows.

- Remove `save_to_file` parameter from `create_template` in `server.py` and `iac_generator.py`
- Remove file-writing and directory creation logic from both locations
- Remove unused `import os` from `iac_generator.py`
- Update tests accordingly

### User experience

Before: The `create_template` tool accepted a `save_to_file` parameter that wrote the generated template directly to disk from within the MCP server process.

After: The `create_template` tool returns the template content in the response. The MCP client (Claude Desktop, Kiro, etc.) can then write it to disk using its own file-writing capabilities, which include user visibility and approval flows.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? Y

Clients that previously passed `save_to_file` to `create_template` will need to handle file writing on the client side instead. The template content is still returned in the response as before.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

