### PR TITLE
feat(syntheticdata-mcp-server): add deprecation notices

### DIFF
--- a/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/server.py
+++ b/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/server.py
@@ -107,9 +107,18 @@ class LoadToStorageInput(BaseModel):
     )
 
 
+DEPRECATION_NOTICE = (
+    'DEPRECATION NOTICE: The Synthetic Data MCP Server (awslabs.syntheticdata-mcp-server) is '
+    'deprecated and will no longer receive updates, bug fixes, or new features. '
+    'The core functionality (generating synthetic data schemas and pandas code) is achievable '
+    'natively by modern AI assistants without requiring an MCP server. '
+    'For S3 uploads, use the S3 MCP Server (awslabs.s3-mcp-server) instead.'
+)
+
 mcp = FastMCP(
     'awslabs.syntheticdata-mcp-server',
-    instructions="""
+    instructions=DEPRECATION_NOTICE
+    + """
     # awslabs Synthetic Data MCP Server
 
     This MCP server provides tools for generating high-quality synthetic data based on business use cases.
@@ -152,7 +161,7 @@ async def get_data_gen_instructions(
         description='A detailed description of the business domain and use case. The more specific and comprehensive the description, the better the data generation instructions will be.',
     ),
 ) -> Dict:
-    """Get instructions for generating synthetic data based on a business description.
+    """[DEPRECATED] Get instructions for generating synthetic data based on a business description.
 
     This tool analyzes a business description and provides detailed instructions
     for generating synthetic data in JSON Lines format.
@@ -215,7 +224,7 @@ async def get_data_gen_instructions(
 
 @mcp.tool(name='validate_and_save_data')
 async def validate_and_save_data(input_data: ValidateAndSaveDataInput) -> Dict:
-    """Validate JSON Lines data and save it as CSV files.
+    """[DEPRECATED] Validate JSON Lines data and save it as CSV files.
 
     This tool validates the structure of JSON Lines data and saves it as CSV files
     using pandas.
@@ -294,7 +303,7 @@ async def validate_and_save_data(input_data: ValidateAndSaveDataInput) -> Dict:
 
 @mcp.tool(name='load_to_storage')
 async def load_to_storage(input_data: LoadToStorageInput) -> Dict:
-    """Load data to one or more storage targets.
+    """[DEPRECATED] Load data to one or more storage targets.
 
     This tool uses the UnifiedDataLoader to load data to configured storage targets.
     Currently supports:
@@ -336,7 +345,7 @@ async def load_to_storage(input_data: LoadToStorageInput) -> Dict:
 
 @mcp.tool(name='execute_pandas_code')
 async def execute_pandas_code(input_data: ExecutePandasCodeInput) -> Dict:
-    """Execute pandas code to generate synthetic data and save it as CSV files.
+    """[DEPRECATED] Execute pandas code to generate synthetic data and save it as CSV files.
 
     This tool runs pandas code in a restricted environment to generate synthetic data.
     It then saves any generated DataFrames as CSV files.
@@ -758,6 +767,9 @@ def _validate_table_data(table_name: str, records: List[Dict]) -> Dict:
 
 def main():
     """Run the MCP server with CLI argument support."""
+    import warnings
+
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
     mcp.run()
 
 

--- a/src/syntheticdata-mcp-server/tests/test_server.py
+++ b/src/syntheticdata-mcp-server/tests/test_server.py
@@ -1,7 +1,9 @@
 """Tests for syntheticdata MCP server functionality."""
 
 import os
+import warnings
 from awslabs.syntheticdata_mcp_server.server import (
+    DEPRECATION_NOTICE,
     ExecutePandasCodeInput,
     LoadToStorageInput,
     ValidateAndSaveDataInput,
@@ -360,7 +362,21 @@ def test_main_cli_arguments(monkeypatch) -> None:
     monkeypatch.setattr('mcp.server.fastmcp.FastMCP.run', mock_run)
 
     # Run main
-    main()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        main()
 
     # Verify run was called
     assert run_called
+
+
+def test_main_emits_deprecation_warning(monkeypatch) -> None:
+    """Test that main() emits a FutureWarning."""
+    monkeypatch.setattr('mcp.server.fastmcp.FastMCP.run', lambda self, **kwargs: None)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        main()
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert DEPRECATION_NOTICE in str(future_warnings[0].message)


### PR DESCRIPTION
## Summary
- Add DEPRECATION_NOTICE constant and prepend to server instructions
- Add [DEPRECATED] prefix to all tool docstrings
- Emit FutureWarning in main() for CLI visibility
- Add test coverage for deprecation warning

## Test plan
- [x] Existing tests pass
- [x] New deprecation warning test passes
- [x] ruff check/format clean

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).