### PR TITLE
feat(frontend-mcp-server): add deprecation notices

### DIFF
--- a/src/frontend-mcp-server/awslabs/frontend_mcp_server/server.py
+++ b/src/frontend-mcp-server/awslabs/frontend_mcp_server/server.py
@@ -21,9 +21,18 @@ from pydantic import Field
 from typing import Literal
 
 
+DEPRECATION_NOTICE = (
+    'DEPRECATION NOTICE: The Frontend MCP Server (awslabs.frontend-mcp-server) is '
+    'deprecated and will no longer receive updates, bug fixes, or new features. '
+    'This server only serves static React/Amplify documentation that modern AI assistants '
+    'already have knowledge of. Consider using project-level documentation or Kiro specs instead.'
+)
+
 mcp = FastMCP(
     'awslabs.frontend-mcp-server',
-    instructions='The Frontend MCP Server provides specialized tools for modern web application development. It offers guidance on React application setup, optimistic UI implementation, and authentication integration. Use these tools when you need expert advice on frontend development best practices.',
+    instructions=DEPRECATION_NOTICE
+    + ' '
+    + 'The Frontend MCP Server provides specialized tools for modern web application development. It offers guidance on React application setup, optimistic UI implementation, and authentication integration. Use these tools when you need expert advice on frontend development best practices.',
     dependencies=[
         'pydantic',
         'loguru',
@@ -41,7 +50,7 @@ async def get_react_docs_by_topic(
         description='The topic of React documentation to retrieve. Topics include: essential-knowledge, troubleshooting.',
     ),
 ) -> str:
-    """Get specific AWS web application UI setup documentation by topic.
+    """[DEPRECATED] Get specific AWS web application UI setup documentation by topic.
 
     Parameters:
         topic: The topic of React documentation to retrieve.
@@ -64,6 +73,9 @@ async def get_react_docs_by_topic(
 
 def main():
     """Run the MCP server with CLI argument support."""
+    import warnings
+
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
     mcp.run()
 
     logger.trace('A trace message.')

--- a/src/frontend-mcp-server/tests/test_server.py
+++ b/src/frontend-mcp-server/tests/test_server.py
@@ -14,7 +14,8 @@
 """Tests for the frontend MCP Server."""
 
 import pytest
-from awslabs.frontend_mcp_server.server import get_react_docs_by_topic
+import warnings
+from awslabs.frontend_mcp_server.server import DEPRECATION_NOTICE, get_react_docs_by_topic, main
 from unittest.mock import patch
 
 
@@ -54,3 +55,15 @@ async def test_get_react_docs_by_topic_invalid():
     # Act & Assert
     with pytest.raises(ValueError, match='Invalid topic:'):
         await get_react_docs_by_topic('invalid-topic')
+
+
+@patch('awslabs.frontend_mcp_server.server.mcp')
+def test_main_emits_deprecation_warning(mock_mcp):
+    """Test that main() emits a FutureWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        main()
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert DEPRECATION_NOTICE in str(future_warnings[0].message)
+    mock_mcp.run.assert_called_once()


### PR DESCRIPTION
## Summary
- Add DEPRECATION_NOTICE constant and prepend to server instructions
- Add [DEPRECATED] prefix to all tool docstrings
- Emit FutureWarning in main() for CLI visibility
- Add test coverage for deprecation warning

## Test plan
- [x] Existing tests pass
- [x] New deprecation warning test passes
- [x] ruff check/format clean

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).