### PR TITLE
chore: release/2026.03.20260313194041

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.0.14'
+__version__ = '0.0.15'

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.14"
+version = "0.0.15"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.0.14"
+version = "0.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.3.20'
+__version__ = '1.3.21'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.20"
+version = "1.3.21"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.3.20"
+version = "1.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },

--- a/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/__init__.py
+++ b/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/__init__.py
@@ -17,4 +17,4 @@
 This package provides an MCP server that creates diagrams using the Python diagrams package DSL.
 """
 
-__version__ = '1.0.23'
+__version__ = '1.0.24'

--- a/src/aws-diagram-mcp-server/pyproject.toml
+++ b/src/aws-diagram-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-diagram-mcp-server"
-version = "1.0.23"
+version = "1.0.24"
 description = "An MCP server that seamlessly creates diagrams using the Python diagrams package DSL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aws-diagram-mcp-server/uv.lock
+++ b/src/aws-diagram-mcp-server/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-diagram-mcp-server"
-version = "1.0.23"
+version = "1.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "bandit" },

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/__init__.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-documentation-mcp-server"""
 
-__version__ = '1.1.19'
+__version__ = '1.1.20'

--- a/src/aws-documentation-mcp-server/pyproject.toml
+++ b/src/aws-documentation-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-documentation-mcp-server"
-version = "1.1.19"
+version = "1.1.20"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-documentation-mcp-server/uv.lock
+++ b/src/aws-documentation-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-documentation-mcp-server"
-version = "1.1.19"
+version = "1.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-healthomics-mcp-server"""
 
-__version__ = '0.0.29'
+__version__ = '0.0.30'

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-healthomics-mcp-server"
-version = "0.0.29"
+version = "0.0.30"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-healthomics-mcp-server"
-version = "0.0.29"
+version = "0.0.30"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/__init__.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs Bedrock Knowledge Base Retrieval MCP Server"""
 
-__version__ = '1.0.18'
+__version__ = '1.0.19'

--- a/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
+++ b/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.bedrock-kb-retrieval-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Knowledge Base Retrieval"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/bedrock-kb-retrieval-mcp-server/uv.lock
+++ b/src/bedrock-kb-retrieval-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-bedrock-kb-retrieval-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.0.17'
+__version__ = '1.0.18'

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.0.17"
+version = "1.0.18"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/uv.lock
+++ b/src/ccapi-mcp-server/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ccapi-mcp-server"
-version = "1.0.17"
+version = "1.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/__init__.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.cfn-mcp-server"""
 
-__version__ = '1.0.18'
+__version__ = '1.0.19'

--- a/src/cfn-mcp-server/pyproject.toml
+++ b/src/cfn-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cfn-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 description = "An AWS Labs Model Context Protocol (MCP) server for doing common cloudformation tasks and for managing your resources in your AWS account"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cfn-mcp-server/uv.lock
+++ b/src/cfn-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cfn-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Application Signals MCP Server."""
 
-__version__ = '0.1.28'
+__version__ = '0.1.29'

--- a/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-applicationsignals-mcp-server"
-version = "0.1.28"
+version = "0.1.29"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Application Signals"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-applicationsignals-mcp-server/uv.lock
+++ b/src/cloudwatch-applicationsignals-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-applicationsignals-mcp-server"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.cloudwatch-mcp-server"""
 
-__version__ = '0.0.21'
+__version__ = '0.0.22'
 MCP_SERVER_VERSION = __version__

--- a/src/cloudwatch-mcp-server/pyproject.toml
+++ b/src/cloudwatch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-mcp-server"
-version = "0.0.21"
+version = "0.0.22"
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudwatch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-mcp-server/uv.lock
+++ b/src/cloudwatch-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-mcp-server"
-version = "0.0.21"
+version = "0.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/__init__.py
+++ b/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/__init__.py
@@ -17,4 +17,4 @@
 This module provides MCP tools for analyzing AWS costs and usage data through the AWS Cost Explorer API.
 """
 
-__version__ = '0.0.20'
+__version__ = '0.0.21'

--- a/src/cost-explorer-mcp-server/pyproject.toml
+++ b/src/cost-explorer-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cost-explorer-mcp-server"
-version = "0.0.20"
+version = "0.0.21"
 description = "MCP server for analyzing AWS costs and usage data through the AWS Cost Explorer API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cost-explorer-mcp-server/uv.lock
+++ b/src/cost-explorer-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cost-explorer-mcp-server"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
+++ b/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Document Loader MCP Server package"""
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'

--- a/src/document-loader-mcp-server/pyproject.toml
+++ b/src/document-loader-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.document-loader-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 description = "An AWS Labs Model Context Protocol (MCP) server for document parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/document-loader-mcp-server/uv.lock
+++ b/src/document-loader-mcp-server/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-document-loader-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.dynamodb-mcp-server"""
 
-__version__ = '2.0.20'
+__version__ = '2.0.21'

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.dynamodb-mcp-server"
-version = "2.0.20"
+version = "2.0.21"
 description = "The official MCP Server for interacting with AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-dynamodb-mcp-server"
-version = "2.0.20"
+version = "2.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-aws-api-mcp-server" },

--- a/src/frontend-mcp-server/awslabs/frontend_mcp_server/__init__.py
+++ b/src/frontend-mcp-server/awslabs/frontend_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.frontend-mcp-server"""
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'

--- a/src/frontend-mcp-server/pyproject.toml
+++ b/src/frontend-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.frontend-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 description = "An AWS Labs Model Context Protocol (MCP) server for frontend"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/frontend-mcp-server/uv.lock
+++ b/src/frontend-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-frontend-mcp-server"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },

--- a/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
+++ b/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """SyntheticData MCP Server package."""
 
-__version__ = '1.0.13'
+__version__ = '1.0.14'

--- a/src/syntheticdata-mcp-server/pyproject.toml
+++ b/src/syntheticdata-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.syntheticdata-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 description = "An AWS Labs Model Context Protocol (MCP) server for syntheticdata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/syntheticdata-mcp-server/uv.lock
+++ b/src/syntheticdata-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-syntheticdata-mcp-server"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/__init__.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.terraform-mcp-server"""
 
-__version__ = '1.0.18'
+__version__ = '1.0.19'

--- a/src/terraform-mcp-server/pyproject.toml
+++ b/src/terraform-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.terraform-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 description = "An AWS Labs Model Context Protocol (MCP) server for terraform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/terraform-mcp-server/uv.lock
+++ b/src/terraform-mcp-server/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-terraform-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "asteval" },


### PR DESCRIPTION
# release/2026.03.20260313194041

Triggered Release Branch (initiated) by @kevin-orellana for @kevin-orellana

## Changes
* amazon-bedrock-agentcore-mcp-server
* aws-api-mcp-server
* aws-diagram-mcp-server
* aws-documentation-mcp-server
* aws-healthomics-mcp-server
* bedrock-kb-retrieval-mcp-server
* ccapi-mcp-server
* cfn-mcp-server
* cloudwatch-applicationsignals-mcp-server
* cloudwatch-mcp-server
* cost-explorer-mcp-server
* document-loader-mcp-server
* dynamodb-mcp-server
* frontend-mcp-server
* syntheticdata-mcp-server
* terraform-mcp-server

## Checklist
- [x] Code changes have been reviewed
- [x] Distribution packages have been built and tested
- [x] Documentation has been updated if applicable

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).