### PR TITLE
feat: add aws_profile support for AWS client creation for billing cos…

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
@@ -128,7 +128,13 @@ DIMENSION REFERENCE:
 - TAG: Cost allocation tag
 - TENANCY: EC2 tenancy (shared, dedicated)
 - USAGE_TYPE: Usage type (e.g., DataTransfer-In-Bytes)
-- RECORD_TYPE: Charge types (e.g., RI fees, usage costs)""",
+- RECORD_TYPE: Charge types (e.g., RI fees, usage costs)
+
+## AUTHENTICATION
+
+- aws_profile: (optional) Named AWS profile from ~/.aws/credentials or ~/.aws/config.
+  When omitted, falls back to the AWS_PROFILE environment variable and then to the
+  default credential chain (instance profile, environment variables, etc.).""",
 )
 async def cost_explorer(
     ctx: Context,
@@ -148,6 +154,7 @@ async def cost_explorer(
     prediction_interval_level: int = 80,
     tag_key: Optional[str] = None,
     cost_category_name: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Main entry point for Cost Explorer operations.
 
@@ -172,6 +179,7 @@ async def cost_explorer(
         prediction_interval_level: Confidence level for forecasts
         tag_key: Tag key to get values for
         cost_category_name: Cost category to get values for
+        aws_profile: Named AWS profile to use for credentials (optional)
 
     Returns:
         Response from the operation handler
@@ -180,7 +188,7 @@ async def cost_explorer(
 
     # Create Cost Explorer client
     try:
-        ce_client = create_aws_client('ce')
+        ce_client = create_aws_client('ce', profile_name=aws_profile)
     except Exception as client_error:
         await ctx.error(f'Failed to create AWS client: {str(client_error)}')
         return format_response(

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/aws_service_base.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/aws_service_base.py
@@ -84,13 +84,19 @@ def get_pricing_region(requested_region: Optional[str] = None) -> str:
     return pricing_region
 
 
-def create_aws_client(service_name: str, region_name: Optional[str] = None) -> Any:
+def create_aws_client(
+    service_name: str,
+    region_name: Optional[str] = None,
+    profile_name: Optional[str] = None,
+) -> Any:
     """Create and return an AWS service client with appropriate security constraints.
 
     Args:
         service_name: AWS service name (e.g., "ce", "pricing")
         region_name: AWS region name (e.g., "us-east-1"). If None, will use the
                      AWS_REGION environment variable or default to "us-east-1".
+        profile_name: AWS named profile to use for credentials. If None, falls back
+                      to the AWS_PROFILE environment variable or default credentials.
 
     Returns:
         boto3.client: AWS service client with security constraints applied
@@ -121,10 +127,10 @@ def create_aws_client(service_name: str, region_name: Optional[str] = None) -> A
 
     region = region_name or os.environ.get('AWS_REGION', 'us-east-1')
 
-    # Create AWS session
-    profile_name = os.environ.get('AWS_PROFILE')
-    if profile_name:
-        session = boto3.Session(profile_name=profile_name, region_name=region)
+    # Create AWS session — prefer explicit profile_name, then AWS_PROFILE env var
+    resolved_profile = profile_name or os.environ.get('AWS_PROFILE')
+    if resolved_profile:
+        session = boto3.Session(profile_name=resolved_profile, region_name=region)
     else:
         session = boto3.Session(region_name=region)
 


### PR DESCRIPTION
## Summary

### Changes

Add optional `aws_profile` support for AWS client creation to enable multi-account usage when running MCP tools.

Currently the tools rely on the default AWS credential chain, which makes it difficult to work with multiple AWS accounts using AWS CLI profiles. This change allows users to optionally pass an `aws_profile` parameter that will be used to create the boto3 session.

Key changes:

- Added optional `aws_profile` parameter
- Updated `create_aws_client` utility to initialize boto3 sessions with a profile when provided
- Maintains backward compatibility by falling back to the default credential chain when the parameter is not specified


### User experience

Before:

Users could only run MCP tools using the default AWS credentials configured in the environment. Switching accounts required modifying environment credentials or AWS configuration.

Example:

aws_access_key_id / environment credentials only


After:

Users can optionally specify an AWS profile when running the tool.

Example:

{
  "service_code": "AmazonEC2",
  "region": "us-east-1",
  "aws_profile": "prod-account"
}

This enables easier multi-account workflows without modifying environment credentials.


## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented


Is this a breaking change? (Y/N)

N


**RFC issue number**:

N/A


Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).