### PR TITLE
chore(aws-dataprocessing-mcp-server): fix to use session or default a…

### DIFF
--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/utils/aws_helper.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/utils/aws_helper.py
@@ -42,13 +42,39 @@ class AwsHelper:
 
     @staticmethod
     def get_aws_region() -> str:
-        """Get the AWS region from the environment if set."""
-        aws_region = os.environ.get(
-            'AWS_REGION',
-        )
-        if not aws_region:
-            return 'us-east-1'
-        return aws_region
+        """Get the AWS region from environment, AWS config, or default.
+
+        This method follows the standard AWS SDK credential/config resolution chain:
+        1. AWS_REGION environment variable (explicit override)
+        2. AWS_DEFAULT_REGION environment variable (legacy override)
+        3. boto3.Session().region_name (reads ~/.aws/config, instance metadata, etc.)
+        4. 'us-east-1' as last resort fallback
+
+        Returns:
+            The AWS region as a string
+        """
+        # Check AWS_REGION environment variable first
+        aws_region = os.environ.get('AWS_REGION')
+        if aws_region:
+            return aws_region
+
+        # Check AWS_DEFAULT_REGION environment variable
+        aws_region = os.environ.get('AWS_DEFAULT_REGION')
+        if aws_region:
+            return aws_region
+
+        # Use boto3 Session to read from AWS config files and other sources
+        try:
+            session = boto3.Session()
+            aws_region = session.region_name
+            if aws_region:
+                return aws_region
+        except Exception:
+            # If boto3 Session fails, continue to fallback
+            pass
+
+        # Last resort fallback
+        return 'us-east-1'
 
     @staticmethod
     def get_aws_profile() -> Optional[str]:

--- a/src/aws-dataprocessing-mcp-server/tests/utils/test_aws_helper.py
+++ b/src/aws-dataprocessing-mcp-server/tests/utils/test_aws_helper.py
@@ -41,14 +41,57 @@ class TestAwsHelper:
         AwsHelper._aws_partition = None
 
     def test_get_aws_region_with_env_var(self):
-        """Test that get_aws_region returns the region from the environment variable."""
+        """Test that get_aws_region returns the region from AWS_REGION environment variable."""
         with patch.dict(os.environ, {'AWS_REGION': 'us-west-2'}):
             assert AwsHelper.get_aws_region() == 'us-west-2'
 
-    def test_get_aws_region_without_env_var(self):
-        """Test that get_aws_region returns None when the environment variable is not set."""
+    def test_get_aws_region_with_default_env_var(self):
+        """Test that get_aws_region returns the region from AWS_DEFAULT_REGION environment variable."""
+        with patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'eu-west-1'}, clear=True):
+            assert AwsHelper.get_aws_region() == 'eu-west-1'
+
+    def test_get_aws_region_prioritizes_aws_region_over_default(self):
+        """Test that AWS_REGION takes precedence over AWS_DEFAULT_REGION."""
+        with patch.dict(
+            os.environ, {'AWS_REGION': 'us-west-2', 'AWS_DEFAULT_REGION': 'eu-west-1'}
+        ):
+            assert AwsHelper.get_aws_region() == 'us-west-2'
+
+    def test_get_aws_region_from_boto3_session(self):
+        """Test that get_aws_region falls back to boto3.Session().region_name when env vars not set."""
+        # Mock boto3.Session to return a region
+        mock_session = MagicMock()
+        mock_session.region_name = 'ap-southeast-2'
+
         with patch.dict(os.environ, {}, clear=True):
-            assert AwsHelper.get_aws_region() == 'us-east-1'
+            with patch('boto3.Session', return_value=mock_session):
+                assert AwsHelper.get_aws_region() == 'ap-southeast-2'
+
+    def test_get_aws_region_boto3_session_no_region(self):
+        """Test that get_aws_region falls back to us-east-1 when boto3.Session returns None."""
+        # Mock boto3.Session to return None for region_name
+        mock_session = MagicMock()
+        mock_session.region_name = None
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('boto3.Session', return_value=mock_session):
+                assert AwsHelper.get_aws_region() == 'us-east-1'
+
+    def test_get_aws_region_boto3_session_exception(self):
+        """Test that get_aws_region falls back to us-east-1 when boto3.Session raises an exception."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('boto3.Session', side_effect=Exception('Session creation failed')):
+                assert AwsHelper.get_aws_region() == 'us-east-1'
+
+    def test_get_aws_region_without_env_var(self):
+        """Test that get_aws_region returns us-east-1 when no region source is available."""
+        # Mock boto3.Session to return None
+        mock_session = MagicMock()
+        mock_session.region_name = None
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('boto3.Session', return_value=mock_session):
+                assert AwsHelper.get_aws_region() == 'us-east-1'
 
     def test_get_aws_profile_with_env_var(self):
         """Test that get_aws_profile returns the profile from the environment variable."""
@@ -187,7 +230,10 @@ class TestAwsHelper:
         mock_session.client.return_value = mock_client
 
         with patch('boto3.Session', return_value=mock_session) as mock_boto3_session:
-            with patch.dict(os.environ, {'AWS_PROFILE': 'test-profile'}):
+            with patch.dict(
+                os.environ, {'AWS_PROFILE': 'test-profile', 'AWS_REGION': 'us-west-2'}
+            ):
+                # Set AWS_REGION to avoid get_aws_region() calling boto3.Session
                 client = AwsHelper.create_boto3_client('s3')
                 assert client == mock_client
                 mock_boto3_session.assert_called_once_with(profile_name='test-profile')


### PR DESCRIPTION
This PR fixes a bug in the AWS region resolution logic for the `aws-dataprocessing-mcp-server`. The `get_aws_region()` method now properly follows the standard AWS SDK credential/config resolution chain instead of hardcoding a fallback to `us-east-1`.

__What was changed:__

- Updated `get_aws_region()` method in `awslabs/aws_dataprocessing_mcp_server/utils/aws_helper.py` to check multiple region sources in order of precedence:

  1. `AWS_REGION` environment variable
  2. `AWS_DEFAULT_REGION` environment variable
  3. `boto3.Session().region_name` (reads from `~/.aws/config`, instance metadata, etc.)
  4. `us-east-1` as last resort fallback

- Added 6 comprehensive test cases to validate the new resolution chain behavior

- Updated 1 existing test to handle the boto3.Session interaction

### User experience

__Before this change:__

- The server ignored user's AWS configuration in `~/.aws/config`
- Only respected the `AWS_REGION` environment variable
- Silently fell back to `us-east-1` when `AWS_REGION` was not set
- Users experienced resources being created in the wrong region without any indication
- Resources appeared to be created successfully (MCP returned success) but were invisible in the expected region's console and CLI
- Users had to explicitly set `AWS_REGION` in their MCP server configuration as a workaround

__After this change:__

- The server respects the user's default region configured in `~/.aws/config`
- Supports both `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables
- Follows the standard AWS SDK region resolution chain that users expect
- Resources are created in the correct region based on user's AWS configuration
- Consistent behavior with other AWS CLI tools and SDKs
- No workarounds needed for users with properly configured AWS environments

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) Y

**RFC issue number**: https://github.com/awslabs/mcp/issues/2677

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).