### PR TITLE
docs(git-repo-research-mcp-server): add migration guide and README deprecation banner

### DIFF
--- a/docs/migration-git-repo-research.md
+++ b/docs/migration-git-repo-research.md
@@ -8,7 +8,7 @@ The `git-repo-research-mcp-server` requires Amazon Bedrock credentials for seman
 
 ## Recommended Alternative: Context7
 
-[Context7](https://github.com/upstash/context7) is an open-source MCP server (~50K GitHub stars) that provides up-to-date documentation and code examples for popular libraries directly in your AI coding workflow.
+[Context7](https://github.com/upstash/context7) is an actively maintained open-source MCP server that provides up-to-date documentation and code examples for popular libraries directly in your AI coding workflow.
 
 ### Installing Context7
 
@@ -34,7 +34,7 @@ The `git-repo-research-mcp-server` requires Amazon Bedrock credentials for seman
 | AWS credentials required | Yes (Bedrock) | No |
 | Private repo support | Yes | No |
 | GitHub repo search | Yes (AWS orgs only) | No |
-| Community support | AWS Labs maintained | ~50K stars, actively maintained |
+| Community support | Deprecated | Actively maintained |
 
 ## Tool Migration
 

--- a/src/git-repo-research-mcp-server/README.md
+++ b/src/git-repo-research-mcp-server/README.md
@@ -1,9 +1,6 @@
 # Git Repo Research MCP Server
 
-> **DEPRECATION NOTICE**: This server is deprecated. For library documentation and code research, we
-> recommend [Context7](https://github.com/upstash/context7) which provides up-to-date docs without
-> requiring AWS credentials. See the [migration guide](../../docs/migration-git-repo-research.md)
-> for details.
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. For library documentation and code research, we recommend [Context7](https://github.com/upstash/context7) which provides up-to-date docs without requiring AWS credentials. See the [migration guide](https://github.com/awslabs/mcp/blob/main/docs/migration-git-repo-research.md) for details.
 
 Model Context Protocol (MCP) server for researching Git repositories using semantic search
 


### PR DESCRIPTION
## Summary
- Add migration guide recommending Context7 as the alternative for library documentation research
- Add deprecation banner to the server README
- Document feature comparison (Context7 vs git-repo-research)
- Document tool-by-tool migration paths
- Address private repo use cases (IDE built-in indexing)

## Test plan
- [ ] Verify migration guide renders correctly on GitHub
- [ ] Verify README deprecation banner renders correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).