### PR TITLE
docs: add migration guides and README banners for nova-canvas and bedrock-data-automation

### DIFF
--- a/docs/migration-bedrock-data-automation.md
+++ b/docs/migration-bedrock-data-automation.md
@@ -15,13 +15,17 @@ The most reliable approach is to use the Amazon Bedrock Data Automation API dire
 ```python
 import boto3
 
+# Use bedrock-data-automation for project management
 client = boto3.client('bedrock-data-automation', region_name='us-east-1')
 
 # List projects
 projects = client.list_data_automation_projects()
 
+# Use bedrock-data-automation-runtime for invocations
+runtime_client = boto3.client('bedrock-data-automation-runtime', region_name='us-east-1')
+
 # Analyze an asset
-response = client.invoke_data_automation_async(
+response = runtime_client.invoke_data_automation_async(
     inputConfiguration={'s3Uri': 's3://your-bucket/your-file.pdf'},
     dataAutomationConfiguration={'dataAutomationProjectArn': 'your-project-arn'},
     outputConfiguration={'s3Uri': 's3://your-bucket/output/'}
@@ -54,7 +58,7 @@ The [aws-api-mcp-server](https://github.com/awslabs/mcp/tree/main/src/aws-api-mc
 |---|---|
 | `getprojects` | `boto3.client('bedrock-data-automation').list_data_automation_projects()` |
 | `getprojectdetails` | `boto3.client('bedrock-data-automation').get_data_automation_project()` |
-| `analyzeasset` | `boto3.client('bedrock-data-automation').invoke_data_automation_async()` |
+| `analyzeasset` | `boto3.client('bedrock-data-automation-runtime').invoke_data_automation_async()` |
 
 ## Summary
 

--- a/docs/migration-nova-canvas.md
+++ b/docs/migration-nova-canvas.md
@@ -4,7 +4,7 @@ This guide helps you migrate from `awslabs.nova-canvas-mcp-server` to the commun
 
 ## Why We're Deprecating
 
-The community-maintained `bedrock-image-mcp-server` is a fork of this server that has grown to include significantly more capabilities — 13 tools vs our 2. With AGI's shift away from focusing on image generation capabilities, this server will no longer be actively maintained.
+The community-maintained `bedrock-image-mcp-server` is a fork of this server that has grown to include significantly more capabilities — 13 tools vs 2. As part of our ongoing effort to reduce overlap and promote well-maintained alternatives, this server will no longer be actively maintained.
 
 ## Recommended Alternative: bedrock-image-mcp-server
 

--- a/src/aws-bedrock-data-automation-mcp-server/README.md
+++ b/src/aws-bedrock-data-automation-mcp-server/README.md
@@ -1,8 +1,6 @@
 # AWS Bedrock Data Automation MCP Server
 
-> **DEPRECATION NOTICE**: This server is deprecated. For Bedrock Data Automation capabilities,
-> use the boto3 API directly or the [aws-api-mcp-server](../aws-api-mcp-server/).
-> See the [migration guide](../../docs/migration-bedrock-data-automation.md) for details.
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. For Bedrock Data Automation capabilities, use the boto3 API directly or the [aws-api-mcp-server](https://github.com/awslabs/mcp/tree/main/src/aws-api-mcp-server). See the [migration guide](https://github.com/awslabs/mcp/blob/main/docs/migration-bedrock-data-automation.md) for details.
 
 A Model Context Protocol (MCP) server for Amazon Bedrock Data Automation that enables AI assistants to analyze documents, images, videos, and audio files using Amazon Bedrock Data Automation projects.
 

--- a/src/nova-canvas-mcp-server/README.md
+++ b/src/nova-canvas-mcp-server/README.md
@@ -1,9 +1,6 @@
 # Amazon Nova Canvas MCP Server
 
-> **DEPRECATION NOTICE**: This server is deprecated. Please use
-> [`bedrock-image-mcp-server`](https://github.com/kalleeh/bedrock-image-mcp-server) instead, which
-> includes all Nova Canvas tools plus Stable Diffusion 3.5, upscaling, and image editing.
-> See the [migration guide](../../docs/migration-nova-canvas.md) for details.
+> **⚠️ DEPRECATION NOTICE**: This server is deprecated and will no longer receive updates. Please use [`bedrock-image-mcp-server`](https://github.com/kalleeh/bedrock-image-mcp-server) instead, which includes all Nova Canvas tools plus Stable Diffusion 3.5, upscaling, and image editing. See the [migration guide](https://github.com/awslabs/mcp/blob/main/docs/migration-nova-canvas.md) for details.
 
 [![smithery badge](https://smithery.ai/badge/@awslabs/nova-canvas-mcp-server)](https://smithery.ai/server/@awslabs/nova-canvas-mcp-server)
 


### PR DESCRIPTION
## Summary
- **nova-canvas-mcp-server**: Migration guide to [bedrock-image-mcp-server](https://github.com/kalleeh/bedrock-image-mcp-server) (community fork with 13 tools vs our 2), README deprecation banner
- **aws-bedrock-data-automation-mcp-server**: Migration guide to boto3 API / aws-api-mcp-server, README deprecation banner

## Test plan
- [ ] Verify migration guides render correctly on GitHub
- [ ] Verify README deprecation banners render correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).