### PR TITLE
chore: add DO_NOT_RELEASE sentinels for deprecated servers

### DIFF
--- a/src/aws-bedrock-data-automation-mcp-server/DO_NOT_RELEASE
+++ b/src/aws-bedrock-data-automation-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,4 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: Use boto3 API directly or aws-api-mcp-server
+Migration guide: docs/migration-bedrock-data-automation.md

--- a/src/core-mcp-server/DO_NOT_RELEASE
+++ b/src/core-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,4 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: Configure individual MCP servers directly
+Migration guide: docs/migration-core.md

--- a/src/frontend-mcp-server/DO_NOT_RELEASE
+++ b/src/frontend-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,4 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: Use Kiro specs or project-level docs
+Migration guide: docs/migration-frontend.md

--- a/src/git-repo-research-mcp-server/DO_NOT_RELEASE
+++ b/src/git-repo-research-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,4 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: Context7 (https://github.com/upstash/context7)
+Migration guide: docs/migration-git-repo-research.md

--- a/src/nova-canvas-mcp-server/DO_NOT_RELEASE
+++ b/src/nova-canvas-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,4 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: bedrock-image-mcp-server (https://github.com/kalleeh/bedrock-image-mcp-server)
+Migration guide: docs/migration-nova-canvas.md

--- a/src/syntheticdata-mcp-server/DO_NOT_RELEASE
+++ b/src/syntheticdata-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,4 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: AI assistants can generate test data natively
+Migration guide: docs/migration-syntheticdata.md


### PR DESCRIPTION
## Summary
- Add DO_NOT_RELEASE sentinel files for 6 deprecated servers whose deprecation warnings have already been published to PyPI
- Prevents accidental future releases: syntheticdata, frontend, git-repo-research, nova-canvas, aws-bedrock-data-automation, core-mcp-server
- Matches the existing pattern used by terraform-mcp-server, aws-diagram-mcp-server, cfn-mcp-server, and cost-explorer-mcp-server

## Test plan
- [x] Verify `release.yml` line ~205 skips packages with DO_NOT_RELEASE sentinel
- [x] Verify license header check skips extensionless DO_NOT_RELEASE files (`**/DO_NOT_RELEASE` in skip list)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).