### PR TITLE
chore: release/2026.03.20260324052209

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.0.15'
+__version__ = '0.0.16'

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.15"
+version = "0.0.16"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.0.15"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.3.21'
+__version__ = '1.3.22'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.21"
+version = "1.3.22"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.3.21"
+version = "1.3.22"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },

--- a/src/aws-bedrock-data-automation-mcp-server/awslabs/aws_bedrock_data_automation_mcp_server/__init__.py
+++ b/src/aws-bedrock-data-automation-mcp-server/awslabs/aws_bedrock_data_automation_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 
 """awslabs.aws-bedrock-data-automation-mcp-server"""
 
-__version__ = '0.0.18'
+__version__ = '0.0.19'

--- a/src/aws-bedrock-data-automation-mcp-server/pyproject.toml
+++ b/src/aws-bedrock-data-automation-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-bedrock-data-automation-mcp-server"
-version = "0.0.18"
+version = "0.0.19"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Data Automation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-bedrock-data-automation-mcp-server/uv.lock
+++ b/src/aws-bedrock-data-automation-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-bedrock-data-automation-mcp-server"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/__init__.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-pricing-mcp-server"""
 
-__version__ = '1.0.26'
+__version__ = '1.0.27'

--- a/src/aws-pricing-mcp-server/pyproject.toml
+++ b/src/aws-pricing-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-pricing-mcp-server"
-version = "1.0.26"
+version = "1.0.27"
 description = "An AWS Labs Model Context Protocol (MCP) server for official pricing of AWS services"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-pricing-mcp-server/uv.lock
+++ b/src/aws-pricing-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-pricing-mcp-server"
-version = "1.0.26"
+version = "1.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.0.18'
+__version__ = '1.0.19'

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/uv.lock
+++ b/src/ccapi-mcp-server/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ccapi-mcp-server"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/__init__.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.cfn-mcp-server"""
 
-__version__ = '1.0.19'
+__version__ = '1.0.20'

--- a/src/cfn-mcp-server/pyproject.toml
+++ b/src/cfn-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cfn-mcp-server"
-version = "1.0.19"
+version = "1.0.20"
 description = "An AWS Labs Model Context Protocol (MCP) server for doing common cloudformation tasks and for managing your resources in your AWS account"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cfn-mcp-server/uv.lock
+++ b/src/cfn-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cfn-mcp-server"
-version = "1.0.19"
+version = "1.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/core-mcp-server/awslabs/core_mcp_server/__init__.py
+++ b/src/core-mcp-server/awslabs/core_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """CORE MCP server package."""
 
-__version__ = '1.0.25'
+__version__ = '1.0.26'

--- a/src/core-mcp-server/pyproject.toml
+++ b/src/core-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.core-mcp-server"
-version = "1.0.25"
+version = "1.0.26"
 description = "An AWS Labs Model Context Protocol (MCP) server for aswlabs Core MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/core-mcp-server/uv.lock
+++ b/src/core-mcp-server/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-core-mcp-server"
-version = "1.0.25"
+version = "1.0.26"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-amazon-kendra-index-mcp-server" },

--- a/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/__init__.py
+++ b/src/cost-explorer-mcp-server/awslabs/cost_explorer_mcp_server/__init__.py
@@ -17,4 +17,4 @@
 This module provides MCP tools for analyzing AWS costs and usage data through the AWS Cost Explorer API.
 """
 
-__version__ = '0.0.21'
+__version__ = '0.0.22'

--- a/src/cost-explorer-mcp-server/pyproject.toml
+++ b/src/cost-explorer-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cost-explorer-mcp-server"
-version = "0.0.21"
+version = "0.0.22"
 description = "MCP server for analyzing AWS costs and usage data through the AWS Cost Explorer API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cost-explorer-mcp-server/uv.lock
+++ b/src/cost-explorer-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cost-explorer-mcp-server"
-version = "0.0.21"
+version = "0.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend-mcp-server/awslabs/frontend_mcp_server/__init__.py
+++ b/src/frontend-mcp-server/awslabs/frontend_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.frontend-mcp-server"""
 
-__version__ = '1.0.12'
+__version__ = '1.0.13'

--- a/src/frontend-mcp-server/pyproject.toml
+++ b/src/frontend-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.frontend-mcp-server"
-version = "1.0.12"
+version = "1.0.13"
 description = "An AWS Labs Model Context Protocol (MCP) server for frontend"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/frontend-mcp-server/uv.lock
+++ b/src/frontend-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-frontend-mcp-server"
-version = "1.0.12"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },

--- a/src/git-repo-research-mcp-server/awslabs/git_repo_research_mcp_server/__init__.py
+++ b/src/git-repo-research-mcp-server/awslabs/git_repo_research_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.git-repo-research-mcp-server"""
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/git-repo-research-mcp-server/pyproject.toml
+++ b/src/git-repo-research-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.git-repo-research-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for researching git repositories"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/git-repo-research-mcp-server/uv.lock
+++ b/src/git-repo-research-mcp-server/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-git-repo-research-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },

--- a/src/nova-canvas-mcp-server/awslabs/nova_canvas_mcp_server/__init__.py
+++ b/src/nova-canvas-mcp-server/awslabs/nova_canvas_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.nova-canvas-mcp-server"""
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/nova-canvas-mcp-server/pyproject.toml
+++ b/src/nova-canvas-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.nova-canvas-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon Nova Canvas"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/nova-canvas-mcp-server/uv.lock
+++ b/src/nova-canvas-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-nova-canvas-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
+++ b/src/syntheticdata-mcp-server/awslabs/syntheticdata_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """SyntheticData MCP Server package."""
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/syntheticdata-mcp-server/pyproject.toml
+++ b/src/syntheticdata-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.syntheticdata-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 description = "An AWS Labs Model Context Protocol (MCP) server for syntheticdata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/syntheticdata-mcp-server/uv.lock
+++ b/src/syntheticdata-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-syntheticdata-mcp-server"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# release/2026.03.20260324052209

Triggered Release Branch (initiated) by @kevin-orellana for @kevin-orellana

## Changes
* amazon-bedrock-agentcore-mcp-server
* aws-api-mcp-server
* aws-bedrock-data-automation-mcp-server
* aws-pricing-mcp-server
* ccapi-mcp-server
* cfn-mcp-server
* cloudwatch-appsignals-mcp-server
* core-mcp-server
* cost-explorer-mcp-server
* frontend-mcp-server
* git-repo-research-mcp-server
* nova-canvas-mcp-server
* syntheticdata-mcp-server

## Checklist
- [ ] Code changes have been reviewed
- [ ] Distribution packages have been built and tested
- [ ] Documentation has been updated if applicable

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).