### PR TITLE
feat(code-doc-gen-mcp-server): add deprecation notices and DO_NOT_RELEASE

### DIFF
--- a/src/code-doc-gen-mcp-server/DO_NOT_RELEASE
+++ b/src/code-doc-gen-mcp-server/DO_NOT_RELEASE
@@ -1,0 +1,6 @@
+This package is deprecated. Do not publish new releases to PyPI.
+
+Replacement: None — modern LLMs handle documentation generation natively.
+Simply prompt your AI assistant to generate documentation.
+
+See https://github.com/awslabs/mcp/issues/2004 for details.

--- a/src/code-doc-gen-mcp-server/awslabs/code_doc_gen_mcp_server/server.py
+++ b/src/code-doc-gen-mcp-server/awslabs/code_doc_gen_mcp_server/server.py
@@ -53,6 +53,16 @@ logger.configure(
     ]
 )
 
+DEPRECATION_NOTICE = (
+    'code-doc-gen-mcp-server is deprecated and will be removed in a future release. '
+    'Modern LLMs now handle documentation generation more effectively using native '
+    'file and code intelligence tools. Simply prompt your AI assistant: '
+    '"Generate comprehensive documentation for this project including README, '
+    'deployment guide, and API docs." For reusable workflows, use Cline Rules, '
+    'Claude Skills, or Kiro Powers. '
+    'See https://github.com/awslabs/mcp/issues/2004 for details.'
+)
+
 
 class _ProjectInfo(BaseModel):
     """Project information model.
@@ -110,7 +120,11 @@ def create_documentation_context(
 
 mcp = FastMCP(
     'awslabs.code-doc-gen-mcp-server',
-    instructions="""Use this server to generate comprehensive code documentation.
+    instructions='DEPRECATION NOTICE: '
+    + DEPRECATION_NOTICE
+    + """
+
+Use this server to generate comprehensive code documentation.
 
 WORKFLOW:
 1. prepare_repository:
@@ -188,11 +202,7 @@ async def prepare_repository(
     NOTE: This tool does NOT analyze the code - that's your job!
     The tool only extracts the directory structure and statistics to help you identify important files.
     """
-    warnings.warn(
-        'prepare_repository tool is deprecated and will be archived. See https://github.com/awslabs/mcp/issues/2004',
-        DeprecationWarning,
-        stacklevel=1,
-    )
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
 
     try:
         # Set up output paths
@@ -321,11 +331,7 @@ async def create_context(
     Returns:
         A DocumentationContext ready for use with other tools
     """
-    warnings.warn(
-        'create_context tool is deprecated and will be archived. See https://github.com/awslabs/mcp/issues/2004',
-        DeprecationWarning,
-        stacklevel=1,
-    )
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
 
     start_time = time.time()
     logger.debug(f'CONTEXT TIMING: Starting create_context at {start_time}')
@@ -372,11 +378,7 @@ async def plan_documentation(
     3. Create appropriate documentation structure
     4. Return documentation plan
     """
-    warnings.warn(
-        'plan_documentation tool is deprecated and will be archived. See https://github.com/awslabs/mcp/issues/2004',
-        DeprecationWarning,
-        stacklevel=1,
-    )
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
 
     start_time = time.time()
     logger.debug(f'PLAN TIMING: Starting plan_documentation at {start_time}')
@@ -459,11 +461,7 @@ async def generate_documentation(
     to write comprehensive content for each section. Do not leave sections empty
     or wait for further instructions - YOU must fill them in!
     """
-    warnings.warn(
-        'generate_documentation tool is deprecated and will be archived. See https://github.com/awslabs/mcp/issues/2004',
-        DeprecationWarning,
-        stacklevel=1,
-    )
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
 
     start_time = time.time()
     logger.debug(f'GENERATE TIMING: Starting generate_documentation at {start_time}')
@@ -546,6 +544,7 @@ async def generate_documentation(
 
 def main():
     """Run the MCP server with CLI argument support."""
+    warnings.warn(DEPRECATION_NOTICE, FutureWarning, stacklevel=2)
     mcp.run()
 
 


### PR DESCRIPTION
## Summary
- Adds `DEPRECATION_NOTICE` constant with migration guidance pointing to RFC #2004
- Emits `FutureWarning` on server startup in `main()` (visible by default, unlike `DeprecationWarning`)
- Changes all tool-level warnings from `DeprecationWarning` → `FutureWarning`
- Prepends deprecation notice to FastMCP `instructions` so AI clients see it
- Adds `DO_NOT_RELEASE` sentinel file to prevent future PyPI publishing

Closes the deprecation gap for code-doc-gen-mcp-server — the README banner and root README DEPRECATED tag were already in place.

## Test plan
- [x] All 62 existing tests pass (`uv run --frozen pytest tests/ -v` — 62 passed)
- [x] FutureWarning correctly emitted in test output for all tool calls and `main()`
- [x] `ruff check` and `ruff format` pass
- [ ] CI passes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).