### PR TITLE
fix(aws-documentation-mcp-server): reuse httpx client across requests

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -27,6 +27,7 @@ from awslabs.aws_documentation_mcp_server.models import (
 from awslabs.aws_documentation_mcp_server.server_utils import (
     DEFAULT_USER_AGENT,
     add_search_result_cache_item,
+    get_http_client,
     read_documentation_impl,
     read_sections_impl,
 )
@@ -337,69 +338,64 @@ async def search_documentation(
         search_url_with_session, search_intent
     )
 
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.post(
-                search_url_with_session,
-                json=request_body,
-                headers={
-                    'Content-Type': 'application/json',
-                    'User-Agent': DEFAULT_USER_AGENT,
-                    'X-MCP-Session-Id': SESSION_UUID,
-                },
-                timeout=30,
-            )
-        except httpx.HTTPError as e:
-            error_msg = f'Error searching AWS docs: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return SearchResponse(
-                search_results=[SearchResult(rank_order=1, url='', title=error_msg, context=None)],
-                facets=None,
-                query_id='',
-            )
+    client = get_http_client()
+    try:
+        response = await client.post(
+            search_url_with_session,
+            json=request_body,
+            headers={
+                'Content-Type': 'application/json',
+                'User-Agent': DEFAULT_USER_AGENT,
+                'X-MCP-Session-Id': SESSION_UUID,
+            },
+            timeout=30,
+        )
+    except httpx.HTTPError as e:
+        error_msg = f'Error searching AWS docs: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return SearchResponse(
+            search_results=[SearchResult(rank_order=1, url='', title=error_msg, context=None)],
+            facets=None,
+            query_id='',
+        )
 
-        if response.status_code >= 400:
-            error_msg = f'Error searching AWS docs - status code {response.status_code}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return SearchResponse(
-                search_results=[
-                    SearchResult(
-                        rank_order=1, url='', title=error_msg, context=None, sections=None
-                    )
-                ],
-                facets=None,
-                query_id='',
-            )
+    if response.status_code >= 400:
+        error_msg = f'Error searching AWS docs - status code {response.status_code}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return SearchResponse(
+            search_results=[
+                SearchResult(rank_order=1, url='', title=error_msg, context=None, sections=None)
+            ],
+            facets=None,
+            query_id='',
+        )
 
-        try:
-            data = response.json()
-            query_id = data.get('queryId', '')
-            raw_facets = data.get('facets', {})
+    try:
+        data = response.json()
+        query_id = data.get('queryId', '')
+        raw_facets = data.get('facets', {})
 
-            # Parse facets to rename keys
-            facets = {}
-            if raw_facets:
-                for key, value in raw_facets.items():
-                    if key == 'aws-docs-search-product':
-                        facets['product_types'] = value
-                    elif key == 'aws-docs-search-guide':
-                        facets['guide_types'] = value
+        facets = {}
+        if raw_facets:
+            for key, value in raw_facets.items():
+                if key == 'aws-docs-search-product':
+                    facets['product_types'] = value
+                elif key == 'aws-docs-search-guide':
+                    facets['guide_types'] = value
 
-        except json.JSONDecodeError as e:
-            error_msg = f'Error parsing search results: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return SearchResponse(
-                search_results=[
-                    SearchResult(
-                        rank_order=1, url='', title=error_msg, context=None, sections=None
-                    )
-                ],
-                facets=None,
-                query_id='',
-            )
+    except json.JSONDecodeError as e:
+        error_msg = f'Error parsing search results: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return SearchResponse(
+            search_results=[
+                SearchResult(rank_order=1, url='', title=error_msg, context=None, sections=None)
+            ],
+            facets=None,
+            query_id='',
+        )
 
     results = []
     if 'suggestions' in data:
@@ -528,38 +524,38 @@ async def recommend(
 
     recommendation_url = f'{RECOMMENDATIONS_API_URL}?path={url_str}&session={SESSION_UUID}'
 
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                recommendation_url,
-                headers={'User-Agent': DEFAULT_USER_AGENT},
-                timeout=30,
+    client = get_http_client()
+    try:
+        response = await client.get(
+            recommendation_url,
+            headers={'User-Agent': DEFAULT_USER_AGENT},
+            timeout=30,
+        )
+    except httpx.HTTPError as e:
+        error_msg = f'Error getting recommendations: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return [RecommendationResult(url='', title=error_msg, context=None)]
+
+    if response.status_code >= 400:
+        error_msg = f'Error getting recommendations - status code {response.status_code}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return [
+            RecommendationResult(
+                url='',
+                title=error_msg,
+                context=None,
             )
-        except httpx.HTTPError as e:
-            error_msg = f'Error getting recommendations: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return [RecommendationResult(url='', title=error_msg, context=None)]
+        ]
 
-        if response.status_code >= 400:
-            error_msg = f'Error getting recommendations - status code {response.status_code}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return [
-                RecommendationResult(
-                    url='',
-                    title=error_msg,
-                    context=None,
-                )
-            ]
-
-        try:
-            data = response.json()
-        except json.JSONDecodeError as e:
-            error_msg = f'Error parsing recommendations: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return [RecommendationResult(url='', title=error_msg, context=None)]
+    try:
+        data = response.json()
+    except json.JSONDecodeError as e:
+        error_msg = f'Error parsing recommendations: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return [RecommendationResult(url='', title=error_msg, context=None)]
 
     results = parse_recommendation_results(data)
     logger.debug(f'Found {len(results)} recommendations for: {url_str}')

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -190,10 +190,22 @@ async def get_available_services(
         await ctx.error(error_msg)
         return error_msg
 
+    if toc_response.status_code >= 400:
+        error_msg = f'Failed to fetch AWS-CN TOC - status code {toc_response.status_code}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
+
     page_raw = response.text
     content_type = response.headers.get('content-type', '')
 
-    page_toc_json = toc_response.json()
+    try:
+        page_toc_json = toc_response.json()
+    except ValueError as e:
+        error_msg = f'Failed to parse AWS-CN TOC JSON: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
     # toc_response = { 'contents' : [ { 'title': '', 'href': '', 'contents': [] } ] }
     services_json = [
         toc_item.get('contents', [])

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -18,6 +18,7 @@ import re
 import uuid
 from awslabs.aws_documentation_mcp_server.server_utils import (
     DEFAULT_USER_AGENT,
+    get_http_client,
     read_documentation_impl,
 )
 
@@ -163,67 +164,60 @@ async def get_available_services(
 
     toc_url_str = 'https://docs.amazonaws.cn/en_us/aws/latest/userguide/toc-contents.json'
     toc_url_with_session = f'{toc_url_str}?session={SESSION_UUID}'
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                url_with_session,
-                follow_redirects=True,
-                headers={'User-Agent': DEFAULT_USER_AGENT},
-                timeout=30,
-            )
-            # Fetch the Table of Contents in the Services page, which contains the list of supported services
-            toc_response = await client.get(
-                toc_url_with_session,
-                follow_redirects=True,
-                headers={'User-Agent': DEFAULT_USER_AGENT, 'Content-Type': 'application/json'},
-                timeout=30,
-            )
-        except httpx.HTTPError as e:
-            error_msg = f'Failed to fetch AWS-CN services page: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
-
-        if response.status_code >= 400:
-            error_msg = (
-                f'Failed to fetch AWS-CN services page - status code {response.status_code}'
-            )
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
-
-        page_raw = response.text
-        content_type = response.headers.get('content-type', '')
-
-        page_toc_json = toc_response.json()
-        # Expecting a toc JSON object that has a href of 'services.html', which contains all of the AWS Services supported in China
-        # toc_response = { 'contents' : [ { 'title: '', 'href': '', 'contents: [] } ] }
-        services_json = [
-            toc_item.get('contents', [])
-            for toc_item in page_toc_json.get('contents', [])
-            if toc_item.get('href') == 'services.html'
-        ]
-
-        # If toc_response does not have `href: services.html`, and services_json is empty, raise an error so
-        # users can self-solve.
-        if len(services_json) == 0:
-            error_msg = (
-                f'Failed fetching list of available AWS Services, please go to {url_str} directly'
-            )
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
-
-        # Filtering out 'Services Unsupported in Amazon Web Services in China'
-        formatted_service_titles = ''
-        service_doc_links = [
-            f'[{service.get("title")}](https://docs.amazonaws.cn/en_us/aws/latest/userguide/{service.get("href")})'
-            for service in services_json[0]
-            if 'Services Unsupported' not in service.get('title')
-        ]
-        formatted_service_titles = '\n\n## Services in Amazon Web Services China\n\n' + '\n'.join(
-            [f'- {service_doc_link}' for service_doc_link in service_doc_links]
+    client = get_http_client()
+    try:
+        response = await client.get(
+            url_with_session,
+            follow_redirects=True,
+            headers={'User-Agent': DEFAULT_USER_AGENT},
+            timeout=30,
         )
+        toc_response = await client.get(
+            toc_url_with_session,
+            follow_redirects=True,
+            headers={'User-Agent': DEFAULT_USER_AGENT, 'Content-Type': 'application/json'},
+            timeout=30,
+        )
+    except httpx.HTTPError as e:
+        error_msg = f'Failed to fetch AWS-CN services page: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
+
+    if response.status_code >= 400:
+        error_msg = f'Failed to fetch AWS-CN services page - status code {response.status_code}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
+
+    page_raw = response.text
+    content_type = response.headers.get('content-type', '')
+
+    page_toc_json = toc_response.json()
+    # toc_response = { 'contents' : [ { 'title': '', 'href': '', 'contents': [] } ] }
+    services_json = [
+        toc_item.get('contents', [])
+        for toc_item in page_toc_json.get('contents', [])
+        if toc_item.get('href') == 'services.html'
+    ]
+
+    if len(services_json) == 0:
+        error_msg = (
+            f'Failed fetching list of available AWS Services, please go to {url_str} directly'
+        )
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
+
+    formatted_service_titles = ''
+    service_doc_links = [
+        f'[{service.get("title")}](https://docs.amazonaws.cn/en_us/aws/latest/userguide/{service.get("href")})'
+        for service in services_json[0]
+        if 'Services Unsupported' not in service.get('title')
+    ]
+    formatted_service_titles = '\n\n## Services in Amazon Web Services China\n\n' + '\n'.join(
+        [f'- {service_doc_link}' for service_doc_link in service_doc_links]
+    )
 
     if is_html_content(page_raw, content_type):
         content = extract_content_from_html(page_raw)

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import httpx
 import os
+import time
 from awslabs.aws_documentation_mcp_server.models import SearchResponse
 from awslabs.aws_documentation_mcp_server.util import (
     extract_content_from_html,
@@ -21,6 +22,7 @@ from awslabs.aws_documentation_mcp_server.util import (
     is_html_content,
 )
 from collections import deque
+from functools import cache
 from importlib.metadata import version
 from loguru import logger
 from mcp.server.fastmcp import Context
@@ -44,6 +46,17 @@ DEFAULT_USER_AGENT = (
 )
 
 
+@cache
+def get_http_client() -> httpx.AsyncClient:
+    """Return a shared httpx.AsyncClient instance.
+
+    Creating a new AsyncClient per request leaks SSL contexts and connection
+    pools in long-running processes. A single cached instance reuses the
+    underlying connection pool across calls.
+    """
+    return httpx.AsyncClient(timeout=30.0)
+
+
 async def read_documentation_impl(
     ctx: Context,
     url_str: str,
@@ -61,31 +74,31 @@ async def read_documentation_impl(
         url_with_session += f'&query_id={query_id}'
         logger.debug(f'Using query_id {query_id}')
 
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                url_with_session,
-                follow_redirects=True,
-                headers={
-                    'User-Agent': DEFAULT_USER_AGENT,
-                    'X-MCP-Session-Id': session_uuid,
-                },
-                timeout=30,
-            )
-        except httpx.HTTPError as e:
-            error_msg = f'Failed to fetch {url_str}: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
+    client = get_http_client()
+    try:
+        response = await client.get(
+            url_with_session,
+            follow_redirects=True,
+            headers={
+                'User-Agent': DEFAULT_USER_AGENT,
+                'X-MCP-Session-Id': session_uuid,
+            },
+            timeout=30,
+        )
+    except httpx.HTTPError as e:
+        error_msg = f'Failed to fetch {url_str}: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
 
-        if response.status_code >= 400:
-            error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
+    if response.status_code >= 400:
+        error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
 
-        page_raw = response.text
-        content_type = response.headers.get('content-type', '')
+    page_raw = response.text
+    content_type = response.headers.get('content-type', '')
 
     if is_html_content(page_raw, content_type):
         content = extract_content_from_html(page_raw)
@@ -94,7 +107,6 @@ async def read_documentation_impl(
 
     result = format_documentation_result(url_str, content, start_index, max_length)
 
-    # Log if content was truncated
     if len(content) > start_index + max_length:
         logger.debug(
             f'Content truncated at {start_index + max_length} of {len(content)} characters'
@@ -103,7 +115,15 @@ async def read_documentation_impl(
     return result
 
 
-SEARCH_RESULT_CACHE = deque(maxlen=3)
+_CACHE_TTL_SECONDS = 30 * 60
+SEARCH_RESULT_CACHE: deque[tuple[float, SearchResponse]] = deque(maxlen=3)
+
+
+def _evict_stale_cache_entries() -> None:
+    """Remove cache entries older than _CACHE_TTL_SECONDS."""
+    now = time.monotonic()
+    while SEARCH_RESULT_CACHE and (now - SEARCH_RESULT_CACHE[-1][0]) > _CACHE_TTL_SECONDS:
+        SEARCH_RESULT_CACHE.pop()
 
 
 def add_search_result_cache_item(search_response: SearchResponse) -> None:
@@ -119,7 +139,8 @@ def add_search_result_cache_item(search_response: SearchResponse) -> None:
         None; updates the global SEARCH_RESULT_CACHE
 
     """
-    SEARCH_RESULT_CACHE.appendleft(search_response)
+    _evict_stale_cache_entries()
+    SEARCH_RESULT_CACHE.appendleft((time.monotonic(), search_response))
 
 
 def get_query_id_from_cache(url: str) -> Optional[str]:
@@ -135,10 +156,10 @@ def get_query_id_from_cache(url: str) -> Optional[str]:
         Query ID of URL, or None
 
     """
-    for _, search_response in enumerate(SEARCH_RESULT_CACHE):
+    _evict_stale_cache_entries()
+    for _timestamp, search_response in SEARCH_RESULT_CACHE:
         for search_result in search_response.search_results:
             if search_result.url == url:
-                # Sanitization of query_id just in case
                 query_id = quote(search_response.query_id)
                 return query_id
 
@@ -163,31 +184,31 @@ async def read_sections_impl(
         url_with_session += f'&query_id={query_id}'
         logger.debug(f'Using query_id {query_id}')
 
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                url_with_session,
-                follow_redirects=True,
-                headers={
-                    'User-Agent': DEFAULT_USER_AGENT,
-                    'X-MCP-Session-Id': session_uuid,
-                },
-                timeout=30,
-            )
-        except httpx.HTTPError as e:
-            error_msg = f'Failed to fetch {url_str}: {str(e)}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
+    client = get_http_client()
+    try:
+        response = await client.get(
+            url_with_session,
+            follow_redirects=True,
+            headers={
+                'User-Agent': DEFAULT_USER_AGENT,
+                'X-MCP-Session-Id': session_uuid,
+            },
+            timeout=30,
+        )
+    except httpx.HTTPError as e:
+        error_msg = f'Failed to fetch {url_str}: {str(e)}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
 
-        if response.status_code >= 400:
-            error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
-            logger.error(error_msg)
-            await ctx.error(error_msg)
-            return error_msg
+    if response.status_code >= 400:
+        error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
 
-        page_raw = response.text
-        content_type = response.headers.get('content-type', '')
+    page_raw = response.text
+    content_type = response.headers.get('content-type', '')
 
     if not is_html_content(page_raw, content_type):
         return 'Cannot extract sections from non-HTML content. Please use the read_documentation tool instead to get the full document content.'

--- a/src/aws-documentation-mcp-server/tests/conftest.py
+++ b/src/aws-documentation-mcp-server/tests/conftest.py
@@ -14,15 +14,29 @@
 """Configuration for pytest."""
 
 import pytest
+import pytest_asyncio
 from awslabs.aws_documentation_mcp_server.server_utils import get_http_client
 
 
-@pytest.fixture(autouse=True)
-def _reset_http_client_cache():
+async def _close_and_clear_http_client():
+    """Close the cached httpx client (if any) and clear the cache."""
+    if get_http_client.cache_info().currsize:
+        client = get_http_client()
+        aclose = getattr(client, 'aclose', None)
+        if aclose and callable(aclose):
+            try:
+                await aclose()
+            except TypeError:
+                pass  # mock objects can't be awaited
+    get_http_client.cache_clear()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_http_client_cache():
     """Reset the cached httpx client between tests."""
-    get_http_client.cache_clear()
+    await _close_and_clear_http_client()
     yield
-    get_http_client.cache_clear()
+    await _close_and_clear_http_client()
 
 
 def pytest_addoption(parser):

--- a/src/aws-documentation-mcp-server/tests/conftest.py
+++ b/src/aws-documentation-mcp-server/tests/conftest.py
@@ -14,6 +14,15 @@
 """Configuration for pytest."""
 
 import pytest
+from awslabs.aws_documentation_mcp_server.server_utils import get_http_client
+
+
+@pytest.fixture(autouse=True)
+def _reset_http_client_cache():
+    """Reset the cached httpx client between tests."""
+    get_http_client.cache_clear()
+    yield
+    get_http_client.cache_clear()
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Replaces per-call `httpx.AsyncClient()` context managers with a single cached
instance. In long-running MCP sessions (hours, sometimes days without restart),
creating and destroying a client per request leaks SSL contexts and connection
pools that CPython's allocator never returns to the OS.

Changes:
- `get_http_client()` backed by `@functools.cache` in `server_utils.py`
- All call sites (`server_aws.py`, `server_aws_cn.py`, `server_utils.py`) use the shared client
- Search result cache gets TTL-based eviction (30 min) so entries don't accumulate
- Test fixture resets the cached client between tests

Fresh PR with the same fix, rebased on current main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).