### PR TITLE
fix(aws-api-mcp-server): cache boto3 clients and reuse requests session

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
@@ -40,17 +40,26 @@ class FileAccessMode(str, Enum):
     NO_ACCESS = 'no-access'
 
 
+_region_cache: dict[str, str] = {}
+
+
 def get_region(profile_name: str | None = None) -> str:
     """Get the region depending on configuration."""
     if AWS_REGION:
         return AWS_REGION
 
+    cache_key = profile_name or '__default__'
+    if cache_key in _region_cache:
+        return _region_cache[cache_key]
+
     fallback_region = 'us-east-1'
-
     if profile_name:
-        return boto3.Session(profile_name=profile_name).region_name or fallback_region
+        region = boto3.Session(profile_name=profile_name).region_name or fallback_region
+    else:
+        region = boto3.Session().region_name or fallback_region
 
-    return boto3.Session().region_name or fallback_region
+    _region_cache[cache_key] = region
+    return region
 
 
 def get_server_directory():

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/helpers.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/helpers.py
@@ -21,6 +21,7 @@ import time
 from botocore.response import StreamingBody
 from contextlib import contextmanager
 from datetime import datetime
+from functools import cache
 from loguru import logger
 from requests.adapters import HTTPAdapter
 from typing import Any
@@ -92,8 +93,9 @@ def validate_aws_region(region: str):
         raise ValueError(error_message)
 
 
+@cache
 def get_requests_session() -> requests.Session:
-    """Configured requests session with common retry strategy."""
+    """Return a shared requests session with retry strategy."""
     retry_strategy = Retry(
         total=3,
         backoff_factor=1,
@@ -102,8 +104,6 @@ def get_requests_session() -> requests.Session:
     )
     session = requests.Session()
     adapter = HTTPAdapter(max_retries=retry_strategy)
-
     session.mount('https://', adapter)
     session.mount('http://', adapter)
-
     return session

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
@@ -44,6 +44,12 @@ CHUNK_SIZE = 4 * 1024 * 1024
 _client_cache: OrderedDict[tuple, Any] = OrderedDict()
 _MAX_CACHED_CLIENTS = 30
 
+
+def clear_client_cache() -> None:
+    """Clear the boto3 client cache. Intended for test fixtures."""
+    _client_cache.clear()
+
+
 _AUTH_ERROR_CODES = frozenset(
     {
         'ExpiredTokenException',

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
@@ -28,12 +28,75 @@ from ..common.config import (
 from ..common.file_system_controls import validate_file_path
 from ..common.helpers import Boto3Encoder, operation_timer
 from botocore.config import Config
+from collections import OrderedDict
 from jmespath.parser import ParsedResult
+from loguru import logger
 from typing import Any
 
 
 TIMEOUT_AFTER_SECONDS = 10
 CHUNK_SIZE = 4 * 1024 * 1024
+
+# LRU cache for boto3 clients. Each client loads the full service model, creates
+# connection pools and SSL contexts - expensive to recreate on every call.
+# Keyed on (service, region, credentials, endpoint) so different profiles get
+# separate clients. OrderedDict gives O(1) LRU eviction.
+_client_cache: OrderedDict[tuple, Any] = OrderedDict()
+_MAX_CACHED_CLIENTS = 30
+
+_AUTH_ERROR_CODES = frozenset(
+    {
+        'ExpiredTokenException',
+        'ExpiredToken',
+        'RequestExpired',
+        'InvalidClientTokenId',
+        'UnrecognizedClientException',
+    }
+)
+
+
+def _get_or_create_client(
+    service_name: str,
+    access_key_id: str,
+    secret_access_key: str,
+    session_token: str | None,
+    region: str,
+    config: Config,
+    endpoint_url: str | None,
+) -> Any:
+    """Return a cached boto3 client, creating one if needed."""
+    key = (service_name, region, access_key_id, secret_access_key, session_token, endpoint_url)
+
+    if key in _client_cache:
+        _client_cache.move_to_end(key)
+        return _client_cache[key]
+
+    if len(_client_cache) >= _MAX_CACHED_CLIENTS:
+        _client_cache.popitem(last=False)
+
+    client = boto3.client(
+        service_name,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        aws_session_token=session_token,
+        config=config,
+        endpoint_url=endpoint_url,
+    )
+    _client_cache[key] = client
+    return client
+
+
+def _evict_client(
+    service_name: str,
+    access_key_id: str,
+    secret_access_key: str,
+    session_token: str | None,
+    region: str,
+    endpoint_url: str | None,
+) -> None:
+    """Remove a client from cache after an auth error."""
+    key = (service_name, region, access_key_id, secret_access_key, session_token, endpoint_url)
+    _client_cache.pop(key, None)
 
 
 def interpret(
@@ -64,30 +127,53 @@ def interpret(
     )
 
     with operation_timer(ir.service_name, ir.operation_python_name, region):
-        client = boto3.client(
+        client = _get_or_create_client(
             ir.service_name,
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
-            aws_session_token=session_token,
-            config=config,
-            endpoint_url=endpoint_url,
+            access_key_id,
+            secret_access_key,
+            session_token,
+            region,
+            config,
+            endpoint_url,
         )
 
-        if client.can_paginate(ir.operation_python_name):
-            response = build_result(
-                paginator=client.get_paginator(ir.operation_python_name),
-                service_name=ir.service_name,
-                operation_name=ir.operation_name,
-                operation_parameters=ir.parameters,
-                pagination_config=pagination_config,
-                client_side_filter=client_side_filter,
-            )
-        else:
-            operation = getattr(client, ir.operation_python_name)
-            response = operation(**parameters)
+        try:
+            if client.can_paginate(ir.operation_python_name):
+                response = build_result(
+                    paginator=client.get_paginator(ir.operation_python_name),
+                    service_name=ir.service_name,
+                    operation_name=ir.operation_name,
+                    operation_parameters=ir.parameters,
+                    pagination_config=pagination_config,
+                    client_side_filter=client_side_filter,
+                )
+            else:
+                operation = getattr(client, ir.operation_python_name)
+                response = operation(**parameters)
 
-            if client_side_filter is not None:
-                response = _apply_filter(response, client_side_filter)
+                if client_side_filter is not None:
+                    response = _apply_filter(response, client_side_filter)
+        except Exception as exc:
+            error_code = ''
+            resp = getattr(exc, 'response', None)
+            if isinstance(resp, dict):
+                error_code = resp.get('Error', {}).get('Code', '')
+            if error_code in _AUTH_ERROR_CODES:
+                logger.info(
+                    'Auth error ({}), evicting cached client for {}/{}',
+                    error_code,
+                    ir.service_name,
+                    region,
+                )
+                _evict_client(
+                    ir.service_name,
+                    access_key_id,
+                    secret_access_key,
+                    session_token,
+                    region,
+                    endpoint_url,
+                )
+            raise
 
         if ir.has_streaming_output and ir.output_file and ir.output_file.path != '-':
             response = _handle_streaming_output(response, ir.output_file)

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -329,8 +329,10 @@ def is_custom_operation(service, operation):
         raise InvalidServiceError(service)
 
     if isinstance(service_command, ServiceCommand):
-        # valid service, unlike s3
-        service_command_table = service_command._get_command_table()
+        service_name = service_command.name
+        if service_name not in _service_command_table_cache:
+            _service_command_table_cache[service_name] = service_command._get_command_table()
+        service_command_table = _service_command_table_cache[service_name]
         operation_command = service_command_table.get(operation)
 
         # valid service can have custom operations.
@@ -371,6 +373,10 @@ cli_data = driver._get_cli_data()
 parser = GlobalArgParser.get_parser()
 driver._add_aliases(command_table, parser)
 
+# Cache for ServiceCommand._get_command_table(). Each call loads and parses
+# service model JSON, which pymalloc never returns to the OS.
+_service_command_table_cache: dict[str, dict] = {}
+
 
 def parse(cli_command: str, default_region_override: str | None = None) -> IRCommand:
     """Parse a CLI command string into an IRCommand object."""
@@ -403,7 +409,9 @@ def _handle_service_command(
         raise MissingOperationError()
 
     service = service_command.name
-    command_table = service_command._get_command_table()
+    if service not in _service_command_table_cache:
+        _service_command_table_cache[service] = service_command._get_command_table()
+    command_table = _service_command_table_cache[service]
 
     operation = remaining[0]
     operation_command = command_table.get(operation)
@@ -493,7 +501,9 @@ def _handle_awscli_customization(
 
     # For custom commands, we need to check if the operation exists in the service's command table
     if hasattr(service_command, '_get_command_table'):
-        service_command_table = service_command._get_command_table()
+        if service not in _service_command_table_cache:
+            _service_command_table_cache[service] = service_command._get_command_table()
+        service_command_table = _service_command_table_cache[service]
         operation_command = service_command_table.get(operation)
     elif hasattr(service_command, 'subcommand_table'):
         # Handle S3-like services that use subcommand_table

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -160,19 +160,19 @@ async def suggest_aws_commands(
         await ctx.error(error_message)
         raise AwsApiMcpError(error_message)
     try:
-        with get_requests_session() as session:
-            response = session.post(
-                ENDPOINT_SUGGEST_AWS_COMMANDS,
-                json={'query': query},
-                timeout=30,
-            )
-            response.raise_for_status()
-            suggestions = response.json().get('suggestions')
-            logger.info(
-                'Suggested commands: {}',
-                [suggestion.get('command') for suggestion in suggestions],
-            )
-            return response.json()
+        session = get_requests_session()
+        response = session.post(
+            ENDPOINT_SUGGEST_AWS_COMMANDS,
+            json={'query': query},
+            timeout=30,
+        )
+        response.raise_for_status()
+        suggestions = response.json().get('suggestions')
+        logger.info(
+            'Suggested commands: {}',
+            [suggestion.get('command') for suggestion in suggestions],
+        )
+        return response.json()
     except Exception as e:
         logger.error('Error while suggesting commands: {}', str(e))
         error_message = 'Failed to execute tool due to internal error. Use your best judgement and existing knowledge to pick a command or point to relevant AWS Documentation.'

--- a/src/aws-api-mcp-server/tests/common/test_config.py
+++ b/src/aws-api-mcp-server/tests/common/test_config.py
@@ -13,6 +13,14 @@ from awslabs.aws_api_mcp_server.core.common.config import (
 from unittest.mock import MagicMock, patch
 
 
+@pytest.fixture(autouse=True)
+def _clear_region_cache():
+    """Clear the region cache between tests."""
+    config_module._region_cache.clear()
+    yield
+    config_module._region_cache.clear()
+
+
 @pytest.mark.parametrize(
     'os_name,uname_sysname,expected_tempdir',
     [

--- a/src/aws-api-mcp-server/tests/common/test_helpers.py
+++ b/src/aws-api-mcp-server/tests/common/test_helpers.py
@@ -13,6 +13,14 @@ from requests.adapters import HTTPAdapter
 from unittest.mock import MagicMock, patch
 
 
+@pytest.fixture(autouse=True)
+def _reset_requests_session():
+    """Reset the cached requests session between tests."""
+    get_requests_session.cache_clear()
+    yield
+    get_requests_session.cache_clear()
+
+
 @pytest.mark.parametrize(
     'valid_region',
     [

--- a/src/aws-api-mcp-server/tests/common/test_helpers.py
+++ b/src/aws-api-mcp-server/tests/common/test_helpers.py
@@ -13,14 +13,6 @@ from requests.adapters import HTTPAdapter
 from unittest.mock import MagicMock, patch
 
 
-@pytest.fixture(autouse=True)
-def _reset_requests_session():
-    """Reset the cached requests session between tests."""
-    get_requests_session.cache_clear()
-    yield
-    get_requests_session.cache_clear()
-
-
 @pytest.mark.parametrize(
     'valid_region',
     [

--- a/src/aws-api-mcp-server/tests/conftest.py
+++ b/src/aws-api-mcp-server/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared test fixtures for aws-api-mcp-server."""
+
+import pytest
+from awslabs.aws_api_mcp_server.core.common.helpers import get_requests_session
+from awslabs.aws_api_mcp_server.core.parser.interpretation import clear_client_cache
+from awslabs.aws_api_mcp_server.core.parser.parser import _service_command_table_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """Reset module-level caches between tests."""
+    clear_client_cache()
+    get_requests_session.cache_clear()
+    yield
+    clear_client_cache()
+    get_requests_session.cache_clear()
+    _service_command_table_cache.clear()


### PR DESCRIPTION
boto3.client() was recreated on every tool call. Each call loads the full
service model JSON, creates a new connection pool, and allocates SSL contexts.
In long-running MCP sessions (hours without restart) this causes steady memory
growth because pymalloc holds the allocated pages.

This PR caches the heavyweight objects:

- **boto3 clients**: LRU cache (OrderedDict, max 30) keyed on service/region/credentials/endpoint. Stale clients are evicted on auth errors so the next call gets a fresh client.
- **Resolved regions**: dict cache per profile. Region doesn't change for a given profile, so creating a Session just to read it is wasteful.
- **requests.Session**: `@functools.cache` on `get_requests_session()` so the retry strategy and adapter are set up once.
- **ServiceCommand._get_command_table()**: dict cache per service name. Each call parses ~590KB of JSON that pymalloc never returns.

All caches are cleared via a root `conftest.py` fixture for test isolation.

Fresh PR with the same fix, rebased on current main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).