### PR TITLE
chore: remove deprecated servers from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,7 +80,6 @@ body:
         - amazon-neptune-mcp-server
         - amazon-qbusiness-anonymous-mcp-server
         - amazon-qindex-mcp-server
-        - amazon-rekognition-mcp-server
         - amazon-sns-sqs-mcp-server
         - aurora-dsql-mcp-server
         - aws-api-mcp-server
@@ -102,9 +101,7 @@ body:
         - ccapi-mcp-server
         - cloudtrail-mcp-server
         - cloudwatch-applicationsignals-mcp-server
-        - cloudwatch-logs-mcp-server
         - cloudwatch-mcp-server
-        - cost-analysis-mcp-server
         - document-loader-mcp-server
         - documentdb-mcp-server
         - dynamodb-mcp-server
@@ -115,7 +112,6 @@ body:
         - healthimaging-mcp-server
         - healthlake-mcp-server
         - iam-mcp-server
-        - lambda-mcp-server
         - lambda-tool-mcp-server
         - mcp-lambda-handler
         - memcached-mcp-server

--- a/.github/ISSUE_TEMPLATE/support_awslabs_mcp_servers.yml
+++ b/.github/ISSUE_TEMPLATE/support_awslabs_mcp_servers.yml
@@ -64,8 +64,6 @@ body:
           required: false
         - label: amazon-qindex-mcp-server
           required: false
-        - label: amazon-rekognition-mcp-server
-          required: false
         - label: amazon-sns-sqs-mcp-server
           required: false
         - label: aurora-dsql-mcp-server
@@ -108,11 +106,7 @@ body:
           required: false
         - label: cloudwatch-applicationsignals-mcp-server
           required: false
-        - label: cloudwatch-logs-mcp-server
-          required: false
         - label: cloudwatch-mcp-server
-          required: false
-        - label: cost-analysis-mcp-server
           required: false
         - label: document-loader-mcp-server
           required: false
@@ -133,8 +127,6 @@ body:
         - label: healthlake-mcp-server
           required: false
         - label: iam-mcp-server
-          required: false
-        - label: lambda-mcp-server
           required: false
         - label: lambda-tool-mcp-server
           required: false


### PR DESCRIPTION
## Summary
- Remove 15 deprecated servers from the bug report dropdown and support template checkboxes
- Add all 59 current active servers (alphabetized)
- Fixes stale server lists that were missing ~30 servers added since the templates were last updated

## Changed files
- `.github/ISSUE_TEMPLATE/bug_report.yml` — server dropdown
- `.github/ISSUE_TEMPLATE/support_awslabs_mcp_servers.yml` — server checkboxes

## Test plan
- [ ] Verify bug report form shows only active servers in dropdown
- [ ] Verify support form shows only active servers in checkboxes
- [ ] Confirm no deprecated server names appear in either template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).