### PR TITLE
fix(mcp-lambda-handler): handle PEP 604 union types in schema generation

### DIFF
--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -16,6 +16,8 @@ import functools
 import inspect
 import json
 import logging
+import sys
+import types
 from awslabs.mcp_lambda_handler.session import DynamoDBSessionStore, NoOpSessionStore, SessionStore
 from awslabs.mcp_lambda_handler.types import (
     Capabilities,
@@ -218,7 +220,10 @@ class MCPLambdaHandler:
                 origin = get_origin(type_hint)
 
                 # Handle Union types (including Optional[T] which is Union[T, None])
-                if origin is Union:
+                # Also handle PEP 604 union syntax (e.g., int | None) on Python 3.10+
+                if origin is Union or (
+                    sys.version_info >= (3, 10) and isinstance(type_hint, types.UnionType)
+                ):
                     args = get_args(type_hint)
                     non_none_args = [arg for arg in args if arg is not type(None)]
                     if len(non_none_args) == 1:


### PR DESCRIPTION
## Summary

Fixes #2354

On Python 3.10+, `int | None` creates a `types.UnionType` instead of `typing.Union`. The `get_type_schema()` function in `MCPLambdaHandler.tool()` only checked for `typing.Union`, causing PEP 604 union types (like `int | None`) to fall through to the default `{"type": "string"}` case.

This means `Optional[int]` parameters (when resolved to `int | None` by `get_type_hints()`) incorrectly generate `{"type": "string"}` instead of `{"type": "integer"}`.

## Fix

Add an `isinstance` check for `types.UnionType` (Python 3.10+) alongside the existing `typing.Union` check, so both syntaxes are handled correctly.

## Test plan

- [ ] `Optional[int]` generates `{"type": "integer"}` in the JSON schema
- [ ] `int | None` generates `{"type": "integer"}` in the JSON schema
- [ ] `Optional[str]` still generates `{"type": "string"}`
- [ ] `Union[int, str]` still works (takes first non-None type)