### PR TITLE
docs: add AWS Deadline Cloud MCP Server reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ Build, deploy, and manage cloud infrastructure with Infrastructure as Code best 
 
 
 
+#### Compute & Rendering
+
+| Server Name | Description | Install |
+|-------------|-------------|---------|
+| [AWS Deadline Cloud MCP Server](src/deadline-cloud-mcp-server) | Render farm management, job submission, and troubleshooting for AWS Deadline Cloud | See [README](src/deadline-cloud-mcp-server/README.md) |
+
 #### Serverless & Functions
 
 | Server Name | Description | Install |

--- a/src/deadline-cloud-mcp-server/README.md
+++ b/src/deadline-cloud-mcp-server/README.md
@@ -1,0 +1,49 @@
+# AWS Deadline Cloud MCP Server
+
+An MCP server for [AWS Deadline Cloud](https://aws.amazon.com/deadline-cloud/) that enables AI assistants to interact with Deadline Cloud services through natural language — submitting jobs, querying farm/queue/job information, troubleshooting failures, and retrieving logs.
+
+> This MCP server lives in the [aws-deadline/deadline-cloud](https://github.com/aws-deadline/deadline-cloud) repository. See the [MCP guide](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/mcp_guide.md) for full documentation.
+
+## Key Features
+
+- List and manage farms, queues, jobs, fleets, and storage profiles
+- Submit Open Job Description job bundles
+- Download job output files
+- Troubleshoot failed jobs with session and worker logs
+- Check authentication status
+
+## Configuration
+
+Install the server:
+
+```bash
+pip install 'deadline[mcp]'
+```
+
+Add to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "deadline-cloud": {
+      "command": "deadline",
+      "args": ["mcp-server"],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+### Prerequisites
+
+- AWS credentials configured (AWS Profiles, environment variables, or `deadline auth login`)
+- Python with `deadline[mcp]` package installed
+
+## Example Prompts
+
+- "List all my AWS Deadline Cloud farms"
+- "Submit the render job in /path/to/my-job-bundle"
+- "Troubleshoot job job-abc123 - why did it fail?"
+- "Get the logs for session session-abc123"
+- "Download output from job job-abc123"


### PR DESCRIPTION
Adds a folder/README for the Deadline Cloud MCP server following the existing pattern for externally-hosted servers (e.g. `aws-knowledge-mcp-server`). The server itself lives in [aws-deadline/deadline-cloud](https://github.com/aws-deadline/deadline-cloud).

This improves discoverability for customers who start at this repo.

Changes:
- New `src/deadline-cloud-mcp-server/README.md` pointing to the source repo and [MCP guide](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/mcp_guide.md)
- Added "Compute & Rendering" section in main README under Infrastructure & Deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).