### PR TITLE
chore: clean up CODEOWNERS ownership transfers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@ NOTICE                                                         @awslabs/mcp-admi
 # DEPRECATED — use billing-cost-management-mcp-server
 /src/cost-explorer-mcp-server                                  @awslabs/mcp-admins
 /src/document-loader-mcp-server                                @awslabs/mcp-admins @awslabs/mcp-maintainers  @andywidjaja @hvital @HaoOliv
-/src/documentdb-mcp-server                                     @awslabs/mcp-admins @awslabs/mcp-maintainers  @theagenticguy
+/src/documentdb-mcp-server                                     @awslabs/mcp-admins @awslabs/mcp-maintainers  @nitinahuja89
 /src/dynamodb-mcp-server                                       @awslabs/mcp-admins @awslabs/mcp-maintainers  @akeyesamzn @ysunio @LeeroyHannigan @amzn-erdemkemer
 /src/ecs-mcp-server                                            @awslabs/mcp-admins @awslabs/mcp-maintainers  @guitar80ep @matthewgoodman13 @nineonine @biagic @tusharbabbar @lewisct
 /src/eks-mcp-server                                            @awslabs/mcp-admins @awslabs/mcp-maintainers  @patrick-yu-amzn @srhsrhsrhsrh


### PR DESCRIPTION
## Summary
- **amazon-kendra-index**: Remove `@krokoko` and `@scottschreckengaust` (AGS Tech placeholders), keep `@tomron-aws` (confirmed owner via PR #2734)
- **aws-bedrock-custom-model-import**: Remove `@krokoko` (AGS Tech placeholder), keep `@saidrhs`
- **aws-location**: Replace placeholders `@scottschreckengaust` and `@theagenticguy` with Location Service team: `@cgalvan` `@sethfitz` `@mojodna` `@saamzn` `@kmgrubbs` (confirmed by Chris Galvan via Kevin Grubbs)

DocumentDB ownership transfer is pending separately — waiting on confirmation from the original author.

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (CI check)
- [ ] Confirm new owners receive review requests on their respective server directories

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).