### PR TITLE
fix: block $out and $merge stages in read-only mode

### DIFF
--- a/src/documentdb-mcp-server/README.md
+++ b/src/documentdb-mcp-server/README.md
@@ -43,7 +43,7 @@ The DocumentDB MCP Server provides the following tools:
 ### Document Operations
 
 - `find`: Query documents from a collection
-- `aggregate`: Run aggregation pipelines
+- `aggregate`: Run aggregation pipelines (pipelines with `$out` or `$merge` stages are blocked in read-only mode)
 - `insert`: Insert documents (blocked in read-only mode)
 - `update`: Update documents (blocked in read-only mode)
 - `delete`: Delete documents (blocked in read-only mode)
@@ -79,8 +79,9 @@ python -m awslabs.documentdb_mcp_server.server --allow-write
 
 By default, the server runs in read-only mode that only allows read operations. This enhances security by preventing any modifications to the database. In read-only mode:
 
-- Read operations (`find`, `aggregate`, `listCollections`) work normally
-- Write operations (`insert`, `update`, `delete`) are blocked and return a permission error
+- Read operations (`find`, `listCollections`) work normally
+- Aggregation pipelines (`aggregate`) work normally, except pipelines containing `$out` or `$merge` stages are blocked
+- Write operations (`insert`, `update`, `delete`, `createCollection`, `dropCollection`) are blocked and return a permission error
 - Connection management operations (`connect`, `disconnect`) work normally
 
 This mode is particularly useful for:

--- a/src/documentdb-mcp-server/awslabs/documentdb_mcp_server/query_tools.py
+++ b/src/documentdb-mcp-server/awslabs/documentdb_mcp_server/query_tools.py
@@ -14,6 +14,7 @@
 
 """Query tools for DocumentDB MCP Server."""
 
+from awslabs.documentdb_mcp_server.config import serverConfig
 from awslabs.documentdb_mcp_server.connection_tools import DocumentDBConnection
 from loguru import logger
 from pydantic import Field
@@ -92,6 +93,18 @@ async def aggregate(
     Returns:
         List[Dict[str, Any]]: List of aggregation results
     """
+    # Check if pipeline contains write stages in read-only mode
+    if serverConfig.read_only_mode:
+        for stage in pipeline:
+            if '$out' in stage or '$merge' in stage:
+                denied_stage = '$out' if '$out' in stage else '$merge'
+                logger.warning(
+                    f'Aggregation operation denied: Pipeline contains write stage ({denied_stage}) in read-only mode'
+                )
+                raise ValueError(
+                    'Operation not permitted: Server is configured in read-only mode. Aggregation pipeline contains write stages ($out or $merge) which are not allowed.'
+                )
+
     try:
         # Get connection
         if connection_id not in DocumentDBConnection._connections:

--- a/src/documentdb-mcp-server/tests/test_query_tools.py
+++ b/src/documentdb-mcp-server/tests/test_query_tools.py
@@ -15,6 +15,7 @@
 
 import pytest
 import uuid
+from awslabs.documentdb_mcp_server.config import serverConfig
 from awslabs.documentdb_mcp_server.connection_tools import DocumentDBConnection
 from awslabs.documentdb_mcp_server.query_tools import (
     aggregate,
@@ -313,3 +314,137 @@ class TestAggregateTool:
         # Act/Assert
         with pytest.raises(ValueError, match='Failed to run aggregation: Generic error'):
             await aggregate(connection_id, 'test_db', 'test_collection', pipeline, 10)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_blocks_out_in_read_only_mode(
+        self, mock_ctx, patch_client, monkeypatch
+    ):
+        """Test that $out stage is blocked in read-only mode."""
+        # Arrange
+        monkeypatch.setattr(serverConfig, 'read_only_mode', True)
+
+        mock_client = patch_client()  # noqa: F841
+        connection_info = DocumentDBConnection.create_connection(
+            'mongodb://example.com:27017/?retryWrites=false'
+        )
+        connection_id = connection_info.connection_id
+
+        # Define a pipeline with $out stage
+        pipeline = [
+            {'$group': {'_id': '$category', 'total': {'$sum': '$value'}}},
+            {'$out': 'output_collection'},
+        ]
+
+        # Act/Assert
+        with pytest.raises(
+            ValueError,
+            match='Operation not permitted: Server is configured in read-only mode',
+        ):
+            await aggregate(connection_id, 'test_db', 'test_collection', pipeline, 10)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_blocks_merge_in_read_only_mode(
+        self, mock_ctx, patch_client, monkeypatch
+    ):
+        """Test that $merge stage is blocked in read-only mode."""
+        # Arrange
+        monkeypatch.setattr(serverConfig, 'read_only_mode', True)
+
+        mock_client = patch_client()  # noqa: F841
+        connection_info = DocumentDBConnection.create_connection(
+            'mongodb://example.com:27017/?retryWrites=false'
+        )
+        connection_id = connection_info.connection_id
+
+        # Define a pipeline with $merge stage
+        pipeline = [
+            {'$group': {'_id': '$category', 'total': {'$sum': '$value'}}},
+            {'$merge': {'into': 'output_collection'}},
+        ]
+
+        # Act/Assert
+        with pytest.raises(
+            ValueError,
+            match='Operation not permitted: Server is configured in read-only mode',
+        ):
+            await aggregate(connection_id, 'test_db', 'test_collection', pipeline, 10)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_allows_out_when_write_enabled(
+        self, mock_ctx, patch_client, monkeypatch
+    ):
+        """Test that $out stage is allowed when write operations are enabled."""
+        # Arrange
+        monkeypatch.setattr(serverConfig, 'read_only_mode', False)
+
+        mock_client = patch_client()  # noqa: F841
+        connection_info = DocumentDBConnection.create_connection(
+            'mongodb://example.com:27017/?retryWrites=false'
+        )
+        connection_id = connection_info.connection_id
+
+        # Set up mock data
+        db_name = 'test_db'
+        collection_name = 'test_collection'
+
+        # Add documents to the collection
+        docs = [
+            {'_id': ObjectId(), 'category': 'A', 'value': 10},
+            {'_id': ObjectId(), 'category': 'B', 'value': 20},
+        ]
+
+        mock_collection = mock_client[db_name][collection_name]
+        for doc in docs:
+            mock_collection.insert_one(doc)
+
+        # Define a pipeline with $out stage
+        pipeline = [
+            {'$group': {'_id': '$category', 'total': {'$sum': '$value'}}},
+            {'$out': 'output_collection'},
+        ]
+
+        # Act - should not raise an error
+        result = await aggregate(connection_id, db_name, collection_name, pipeline, 10)
+
+        # Assert - in mock implementation, this should succeed
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_allows_merge_when_write_enabled(
+        self, mock_ctx, patch_client, monkeypatch
+    ):
+        """Test that $merge stage is allowed when write operations are enabled."""
+        # Arrange
+        monkeypatch.setattr(serverConfig, 'read_only_mode', False)
+
+        mock_client = patch_client()  # noqa: F841
+        connection_info = DocumentDBConnection.create_connection(
+            'mongodb://example.com:27017/?retryWrites=false'
+        )
+        connection_id = connection_info.connection_id
+
+        # Set up mock data
+        db_name = 'test_db'
+        collection_name = 'test_collection'
+
+        # Add documents to the collection
+        docs = [
+            {'_id': ObjectId(), 'category': 'A', 'value': 10},
+            {'_id': ObjectId(), 'category': 'B', 'value': 20},
+        ]
+
+        mock_collection = mock_client[db_name][collection_name]
+        for doc in docs:
+            mock_collection.insert_one(doc)
+
+        # Define a pipeline with $merge stage
+        pipeline = [
+            {'$group': {'_id': '$category', 'total': {'$sum': '$value'}}},
+            {'$merge': {'into': 'output_collection'}},
+        ]
+
+        # Act - should not raise an error
+        result = await aggregate(connection_id, db_name, collection_name, pipeline, 10)
+
+        # Assert - in mock implementation, this should succeed
+        assert isinstance(result, list)


### PR DESCRIPTION

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Add validation to prevent aggregation pipelines from using write stages ($out and $merge) when the server is running in read-only mode. This ensures complete protection against database modifications in read-only mode.

- Add serverConfig check in aggregate function to block $out and $merge stages
- Add comprehensive test coverage for the new validation
- Update README to document the restriction

### Changes

Added validation

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).


## Test output:
```
collected 14 items

tests/test_query_tools.py::TestFindTool::test_find_success PASSED                     [  7%]
tests/test_query_tools.py::TestFindTool::test_find_with_projection PASSED             [ 14%]
tests/test_query_tools.py::TestFindTool::test_find_with_limit PASSED                  [ 21%]
tests/test_query_tools.py::TestFindTool::test_find_connection_not_found PASSED        [ 28%]
tests/test_query_tools.py::TestFindTool::test_find_handles_generic_exception PASSED   [ 35%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_success PASSED           [ 42%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_with_limit PASSED        [ 50%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_with_limit_in_pipeline PASSED [ 57%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_connection_not_found PASSED [ 64%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_handles_generic_exception PASSED [ 71%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_blocks_out_in_read_only_mode PASSED [ 78%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_blocks_merge_in_read_only_mode PASSED [ 85%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_allows_out_when_write_enabled PASSED [ 92%]
tests/test_query_tools.py::TestAggregateTool::test_aggregate_allows_merge_when_write_enabled PASSED [100%]
```
