### PR TITLE
fix(ecs-mcp-server): handle string start_time/end_time in calculate_time_window

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/time_utils.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/time_utils.py
@@ -17,13 +17,22 @@ Utility functions for handling time calculations.
 """
 
 import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
+
+
+def _parse_datetime(value: Union[str, datetime.datetime]) -> datetime.datetime:
+    """Parse a datetime value that may be a string (from MCP JSON) or datetime object."""
+    if isinstance(value, str):
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.datetime.fromisoformat(value)
+    return value
 
 
 def calculate_time_window(
     time_window: int = 3600,
-    start_time: Optional[datetime.datetime] = None,
-    end_time: Optional[datetime.datetime] = None,
+    start_time: Optional[Union[str, datetime.datetime]] = None,
+    end_time: Optional[Union[str, datetime.datetime]] = None,
 ) -> Tuple[datetime.datetime, datetime.datetime]:
     """
     Calculate the actual start time and end time for a time window.
@@ -49,12 +58,14 @@ def calculate_time_window(
         # If no end_time provided, use current time
         actual_end_time = now
     else:
+        end_time = _parse_datetime(end_time)
         # Ensure end_time is timezone-aware
         actual_end_time = (
             end_time if end_time.tzinfo else end_time.replace(tzinfo=datetime.timezone.utc)
         )
 
     if start_time is not None:
+        start_time = _parse_datetime(start_time)
         # If start_time provided, use it directly
         actual_start_time = (
             start_time if start_time.tzinfo else start_time.replace(tzinfo=datetime.timezone.utc)

--- a/src/ecs-mcp-server/tests/unit/utils/test_time_utils.py
+++ b/src/ecs-mcp-server/tests/unit/utils/test_time_utils.py
@@ -58,3 +58,20 @@ class TestTimeUtils(unittest.TestCase):
         self.assertIsNotNone(start_time)
         self.assertIsNotNone(end_time)
         self.assertEqual((end_time - start_time).total_seconds(), 7200)
+
+    def test_string_iso_format(self):
+        """Test with ISO format strings as passed via MCP JSON."""
+        start_time, end_time = calculate_time_window(
+            start_time="2025-05-01T00:00:00Z",
+            end_time="2025-05-02T00:00:00Z",
+        )
+        self.assertEqual(start_time, datetime.datetime(2025, 5, 1, tzinfo=datetime.timezone.utc))
+        self.assertEqual(end_time, datetime.datetime(2025, 5, 2, tzinfo=datetime.timezone.utc))
+
+    def test_string_with_offset(self):
+        """Test with ISO format strings containing timezone offset."""
+        start_time, end_time = calculate_time_window(
+            start_time="2025-05-01T09:00:00+09:00",
+            end_time="2025-05-01T10:00:00+09:00",
+        )
+        self.assertEqual((end_time - start_time).total_seconds(), 3600)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #2858

## Summary

### Changes

When invoking ECS troubleshooting tools via MCP, `start_time` and `end_time` parameters arrive as JSON strings (e.g. `"2026-04-03T10:00:00Z"`), but `calculate_time_window()` expects `datetime` objects and crashes with `AttributeError: 'str' object has no attribute 'tzinfo'`.

- Add `_parse_datetime()` helper that converts ISO format strings to `datetime` objects
- Update type hints to accept `Union[str, datetime.datetime]`
- Handle `Z` suffix for Python 3.10 compatibility (`fromisoformat` only supports `Z` in 3.11+)

### User experience

Before: MCP calls with string timestamps crash with `AttributeError`.
After: String timestamps are automatically parsed, troubleshooting tools work as expected.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).