### PR TITLE
fix(aws-network-mcp-server): handle missing PublicIp in NAT gateway addresses

### DIFF
--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/utils/vcp_details.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/utils/vcp_details.py
@@ -248,9 +248,11 @@ def process_nat_gateways(nat_gateways: Dict[str, Any]) -> List[NatGatewayDict]:
             }
         )
 
-        for address in nat['NatGatewayAddresses']:
-            gw.private_ips.append(address['PrivateIp'])
-            gw.public_ips.append(address['PublicIp'])
+        for address in nat.get('NatGatewayAddresses', []):
+            if 'PrivateIp' in address:
+                gw.private_ips.append(address['PrivateIp'])
+            if 'PublicIp' in address:
+                gw.public_ips.append(address['PublicIp'])
 
         result.append(gw)
 

--- a/src/aws-network-mcp-server/tests/utils/test_vcp_details.py
+++ b/src/aws-network-mcp-server/tests/utils/test_vcp_details.py
@@ -270,6 +270,28 @@ class TestProcessNatGateways:
 
         assert result == []
 
+    def test_private_nat_gateway_no_public_ip(self):
+        """Test processing private NAT gateway without PublicIp."""
+        data = {
+            'NatGateways': [
+                {
+                    'NatGatewayId': 'nat-private',
+                    'State': 'available',
+                    'SubnetId': 'subnet-456',
+                    'NatGatewayAddresses': [
+                        {'PrivateIp': '10.0.1.10'},
+                    ],
+                }
+            ]
+        }
+
+        result = process_nat_gateways(data)
+
+        assert len(result) == 1
+        assert result[0].id == 'nat-private'
+        assert result[0].private_ips == ['10.0.1.10']
+        assert result[0].public_ips == []
+
 
 class TestProcessNacls:
     """Test process_nacls function."""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #2836

## Summary

### Changes

`process_nat_gateways()` crashes with `KeyError: 'PublicIp'` when processing private NAT gateways, which do not have `PublicIp` in their `NatGatewayAddresses`. Also crashes if `NatGatewayAddresses` key is missing entirely.

- Use `.get()` with default empty list for `NatGatewayAddresses`
- Check key existence before accessing `PrivateIp` and `PublicIp`

### User experience

Before: `get_vpc_network` tool crashes with `KeyError` for VPCs containing private NAT gateways.
After: Private NAT gateways are processed correctly with empty `public_ips` list.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).