### PR TITLE
fix(amazon-bedrock-agentcore-mcp-server): skip signal handlers on Windows

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
@@ -17,6 +17,7 @@
 import asyncio
 import os
 import signal
+import sys
 from .tools import docs, gateway, memory, runtime
 from .utils import cache
 from collections.abc import AsyncIterator
@@ -100,11 +101,12 @@ _code_interpreter_cleanup = None
 async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
     """Manage server lifecycle — browser cleanup task, code interpreter cleanup, and graceful shutdown."""
     if _browser_cm is not None and _browser_sm is not None:
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(
-                sig, lambda cm=_browser_cm: asyncio.ensure_future(cm.cleanup())
-            )
+        if sys.platform != 'win32':
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(
+                    sig, lambda cm=_browser_cm: asyncio.ensure_future(cm.cleanup())
+                )
 
         from .tools.browser import cleanup_stale_sessions
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #2752

## Summary

### Changes

The MCP server crashes on Windows with `NotImplementedError` because `asyncio.add_signal_handler()` is not supported on Windows event loops.

- Guard `add_signal_handler` calls with `sys.platform != 'win32'` check
- On Windows, signal handlers are skipped — cleanup still happens via the `finally` block in the lifespan context manager

### User experience

Before: Server crashes immediately on Windows with `NotImplementedError: loop.add_signal_handler()`.
After: Server starts and runs on Windows. Browser session cleanup is handled by the `finally` block.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).