### PR TITLE
docs: remove misleading namespace comment from verify_package_name.py

### DIFF
--- a/scripts/verify_package_name.py
+++ b/scripts/verify_package_name.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file is part of the awslabs namespace.
-# It is intentionally minimal to support PEP 420 namespace packages.
 """Script to verify that README files correctly reference package names from pyproject.toml files.
 
 This script extracts the package name from a pyproject.toml file and checks if the README.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #2700

## Summary

### Changes

`scripts/verify_package_name.py` contains a comment stating it is "part of the awslabs namespace" and "intentionally minimal to support PEP 420 namespace packages." This was copied from namespace package `__init__.py` files and is misleading — the file is a validation script, not a namespace package initializer.

- Remove the two misleading comment lines
- The module docstring already accurately describes the script's purpose

### User experience

No functional change. Removes misleading comments that could confuse contributors.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).