### PR TITLE
fix(mysql-mcp-server): convert --readonly flag from string to bool

### DIFF
--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
@@ -233,7 +233,10 @@ def main():
     parser.add_argument('--database', required=True, help='Database name')
     parser.add_argument('--region', required=True, help='AWS region')
     parser.add_argument(
-        '--readonly', required=True, help='Enforce NL to SQL to only allow readonly sql statement'
+        '--readonly',
+        required=True,
+        type=lambda x: x.lower() == 'true',
+        help='Enforce NL to SQL to only allow readonly sql statement (true/false)',
     )
     args = parser.parse_args()
 
@@ -264,7 +267,7 @@ def main():
                 secret_arn=args.secret_arn,
                 database=args.database,
                 region=args.region,
-                readonly=args.readonly.lower(),
+                readonly=args.readonly,
             )
 
             # Test database connection
@@ -291,7 +294,7 @@ def main():
                 secret_arn=args.secret_arn,
                 database=args.database,
                 region=args.region,
-                readonly=args.readonly.lower(),
+                readonly=args.readonly,
                 hostname=args.hostname,
                 port=args.port,
             )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #2379

## Summary

### Changes

The `--readonly` CLI argument was defined as a plain string in argparse. The value `"false"` is truthy in Python, so the server was always in read-only mode regardless of the flag value.

- Add `type=lambda x: x.lower() == 'true'` to the argparse `--readonly` argument so it converts directly to `bool`
- Remove now-unnecessary `.lower()` calls on `args.readonly`

### User experience

Before: `--readonly False` is ignored — server is always read-only.
After: `--readonly False` correctly enables write queries.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).