### PR TITLE
feat(dynamodb): validate hostname against Secrets Manager in source DB Analyser tool

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,7 +215,7 @@
         "filename": "src/dynamodb-mcp-server/README.md",
         "hashed_secret": "37b5ecd16fe6c599c85077c7992427df62b2ab71",
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 285,
         "is_secret": false
       }
     ],
@@ -962,5 +962,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T17:03:19Z"
+  "generated_at": "2026-04-08T09:50:14Z"
 }

--- a/src/dynamodb-mcp-server/CHANGELOG.md
+++ b/src/dynamodb-mcp-server/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-07
+
+### Changed
+
+- **BREAKING CHANGE:** Connection-based managed mode in `source_db_analyzer` now requires the Secrets Manager secret to contain a `host` field. If your secret only has `username` and `password`, add the `host` field matching your database endpoint before upgrading. RDS-managed secrets already include this field. RDS Data API mode and self-service mode are not affected.
+
+### Added
+
+- Hostname validation against Secrets Manager secret for connection-based managed mode, ensuring credentials are only used with the intended database host.
+
 ## [2.0.4] - 2025-11-21
 
 ### Added

--- a/src/dynamodb-mcp-server/README.md
+++ b/src/dynamodb-mcp-server/README.md
@@ -218,7 +218,22 @@ Managed mode allows you to connect the tool to AWS RDS Data API to analyze exist
 **For Connection-based access:**
 1. MySQL server accessible from your environment
 2. Database credentials stored in AWS Secrets Manager
-3. AWS credentials with permissions to access Secrets Manager
+3. The Secrets Manager secret **must** contain a `host` field matching your database hostname (in addition to `username` and `password`). This ensures credentials are only used with the intended database host. RDS-managed secrets include this field automatically. If you created your secret manually, ensure it follows the [standard structure](https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_secret_json_structure.html):
+
+   ```bash
+   aws secretsmanager create-secret \
+       --name "my-db-secret" \
+       --secret-string '{
+           "engine": "mysql",
+           "host": "my-db.cluster-xxx.us-east-1.rds.amazonaws.com",
+           "username": "<username>",
+           "password": "<password>",
+           "dbname": "<database name>",
+           "port": 3306
+       }'
+   ```
+
+4. AWS credentials with permissions to access Secrets Manager
 
 **For both connection methods:**
 4. Enable Performance Schema for access pattern analysis (optional but recommended):

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.dynamodb-mcp-server"""
 
-__version__ = '2.0.24'
+__version__ = '2.0.9223372036854775807'

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/db_analyzer/mysql.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/db_analyzer/mysql.py
@@ -14,6 +14,8 @@
 
 """MySQL database analyzer plugin."""
 
+import boto3
+import json
 from awslabs.dynamodb_mcp_server.common import validate_source_identifier
 from awslabs.dynamodb_mcp_server.db_analyzer.base_plugin import DatabasePlugin
 from awslabs.mysql_mcp_server.connection.asyncmy_pool_connection import AsyncmyPoolConnection
@@ -399,7 +401,8 @@ class MySQLPlugin(DatabasePlugin):
                 readonly=DEFAULT_READONLY,
             )
         else:
-            # Connection-based access
+            # Connection-based access - ensure hostname matches the secret
+            hostname = _get_validated_hostname(hostname, secret_arn, region)
             db_connection = AsyncmyPoolConnection(
                 hostname=hostname,
                 port=port,
@@ -462,3 +465,32 @@ class MySQLPlugin(DatabasePlugin):
             'performance_feature': 'Performance Schema',
             'skipped_queries': skipped_queries,
         }
+
+
+def _get_validated_hostname(hostname: str, secret_arn: str, region: str) -> str:
+    """Validate that the provided hostname matches the host stored in the Secrets Manager secret.
+
+    Ensures the connection target is consistent with the credential source.
+    """
+    try:
+        client = boto3.client('secretsmanager', region_name=region)
+        response = client.get_secret_value(SecretId=secret_arn)
+        secret = json.loads(response['SecretString'])
+    except Exception as e:
+        raise ValueError(f'Failed to retrieve secret for hostname validation: {str(e)}')
+
+    secret_host = secret.get('host') or secret.get('Host')
+    if not secret_host:
+        raise ValueError(
+            'The Secrets Manager secret must contain a "host" field for connection-based '
+            'managed mode. Please update your secret to include the database hostname.'
+        )
+
+    if hostname.lower() != secret_host.lower():
+        raise ValueError(
+            f'The provided hostname "{hostname}" does not match the host in the '
+            'Secrets Manager secret. Update the secret\'s "host" field to match '
+            'your database endpoint, or correct the hostname parameter.'
+        )
+
+    return secret_host

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.dynamodb-mcp-server"
-version = "2.0.24"
+version = "2.0.9223372036854775807"
 description = "The official MCP Server for interacting with AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamodb-mcp-server/tests/db_analyzer/test_mysql_managed_mode.py
+++ b/src/dynamodb-mcp-server/tests/db_analyzer/test_mysql_managed_mode.py
@@ -18,8 +18,10 @@ These tests cover the execute_managed_mode and _execute_query_batch methods
 in the MySQLPlugin class which require mocking the MySQL MCP server connection.
 """
 
+import json
 import pytest
-from unittest.mock import patch
+from awslabs.dynamodb_mcp_server.db_analyzer.mysql import _get_validated_hostname
+from unittest.mock import Mock, patch
 
 
 class TestMySQLManagedMode:
@@ -270,3 +272,105 @@ class TestMySQLExecuteQueryBatch:
         assert 'comprehensive_table_analysis' in all_results
         assert 'comprehensive_index_analysis' in all_results
         assert len(all_errors) == 0
+
+
+class TestGetValidatedHostname:
+    """Tests for _get_validated_hostname hostname-secret consistency check."""
+
+    def test_matching_hostname(self):
+        """Test that matching hostname returns the secret host."""
+        secret_json = json.dumps(
+            {
+                'username': 'user',
+                'password': 'pass',  # pragma: allowlist secret
+                'host': 'my-db.cluster-xxx.us-east-1.rds.amazonaws.com',
+            }
+        )
+
+        with patch('awslabs.dynamodb_mcp_server.db_analyzer.mysql.boto3') as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.client.return_value = mock_client
+            mock_client.get_secret_value.return_value = {'SecretString': secret_json}
+
+            result = _get_validated_hostname(
+                'my-db.cluster-xxx.us-east-1.rds.amazonaws.com',
+                'arn:aws:secretsmanager:us-east-1:123:secret:test',
+                'us-east-1',
+            )
+            assert result == 'my-db.cluster-xxx.us-east-1.rds.amazonaws.com'
+
+    def test_mismatched_hostname_returns_secret_host(self):
+        """Test that mismatched hostname raises ValueError."""
+        secret_json = json.dumps(
+            {
+                'username': 'user',
+                'password': 'pass',  # pragma: allowlist secret
+                'host': 'legitimate-db.us-east-1.rds.amazonaws.com',
+            }
+        )
+
+        with patch('awslabs.dynamodb_mcp_server.db_analyzer.mysql.boto3') as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.client.return_value = mock_client
+            mock_client.get_secret_value.return_value = {'SecretString': secret_json}
+
+            with pytest.raises(ValueError, match='does not match the host'):
+                _get_validated_hostname(
+                    'attacker.example.com',
+                    'arn:aws:secretsmanager:us-east-1:123:secret:test',
+                    'us-east-1',
+                )
+
+    def test_case_insensitive_match(self):
+        """Test that hostname comparison is case-insensitive."""
+        secret_json = json.dumps(
+            {
+                'username': 'user',
+                'password': 'pass',  # pragma: allowlist secret
+                'host': 'My-DB.us-east-1.rds.amazonaws.com',
+            }
+        )
+
+        with patch('awslabs.dynamodb_mcp_server.db_analyzer.mysql.boto3') as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.client.return_value = mock_client
+            mock_client.get_secret_value.return_value = {'SecretString': secret_json}
+
+            result = _get_validated_hostname(
+                'my-db.us-east-1.rds.amazonaws.com',
+                'arn:aws:secretsmanager:us-east-1:123:secret:test',
+                'us-east-1',
+            )
+            assert result == 'My-DB.us-east-1.rds.amazonaws.com'
+
+    def test_missing_host_in_secret_raises_error(self):
+        """Test that missing host field in secret raises ValueError."""
+        secret_json = json.dumps(
+            {'username': 'user', 'password': 'pass'}  # pragma: allowlist secret
+        )
+
+        with patch('awslabs.dynamodb_mcp_server.db_analyzer.mysql.boto3') as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.client.return_value = mock_client
+            mock_client.get_secret_value.return_value = {'SecretString': secret_json}
+
+            with pytest.raises(ValueError, match='must contain a "host" field'):
+                _get_validated_hostname(
+                    'some-host',
+                    'arn:aws:secretsmanager:us-east-1:123:secret:test',
+                    'us-east-1',
+                )
+
+    def test_secrets_manager_failure_raises_error(self):
+        """Test that Secrets Manager failure raises ValueError."""
+        with patch('awslabs.dynamodb_mcp_server.db_analyzer.mysql.boto3') as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.client.return_value = mock_client
+            mock_client.get_secret_value.side_effect = Exception('Access denied')
+
+            with pytest.raises(ValueError, match='Failed to retrieve secret'):
+                _get_validated_hostname(
+                    'some-host',
+                    'arn:aws:secretsmanager:us-east-1:123:secret:test',
+                    'us-east-1',
+                )

--- a/src/dynamodb-mcp-server/tests/test_dynamodb_server.py
+++ b/src/dynamodb-mcp-server/tests/test_dynamodb_server.py
@@ -135,18 +135,22 @@ async def test_source_db_analyzer_connection_method_precedence(mysql_env_setup, 
     """Test that explicit connection parameters take precedence over environment variables."""
     # mysql_env_setup fixture sets MYSQL_CLUSTER_ARN, MYSQL_SECRET_ARN, AWS_REGION
     # Pass explicit hostname parameter - this should take precedence over env cluster_arn
-    result = await source_db_analyzer(
-        source_db_type='mysql',
-        source_identifier='test',
-        execution_mode='managed',
-        pattern_analysis_days=30,
-        max_query_results=None,
-        aws_cluster_arn=None,  # No explicit cluster_arn
-        hostname='explicit-hostname',  # Explicit hostname should pass
-        aws_secret_arn=None,  # Will use env var
-        aws_region=None,  # Will use env var
-        output_dir=str(tmp_path),
-    )
+    with patch(
+        'awslabs.dynamodb_mcp_server.db_analyzer.mysql._get_validated_hostname',
+        return_value='explicit-hostname',
+    ):
+        result = await source_db_analyzer(
+            source_db_type='mysql',
+            source_identifier='test',
+            execution_mode='managed',
+            pattern_analysis_days=30,
+            max_query_results=None,
+            aws_cluster_arn=None,  # No explicit cluster_arn
+            hostname='explicit-hostname',  # Explicit hostname should pass
+            aws_secret_arn=None,  # Will use env var
+            aws_region=None,  # Will use env var
+            output_dir=str(tmp_path),
+        )
 
     # The test validates the precedence works: it used Asyncmy connection-based access (hostname)
     # instead of RDS Data API (cluster_arn), even though env had MYSQL_CLUSTER_ARN
@@ -162,18 +166,22 @@ async def test_source_db_analyzer_env_hostname_only_fallback(mysql_env_setup, tm
     os.environ['MYSQL_HOSTNAME'] = 'env-hostname-test'
 
     try:
-        result = await source_db_analyzer(
-            source_db_type='mysql',
-            source_identifier='test',
-            execution_mode='managed',
-            pattern_analysis_days=30,
-            max_query_results=None,
-            aws_cluster_arn=None,  # No explicit cluster_arn
-            hostname=None,  # No explicit hostname - should use env
-            aws_secret_arn=None,  # Will use env var from fixture
-            aws_region=None,  # Will use env var from fixture
-            output_dir=str(tmp_path),
-        )
+        with patch(
+            'awslabs.dynamodb_mcp_server.db_analyzer.mysql._get_validated_hostname',
+            return_value='env-hostname-test',
+        ):
+            result = await source_db_analyzer(
+                source_db_type='mysql',
+                source_identifier='test',
+                execution_mode='managed',
+                pattern_analysis_days=30,
+                max_query_results=None,
+                aws_cluster_arn=None,  # No explicit cluster_arn
+                hostname=None,  # No explicit hostname - should use env
+                aws_secret_arn=None,  # Will use env var from fixture
+                aws_region=None,  # Will use env var from fixture
+                output_dir=str(tmp_path),
+            )
     finally:
         # Restore original state
         if original_cluster:

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-dynamodb-mcp-server"
-version = "2.0.24"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-aws-api-mcp-server" },


### PR DESCRIPTION
## Summary

Ensure the user-supplied hostname matches the host stored in the Secrets Manager secret before establishing a MySQL connection. This adds a consistency check so credentials are only used with the intended database endpoint.

### Changes

- Add _get_validated_hostname() to verify hostname-secret consistency
- Require Secrets Manager secret to contain a 'host' field
- Bump version to 2.1.0 (breaking change for connection-based mode)
- Update README with migration notice and updated prerequisites
- Add tests for hostname validation logic

### User experience

**No change for most users.** RDS Data API mode and self-service mode are unaffected. Users on connection-based managed mode whose Secrets Manager secret was created by RDS will see no difference, RDS-managed secrets already include the `host` field.

**Breaking change for connection-based managed mode users with manually-created secrets.** If the secret only contains `username` and `password` (no `host` field), the tool will return:

```
Analysis failed: The Secrets Manager secret must contain a "host" field for connection-based managed mode. Please update your secret to include the database hostname.
```

**If the provided hostname doesn't match the secret's `host` field**, the tool will return:

```
Analysis failed: The provided hostname "my-host.example.com" does not match the host in the Secrets Manager secret. Update the secret's "host" field to match your database endpoint, or correct the hostname parameter.
```

Both errors are actionable and guide the user to the fix. The README now includes a CLI example for creating a secret with the required structure.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) Y

**RFC issue number**:

Checklist:

* [X] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
