### PR TITLE
fix(openapi): pin fastmcp <3.0.0 to prevent startup crash

### DIFF
--- a/src/openapi-mcp-server/pyproject.toml
+++ b/src/openapi-mcp-server/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "fastmcp>=2.14.0",
+    "fastmcp>=2.14.0,<3.0.0",
     "httpx>=0.28.1",
     "pydantic>=2.11.7",
     "typing-extensions>=4.14.1",


### PR DESCRIPTION
## Problem

The openapi-mcp-server crashes on startup for all new installations because `pyproject.toml` specifies `fastmcp>=2.14.0` with no upper bound. When `uvx` resolves dependencies, it installs fastmcp 3.x which removed several APIs the server depends on:

- `RouteType` (removed in 3.0)
- `FastMCPOpenAPI` (removed in 3.0)
- `get_prompts()` (removed in 3.0)

This means **every new user** who installs the openapi-mcp-server gets a crash on startup.

## Fix

Pin `fastmcp>=2.14.0,<3.0.0` to prevent the breaking 3.x release from being installed.

## Related

Fixes #2533. PR #2687 bumps the fastmcp version but does not add an upper bound, so it does not actually fix the root cause.