### PR TITLE
fix: skip asyncio signal handler registration on Windows in agentcore server

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
@@ -17,6 +17,7 @@
 import asyncio
 import os
 import signal
+import sys
 from .tools import docs, gateway, memory, runtime
 from .utils import cache
 from collections.abc import AsyncIterator
@@ -100,11 +101,15 @@ _code_interpreter_cleanup = None
 async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
     """Manage server lifecycle — browser cleanup task, code interpreter cleanup, and graceful shutdown."""
     if _browser_cm is not None and _browser_sm is not None:
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(
-                sig, lambda cm=_browser_cm: asyncio.ensure_future(cm.cleanup())
-            )
+        # Register signal handlers for graceful browser cleanup on platforms
+        # that support it. Windows does not support asyncio signal handlers,
+        # so we skip registration there to avoid a NotImplementedError crash.
+        if sys.platform != 'win32':
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(
+                    sig, lambda cm=_browser_cm: asyncio.ensure_future(cm.cleanup())
+                )
 
         from .tools.browser import cleanup_stale_sessions
 


### PR DESCRIPTION
## Summary

- Guard `asyncio.add_signal_handler()` calls with a `sys.platform != 'win32'` check in the `amazon-bedrock-agentcore-mcp-server`
- On Windows, `asyncio.add_signal_handler()` raises `NotImplementedError`, causing the server to crash during startup before becoming usable
- Signal handlers are only needed on Unix-based platforms for graceful browser cleanup; on Windows the parent process manages lifecycle via stdio closure

Fixes #2752

## Contributor Statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).