### PR TITLE
fix(ecs-mcp-server): parse string start_time/end_time in calculate_time_window

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/time_utils.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/time_utils.py
@@ -17,13 +17,33 @@ Utility functions for handling time calculations.
 """
 
 import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
+
+
+def _ensure_datetime(value: Optional[Union[str, datetime.datetime]]) -> Optional[datetime.datetime]:
+    """Convert a string to a datetime object if necessary.
+
+    Parameters
+    ----------
+    value : str or datetime or None
+        A datetime object, an ISO-8601 string, or None.
+
+    Returns
+    -------
+    datetime or None
+        The parsed datetime, or None if the input was None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return value
 
 
 def calculate_time_window(
     time_window: int = 3600,
-    start_time: Optional[datetime.datetime] = None,
-    end_time: Optional[datetime.datetime] = None,
+    start_time: Optional[Union[str, datetime.datetime]] = None,
+    end_time: Optional[Union[str, datetime.datetime]] = None,
 ) -> Tuple[datetime.datetime, datetime.datetime]:
     """
     Calculate the actual start time and end time for a time window.
@@ -32,16 +52,23 @@ def calculate_time_window(
     ----------
     time_window : int, optional
         Time window in seconds (default: 3600)
-    start_time : datetime, optional
-        Explicit start time (takes precedence over time_window if provided)
-    end_time : datetime, optional
-        Explicit end time (defaults to current time if not provided)
+    start_time : datetime or str, optional
+        Explicit start time (takes precedence over time_window if provided).
+        Accepts datetime objects or ISO-8601 strings.
+    end_time : datetime or str, optional
+        Explicit end time (defaults to current time if not provided).
+        Accepts datetime objects or ISO-8601 strings.
 
     Returns
     -------
     Tuple[datetime.datetime, datetime.datetime]
         Tuple of (actual_start_time, actual_end_time) with timezone info
     """
+    # Coerce string inputs to datetime objects so callers (e.g. MCP JSON
+    # payloads) can pass ISO-8601 strings without triggering an AttributeError.
+    start_time = _ensure_datetime(start_time)
+    end_time = _ensure_datetime(end_time)
+
     now = datetime.datetime.now(datetime.timezone.utc)
 
     # Handle provided start_time and end_time

--- a/src/ecs-mcp-server/tests/unit/utils/test_time_utils.py
+++ b/src/ecs-mcp-server/tests/unit/utils/test_time_utils.py
@@ -5,7 +5,7 @@ Unit tests for the time_utils module.
 import datetime
 import unittest
 
-from awslabs.ecs_mcp_server.utils.time_utils import calculate_time_window
+from awslabs.ecs_mcp_server.utils.time_utils import calculate_time_window, _ensure_datetime
 
 
 class TestTimeUtils(unittest.TestCase):
@@ -58,3 +58,57 @@ class TestTimeUtils(unittest.TestCase):
         self.assertIsNotNone(start_time)
         self.assertIsNotNone(end_time)
         self.assertEqual((end_time - start_time).total_seconds(), 7200)
+
+    # -- Tests for string-to-datetime coercion (issue #2858) --
+
+    def test_string_end_time_with_z_suffix(self):
+        """Test that an ISO-8601 string end_time with Z suffix is parsed correctly."""
+        start_time, end_time = calculate_time_window(
+            time_window=3600,
+            end_time="2026-04-03T12:00:00Z",
+        )
+        self.assertEqual(end_time, datetime.datetime(2026, 4, 3, 12, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual((end_time - start_time).total_seconds(), 3600)
+
+    def test_string_start_time_and_end_time(self):
+        """Test that both start_time and end_time as strings are parsed correctly."""
+        start_time, end_time = calculate_time_window(
+            start_time="2026-04-03T10:00:00Z",
+            end_time="2026-04-03T12:00:00Z",
+        )
+        self.assertEqual(start_time, datetime.datetime(2026, 4, 3, 10, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual(end_time, datetime.datetime(2026, 4, 3, 12, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual((end_time - start_time).total_seconds(), 7200)
+
+    def test_string_with_timezone_offset(self):
+        """Test that an ISO-8601 string with explicit timezone offset is parsed correctly."""
+        start_time, end_time = calculate_time_window(
+            end_time="2026-04-03T14:00:00+02:00",
+        )
+        # +02:00 means 12:00 UTC
+        self.assertEqual(end_time.utcoffset(), datetime.timedelta(hours=2))
+        self.assertEqual(end_time.hour, 14)
+
+    def test_string_start_time_only(self):
+        """Test that a string start_time without end_time works (end defaults to now)."""
+        start_time, end_time = calculate_time_window(
+            start_time="2026-01-01T00:00:00Z",
+        )
+        self.assertEqual(start_time, datetime.datetime(2026, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc))
+        # end_time should be approximately now
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self.assertTrue(abs((end_time - now).total_seconds()) < 5)
+
+    def test_ensure_datetime_none(self):
+        """Test that _ensure_datetime returns None for None input."""
+        self.assertIsNone(_ensure_datetime(None))
+
+    def test_ensure_datetime_passthrough(self):
+        """Test that _ensure_datetime passes through datetime objects unchanged."""
+        dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        self.assertEqual(_ensure_datetime(dt), dt)
+
+    def test_ensure_datetime_string(self):
+        """Test that _ensure_datetime parses ISO-8601 strings."""
+        result = _ensure_datetime("2026-04-03T12:00:00Z")
+        self.assertEqual(result, datetime.datetime(2026, 4, 3, 12, 0, 0, tzinfo=datetime.timezone.utc))


### PR DESCRIPTION
## Summary

- Adds `_ensure_datetime()` helper to `utils/time_utils.py` that coerces ISO-8601 strings to `datetime` objects before they reach the existing timezone-handling logic
- Calls `_ensure_datetime()` at the top of `calculate_time_window()` so both `start_time` and `end_time` work whether passed as `datetime` objects or strings (the latter being what MCP JSON payloads always deliver)
- Adds 7 new unit tests covering string inputs with Z suffix, explicit timezone offsets, mixed string/None args, and the helper function itself

## Test plan

- [x] All 13 tests in `tests/unit/utils/test_time_utils.py` pass (6 existing + 7 new)
- [x] Existing datetime-based callers are unaffected (passthrough behavior verified)
- [x] Strings with `Z` suffix and explicit `+HH:MM` offsets both parse correctly

Fixes #2858

## Contributor Statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).