### PR TITLE
fix(aws-network): guard against missing PublicIp in NAT gateway addresses

### DIFF
--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/utils/vcp_details.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/utils/vcp_details.py
@@ -248,9 +248,11 @@ def process_nat_gateways(nat_gateways: Dict[str, Any]) -> List[NatGatewayDict]:
             }
         )
 
-        for address in nat['NatGatewayAddresses']:
-            gw.private_ips.append(address['PrivateIp'])
-            gw.public_ips.append(address['PublicIp'])
+        for address in nat.get('NatGatewayAddresses', []):
+            if 'PrivateIp' in address:
+                gw.private_ips.append(address['PrivateIp'])
+            if 'PublicIp' in address:
+                gw.public_ips.append(address['PublicIp'])
 
         result.append(gw)
 

--- a/src/aws-network-mcp-server/tests/utils/test_vcp_details.py
+++ b/src/aws-network-mcp-server/tests/utils/test_vcp_details.py
@@ -270,6 +270,47 @@ class TestProcessNatGateways:
 
         assert result == []
 
+    def test_nat_gateway_without_public_ip(self):
+        """Test processing NAT gateway in private subnet without public IP."""
+        data = {
+            'NatGateways': [
+                {
+                    'NatGatewayId': 'nat-456',
+                    'State': 'available',
+                    'SubnetId': 'subnet-456',
+                    'NatGatewayAddresses': [
+                        {'PrivateIp': '10.0.1.5'},
+                    ],
+                }
+            ]
+        }
+
+        result = process_nat_gateways(data)
+
+        assert len(result) == 1
+        assert result[0].id == 'nat-456'
+        assert result[0].private_ips == ['10.0.1.5']
+        assert result[0].public_ips == []
+
+    def test_nat_gateway_without_addresses(self):
+        """Test processing NAT gateway without NatGatewayAddresses field."""
+        data = {
+            'NatGateways': [
+                {
+                    'NatGatewayId': 'nat-789',
+                    'State': 'pending',
+                    'SubnetId': 'subnet-789',
+                }
+            ]
+        }
+
+        result = process_nat_gateways(data)
+
+        assert len(result) == 1
+        assert result[0].id == 'nat-789'
+        assert result[0].private_ips == []
+        assert result[0].public_ips == []
+
 
 class TestProcessNacls:
     """Test process_nacls function."""


### PR DESCRIPTION
## Summary

Fixes #2836

`process_nat_gateways` in `vcp_details.py` crashes with `KeyError: 'PublicIp'` when a NAT Gateway does not have a public IP assigned (e.g., private NAT gateways). The `NatGatewayAddresses` field itself may also be absent for gateways in a pending state.

## Changes

- Use `nat.get('NatGatewayAddresses', [])` instead of `nat['NatGatewayAddresses']` to handle missing field
- Check for key existence before accessing `PrivateIp` and `PublicIp` in each address entry
- Add two test cases covering NAT gateways without public IPs and without addresses entirely

## Test plan

- [x] Existing tests pass (19/19)
- [x] New test: NAT gateway with only PrivateIp (no PublicIp) processes without error
- [x] New test: NAT gateway without NatGatewayAddresses field processes without error

## Contributor Statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).