### PR TITLE
feat(agentcore): Add AWS Agent Registry discovery tools

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/README.md
+++ b/src/amazon-bedrock-agentcore-mcp-server/README.md
@@ -11,6 +11,7 @@ This MCP server provides comprehensive access to Amazon Bedrock AgentCore docume
 - **Browser Automation**: 25 cloud-based browser tools for web navigation, interaction, and data extraction — no local browser installation required
 - **Comprehensive Coverage**: Access documentation for all AgentCore services including Runtime, Memory, Code Interpreter, Browser, Gateway, Observability, and Identity
 - **Smart Caching**: Efficient document caching with on-demand content loading for optimal performance
+- **Registry Discovery**: Search, list, and inspect AWS Agent Registry records and registries
 - **Curated Documentation List**: Uses llm.txt as a curated list of relevant AgentCore documentations, always fetching the latest version of the file
 
 ## Prerequisites
@@ -261,3 +262,75 @@ Complete gateway deployment guide covering:
 - Common patterns and troubleshooting
 
 Use this tool when deploying MCP Gateways to provide managed endpoints for Model Context Protocol servers.
+
+### search_registry
+
+Search AWS Agent Registry for MCP tools, A2A agents, or custom resources using natural language.
+
+```python
+search_registry(query: str, registry_arn: str, max_results: int = 5) -> str
+```
+
+**Parameters:**
+- `query` (str, required): Natural language search query describing what you need
+- `registry_arn` (str, required): Registry ARN to search within
+- `max_results` (int, optional, default: 5): Maximum number of results to return
+
+**Returns:**
+JSON string of matching records with name, description, type, status, and relevance score. MCP descriptor records include endpoint, transport type, and tool names.
+
+### list_records
+
+List all records in a specific Agent Registry.
+
+```python
+list_records(registry_id: str) -> str
+```
+
+**Parameters:**
+- `registry_id` (str, required): Registry ID to list records from
+
+**Returns:**
+JSON array of records with name, record ID, descriptor type, and status.
+
+### get_record
+
+Get full details of a specific registry record including descriptors.
+
+```python
+get_record(registry_id: str, record_id: str) -> str
+```
+
+**Parameters:**
+- `registry_id` (str, required): Registry ID
+- `record_id` (str, required): Record ID
+
+**Returns:**
+Full record details as JSON with parsed inline descriptor content.
+
+### list_registries
+
+List all Agent Registries in the AWS account.
+
+```python
+list_registries() -> str
+```
+
+**Parameters:** None
+
+**Returns:**
+JSON array of registries with name, registry ID, status, and auto-approval configuration.
+
+## Environment Variables
+
+### `AGENTCORE_ENABLE_TOOLS`
+
+Comma-separated list of service names to enable. When set, only the listed services are registered. If not set, all services are enabled by default.
+
+### `AGENTCORE_DISABLE_TOOLS`
+
+Comma-separated list of service names to disable. When set, the listed services are excluded from registration. If both `AGENTCORE_ENABLE_TOOLS` and `AGENTCORE_DISABLE_TOOLS` are set, `AGENTCORE_ENABLE_TOOLS` takes precedence.
+
+**Valid service names:** `runtime`, `memory`, `gateway`, `registry`, `browser`, `code_interpreter`
+
+> **Note:** Documentation tools (`search_agentcore_docs`, `fetch_agentcore_doc`) are always registered and cannot be disabled.

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
@@ -141,6 +141,15 @@ if _is_service_enabled('memory'):
 if _is_service_enabled('gateway'):
     mcp.tool()(gateway.manage_agentcore_gateway)
 
+if _is_service_enabled('registry'):
+    from .tools.registry import get_record, list_records, list_registries, search_registry
+
+    mcp.tool()(search_registry)
+    mcp.tool()(list_records)
+    mcp.tool()(get_record)
+    mcp.tool()(list_registries)
+    logger.info('Registry tools registered (4 tools)')
+
 if _is_service_enabled('browser'):
     try:
         from .tools.browser import register_browser_tools

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/registry.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/registry.py
@@ -1,0 +1,236 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Agent Registry Tools - Search, list, and inspect AWS Agent Registry records and registries.
+
+Exposes AWS Agent Registry control plane and data plane APIs as MCP tools,
+enabling AI assistants to discover MCP servers, A2A agents, agent skills,
+and custom resources programmatically.
+"""
+
+import boto3
+import json
+import os
+from loguru import logger
+from pydantic import Field
+from typing import Optional
+
+
+# Lazily initialized boto3 clients
+_cp_client = None
+_dp_client = None
+
+
+def _get_cp_client():
+    """Return the control plane client, creating it lazily on first call.
+
+    Creates a boto3 client for the ``bedrock-agentcore-control`` service.
+    The AWS region is read from the ``AWS_REGION`` environment variable,
+    defaulting to ``us-west-2`` when not set.  The client is cached in the
+    module-level ``_cp_client`` variable and reused on subsequent calls.
+    """
+    global _cp_client
+    if _cp_client is None:
+        region = os.environ.get('AWS_REGION', 'us-west-2')
+        logger.info(f'Creating bedrock-agentcore-control client in {region}')
+        session = boto3.Session(region_name=region)
+        _cp_client = session.client('bedrock-agentcore-control')
+    return _cp_client
+
+
+def _get_dp_client():
+    """Return the data plane client, creating it lazily on first call.
+
+    Creates a boto3 client for the ``bedrock-agentcore-registry`` service
+    with a custom endpoint URL of
+    ``https://bedrock-agentcore.{region}.amazonaws.com``.  The AWS region
+    is read from the ``AWS_REGION`` environment variable, defaulting to
+    ``us-west-2`` when not set.  The client is cached in the module-level
+    ``_dp_client`` variable and reused on subsequent calls.
+    """
+    global _dp_client
+    if _dp_client is None:
+        region = os.environ.get('AWS_REGION', 'us-west-2')
+        endpoint_url = f'https://bedrock-agentcore.{region}.amazonaws.com'
+        logger.info(
+            f'Creating bedrock-agentcore-registry client in {region} (endpoint: {endpoint_url})'
+        )
+        session = boto3.Session(region_name=region)
+        _dp_client = session.client('bedrock-agentcore-registry', endpoint_url=endpoint_url)
+    return _dp_client
+
+
+def _parse_inline_json(content: str) -> Optional[dict]:
+    """Safely parse a JSON string, returning None on failure.
+
+    Args:
+        content: A string that may contain valid JSON.
+
+    Returns:
+        The parsed JSON object, or ``None`` if parsing fails.
+    """
+    try:
+        return json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        logger.debug(f'Failed to parse inline JSON content: {content[:100]}...')
+        return None
+
+
+async def search_registry(
+    query: str = Field(..., description='Natural language search query describing what you need'),
+    registry_arn: str = Field(..., description='Registry ARN to search within'),
+    max_results: int = Field(5, description='Maximum number of results to return (default: 5)'),
+) -> str:
+    """Search AWS Agent Registry for MCP tools, A2A agents, or custom resources.
+
+    Performs a semantic search across approved registry records, returning
+    results ranked by relevance.  For MCP descriptor records the response
+    includes parsed connection details (endpoint, transport type, tool names).
+    """
+    try:
+        results = _get_dp_client().search_registry_records(
+            registryIds=[registry_arn],
+            searchQuery=query,
+            maxResults=max_results,
+        )
+
+        records = results.get('registryRecords', [])
+        if not records:
+            return f'No results found for: {query}'
+
+        output = []
+        for rec in records:
+            entry = {
+                'name': rec['name'],
+                'description': rec.get('description', ''),
+                'type': rec.get('descriptorType', 'N/A'),
+                'status': rec.get('status', 'N/A'),
+                'score': rec.get('score', 'N/A'),
+            }
+
+            # Parse MCP descriptors for connection details
+            descriptors = rec.get('descriptors', {})
+            if 'mcp' in descriptors:
+                server_raw = descriptors['mcp'].get('server', {}).get('inlineContent', '{}')
+                server_info = _parse_inline_json(server_raw)
+                if server_info:
+                    packages = server_info.get('packages', [])
+                    if packages:
+                        transport = packages[0].get('transport', {})
+                        entry['endpoint'] = transport.get('url', 'N/A')
+                        entry['transport_type'] = transport.get('type', 'N/A')
+
+                tools_raw = descriptors['mcp'].get('tools', {}).get('inlineContent', '{}')
+                tools_info = _parse_inline_json(tools_raw)
+                if tools_info:
+                    entry['tools'] = [t['name'] for t in tools_info.get('tools', [])]
+
+            output.append(entry)
+
+        return json.dumps(output, indent=2)
+    except Exception as e:
+        logger.error(f'Error searching registry: {e}')
+        return json.dumps({'error': str(e)})
+
+
+async def list_records(
+    registry_id: str = Field(..., description='Registry ID to list records from'),
+) -> str:
+    """List all records in a specific Agent Registry.
+
+    Returns a JSON array of records with their name, record ID, descriptor
+    type, and status.  Returns an empty array when the registry contains
+    no records.
+    """
+    try:
+        results = _get_cp_client().list_registry_records(registryId=registry_id)
+
+        records = []
+        for rec in results.get('registryRecords', []):
+            records.append(
+                {
+                    'name': rec['name'],
+                    'recordId': rec.get('recordId', 'N/A'),
+                    'type': rec.get('descriptorType', 'N/A'),
+                    'status': rec.get('status', 'N/A'),
+                }
+            )
+
+        return json.dumps(records, indent=2)
+    except Exception as e:
+        logger.error(f'Error listing registry records: {e}')
+        return json.dumps({'error': str(e)})
+
+
+async def get_record(
+    registry_id: str = Field(..., description='Registry ID'),
+    record_id: str = Field(..., description='Record ID'),
+) -> str:
+    """Get full details of a specific registry record including descriptors.
+
+    Strips ``ResponseMetadata`` from the API response and parses inline
+    JSON content in MCP, A2A, and custom descriptors, adding a ``parsed``
+    field alongside ``inlineContent`` for readability.  Malformed inline
+    JSON is silently skipped.
+    """
+    try:
+        rec = _get_cp_client().get_registry_record(registryId=registry_id, recordId=record_id)
+
+        # Strip ResponseMetadata
+        output = {k: v for k, v in rec.items() if k != 'ResponseMetadata'}
+
+        # Parse inline descriptors for readability
+        descriptors = output.get('descriptors', {})
+        for dtype in ['mcp', 'a2a', 'custom']:
+            if dtype in descriptors:
+                for field_name in descriptors[dtype]:
+                    content = descriptors[dtype][field_name].get('inlineContent')
+                    if content:
+                        parsed = _parse_inline_json(content)
+                        if parsed is not None:
+                            descriptors[dtype][field_name]['parsed'] = parsed
+
+        return json.dumps(output, indent=2, default=str)
+    except Exception as e:
+        logger.error(f'Error getting registry record: {e}')
+        return json.dumps({'error': str(e)})
+
+
+async def list_registries() -> str:
+    """List all AgentCore Registries in the AWS account.
+
+    Returns a JSON array of registries with their name, registry ID,
+    status, and auto-approval configuration.  Returns an empty array
+    when the account contains no registries.
+    """
+    try:
+        results = _get_cp_client().list_registries()
+
+        registries = []
+        for reg in results.get('registries', []):
+            registries.append(
+                {
+                    'name': reg['name'],
+                    'registryId': reg.get('registryId', 'N/A'),
+                    'status': reg.get('status', 'N/A'),
+                    'autoApproval': reg.get('approvalConfiguration', {}).get(
+                        'autoApproval', 'N/A'
+                    ),
+                }
+            )
+
+        return json.dumps(registries, indent=2)
+    except Exception as e:
+        logger.error(f'Error listing registries: {e}')
+        return json.dumps({'error': str(e)})

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_registry.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_registry.py
@@ -1,0 +1,518 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Agent Registry tools."""
+
+import json
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry import (
+    get_record,
+    list_records,
+    list_registries,
+    search_registry,
+)
+from unittest.mock import MagicMock, patch
+
+
+class TestSearchRegistry:
+    """Test cases for the search_registry tool function."""
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_dp_client')
+    async def test_search_success_with_results(self, mock_get_client):
+        """Test search returns JSON with all required fields for matching records."""
+        mock_client = MagicMock()
+        mock_client.search_registry_records.return_value = {
+            'registryRecords': [
+                {
+                    'name': 'my-mcp-server',
+                    'description': 'A useful MCP server',
+                    'descriptorType': 'MCP',
+                    'status': 'APPROVED',
+                    'score': 0.95,
+                }
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await search_registry(
+            query='useful server',
+            registry_arn='arn:aws:bedrock:us-west-2:123456789012:registry/my-registry',
+        )
+
+        parsed = json.loads(result)
+        assert len(parsed) == 1
+        record = parsed[0]
+        assert record['name'] == 'my-mcp-server'
+        assert record['description'] == 'A useful MCP server'
+        assert record['type'] == 'MCP'
+        assert record['status'] == 'APPROVED'
+        assert record['score'] == 0.95
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_dp_client')
+    async def test_search_no_results(self, mock_get_client):
+        """Test search returns 'No results found' when no records match."""
+        mock_client = MagicMock()
+        mock_client.search_registry_records.return_value = {'registryRecords': []}
+        mock_get_client.return_value = mock_client
+
+        result = await search_registry(
+            query='nonexistent',
+            registry_arn='arn:aws:bedrock:us-west-2:123456789012:registry/my-registry',
+        )
+
+        assert 'No results found' in result
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_dp_client')
+    async def test_search_api_error(self, mock_get_client):
+        """Test search returns JSON error when API raises an exception."""
+        mock_client = MagicMock()
+        mock_client.search_registry_records.side_effect = Exception('API error')
+        mock_get_client.return_value = mock_client
+
+        result = await search_registry(
+            query='test',
+            registry_arn='arn:aws:bedrock:us-west-2:123456789012:registry/my-registry',
+        )
+
+        parsed = json.loads(result)
+        assert 'error' in parsed
+        assert 'API error' in parsed['error']
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_dp_client')
+    async def test_search_mcp_descriptor_parsing(self, mock_get_client):
+        """Test search parses MCP descriptor inline JSON for endpoint, transport, and tools."""
+        server_content = json.dumps(
+            {
+                'packages': [
+                    {
+                        'transport': {
+                            'url': 'https://example.com/mcp',
+                            'type': 'sse',
+                        }
+                    }
+                ]
+            }
+        )
+        tools_content = json.dumps(
+            {
+                'tools': [
+                    {'name': 'tool_a'},
+                    {'name': 'tool_b'},
+                ]
+            }
+        )
+        mock_client = MagicMock()
+        mock_client.search_registry_records.return_value = {
+            'registryRecords': [
+                {
+                    'name': 'mcp-server',
+                    'description': 'An MCP server',
+                    'descriptorType': 'MCP',
+                    'status': 'APPROVED',
+                    'score': 0.9,
+                    'descriptors': {
+                        'mcp': {
+                            'server': {'inlineContent': server_content},
+                            'tools': {'inlineContent': tools_content},
+                        }
+                    },
+                }
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await search_registry(
+            query='mcp',
+            registry_arn='arn:aws:bedrock:us-west-2:123456789012:registry/my-registry',
+        )
+
+        parsed = json.loads(result)
+        record = parsed[0]
+        assert record['endpoint'] == 'https://example.com/mcp'
+        assert record['transport_type'] == 'sse'
+        assert record['tools'] == ['tool_a', 'tool_b']
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_dp_client')
+    async def test_search_malformed_mcp_descriptor(self, mock_get_client):
+        """Test search handles malformed MCP descriptor JSON without raising."""
+        mock_client = MagicMock()
+        mock_client.search_registry_records.return_value = {
+            'registryRecords': [
+                {
+                    'name': 'bad-mcp',
+                    'description': 'Bad descriptor',
+                    'descriptorType': 'MCP',
+                    'status': 'APPROVED',
+                    'score': 0.5,
+                    'descriptors': {
+                        'mcp': {
+                            'server': {'inlineContent': '{not valid json!!!'},
+                            'tools': {'inlineContent': 'also bad'},
+                        }
+                    },
+                }
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await search_registry(
+            query='bad',
+            registry_arn='arn:aws:bedrock:us-west-2:123456789012:registry/my-registry',
+        )
+
+        parsed = json.loads(result)
+        assert len(parsed) == 1
+        record = parsed[0]
+        assert record['name'] == 'bad-mcp'
+        assert record['type'] == 'MCP'
+        # MCP-specific fields should not be present when parsing fails
+        assert 'endpoint' not in record
+        assert 'transport_type' not in record
+
+
+class TestListRecords:
+    """Test cases for the list_records tool function."""
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_list_records_success(self, mock_get_client):
+        """Test list_records returns JSON with all required fields."""
+        mock_client = MagicMock()
+        mock_client.list_registry_records.return_value = {
+            'registryRecords': [
+                {
+                    'name': 'record-one',
+                    'recordId': 'rec-001',
+                    'descriptorType': 'MCP',
+                    'status': 'APPROVED',
+                },
+                {
+                    'name': 'record-two',
+                    'recordId': 'rec-002',
+                    'descriptorType': 'A2A',
+                    'status': 'PENDING',
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await list_records(registry_id='test-registry')
+
+        parsed = json.loads(result)
+        assert len(parsed) == 2
+        assert parsed[0]['name'] == 'record-one'
+        assert parsed[0]['recordId'] == 'rec-001'
+        assert parsed[0]['type'] == 'MCP'
+        assert parsed[0]['status'] == 'APPROVED'
+        assert parsed[1]['name'] == 'record-two'
+        assert parsed[1]['recordId'] == 'rec-002'
+        assert parsed[1]['type'] == 'A2A'
+        assert parsed[1]['status'] == 'PENDING'
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_list_records_empty(self, mock_get_client):
+        """Test list_records returns empty JSON array when no records exist."""
+        mock_client = MagicMock()
+        mock_client.list_registry_records.return_value = {'registryRecords': []}
+        mock_get_client.return_value = mock_client
+
+        result = await list_records(registry_id='empty-registry')
+
+        parsed = json.loads(result)
+        assert parsed == []
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_list_records_api_error(self, mock_get_client):
+        """Test list_records returns JSON error when API raises an exception."""
+        mock_client = MagicMock()
+        mock_client.list_registry_records.side_effect = Exception('Access denied')
+        mock_get_client.return_value = mock_client
+
+        result = await list_records(registry_id='test-registry')
+
+        parsed = json.loads(result)
+        assert 'error' in parsed
+        assert 'Access denied' in parsed['error']
+
+
+class TestGetRecord:
+    """Test cases for the get_record tool function."""
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_get_record_success(self, mock_get_client):
+        """Test get_record returns full record as JSON."""
+        mock_client = MagicMock()
+        mock_client.get_registry_record.return_value = {
+            'name': 'my-record',
+            'recordId': 'rec-123',
+            'status': 'APPROVED',
+            'descriptorType': 'CUSTOM',
+            'ResponseMetadata': {'RequestId': 'abc'},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_record(registry_id='test-registry', record_id='rec-123')
+
+        parsed = json.loads(result)
+        assert parsed['name'] == 'my-record'
+        assert parsed['recordId'] == 'rec-123'
+        assert parsed['status'] == 'APPROVED'
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_get_record_strips_response_metadata(self, mock_get_client):
+        """Test get_record strips ResponseMetadata from output."""
+        mock_client = MagicMock()
+        mock_client.get_registry_record.return_value = {
+            'name': 'my-record',
+            'ResponseMetadata': {'RequestId': 'abc', 'HTTPStatusCode': 200},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_record(registry_id='test-registry', record_id='rec-123')
+
+        parsed = json.loads(result)
+        assert 'ResponseMetadata' not in parsed
+        assert parsed['name'] == 'my-record'
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_get_record_parses_inline_json(self, mock_get_client):
+        """Test get_record parses valid inline JSON and adds 'parsed' field."""
+        inline_data = {'key': 'value', 'nested': {'a': 1}}
+        mock_client = MagicMock()
+        mock_client.get_registry_record.return_value = {
+            'name': 'mcp-record',
+            'descriptors': {
+                'mcp': {
+                    'server': {
+                        'inlineContent': json.dumps(inline_data),
+                    }
+                }
+            },
+            'ResponseMetadata': {'RequestId': 'xyz'},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_record(registry_id='test-registry', record_id='rec-456')
+
+        parsed = json.loads(result)
+        server_desc = parsed['descriptors']['mcp']['server']
+        assert 'parsed' in server_desc
+        assert server_desc['parsed'] == inline_data
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_get_record_malformed_inline_json(self, mock_get_client):
+        """Test get_record handles malformed inline JSON without raising."""
+        mock_client = MagicMock()
+        mock_client.get_registry_record.return_value = {
+            'name': 'bad-record',
+            'descriptors': {
+                'mcp': {
+                    'server': {
+                        'inlineContent': 'this is not json {{{',
+                    }
+                }
+            },
+            'ResponseMetadata': {'RequestId': 'xyz'},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await get_record(registry_id='test-registry', record_id='rec-789')
+
+        parsed = json.loads(result)
+        server_desc = parsed['descriptors']['mcp']['server']
+        assert 'parsed' not in server_desc
+        assert server_desc['inlineContent'] == 'this is not json {{{'
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_get_record_api_error(self, mock_get_client):
+        """Test get_record returns JSON error when API raises an exception."""
+        mock_client = MagicMock()
+        mock_client.get_registry_record.side_effect = Exception('Record not found')
+        mock_get_client.return_value = mock_client
+
+        result = await get_record(registry_id='test-registry', record_id='bad-id')
+
+        parsed = json.loads(result)
+        assert 'error' in parsed
+        assert 'Record not found' in parsed['error']
+
+
+class TestListRegistries:
+    """Test cases for the list_registries tool function."""
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_list_registries_success(self, mock_get_client):
+        """Test list_registries returns JSON with all required fields."""
+        mock_client = MagicMock()
+        mock_client.list_registries.return_value = {
+            'registries': [
+                {
+                    'name': 'prod-registry',
+                    'registryId': 'reg-001',
+                    'status': 'ACTIVE',
+                    'approvalConfiguration': {'autoApproval': True},
+                },
+                {
+                    'name': 'dev-registry',
+                    'registryId': 'reg-002',
+                    'status': 'ACTIVE',
+                    'approvalConfiguration': {'autoApproval': False},
+                },
+            ]
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await list_registries()
+
+        parsed = json.loads(result)
+        assert len(parsed) == 2
+        assert parsed[0]['name'] == 'prod-registry'
+        assert parsed[0]['registryId'] == 'reg-001'
+        assert parsed[0]['status'] == 'ACTIVE'
+        assert parsed[0]['autoApproval'] is True
+        assert parsed[1]['name'] == 'dev-registry'
+        assert parsed[1]['registryId'] == 'reg-002'
+        assert parsed[1]['autoApproval'] is False
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_list_registries_empty(self, mock_get_client):
+        """Test list_registries returns empty JSON array when no registries exist."""
+        mock_client = MagicMock()
+        mock_client.list_registries.return_value = {'registries': []}
+        mock_get_client.return_value = mock_client
+
+        result = await list_registries()
+
+        parsed = json.loads(result)
+        assert parsed == []
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry._get_cp_client')
+    async def test_list_registries_api_error(self, mock_get_client):
+        """Test list_registries returns JSON error when API raises an exception."""
+        mock_client = MagicMock()
+        mock_client.list_registries.side_effect = Exception('Service unavailable')
+        mock_get_client.return_value = mock_client
+
+        result = await list_registries()
+
+        parsed = json.loads(result)
+        assert 'error' in parsed
+        assert 'Service unavailable' in parsed['error']
+
+
+class TestClientInitialization:
+    """Test cases for lazy client initialization."""
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry.boto3.Session')
+    def test_lazy_init_cp_client(self, mock_session_cls):
+        """Test _get_cp_client creates client on first call."""
+        import awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry as reg_module
+
+        # Reset module-level client
+        reg_module._cp_client = None
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+
+        result = reg_module._get_cp_client()
+
+        assert result is mock_client
+        mock_session.client.assert_called_once_with('bedrock-agentcore-control')
+
+        # Clean up
+        reg_module._cp_client = None
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry.boto3.Session')
+    def test_lazy_init_dp_client(self, mock_session_cls):
+        """Test _get_dp_client creates client on first call."""
+        import awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry as reg_module
+
+        # Reset module-level client
+        reg_module._dp_client = None
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+
+        result = reg_module._get_dp_client()
+
+        assert result is mock_client
+        mock_session.client.assert_called_once()
+        call_args = mock_session.client.call_args
+        assert call_args[0][0] == 'bedrock-agentcore-registry'
+        assert 'endpoint_url' in call_args[1]
+
+        # Clean up
+        reg_module._dp_client = None
+
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry.boto3.Session')
+    def test_client_reuse(self, mock_session_cls):
+        """Test _get_cp_client returns the same object on subsequent calls."""
+        import awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry as reg_module
+
+        reg_module._cp_client = None
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+
+        first = reg_module._get_cp_client()
+        second = reg_module._get_cp_client()
+
+        assert first is second
+        # Session should only be created once
+        assert mock_session_cls.call_count == 1
+
+        # Clean up
+        reg_module._cp_client = None
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry.boto3.Session')
+    def test_region_default(self, mock_session_cls):
+        """Test default region is us-west-2 when AWS_REGION is not set."""
+        import awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry as reg_module
+
+        reg_module._cp_client = None
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.client.return_value = MagicMock()
+
+        reg_module._get_cp_client()
+
+        mock_session_cls.assert_called_once_with(region_name='us-west-2')
+
+        # Clean up
+        reg_module._cp_client = None
+
+    @patch.dict('os.environ', {'AWS_REGION': 'eu-west-1'})
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry.boto3.Session')
+    def test_region_from_env(self, mock_session_cls):
+        """Test region is read from AWS_REGION environment variable."""
+        import awslabs.amazon_bedrock_agentcore_mcp_server.tools.registry as reg_module
+
+        reg_module._cp_client = None
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.client.return_value = MagicMock()
+
+        reg_module._get_cp_client()
+
+        mock_session_cls.assert_called_once_with(region_name='eu-west-1')
+
+        # Clean up
+        reg_module._cp_client = None


### PR DESCRIPTION
Add four registry MCP tools to the amazon-bedrock-agentcore-mcp-server
package for discovering and inspecting AWS Agent Registry resources:

| Tool | Description |
|------|-------------|
| `search_registry` | Semantic search across approved registry records |
| `list_records` | List all records in a specific registry |
| `get_record` | Get full details of a specific registry record |
| `list_registries` | List all registries in the AWS account |

Implementation details:
- New tools/registry.py module with lazy boto3 client initialization
- Two clients: control plane (CRUD) and data plane (semantic search)
- Inline JSON parsing for MCP/A2A/custom descriptors
- Service-enable guard via _is_service_enabled("registry")
- 21 unit tests covering all tools, error handling, and client init
- README updated with tool docs and environment variable reference

<!-- markdownlint-disable MD041 MD043 -->

Fixes N/A

## Summary

### Changes

Add four AWS Agent Registry MCP tools (`search_registry`, `list_records`, `get_record`, `list_registries`) to the existing `amazon-bedrock-agentcore-mcp-server` package. The Registry is a fully managed discovery service within Amazon Bedrock AgentCore that provides a centralized catalog for organizing, curating, and discovering MCP servers, A2A agents, agent skills, and custom resources.

**New files:**
- `tools/registry.py` — Registry tool module with lazy boto3 client initialization (control plane + data plane), inline JSON parsing for MCP/A2A/custom descriptors, and error handling as JSON return values
- `tests/test_registry.py` — 21 unit tests covering all four tools, error paths, MCP descriptor parsing, client initialization, and region configuration

**Modified files:**
- `server.py` — Register registry tools behind `_is_service_enabled('registry')` guard
- `README.md` — Added tool documentation, feature listing, and environment variable reference

### User experience

**Before:** Users had no way to discover or inspect AWS Agent Registry resources through the MCP server.

**After:** Users can:
- Search registries using natural language queries to find relevant MCP servers, A2A agents, and other resources
- List all records in a specific registry to see available resources
- Get full details of a specific registry record including parsed descriptor content
- List all registries in their AWS account
- Enable/disable registry tools via `AGENTCORE_ENABLE_TOOLS` / `AGENTCORE_DISABLE_TOOLS` environment variables

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:
* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
