### PR TITLE
fix(support): Handle FastMCP 3.x removal of settings attribute

### DIFF
--- a/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/server.py
+++ b/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/server.py
@@ -784,8 +784,12 @@ def main():
     if args.debug:
         # Enable more detailed error tracking and performance monitoring
         logger.debug('Enabling detailed performance tracking and error monitoring')
-        # Hook into FastMCP to track performance
-        mcp.settings.debug = True
+        # Enable FastMCP debug mode (compatible with both v2 and v3)
+        try:
+            mcp.settings.debug = True
+        except AttributeError:
+            # FastMCP 3.x removed the .settings attribute
+            mcp.debug = True
         # You could add more diagnostics setup here
 
     logger.debug('Starting awslabs_support_mcp_server MCP server')


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'FastMCP' object has no attribute 'settings'` crash when starting the AWS Support MCP server with the `--debug` flag.

## Problem

FastMCP 3.x removed the `.settings` attribute from the `FastMCP` class. The current code at `server.py:788` does:

```python
mcp.settings.debug = True
```

This crashes immediately when `--debug` is passed:

```
AttributeError: 'FastMCP' object has no attribute 'settings'
```

Since `pyproject.toml` specifies `fastmcp>=2.0.0`, and the latest resolved version is `fastmcp==3.2.4`, this affects all new installations.

## Fix

Added a try/except fallback that supports both FastMCP 2.x and 3.x:

```python
try:
    mcp.settings.debug = True
except AttributeError:
    # FastMCP 3.x removed the .settings attribute
    mcp.debug = True
```

## Testing

- Verified the server starts successfully with `--debug` flag using `fastmcp==3.2.4` and `mcp==1.27.0`
- Verified the server starts successfully without `--debug` flag (no change in behavior)