### PR TITLE
fix(agentcore): correct Code Interpreter integration source

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/code_interpreter/client.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/code_interpreter/client.py
@@ -24,7 +24,7 @@ from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
 from loguru import logger
 
 
-MCP_INTEGRATION_SOURCE = 'awslabs-mcp-code-interpreter-server'
+MCP_INTEGRATION_SOURCE = 'awslabs-agentcore-mcp-server'
 DEFAULT_IDENTIFIER = 'aws.codeinterpreter.v1'
 
 # Per-region clients for region-level operations (get_session, list_sessions)

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/code_interpreter/test_client.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/code_interpreter/test_client.py
@@ -68,7 +68,7 @@ class TestGetClient:
         assert client is mock_instance
         mock_ci_class.assert_called_once_with(
             region='us-west-2',
-            integration_source='awslabs-mcp-code-interpreter-server',
+            integration_source='awslabs-agentcore-mcp-server',
         )
 
     @patch(
@@ -110,7 +110,7 @@ class TestGetClient:
 
         mock_ci_class.assert_called_once_with(
             region='ap-northeast-1',
-            integration_source='awslabs-mcp-code-interpreter-server',
+            integration_source='awslabs-agentcore-mcp-server',
         )
 
 
@@ -144,7 +144,7 @@ class TestCreateSessionClient:
 
         mock_ci_class.assert_called_once_with(
             region='eu-west-1',
-            integration_source='awslabs-mcp-code-interpreter-server',
+            integration_source='awslabs-agentcore-mcp-server',
         )
 
 


### PR DESCRIPTION
## Summary

- Fix `MCP_INTEGRATION_SOURCE` in the Code Interpreter client from `awslabs-mcp-code-interpreter-server` to `awslabs-agentcore-mcp-server` to match the unified server name
- Update 3 test assertions to match

## Test plan

- [x] Existing unit tests pass with updated assertion values
- [x] No functional change — only the `integration_source` string sent in boto3 client constructor

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).