### PR TITLE
fix(iam-mcp-server): remove accidental ctx parameter leak blocking list_users, get_user, create_user

### DIFF
--- a/src/iam-mcp-server/CHANGELOG.md
+++ b/src/iam-mcp-server/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the AWS IAM MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `list_users`, `get_user`, and `create_user` were unusable because their handler signatures declared `ctx: CallToolResult` as a required parameter. `CallToolResult` is a response type from `mcp.types`, not the FastMCP injectable `Context`, so FastMCP exposed `ctx` in the JSON schema as a required client-facing argument that no MCP client could satisfy. Calls consistently failed with `1 validation error for list_usersArguments: ctx Field required`. The `ctx` parameter was never referenced in the handler bodies and has been removed, matching the signature shape of all other tools in the server.
+
 ## [1.1.0] - 2025-06-23
 
 ### Added

--- a/src/iam-mcp-server/awslabs/iam_mcp_server/server.py
+++ b/src/iam-mcp-server/awslabs/iam_mcp_server/server.py
@@ -38,7 +38,6 @@ from awslabs.iam_mcp_server.models import (
 )
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
-from mcp.types import CallToolResult
 from pydantic import Field
 from typing import Any, Dict, List, Optional, Union
 
@@ -161,7 +160,6 @@ mcp = FastMCP(
 
 @mcp.tool()
 async def list_users(
-    ctx: CallToolResult,
     path_prefix: Optional[str] = Field(
         description='Path prefix to filter users (e.g., "/division_abc/")', default=None
     ),
@@ -178,7 +176,6 @@ async def list_users(
     - Results may be paginated for accounts with many users
 
     Args:
-        ctx: MCP context for error reporting
         path_prefix: Optional path prefix to filter users
         max_items: Maximum number of users to return
 
@@ -229,7 +226,7 @@ async def list_users(
 
 @mcp.tool()
 async def get_user(
-    ctx: CallToolResult, user_name: str = Field(description='The name of the IAM user to retrieve')
+    user_name: str = Field(description='The name of the IAM user to retrieve'),
 ) -> UserDetailsResponse:
     """Get detailed information about a specific IAM user.
 
@@ -243,7 +240,6 @@ async def get_user(
     - Check access keys to identify potential security issues
 
     Args:
-        ctx: MCP context for error reporting
         user_name: The name of the IAM user
 
     Returns:
@@ -317,7 +313,6 @@ async def get_user(
 
 @mcp.tool()
 async def create_user(
-    ctx: CallToolResult,
     user_name: str = Field(description='The name of the new IAM user'),
     path: str = Field(description='The path for the user', default='/'),
     permissions_boundary: Optional[str] = Field(
@@ -339,7 +334,6 @@ async def create_user(
     - Follow the principle of least privilege when assigning permissions later
 
     Args:
-        ctx: MCP context for error reporting
         user_name: The name of the new IAM user
         path: The path for the user (default: '/')
         permissions_boundary: Optional ARN of the permissions boundary policy

--- a/src/iam-mcp-server/tests/test_server.py
+++ b/src/iam-mcp-server/tests/test_server.py
@@ -28,7 +28,7 @@ from awslabs.iam_mcp_server.errors import (
 from awslabs.iam_mcp_server.models import UsersListResponse
 from botocore.exceptions import ClientError as BotoClientError
 from datetime import datetime
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 
 def test_get_iam_client():
@@ -122,14 +122,12 @@ async def test_list_users_mock():
         'IsTruncated': False,
     }
 
-    mock_ctx = AsyncMock()
-
     with patch('awslabs.iam_mcp_server.server.get_iam_client') as mock_get_client:
         mock_client = Mock()
         mock_client.list_users.return_value = mock_response
         mock_get_client.return_value = mock_client
 
-        result = await list_users(mock_ctx)
+        result = await list_users()
 
         assert isinstance(result, UsersListResponse)
         assert len(result.users) == 1
@@ -146,10 +144,8 @@ async def test_create_user_readonly_mode():
     # Set readonly mode
     Context.initialize(readonly=True)
 
-    mock_ctx = AsyncMock()
-
     with pytest.raises(IamClientError) as exc_info:
-        await create_user(mock_ctx, user_name='test-user', confirmed=False)
+        await create_user(user_name='test-user', confirmed=False)
 
     assert 'read-only mode' in str(exc_info.value)
 
@@ -173,14 +169,12 @@ async def test_create_user_success():
         }
     }
 
-    mock_ctx = AsyncMock()
-
     with patch('awslabs.iam_mcp_server.server.get_iam_client') as mock_get_client:
         mock_client = Mock()
         mock_client.create_user.return_value = mock_response
         mock_get_client.return_value = mock_client
 
-        result = await create_user(mock_ctx, user_name='new-user')
+        result = await create_user(user_name='new-user')
 
         assert isinstance(result, CreateUserResponse)
         assert result.user.user_name == 'new-user'
@@ -507,8 +501,6 @@ async def test_get_user():
         ]
     }
 
-    mock_ctx = AsyncMock()
-
     with patch('awslabs.iam_mcp_server.server.get_iam_client') as mock_get_client:
         mock_client = Mock()
         mock_client.get_user.return_value = mock_user_response
@@ -518,7 +510,7 @@ async def test_get_user():
         mock_client.list_access_keys.return_value = mock_keys_response
         mock_get_client.return_value = mock_client
 
-        result = await get_user(mock_ctx, user_name='test-user')
+        result = await get_user(user_name='test-user')
 
         assert result.user.user_name == 'test-user'
         assert len(result.attached_policies) == 1
@@ -1786,10 +1778,9 @@ async def test_confirmation_gate_create_user():
     from awslabs.iam_mcp_server.server import create_user
 
     Context.initialize(readonly=False, require_confirmation=True)
-    mock_ctx = Mock()
 
     with pytest.raises(IamValidationError) as exc_info:
-        await create_user(mock_ctx, user_name='test-user', confirmed=False)
+        await create_user(user_name='test-user', confirmed=False)
     assert 'CONFIRMATION REQUIRED' in str(exc_info.value)
 
 
@@ -2257,3 +2248,23 @@ async def test_trust_policy_multiple_allow_statements():
             confirmed=True,
         )
         assert result['Role']['RoleName'] == 'multi-principal-role'
+
+
+@pytest.mark.asyncio
+async def test_registered_tool_schemas_have_no_leaked_context_param():
+    """Regression: no registered tool should expose an internal `ctx` parameter.
+
+    Previously, `list_users`, `get_user`, and `create_user` annotated `ctx` as
+    `mcp.types.CallToolResult` (a response type). FastMCP only auto-injects
+    parameters typed as `Context`; anything else becomes a required client-facing
+    argument, which made those tools unusable from every MCP client.
+    """
+    from awslabs.iam_mcp_server.server import mcp
+
+    tools = await mcp.list_tools()
+    offenders = []
+    for tool in tools:
+        params = (tool.inputSchema or {}).get('properties', {}) or {}
+        if 'ctx' in params:
+            offenders.append(tool.name)
+    assert not offenders, f'Tools leaking internal ctx param into public schema: {offenders}'


### PR DESCRIPTION
## Problem

In `awslabs.iam-mcp-server`, three tools are unusable from every MCP client: `list_users`, `get_user`, and `create_user`. Each call fails schema validation with:

```
1 validation error for list_usersArguments
ctx   Field required [type=missing]
```

Reproduced against `awslabs.iam-mcp-server@1.0.17` via stdio transport; the same signatures are present on `main`.

## Root cause

In `src/iam-mcp-server/awslabs/iam_mcp_server/server.py`, those three handlers annotate `ctx` as `mcp.types.CallToolResult`:

```python
from mcp.types import CallToolResult
...
async def list_users(
    ctx: CallToolResult,   # ← wrong type
    path_prefix: Optional[str] = Field(...),
    ...
```

`CallToolResult` is a server-side **response** type, not the FastMCP injectable `Context`. FastMCP only auto-injects (and strips from the schema) parameters typed as `Context`; any other type is treated as a normal client-facing parameter. Because `ctx` has no default, it becomes a required schema property that no MCP client can populate, so every call fails before reaching the handler body.

The remaining ~30 tools in the file don't declare a `ctx` parameter and work correctly — confirming this was accidental. `ctx` is not referenced inside any of the three handler bodies either (only in docstrings), so removing it is safe.

## Fix

- Drop the `ctx` parameter from the three handler signatures and their docstring `Args:` blocks.
- Remove the now-unused `from mcp.types import CallToolResult` import.
- Update four test call sites that passed a positional `mock_ctx` (and drop the now-unused `AsyncMock` import).
- Add `test_registered_tool_schemas_have_no_leaked_context_param` — a regression test that iterates all registered tools via `mcp.list_tools()` and asserts none expose a `ctx` property in their `inputSchema`.
- Add an Unreleased section to `CHANGELOG.md` describing the fix.

## Verification

```
$ uv venv --python 3.10 && uv sync --all-groups
$ .venv/bin/python -m pytest tests/
============================= 166 passed in 0.57s ==============================

$ pre-commit run --files src/iam-mcp-server/awslabs/iam_mcp_server/server.py \
                        src/iam-mcp-server/tests/test_server.py \
                        src/iam-mcp-server/CHANGELOG.md
... all hooks pass (ruff check, ruff format, license header, secrets, etc.)
```

No behavior change for any working tool; three previously broken tools now callable.

## Backward compatibility

The tool schemas change (required `ctx` goes away), but since every client was already rejected by the old schema, there are no callers in the field that could break.