### PR TITLE
feat(agentcore): Add operational Policy tools sub-package

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/__init__.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Policy tools sub-package for the unified AgentCore MCP server.
+
+Provides 15 policy tools via Amazon Bedrock AgentCore Policy APIs.
+
+Tools that create billable resources or incur compute costs:
+- policy_engine_create: Provisions a policy engine (AWS infrastructure charges)
+- policy_create: Invokes validation pipeline and provisions a policy
+- policy_update: Re-invokes validation pipeline
+- policy_generation_start: AI-powered generation (foundation model
+  invocation; typically the most expensive Policy operation per call)
+
+Read-only tools (no cost):
+- policy_engine_get, policy_engine_list,
+  policy_get, policy_list,
+  policy_generation_get, policy_generation_list,
+  policy_generation_list_assets,
+  get_policy_guide
+
+Destructive tools (permanent, irreversible):
+- policy_engine_delete: Permanently deletes a policy engine
+  (requires zero associated policies first)
+- policy_delete: Permanently deletes a policy
+"""
+
+from .engines import PolicyEngineTools
+from .generations import PolicyGenerationTools
+from .guide import GuideTools
+from .policies import PolicyTools
+from .policy_client import get_policy_client
+from loguru import logger
+
+
+def register_policy_tools(mcp):
+    """Register all Policy tools with the MCP server.
+
+    Creates a cached boto3 client for the Policy control plane and
+    registers all tool groups against it.
+    """
+    groups = [
+        ('engines', PolicyEngineTools, get_policy_client),
+        ('policies', PolicyTools, get_policy_client),
+        ('generations', PolicyGenerationTools, get_policy_client),
+        ('guide', GuideTools, None),
+    ]
+    for name, cls, client_factory in groups:
+        try:
+            if client_factory is not None:
+                cls(client_factory).register(mcp)
+            else:
+                cls().register(mcp)
+        except Exception as e:
+            raise RuntimeError(f'Failed to register policy {name} tools: {e}') from e
+    logger.info('All policy tool groups registered successfully')

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/engines.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/engines.py
@@ -1,0 +1,265 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Policy Engine tools for AgentCore Policy control plane.
+
+A Policy Engine is a top-level authorization container that holds
+Cedar-based policies. Engines can be attached to Gateways to enforce
+access control on tool invocations.
+"""
+
+from .error_handler import handle_policy_error
+from .models import (
+    DeletePolicyEngineResponse,
+    ErrorResponse,
+    ListPolicyEnginesResponse,
+    PolicyEngineResponse,
+)
+from loguru import logger
+from mcp.server.fastmcp import Context
+from pydantic import Field
+from typing import Annotated, Any
+
+
+class PolicyEngineTools:
+    """Tools for managing AgentCore Policy Engines."""
+
+    def __init__(self, client_factory):
+        """Initialize with a callable that returns a boto3 control plane client."""
+        self._get_client = client_factory
+
+    def register(self, mcp):
+        """Register policy engine tools with the MCP server."""
+        mcp.tool(name='policy_engine_create')(self.policy_engine_create)
+        mcp.tool(name='policy_engine_get')(self.policy_engine_get)
+        mcp.tool(name='policy_engine_update')(self.policy_engine_update)
+        mcp.tool(name='policy_engine_delete')(self.policy_engine_delete)
+        mcp.tool(name='policy_engine_list')(self.policy_engine_list)
+
+    async def policy_engine_create(
+        self,
+        ctx: Context,
+        name: Annotated[
+            str,
+            Field(
+                description=(
+                    'Immutable name for the policy engine, unique within the '
+                    'account. Pattern: [A-Za-z][A-Za-z0-9_]*, max 48 chars.'
+                )
+            ),
+        ],
+        description: Annotated[
+            str | None,
+            Field(description='Purpose and scope of the policy engine (1-4096 chars)'),
+        ] = None,
+        encryption_key_arn: Annotated[
+            str | None,
+            Field(description='KMS key ARN for encryption at rest'),
+        ] = None,
+        client_token: Annotated[
+            str | None,
+            Field(description='Idempotency token (33-256 chars)'),
+        ] = None,
+        tags: Annotated[
+            dict[str, str] | None,
+            Field(description='Tags as key-value pairs (max 50)'),
+        ] = None,
+    ) -> PolicyEngineResponse | ErrorResponse:
+        """Create a new AgentCore Policy Engine.
+
+        COST WARNING: Creating a policy engine provisions AWS
+        infrastructure and incurs AWS charges. The engine starts in
+        CREATING status and transitions to ACTIVE when ready. Use
+        policy_engine_get to poll the status.
+
+        Returns the created policy engine details including its ID and ARN.
+        """
+        logger.info(f'Creating policy engine: {name}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {'name': name}
+            if description is not None:
+                kwargs['description'] = description
+            if encryption_key_arn is not None:
+                kwargs['encryptionKeyArn'] = encryption_key_arn
+            if client_token is not None:
+                kwargs['clientToken'] = client_token
+            if tags is not None:
+                kwargs['tags'] = tags
+
+            response = client.create_policy_engine(**kwargs)
+
+            return PolicyEngineResponse(
+                status='success',
+                message=(
+                    f'Policy engine "{name}" creation requested. '
+                    f'ID: {response.get("policyEngineId", "unknown")}. '
+                    f'Status: {response.get("status", "CREATING")}.'
+                ),
+                policy_engine=response,
+            )
+        except Exception as e:
+            return handle_policy_error('CreatePolicyEngine', e)
+
+    async def policy_engine_get(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(
+                description=(
+                    'Policy engine ID (12-59 chars). Pattern: [A-Za-z][A-Za-z0-9_]*-[a-z0-9_]{10}'
+                )
+            ),
+        ],
+    ) -> PolicyEngineResponse | ErrorResponse:
+        """Get details of an AgentCore Policy Engine.
+
+        Returns the policy engine including status, encryption config,
+        and timestamps. This is a read-only operation with no cost
+        implications.
+        """
+        logger.info(f'Getting policy engine: {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            response = client.get_policy_engine(policyEngineId=policy_engine_id)
+
+            return PolicyEngineResponse(
+                status='success',
+                message=(
+                    f'Policy engine {policy_engine_id} retrieved. '
+                    f'Status: {response.get("status", "UNKNOWN")}.'
+                ),
+                policy_engine=response,
+            )
+        except Exception as e:
+            return handle_policy_error('GetPolicyEngine', e)
+
+    async def policy_engine_update(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Policy engine ID to update'),
+        ],
+        description: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    'UpdatedDescription object with "optionalValue" key. '
+                    'Set {"optionalValue": "new text"} to change the '
+                    'description, or {"optionalValue": null} to clear it. '
+                    'Omit the parameter entirely to leave the description '
+                    'unchanged.'
+                )
+            ),
+        ] = None,
+    ) -> PolicyEngineResponse | ErrorResponse:
+        """Update an AgentCore Policy Engine.
+
+        Currently only the description can be updated. The engine's name
+        and encryption configuration are immutable after creation.
+        """
+        logger.info(f'Updating policy engine: {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {'policyEngineId': policy_engine_id}
+            if description is not None:
+                kwargs['description'] = description
+
+            response = client.update_policy_engine(**kwargs)
+
+            return PolicyEngineResponse(
+                status='success',
+                message=(
+                    f'Policy engine {policy_engine_id} update requested. '
+                    f'Status: {response.get("status", "UPDATING")}.'
+                ),
+                policy_engine=response,
+            )
+        except Exception as e:
+            return handle_policy_error('UpdatePolicyEngine', e)
+
+    async def policy_engine_delete(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Policy engine ID to delete'),
+        ],
+    ) -> DeletePolicyEngineResponse | ErrorResponse:
+        """Delete an AgentCore Policy Engine.
+
+        WARNING: This permanently deletes the policy engine. The engine
+        must not have any associated policies before deletion — delete
+        all policies first with policy_delete, then delete the engine.
+        This action cannot be undone.
+        """
+        logger.info(f'Deleting policy engine: {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            response = client.delete_policy_engine(policyEngineId=policy_engine_id)
+
+            return DeletePolicyEngineResponse(
+                status='success',
+                message=f'Policy engine {policy_engine_id} deletion requested.',
+                policy_engine_id=response.get('policyEngineId', policy_engine_id),
+                policy_engine_status=response.get('status', 'DELETING'),
+            )
+        except Exception as e:
+            return handle_policy_error('DeletePolicyEngine', e)
+
+    async def policy_engine_list(
+        self,
+        ctx: Context,
+        max_results: Annotated[
+            int | None,
+            Field(description='Max results per page (1-100, default 10)'),
+        ] = None,
+        next_token: Annotated[
+            str | None,
+            Field(description='Pagination token from previous response'),
+        ] = None,
+    ) -> ListPolicyEnginesResponse | ErrorResponse:
+        """List AgentCore Policy Engines in the account.
+
+        Returns policy engine summaries with IDs, ARNs, status, and
+        timestamps. This is a read-only operation with no cost
+        implications.
+        """
+        logger.info('Listing policy engines')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {}
+            if max_results is not None:
+                kwargs['maxResults'] = max_results
+            if next_token is not None:
+                kwargs['nextToken'] = next_token
+
+            response = client.list_policy_engines(**kwargs)
+            engines = response.get('policyEngines', [])
+
+            return ListPolicyEnginesResponse(
+                status='success',
+                message=f'Found {len(engines)} policy engine(s).',
+                policy_engines=engines,
+                next_token=response.get('nextToken'),
+            )
+        except Exception as e:
+            return handle_policy_error('ListPolicyEngines', e)

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/error_handler.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/error_handler.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Error handling utilities for AgentCore Policy tools."""
+
+from .models import ErrorResponse
+from botocore.exceptions import ClientError
+from loguru import logger
+
+
+def handle_policy_error(operation: str, error: Exception) -> ErrorResponse:
+    """Convert an exception into a structured ErrorResponse.
+
+    Extracts error code, message, and HTTP status from botocore ClientError.
+    Falls back to generic error info for other exception types.
+
+    Args:
+        operation: Name of the operation that failed (e.g. 'CreatePolicyEngine').
+        error: The exception that was raised.
+
+    Returns:
+        ErrorResponse with structured error details.
+    """
+    if isinstance(error, ClientError):
+        error_info = error.response.get('Error', {})
+        code = error_info.get('Code', 'Unknown')
+        msg = error_info.get('Message', str(error))
+        http_status = str(error.response.get('ResponseMetadata', {}).get('HTTPStatusCode', ''))
+        logger.error(f'{operation} failed: {code} - {msg}')
+        return ErrorResponse(
+            message=f'{operation} failed: {msg}',
+            error_type=code,
+            error_code=http_status,
+        )
+
+    logger.error(f'{operation} failed: {type(error).__name__}: {error}')
+    return ErrorResponse(
+        message=f'{operation} failed: {error}',
+        error_type=type(error).__name__,
+    )

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/generations.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/generations.py
@@ -1,0 +1,276 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Policy Generation tools for AgentCore Policy control plane.
+
+Policy generation uses AI to translate natural-language policy intent
+into Cedar policy statements. Generated assets auto-delete after 7 days;
+reference them in policy_create via the "policyGeneration" union variant
+to promote them into persistent policies.
+"""
+
+from .error_handler import handle_policy_error
+from .models import (
+    ErrorResponse,
+    ListPolicyGenerationAssetsResponse,
+    ListPolicyGenerationsResponse,
+    PolicyGenerationResponse,
+)
+from loguru import logger
+from mcp.server.fastmcp import Context
+from pydantic import Field
+from typing import Annotated, Any
+
+
+class PolicyGenerationTools:
+    """Tools for AI-powered Cedar policy generation."""
+
+    def __init__(self, client_factory):
+        """Initialize with a callable that returns a boto3 control plane client."""
+        self._get_client = client_factory
+
+    def register(self, mcp):
+        """Register policy generation tools with the MCP server."""
+        mcp.tool(name='policy_generation_start')(self.policy_generation_start)
+        mcp.tool(name='policy_generation_get')(self.policy_generation_get)
+        mcp.tool(name='policy_generation_list')(self.policy_generation_list)
+        mcp.tool(name='policy_generation_list_assets')(self.policy_generation_list_assets)
+
+    async def policy_generation_start(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Policy engine ID providing context for generation'),
+        ],
+        name: Annotated[
+            str,
+            Field(
+                description=(
+                    'Name for tracking this generation request. '
+                    'Pattern: [A-Za-z][A-Za-z0-9_]*, max 48 chars.'
+                )
+            ),
+        ],
+        content: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    'Content union. Specify key "rawText" with a natural-'
+                    'language description (1-2000 chars) of the desired '
+                    'policy behavior. Example: '
+                    '{"rawText": "Allow users in group Admins to invoke '
+                    'the weather tool during business hours"}.'
+                )
+            ),
+        ],
+        resource: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    'Resource union identifying the target for this '
+                    'policy. Specify key "arn" with the resource ARN '
+                    '(20-1011 chars). Currently only Gateway ARNs are '
+                    'supported. Example: '
+                    '{"arn": "arn:aws:bedrock-agentcore:us-east-1:'
+                    '123456789012:gateway/my-gateway-abc123"}.'
+                )
+            ),
+        ],
+        client_token: Annotated[
+            str | None,
+            Field(description='Idempotency token (33-256 chars)'),
+        ] = None,
+    ) -> PolicyGenerationResponse | ErrorResponse:
+        """Start an AI-powered Cedar policy generation from natural language.
+
+        COST WARNING: Policy generation invokes foundation models and
+        consumes significant compute resources. This is typically the
+        most expensive Policy operation per call. Each invocation incurs
+        AWS charges.
+
+        The generation is asynchronous — starts in GENERATING and
+        transitions to GENERATED or GENERATE_FAILED. Poll with
+        policy_generation_get. Generated assets auto-delete after 7
+        days. To persist a generated policy, reference its asset in
+        policy_create via the "policyGeneration" union variant.
+        """
+        logger.info(f'Starting policy generation "{name}" in engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {
+                'policyEngineId': policy_engine_id,
+                'name': name,
+                'content': content,
+                'resource': resource,
+            }
+            if client_token is not None:
+                kwargs['clientToken'] = client_token
+
+            response = client.start_policy_generation(**kwargs)
+
+            return PolicyGenerationResponse(
+                status='success',
+                message=(
+                    f'Policy generation "{name}" started. '
+                    f'ID: {response.get("policyGenerationId", "unknown")}. '
+                    f'Status: {response.get("status", "GENERATING")}.'
+                ),
+                policy_generation=response,
+            )
+        except Exception as e:
+            return handle_policy_error('StartPolicyGeneration', e)
+
+    async def policy_generation_get(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Policy engine ID'),
+        ],
+        policy_generation_id: Annotated[
+            str,
+            Field(description='Policy generation ID (12-59 chars)'),
+        ],
+    ) -> PolicyGenerationResponse | ErrorResponse:
+        """Get details of an AgentCore Policy Generation.
+
+        Returns the generation including status, findings, and resource
+        context. Use to poll after policy_generation_start. This is a
+        read-only operation with no cost implications.
+        """
+        logger.info(
+            f'Getting policy generation {policy_generation_id} in engine {policy_engine_id}'
+        )
+
+        try:
+            client = self._get_client()
+            response = client.get_policy_generation(
+                policyEngineId=policy_engine_id,
+                policyGenerationId=policy_generation_id,
+            )
+
+            return PolicyGenerationResponse(
+                status='success',
+                message=(
+                    f'Policy generation {policy_generation_id} retrieved. '
+                    f'Status: {response.get("status", "UNKNOWN")}.'
+                ),
+                policy_generation=response,
+            )
+        except Exception as e:
+            return handle_policy_error('GetPolicyGeneration', e)
+
+    async def policy_generation_list(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Policy engine ID'),
+        ],
+        max_results: Annotated[
+            int | None,
+            Field(description='Max results per page (1-100)'),
+        ] = None,
+        next_token: Annotated[
+            str | None,
+            Field(description='Pagination token'),
+        ] = None,
+    ) -> ListPolicyGenerationsResponse | ErrorResponse:
+        """List policy generations within a Policy Engine.
+
+        Returns policy generation summaries with IDs, ARNs, status,
+        resource context, and timestamps. Generated assets auto-delete
+        after 7 days. This is a read-only operation with no cost
+        implications.
+        """
+        logger.info(f'Listing policy generations in engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {'policyEngineId': policy_engine_id}
+            if max_results is not None:
+                kwargs['maxResults'] = max_results
+            if next_token is not None:
+                kwargs['nextToken'] = next_token
+
+            response = client.list_policy_generations(**kwargs)
+            generations = response.get('policyGenerations', [])
+
+            return ListPolicyGenerationsResponse(
+                status='success',
+                message=f'Found {len(generations)} policy generation(s).',
+                policy_generations=generations,
+                next_token=response.get('nextToken'),
+            )
+        except Exception as e:
+            return handle_policy_error('ListPolicyGenerations', e)
+
+    async def policy_generation_list_assets(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Policy engine ID'),
+        ],
+        policy_generation_id: Annotated[
+            str,
+            Field(description='Policy generation ID'),
+        ],
+        max_results: Annotated[
+            int | None,
+            Field(description='Max results per page (1-100, default 10)'),
+        ] = None,
+        next_token: Annotated[
+            str | None,
+            Field(description='Pagination token'),
+        ] = None,
+    ) -> ListPolicyGenerationAssetsResponse | ErrorResponse:
+        """List Cedar policies and findings produced by policy generation.
+
+        Returns generated policy assets — each with its Cedar definition
+        (if translatable), the original natural-language fragment, and
+        validation findings (VALID, INVALID, NOT_TRANSLATABLE, ALLOW_ALL,
+        ALLOW_NONE, DENY_ALL, DENY_NONE). Use assets with VALID findings
+        in policy_create via the "policyGeneration" definition variant.
+        This is a read-only operation with no cost implications.
+        """
+        logger.info(
+            f'Listing assets for policy generation {policy_generation_id} '
+            f'in engine {policy_engine_id}'
+        )
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {
+                'policyEngineId': policy_engine_id,
+                'policyGenerationId': policy_generation_id,
+            }
+            if max_results is not None:
+                kwargs['maxResults'] = max_results
+            if next_token is not None:
+                kwargs['nextToken'] = next_token
+
+            response = client.list_policy_generation_assets(**kwargs)
+            assets = response.get('policyGenerationAssets', [])
+
+            return ListPolicyGenerationAssetsResponse(
+                status='success',
+                message=f'Found {len(assets)} policy generation asset(s).',
+                policy_generation_assets=assets,
+                next_token=response.get('nextToken'),
+            )
+        except Exception as e:
+            return handle_policy_error('ListPolicyGenerationAssets', e)

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/guide.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/guide.py
@@ -1,0 +1,470 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static guide tool for AgentCore Policy."""
+
+from .models import PolicyGuideResponse
+from mcp.server.fastmcp import Context
+
+
+POLICY_GUIDE = """
+# AgentCore Policy — Comprehensive Guide
+
+## Overview
+
+AgentCore Policy provides Cedar-based authorization for agent tool
+invocations. It has three primary concepts:
+
+- **Policy Engine** — Top-level container that holds a set of Cedar
+  policies. Attached to a Gateway to enforce access control on tools
+  exposed through that gateway.
+- **Policy** — A Cedar policy statement defining who (principals) can
+  perform what (actions) on which resources, under which conditions.
+  Cedar uses a default-deny model; `forbid` statements override
+  `permit` statements.
+- **Policy Generation** — AI-powered translation of natural-language
+  policy intent into Cedar syntax. Produces candidate assets you
+  review and promote into real policies.
+
+---
+
+## Prerequisites
+
+### For MCP tools (this sub-package)
+- AWS credentials configured (AWS_PROFILE, AWS_ACCESS_KEY_ID, or IAM role)
+- AWS_REGION environment variable (defaults to us-east-1)
+- No additional installation — tools use boto3 bundled with the MCP server
+
+### For CLI commands referenced in this guide
+The `agentcore` CLI is a separate tool for project scaffolding,
+deployment, and management. Install it before using any `agentcore`
+commands:
+
+```bash
+npm install -g @aws/agentcore-cli
+```
+
+For installation details, supported platforms, and authentication setup,
+see: https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore-cli.html
+
+Note: The MCP tools in this server call the AgentCore APIs directly via
+boto3. You do NOT need the CLI installed to use the MCP tools. The CLI
+is only needed if you want to use the project scaffolding and deployment
+commands described in the "CLI Commands" section below.
+
+---
+
+## Tool Cost Tiers
+
+### Read-only tools (no cost)
+- policy_engine_get — Get policy engine details
+- policy_engine_list — List policy engines
+- policy_get — Get policy details (use to poll async status)
+- policy_list — List policies in an engine
+- policy_generation_get — Get generation details (use to poll async status)
+- policy_generation_list — List generations in an engine
+- policy_generation_list_assets — List generated policy assets
+- get_policy_guide — This guide
+
+### Tools that create billable resources or incur compute costs
+- policy_engine_create — Provisions a policy engine (infrastructure charges)
+- policy_create — Invokes validation pipeline and provisions a policy
+- policy_update — Re-invokes validation pipeline
+- policy_generation_start — AI-powered generation (foundation model
+  invocation; typically the most expensive Policy operation per call)
+
+### Destructive tools (permanent, irreversible)
+- policy_engine_delete — Permanently deletes the policy engine
+  (requires zero associated policies first)
+- policy_delete — Permanently deletes a policy
+
+---
+
+## CLI Commands
+
+Policy engines and policies are declared in `agentcore.json` under the
+top-level `policyEngines` array and created during `agentcore deploy`.
+The CLI does not currently provide dedicated `agentcore add policy-engine`
+or `agentcore add policy` subcommands — edit `agentcore.json` directly
+and redeploy.
+
+### Attach a policy engine to a Gateway
+
+```bash
+agentcore add gateway \
+  --name MyGateway \
+  --runtimes MyAgent \
+  --policy-engine MyPolicyEngine \
+  --policy-engine-mode LOG_ONLY
+```
+
+| Flag                          | Description                                |
+| ----------------------------- | ------------------------------------------ |
+| `--policy-engine <n>`         | Policy engine name (must exist in config)  |
+| `--policy-engine-mode <mode>` | `LOG_ONLY` or `ENFORCE`                    |
+
+### Check policy deployment status
+
+```bash
+# All policy engines
+agentcore status --type policy-engine
+
+# All policies
+agentcore status --type policy
+
+# JSON output
+agentcore status --type policy-engine --json
+```
+
+### Deploy policy engine and policies
+
+After editing `agentcore.json`, run:
+
+```bash
+agentcore deploy -y
+```
+
+Async status transitions (CREATING → ACTIVE, UPDATING → ACTIVE,
+DELETING → deleted) can be polled via the MCP tools `policy_engine_get`
+and `policy_get`, or via `agentcore status`.
+
+---
+
+## agentcore.json Schema — policyEngines Section
+
+```json
+{
+  "policyEngines": [
+    {
+      "name": "MyPolicyEngine",
+      "description": "Authorization for production tools",
+      "encryptionKeyArn": "arn:aws:kms:us-east-1:123:key/abc",
+      "tags": { "env": "prod" },
+      "policies": [
+        {
+          "name": "AdminFullAccess",
+          "description": "Admins can invoke all tools",
+          "statement": "permit(principal in Group::\\"Admins\\", action, resource);",
+          "validationMode": "FAIL_ON_ANY_FINDINGS"
+        },
+        {
+          "name": "RestrictWeatherToBusinessHours",
+          "description": "Weather tool allowed 9am-5pm only",
+          "sourceFile": "policies/business-hours.cedar"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Schema constraints
+
+- **policyEngines[].name**: Pattern `[A-Za-z][A-Za-z0-9_]*`, 1-48 chars,
+  required. Immutable after creation.
+- **policyEngines[].description**: 1-4096 chars, optional.
+- **policyEngines[].encryptionKeyArn**: KMS key ARN for encryption at
+  rest, optional.
+- **policyEngines[].tags**: Map of tag key → tag value, optional
+  (max 50 tags).
+- **policyEngines[].policies[].name**: Pattern
+  `[A-Za-z][A-Za-z0-9_]*`, 1-48 chars, required. Immutable.
+- **policyEngines[].policies[].statement**: Cedar policy text
+  (35-10000 chars when sent to the API). Required unless `sourceFile`
+  is used.
+- **policyEngines[].policies[].sourceFile**: Path to a `.cedar` file
+  relative to the project root. CLI-only convenience; the file
+  contents are read at deploy time and passed as `statement`.
+- **policyEngines[].policies[].validationMode**:
+  `FAIL_ON_ANY_FINDINGS` (default) or `IGNORE_ALL_FINDINGS`.
+
+### Attaching a policy engine to a gateway
+
+The gateway config carries a `policyEngineConfiguration` block:
+
+```json
+{
+  "gateways": [
+    {
+      "name": "MyGateway",
+      "policyEngineConfiguration": {
+        "policyEngineName": "MyPolicyEngine",
+        "mode": "ENFORCE"
+      }
+    }
+  ]
+}
+```
+
+- **mode**: `LOG_ONLY` evaluates policies and logs decisions but does
+  not block. `ENFORCE` actively allows or denies based on policy
+  evaluation. Always deploy first in `LOG_ONLY`, inspect the logs,
+  then switch to `ENFORCE`.
+
+---
+
+## Common Patterns
+
+### Create a policy engine and a policy via MCP tools
+
+```python
+# 1. Create the engine
+await policy_engine_create(
+    name="ProdAuth",
+    description="Production authorization rules",
+)
+# Poll: await policy_engine_get(policy_engine_id="ProdAuth-abcdefghij")
+# Wait for status == "ACTIVE"
+
+# 2. Create a Cedar policy inside it
+await policy_create(
+    policy_engine_id="ProdAuth-abcdefghij",
+    name="AdminAccess",
+    definition={
+        "cedar": {
+            "statement": (
+                'permit(principal in Group::"Admins", '
+                'action, resource);'
+            )
+        }
+    },
+    validation_mode="FAIL_ON_ANY_FINDINGS",
+)
+# Poll: await policy_get(policy_engine_id=..., policy_id=...)
+```
+
+### Generate a policy from natural language
+
+```python
+# 1. Start generation
+gen = await policy_generation_start(
+    policy_engine_id="ProdAuth-abcdefghij",
+    name="BusinessHoursGen",
+    content={
+        "rawText": (
+            "Allow Admins to invoke any tool. Allow Users to "
+            "invoke the weather tool only between 9am and 5pm UTC."
+        )
+    },
+    resource={
+        "arn": (
+            "arn:aws:bedrock-agentcore:us-east-1:123456789012:"
+            "gateway/my-gateway-abc123"
+        )
+    },
+)
+# Poll: await policy_generation_get(...)
+# Wait for status == "GENERATED"
+
+# 2. Review the generated assets
+assets = await policy_generation_list_assets(
+    policy_engine_id="ProdAuth-abcdefghij",
+    policy_generation_id="BusinessHoursGen-abcdefghij",
+)
+# Inspect each asset's "findings" — only promote those with "VALID".
+
+# 3. Promote a valid asset into a real policy
+await policy_create(
+    policy_engine_id="ProdAuth-abcdefghij",
+    name="BusinessHoursPolicy",
+    definition={
+        "policyGeneration": {
+            "policyGenerationId": "BusinessHoursGen-abcdefghij",
+            "policyGenerationAssetId": "asset-abcdefghij",
+        }
+    },
+)
+```
+
+### Update only the description of an engine or policy
+
+```python
+# Update description
+await policy_engine_update(
+    policy_engine_id="ProdAuth-abcdefghij",
+    description={"optionalValue": "Updated description"},
+)
+
+# Clear description
+await policy_engine_update(
+    policy_engine_id="ProdAuth-abcdefghij",
+    description={"optionalValue": None},
+)
+
+# Leave description unchanged — simply omit the parameter entirely.
+```
+
+### Delete order
+
+Engines cannot be deleted while they hold policies. The correct order is:
+
+```python
+# 1. List and delete all policies in the engine
+policies = await policy_list(policy_engine_id="ProdAuth-abcdefghij")
+for p in policies.policies:
+    await policy_delete(
+        policy_engine_id="ProdAuth-abcdefghij",
+        policy_id=p["policyId"],
+    )
+    # Poll policy_get until deletion completes
+
+# 2. Then delete the engine
+await policy_engine_delete(policy_engine_id="ProdAuth-abcdefghij")
+```
+
+---
+
+## Validation Modes and Findings
+
+When a policy is created or updated, Cedar validates it against the
+schema derived from the associated Gateway's tools. Each finding has
+a type:
+
+| Finding Type       | Meaning                                               |
+| ------------------ | ----------------------------------------------------- |
+| `VALID`            | Policy is ready to use                                |
+| `INVALID`          | Policy has validation errors that must be fixed      |
+| `NOT_TRANSLATABLE` | Input couldn't be converted to a policy (generation) |
+| `ALLOW_ALL`        | Policy would allow all actions (security risk)       |
+| `ALLOW_NONE`       | Policy would allow no actions (unusable)             |
+| `DENY_ALL`         | Policy would deny all actions (over-restrictive)     |
+| `DENY_NONE`        | Policy would deny no actions (ineffective)           |
+
+`FAIL_ON_ANY_FINDINGS` (default) rejects the create/update if any
+finding is present. `IGNORE_ALL_FINDINGS` creates the policy
+regardless — use sparingly and only after manual review.
+
+---
+
+## Troubleshooting
+
+### Policy engine stuck in CREATING
+- Check the engine's `statusReasons` via `policy_engine_get`
+- Verify KMS key permissions if `encryptionKeyArn` was provided
+- Check AWS CloudTrail for the CreatePolicyEngine call
+
+### Policy stuck in CREATE_FAILED
+- Call `policy_get` and inspect `statusReasons` for validation
+  findings
+- If the policy depends on a Gateway's tool schema, the Gateway must
+  be fully deployed first
+- Try `validation_mode="IGNORE_ALL_FINDINGS"` only after confirming
+  the findings are acceptable
+
+### AccessDeniedException
+Required control-plane permissions on `bedrock-agentcore-control:*`:
+CreatePolicyEngine, GetPolicyEngine, UpdatePolicyEngine,
+DeletePolicyEngine, ListPolicyEngines, CreatePolicy, GetPolicy,
+UpdatePolicy, DeletePolicy, ListPolicies, StartPolicyGeneration,
+GetPolicyGeneration, ListPolicyGenerations,
+ListPolicyGenerationAssets. See IAM Permissions below.
+
+### ConflictException on create
+A policy engine or policy with that name already exists in the
+account/engine. Names are immutable and unique — choose a different
+name or delete the existing resource.
+
+### Policy engine cannot be deleted
+Engines must have zero associated policies before deletion. Use
+`policy_list` to enumerate, `policy_delete` each, poll `policy_get`
+until each is gone, then `policy_engine_delete`.
+
+### StartPolicyGeneration returns ValidationException
+- The `resource.arn` must be a Gateway ARN the caller has visibility to
+- The natural-language content must be 1-2000 chars
+
+### Stale credentials after refresh
+Known issue: boto3 clients are cached. If credentials expire, restart
+the MCP server. Workaround: set `AGENTCORE_DISABLE_TOOLS=policy`
+temporarily and restart.
+
+### Generated assets disappearing
+Policy generation assets auto-delete after 7 days. Promote valuable
+assets into real policies with `policy_create` before the expiration
+window closes.
+
+---
+
+## IAM Permissions
+
+All Policy APIs are control plane (`bedrock-agentcore-control`).
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock-agentcore:CreatePolicyEngine",
+    "bedrock-agentcore:GetPolicyEngine",
+    "bedrock-agentcore:UpdatePolicyEngine",
+    "bedrock-agentcore:DeletePolicyEngine",
+    "bedrock-agentcore:ListPolicyEngines",
+    "bedrock-agentcore:CreatePolicy",
+    "bedrock-agentcore:GetPolicy",
+    "bedrock-agentcore:UpdatePolicy",
+    "bedrock-agentcore:DeletePolicy",
+    "bedrock-agentcore:ListPolicies",
+    "bedrock-agentcore:StartPolicyGeneration",
+    "bedrock-agentcore:GetPolicyGeneration",
+    "bedrock-agentcore:ListPolicyGenerations",
+    "bedrock-agentcore:ListPolicyGenerationAssets"
+  ],
+  "Resource": "arn:aws:bedrock-agentcore:*:*:policy-engine/*"
+}
+```
+
+If `encryptionKeyArn` is provided on `policy_engine_create`, also grant
+`kms:Encrypt`, `kms:Decrypt`, `kms:GenerateDataKey`, and
+`kms:DescribeKey` on that key.
+
+---
+
+## Migration from bedrock-agentcore-starter-toolkit
+
+The old Python starter toolkit is deprecated. Migrate to the new
+`agentcore` CLI and `agentcore.json`:
+
+1. Replace any direct SDK setup of policy engines / policies with a
+   `policyEngines` section in `agentcore.json`.
+2. Reference the engine from a gateway via `policyEngineConfiguration`
+   instead of passing it programmatically.
+3. Deploy with `agentcore deploy` instead of invoking
+   `CreatePolicyEngine` / `CreatePolicy` directly from your agent code.
+4. Use the MCP tools in this server (`policy_*`) for interactive
+   inspection and one-off operations — but keep declarative config in
+   `agentcore.json` for reproducibility.
+5. Generated policies (from `policy_generation_start`) remain
+   ephemeral (7-day TTL) — promote valid assets into the
+   `policyEngines[].policies[]` config if you want them persisted
+   across deploys.
+""".strip()
+
+
+class GuideTools:
+    """Static guide tool for AgentCore Policy."""
+
+    def register(self, mcp):
+        """Register guide tools with the MCP server."""
+        mcp.tool(name='get_policy_guide')(self.get_policy_guide)
+
+    async def get_policy_guide(self, ctx: Context) -> PolicyGuideResponse:
+        """Get the comprehensive AgentCore Policy guide.
+
+        Returns a detailed reference covering: CLI commands,
+        agentcore.json schema, Cedar policy concepts, policy generation
+        workflow, cost tiers, common patterns, troubleshooting, IAM
+        permissions, and migration notes.
+
+        This is a read-only operation with no cost implications.
+        """
+        return PolicyGuideResponse(guide=POLICY_GUIDE)

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/models.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/models.py
@@ -1,0 +1,125 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic response models for AgentCore Policy tools."""
+
+from pydantic import BaseModel, Field
+from typing import Any
+
+
+class ErrorResponse(BaseModel):
+    """Structured error response returned when an API call fails."""
+
+    status: str = Field(default='error', description='Always "error"')
+    message: str = Field(..., description='Human-readable error message')
+    error_type: str = Field(default='Unknown', description='Error code or exception type')
+    error_code: str = Field(default='', description='HTTP status code if available')
+
+
+class PolicyEngineResponse(BaseModel):
+    """Response for single policy engine operations (create, get, update)."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_engine: dict[str, Any] = Field(
+        default_factory=dict, description='Policy engine resource details'
+    )
+
+
+class DeletePolicyEngineResponse(BaseModel):
+    """Response for delete_policy_engine."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_engine_id: str = Field(default='', description='Deleted policy engine ID')
+    policy_engine_status: str = Field(
+        default='', description='Policy engine status after deletion'
+    )
+
+
+class ListPolicyEnginesResponse(BaseModel):
+    """Response for list_policy_engines."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_engines: list[dict[str, Any]] = Field(
+        default_factory=list, description='List of policy engine summaries'
+    )
+    next_token: str | None = Field(default=None, description='Pagination token')
+
+
+class PolicyResponse(BaseModel):
+    """Response for single policy operations (create, get, update)."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy: dict[str, Any] = Field(default_factory=dict, description='Policy resource details')
+
+
+class DeletePolicyResponse(BaseModel):
+    """Response for delete_policy."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_id: str = Field(default='', description='Deleted policy ID')
+    policy_status: str = Field(default='', description='Policy status after deletion')
+
+
+class ListPoliciesResponse(BaseModel):
+    """Response for list_policies."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policies: list[dict[str, Any]] = Field(
+        default_factory=list, description='List of policy summaries'
+    )
+    next_token: str | None = Field(default=None, description='Pagination token')
+
+
+class PolicyGenerationResponse(BaseModel):
+    """Response for single policy generation operations (start, get)."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_generation: dict[str, Any] = Field(
+        default_factory=dict, description='Policy generation details'
+    )
+
+
+class ListPolicyGenerationsResponse(BaseModel):
+    """Response for list_policy_generations."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_generations: list[dict[str, Any]] = Field(
+        default_factory=list, description='List of policy generation summaries'
+    )
+    next_token: str | None = Field(default=None, description='Pagination token')
+
+
+class ListPolicyGenerationAssetsResponse(BaseModel):
+    """Response for list_policy_generation_assets."""
+
+    status: str = Field(..., description='Operation status')
+    message: str = Field(..., description='Human-readable result')
+    policy_generation_assets: list[dict[str, Any]] = Field(
+        default_factory=list, description='List of generated policy asset details'
+    )
+    next_token: str | None = Field(default=None, description='Pagination token')
+
+
+class PolicyGuideResponse(BaseModel):
+    """Response for get_policy_guide."""
+
+    guide: str = Field(..., description='The comprehensive Policy reference guide')

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/policies.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/policies.py
@@ -1,0 +1,348 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Policy CRUD tools for AgentCore Policy control plane.
+
+A Policy is a Cedar-based authorization rule stored within a Policy
+Engine. Policies are validated against the Cedar schema generated from
+associated Gateway tools' input schemas. Create/Update/Delete are
+asynchronous operations — poll with policy_get to observe status.
+"""
+
+from .error_handler import handle_policy_error
+from .models import (
+    DeletePolicyResponse,
+    ErrorResponse,
+    ListPoliciesResponse,
+    PolicyResponse,
+)
+from loguru import logger
+from mcp.server.fastmcp import Context
+from pydantic import Field
+from typing import Annotated, Any
+
+
+class PolicyTools:
+    """Tools for managing Cedar Policies within an AgentCore Policy Engine."""
+
+    def __init__(self, client_factory):
+        """Initialize with a callable that returns a boto3 control plane client."""
+        self._get_client = client_factory
+
+    def register(self, mcp):
+        """Register policy tools with the MCP server."""
+        mcp.tool(name='policy_create')(self.policy_create)
+        mcp.tool(name='policy_get')(self.policy_get)
+        mcp.tool(name='policy_update')(self.policy_update)
+        mcp.tool(name='policy_delete')(self.policy_delete)
+        mcp.tool(name='policy_list')(self.policy_list)
+
+    async def policy_create(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Parent policy engine ID (12-59 chars)'),
+        ],
+        name: Annotated[
+            str,
+            Field(
+                description=(
+                    'Immutable, unique policy name. Pattern: [A-Za-z][A-Za-z0-9_]*, max 48 chars.'
+                )
+            ),
+        ],
+        definition: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    'PolicyDefinition union. Specify exactly one key: '
+                    '"cedar" with {"statement": "<cedar policy text>"} '
+                    'for a raw Cedar statement (35-10000 chars), OR '
+                    '"policyGeneration" with '
+                    '{"policyGenerationId": "<id>", '
+                    '"policyGenerationAssetId": "<id>"} to reference a '
+                    'generated asset from a previous policy generation.'
+                )
+            ),
+        ],
+        description: Annotated[
+            str | None,
+            Field(description='Human-readable description (1-4096 chars)'),
+        ] = None,
+        validation_mode: Annotated[
+            str | None,
+            Field(
+                description=(
+                    'How policy validation findings are handled. '
+                    '"FAIL_ON_ANY_FINDINGS" (default) rejects policies '
+                    'with validation findings. "IGNORE_ALL_FINDINGS" '
+                    'creates the policy regardless of findings.'
+                )
+            ),
+        ] = None,
+        client_token: Annotated[
+            str | None,
+            Field(description='Idempotency token (33-256 chars)'),
+        ] = None,
+    ) -> PolicyResponse | ErrorResponse:
+        """Create a Cedar policy within an AgentCore Policy Engine.
+
+        COST WARNING: Creating a policy invokes the validation pipeline
+        and provisions a billable policy resource. This incurs AWS
+        charges.
+
+        Policies are validated against the Cedar schema derived from
+        the parent policy engine's associated Gateway tools. Create is
+        asynchronous — the policy starts in CREATING and transitions to
+        ACTIVE or CREATE_FAILED. Poll with policy_get.
+        """
+        logger.info(f'Creating policy "{name}" in engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {
+                'policyEngineId': policy_engine_id,
+                'name': name,
+                'definition': definition,
+            }
+            if description is not None:
+                kwargs['description'] = description
+            if validation_mode is not None:
+                kwargs['validationMode'] = validation_mode
+            if client_token is not None:
+                kwargs['clientToken'] = client_token
+
+            response = client.create_policy(**kwargs)
+
+            return PolicyResponse(
+                status='success',
+                message=(
+                    f'Policy "{name}" creation requested. '
+                    f'ID: {response.get("policyId", "unknown")}. '
+                    f'Status: {response.get("status", "CREATING")}.'
+                ),
+                policy=response,
+            )
+        except Exception as e:
+            return handle_policy_error('CreatePolicy', e)
+
+    async def policy_get(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Parent policy engine ID'),
+        ],
+        policy_id: Annotated[
+            str,
+            Field(description='Policy ID (12-59 chars)'),
+        ],
+    ) -> PolicyResponse | ErrorResponse:
+        """Get details of a Cedar policy.
+
+        Returns the full policy including its Cedar definition, status,
+        and timestamps. This is a read-only operation with no cost
+        implications. Use to poll status after create/update/delete.
+        """
+        logger.info(f'Getting policy {policy_id} from engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            response = client.get_policy(
+                policyEngineId=policy_engine_id,
+                policyId=policy_id,
+            )
+
+            return PolicyResponse(
+                status='success',
+                message=(
+                    f'Policy {policy_id} retrieved. Status: {response.get("status", "UNKNOWN")}.'
+                ),
+                policy=response,
+            )
+        except Exception as e:
+            return handle_policy_error('GetPolicy', e)
+
+    async def policy_update(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Parent policy engine ID'),
+        ],
+        policy_id: Annotated[
+            str,
+            Field(description='Policy ID to update'),
+        ],
+        definition: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    'New PolicyDefinition replacing the existing one. '
+                    'Union with one key: "cedar" ({"statement": "..."}) '
+                    'or "policyGeneration" ({"policyGenerationId": ..., '
+                    '"policyGenerationAssetId": ...}).'
+                )
+            ),
+        ] = None,
+        description: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    'UpdatedDescription object with "optionalValue" key. '
+                    'Set {"optionalValue": "new text"} to update, '
+                    '{"optionalValue": null} to clear. Omit to leave '
+                    'unchanged.'
+                )
+            ),
+        ] = None,
+        validation_mode: Annotated[
+            str | None,
+            Field(
+                description=(
+                    'Validation mode for this update: '
+                    '"FAIL_ON_ANY_FINDINGS" or "IGNORE_ALL_FINDINGS".'
+                )
+            ),
+        ] = None,
+    ) -> PolicyResponse | ErrorResponse:
+        """Update a Cedar policy.
+
+        COST WARNING: Updating a policy re-invokes the validation
+        pipeline and consumes compute resources. This incurs AWS
+        charges.
+
+        Update is asynchronous — status transitions through UPDATING.
+        Poll with policy_get.
+        """
+        logger.info(f'Updating policy {policy_id} in engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {
+                'policyEngineId': policy_engine_id,
+                'policyId': policy_id,
+            }
+            if definition is not None:
+                kwargs['definition'] = definition
+            if description is not None:
+                kwargs['description'] = description
+            if validation_mode is not None:
+                kwargs['validationMode'] = validation_mode
+
+            response = client.update_policy(**kwargs)
+
+            return PolicyResponse(
+                status='success',
+                message=(
+                    f'Policy {policy_id} update requested. '
+                    f'Status: {response.get("status", "UPDATING")}.'
+                ),
+                policy=response,
+            )
+        except Exception as e:
+            return handle_policy_error('UpdatePolicy', e)
+
+    async def policy_delete(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Parent policy engine ID'),
+        ],
+        policy_id: Annotated[
+            str,
+            Field(description='Policy ID to delete'),
+        ],
+    ) -> DeletePolicyResponse | ErrorResponse:
+        """Delete a Cedar policy.
+
+        WARNING: This permanently deletes the policy. Delete is
+        asynchronous — status transitions through DELETING. This
+        action cannot be undone.
+        """
+        logger.info(f'Deleting policy {policy_id} from engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            response = client.delete_policy(
+                policyEngineId=policy_engine_id,
+                policyId=policy_id,
+            )
+
+            return DeletePolicyResponse(
+                status='success',
+                message=f'Policy {policy_id} deletion requested.',
+                policy_id=response.get('policyId', policy_id),
+                policy_status=response.get('status', 'DELETING'),
+            )
+        except Exception as e:
+            return handle_policy_error('DeletePolicy', e)
+
+    async def policy_list(
+        self,
+        ctx: Context,
+        policy_engine_id: Annotated[
+            str,
+            Field(description='Parent policy engine ID'),
+        ],
+        target_resource_scope: Annotated[
+            str | None,
+            Field(
+                description=(
+                    'Filter policies by target resource scope '
+                    '(20-1011 chars). Typically a Gateway ARN.'
+                )
+            ),
+        ] = None,
+        max_results: Annotated[
+            int | None,
+            Field(description='Max results per page (1-100, default 10)'),
+        ] = None,
+        next_token: Annotated[
+            str | None,
+            Field(description='Pagination token'),
+        ] = None,
+    ) -> ListPoliciesResponse | ErrorResponse:
+        """List Cedar policies within a Policy Engine.
+
+        Returns policy summaries with IDs, ARNs, definitions, status,
+        and timestamps. Optionally filter by target resource scope
+        (e.g. a Gateway ARN). This is a read-only operation with no
+        cost implications.
+        """
+        logger.info(f'Listing policies in engine {policy_engine_id}')
+
+        try:
+            client = self._get_client()
+            kwargs: dict[str, Any] = {'policyEngineId': policy_engine_id}
+            if target_resource_scope is not None:
+                kwargs['targetResourceScope'] = target_resource_scope
+            if max_results is not None:
+                kwargs['maxResults'] = max_results
+            if next_token is not None:
+                kwargs['nextToken'] = next_token
+
+            response = client.list_policies(**kwargs)
+            policies = response.get('policies', [])
+
+            return ListPoliciesResponse(
+                status='success',
+                message=f'Found {len(policies)} policy(ies).',
+                policies=policies,
+                next_token=response.get('nextToken'),
+            )
+        except Exception as e:
+            return handle_policy_error('ListPolicies', e)

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/policy_client.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/policy_client.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cached boto3 client wrapper for AgentCore Policy APIs.
+
+AgentCore Policy APIs (policy engines, policies, policy generation) all
+live on the control plane (bedrock-agentcore-control). A single cached
+client is shared across all Policy tool groups.
+"""
+
+import boto3
+from awslabs.amazon_bedrock_agentcore_mcp_server.utils.user_agent import (
+    build_user_agent,
+)
+from botocore.config import Config
+from loguru import logger
+from os import getenv
+from typing import Any
+
+
+MCP_USER_AGENT = build_user_agent('policy')
+
+_policy_clients: dict[str, Any] = {}
+
+
+def get_policy_client(region_name: str | None = None) -> Any:
+    """Get a cached boto3 client for Policy control plane operations.
+
+    Used by all Policy tool groups — policy engines, policies, and
+    policy generation. All operations go through the
+    bedrock-agentcore-control service.
+
+    Args:
+        region_name: AWS region. Defaults to AWS_REGION env var or us-east-1.
+
+    Returns:
+        Cached boto3 client for bedrock-agentcore-control.
+    """
+    region = region_name or getenv('AWS_REGION') or 'us-east-1'
+
+    if region in _policy_clients:
+        return _policy_clients[region]
+
+    session = boto3.Session(region_name=region)
+    client = session.client(
+        'bedrock-agentcore-control',
+        config=Config(user_agent_extra=MCP_USER_AGENT),
+    )
+    _policy_clients[region] = client
+
+    logger.info(f'Created bedrock-agentcore-control client for region={region}')
+    return client

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/conftest.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/conftest.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for AgentCore Policy tool tests.
+
+This file must be placed at tests/policy/conftest.py — NOT inside
+the tools/policy/ source package.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+@pytest.fixture
+def mock_ctx():
+    """Create a mock MCP Context."""
+    ctx = MagicMock()
+    ctx.error = AsyncMock()
+    ctx.info = AsyncMock()
+    return ctx
+
+
+@pytest.fixture
+def mock_boto3_client():
+    """Create a mock boto3 client for Policy APIs."""
+    return MagicMock()
+
+
+@pytest.fixture
+def client_factory(mock_boto3_client):
+    """Create a client factory that returns the mock boto3 client."""
+    return lambda: mock_boto3_client

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_engines.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_engines.py
@@ -1,0 +1,274 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy engine tools."""
+
+import pytest
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.engines import (
+    PolicyEngineTools,
+)
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.models import (
+    DeletePolicyEngineResponse,
+    ErrorResponse,
+    ListPolicyEnginesResponse,
+    PolicyEngineResponse,
+)
+from botocore.exceptions import ClientError
+
+
+class TestPolicyEngineCreate:
+    """Tests for policy_engine_create tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Creates policy engine and returns ID and status."""
+        mock_boto3_client.create_policy_engine.return_value = {
+            'policyEngineId': 'ProdAuth-abcdefghij',
+            'name': 'ProdAuth',
+            'status': 'CREATING',
+            'policyEngineArn': (
+                'arn:aws:bedrock-agentcore:us-east-1:123:policy-engine/ProdAuth-abcdefghij'
+            ),
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_create(ctx=mock_ctx, name='ProdAuth')
+        assert isinstance(result, PolicyEngineResponse)
+        assert result.status == 'success'
+        assert 'ProdAuth-abcdefghij' in result.message
+        assert result.policy_engine['name'] == 'ProdAuth'
+        mock_boto3_client.create_policy_engine.assert_called_once_with(name='ProdAuth')
+
+    @pytest.mark.asyncio
+    async def test_with_all_params(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes all optional params to the API."""
+        mock_boto3_client.create_policy_engine.return_value = {
+            'policyEngineId': 'eng-id',
+            'status': 'CREATING',
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_create(
+            ctx=mock_ctx,
+            name='MyEngine',
+            description='A production engine',
+            encryption_key_arn='arn:aws:kms:us-east-1:123:key/abc',
+            client_token='a' * 33,
+            tags={'env': 'prod'},
+        )
+        assert isinstance(result, PolicyEngineResponse)
+        assert result.status == 'success'
+        kw = mock_boto3_client.create_policy_engine.call_args.kwargs
+        assert kw['description'] == 'A production engine'
+        assert kw['encryptionKeyArn'] == 'arn:aws:kms:us-east-1:123:key/abc'
+        assert kw['clientToken'] == 'a' * 33
+        assert kw['tags'] == {'env': 'prod'}
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.create_policy_engine.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ValidationException', 'Message': 'bad name'},
+                'ResponseMetadata': {'HTTPStatusCode': 400},
+            },
+            'CreatePolicyEngine',
+        )
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_create(ctx=mock_ctx, name='bad!')
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+        assert 'bad name' in result.message
+
+
+class TestPolicyEngineGet:
+    """Tests for policy_engine_get tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns policy engine details on success."""
+        mock_boto3_client.get_policy_engine.return_value = {
+            'policyEngineId': 'eng-id',
+            'status': 'ACTIVE',
+            'name': 'ProdAuth',
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_get(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, PolicyEngineResponse)
+        assert result.status == 'success'
+        assert result.policy_engine['status'] == 'ACTIVE'
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse when engine not found."""
+        mock_boto3_client.get_policy_engine.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ResourceNotFoundException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 404},
+            },
+            'GetPolicyEngine',
+        )
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_get(ctx=mock_ctx, policy_engine_id='nonexist')
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyEngineUpdate:
+    """Tests for policy_engine_update tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Updates policy engine description and returns response."""
+        mock_boto3_client.update_policy_engine.return_value = {
+            'policyEngineId': 'eng-id',
+            'status': 'UPDATING',
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_update(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            description={'optionalValue': 'Updated desc'},
+        )
+        assert isinstance(result, PolicyEngineResponse)
+        assert result.status == 'success'
+        mock_boto3_client.update_policy_engine.assert_called_once_with(
+            policyEngineId='eng-id',
+            description={'optionalValue': 'Updated desc'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_params_omits_description(self, mock_ctx, client_factory, mock_boto3_client):
+        """Omitting description leaves the field out of the API call."""
+        mock_boto3_client.update_policy_engine.return_value = {
+            'policyEngineId': 'eng-id',
+            'status': 'ACTIVE',
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_update(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, PolicyEngineResponse)
+        kw = mock_boto3_client.update_policy_engine.call_args.kwargs
+        assert 'description' not in kw
+        assert kw['policyEngineId'] == 'eng-id'
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.update_policy_engine.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ConflictException', 'Message': 'conflict'},
+                'ResponseMetadata': {'HTTPStatusCode': 409},
+            },
+            'UpdatePolicyEngine',
+        )
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_update(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyEngineDelete:
+    """Tests for policy_engine_delete tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Deletes engine and returns DELETING status."""
+        mock_boto3_client.delete_policy_engine.return_value = {
+            'policyEngineId': 'eng-id',
+            'status': 'DELETING',
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_delete(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, DeletePolicyEngineResponse)
+        assert result.status == 'success'
+        assert result.policy_engine_id == 'eng-id'
+        assert result.policy_engine_status == 'DELETING'
+
+    @pytest.mark.asyncio
+    async def test_conflict_when_has_policies(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ConflictException (engine has policies)."""
+        mock_boto3_client.delete_policy_engine.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'ConflictException',
+                    'Message': 'engine has associated policies',
+                },
+                'ResponseMetadata': {'HTTPStatusCode': 409},
+            },
+            'DeletePolicyEngine',
+        )
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_delete(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+        assert 'associated policies' in result.message
+
+
+class TestPolicyEngineList:
+    """Tests for policy_engine_list tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns list of policy engines with pagination token."""
+        mock_boto3_client.list_policy_engines.return_value = {
+            'policyEngines': [
+                {'policyEngineId': 'e1', 'status': 'ACTIVE'},
+                {'policyEngineId': 'e2', 'status': 'CREATING'},
+            ],
+            'nextToken': 'tok123',
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_list(ctx=mock_ctx)
+        assert isinstance(result, ListPolicyEnginesResponse)
+        assert result.status == 'success'
+        assert len(result.policy_engines) == 2
+        assert result.next_token == 'tok123'
+
+    @pytest.mark.asyncio
+    async def test_with_pagination(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes pagination params to API."""
+        mock_boto3_client.list_policy_engines.return_value = {
+            'policyEngines': [],
+            'nextToken': None,
+        }
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_list(ctx=mock_ctx, max_results=10, next_token='prev')
+        assert isinstance(result, ListPolicyEnginesResponse)
+        assert result.status == 'success'
+        mock_boto3_client.list_policy_engines.assert_called_once_with(
+            maxResults=10, nextToken='prev'
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_ctx, client_factory, mock_boto3_client):
+        """Handles empty policy engine list."""
+        mock_boto3_client.list_policy_engines.return_value = {'policyEngines': []}
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_list(ctx=mock_ctx)
+        assert isinstance(result, ListPolicyEnginesResponse)
+        assert result.status == 'success'
+        assert len(result.policy_engines) == 0
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.list_policy_engines.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ServiceException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 500},
+            },
+            'ListPolicyEngines',
+        )
+        tools = PolicyEngineTools(client_factory)
+        result = await tools.policy_engine_list(ctx=mock_ctx)
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_error_handler.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_error_handler.py
@@ -1,0 +1,79 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy error handler."""
+
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.error_handler import (
+    handle_policy_error,
+)
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.models import (
+    ErrorResponse,
+)
+from botocore.exceptions import ClientError
+
+
+class TestHandlePolicyError:
+    """Tests for handle_policy_error."""
+
+    def test_handles_client_error(self):
+        """Extracts code, message, HTTP status from ClientError."""
+        error = ClientError(
+            {
+                'Error': {'Code': 'ValidationException', 'Message': 'bad input'},
+                'ResponseMetadata': {'HTTPStatusCode': 400},
+            },
+            'CreatePolicyEngine',
+        )
+        result = handle_policy_error('CreatePolicyEngine', error)
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+        assert 'bad input' in result.message
+        assert result.error_type == 'ValidationException'
+        assert result.error_code == '400'
+
+    def test_handles_conflict_exception(self):
+        """Correctly handles ConflictException (e.g. delete engine with policies)."""
+        error = ClientError(
+            {
+                'Error': {
+                    'Code': 'ConflictException',
+                    'Message': 'engine has associated policies',
+                },
+                'ResponseMetadata': {'HTTPStatusCode': 409},
+            },
+            'DeletePolicyEngine',
+        )
+        result = handle_policy_error('DeletePolicyEngine', error)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_type == 'ConflictException'
+        assert result.error_code == '409'
+        assert 'associated policies' in result.message
+
+    def test_handles_generic_exception(self):
+        """Falls back to exception type name for non-ClientError."""
+        error = ValueError('something went wrong')
+        result = handle_policy_error('SomeOperation', error)
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+        assert 'something went wrong' in result.message
+        assert result.error_type == 'ValueError'
+        assert result.error_code == ''
+
+    def test_handles_runtime_error(self):
+        """Handles RuntimeError with correct type name."""
+        error = RuntimeError('connection lost')
+        result = handle_policy_error('GetPolicy', error)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_type == 'RuntimeError'
+        assert 'connection lost' in result.message

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_generations.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_generations.py
@@ -1,0 +1,289 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy generation tools."""
+
+import pytest
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.generations import (
+    PolicyGenerationTools,
+)
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.models import (
+    ErrorResponse,
+    ListPolicyGenerationAssetsResponse,
+    ListPolicyGenerationsResponse,
+    PolicyGenerationResponse,
+)
+from botocore.exceptions import ClientError
+
+
+CONTENT = {'rawText': 'Allow Admins to invoke all tools.'}
+RESOURCE = {'arn': ('arn:aws:bedrock-agentcore:us-east-1:123:gateway/gw-abcdefghij')}
+
+
+class TestPolicyGenerationStart:
+    """Tests for policy_generation_start tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Starts generation and returns ID and status."""
+        mock_boto3_client.start_policy_generation.return_value = {
+            'policyGenerationId': 'gen-abcdefghij',
+            'name': 'MyGen',
+            'status': 'GENERATING',
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_start(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='MyGen',
+            content=CONTENT,
+            resource=RESOURCE,
+        )
+        assert isinstance(result, PolicyGenerationResponse)
+        assert result.status == 'success'
+        assert 'gen-abcdefghij' in result.message
+        kw = mock_boto3_client.start_policy_generation.call_args.kwargs
+        assert kw['policyEngineId'] == 'eng-id'
+        assert kw['name'] == 'MyGen'
+        assert kw['content'] == CONTENT
+        assert kw['resource'] == RESOURCE
+
+    @pytest.mark.asyncio
+    async def test_with_client_token(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes client_token to the API."""
+        mock_boto3_client.start_policy_generation.return_value = {
+            'policyGenerationId': 'gen-id',
+            'status': 'GENERATING',
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_start(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='MyGen',
+            content=CONTENT,
+            resource=RESOURCE,
+            client_token='a' * 33,
+        )
+        assert isinstance(result, PolicyGenerationResponse)
+        kw = mock_boto3_client.start_policy_generation.call_args.kwargs
+        assert kw['clientToken'] == 'a' * 33
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.start_policy_generation.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'ServiceQuotaExceededException',
+                    'Message': 'quota exceeded',
+                },
+                'ResponseMetadata': {'HTTPStatusCode': 402},
+            },
+            'StartPolicyGeneration',
+        )
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_start(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='MyGen',
+            content=CONTENT,
+            resource=RESOURCE,
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+        assert 'quota exceeded' in result.message
+
+
+class TestPolicyGenerationGet:
+    """Tests for policy_generation_get tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns generation details on success."""
+        mock_boto3_client.get_policy_generation.return_value = {
+            'policyGenerationId': 'gen-id',
+            'status': 'GENERATED',
+            'findings': 'all good',
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_get(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_generation_id='gen-id',
+        )
+        assert isinstance(result, PolicyGenerationResponse)
+        assert result.status == 'success'
+        assert result.policy_generation['status'] == 'GENERATED'
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse when generation not found."""
+        mock_boto3_client.get_policy_generation.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ResourceNotFoundException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 404},
+            },
+            'GetPolicyGeneration',
+        )
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_get(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_generation_id='nope',
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyGenerationList:
+    """Tests for policy_generation_list tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns list of generations with pagination token."""
+        mock_boto3_client.list_policy_generations.return_value = {
+            'policyGenerations': [
+                {'policyGenerationId': 'g1', 'status': 'GENERATED'},
+                {'policyGenerationId': 'g2', 'status': 'GENERATING'},
+            ],
+            'nextToken': 'tok',
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, ListPolicyGenerationsResponse)
+        assert result.status == 'success'
+        assert len(result.policy_generations) == 2
+        assert result.next_token == 'tok'
+
+    @pytest.mark.asyncio
+    async def test_with_pagination(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes pagination params to API."""
+        mock_boto3_client.list_policy_generations.return_value = {
+            'policyGenerations': [],
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            max_results=50,
+            next_token='prev',
+        )
+        assert isinstance(result, ListPolicyGenerationsResponse)
+        kw = mock_boto3_client.list_policy_generations.call_args.kwargs
+        assert kw['maxResults'] == 50
+        assert kw['nextToken'] == 'prev'
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.list_policy_generations.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ServiceException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 500},
+            },
+            'ListPolicyGenerations',
+        )
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyGenerationListAssets:
+    """Tests for policy_generation_list_assets tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns list of assets with findings."""
+        mock_boto3_client.list_policy_generation_assets.return_value = {
+            'policyGenerationAssets': [
+                {
+                    'policyGenerationAssetId': 'asset-1',
+                    'findings': [{'type': 'VALID'}],
+                    'rawTextFragment': 'Allow Admins',
+                },
+                {
+                    'policyGenerationAssetId': 'asset-2',
+                    'findings': [{'type': 'NOT_TRANSLATABLE'}],
+                    'rawTextFragment': 'Do something unclear',
+                },
+            ],
+            'nextToken': None,
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list_assets(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_generation_id='gen-id',
+        )
+        assert isinstance(result, ListPolicyGenerationAssetsResponse)
+        assert result.status == 'success'
+        assert len(result.policy_generation_assets) == 2
+        assert result.next_token is None
+
+    @pytest.mark.asyncio
+    async def test_with_pagination(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes pagination params to API."""
+        mock_boto3_client.list_policy_generation_assets.return_value = {
+            'policyGenerationAssets': [],
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list_assets(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_generation_id='gen-id',
+            max_results=5,
+            next_token='tok',
+        )
+        assert isinstance(result, ListPolicyGenerationAssetsResponse)
+        kw = mock_boto3_client.list_policy_generation_assets.call_args.kwargs
+        assert kw['policyEngineId'] == 'eng-id'
+        assert kw['policyGenerationId'] == 'gen-id'
+        assert kw['maxResults'] == 5
+        assert kw['nextToken'] == 'tok'
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_ctx, client_factory, mock_boto3_client):
+        """Handles empty asset list."""
+        mock_boto3_client.list_policy_generation_assets.return_value = {
+            'policyGenerationAssets': [],
+        }
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list_assets(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_generation_id='gen-id',
+        )
+        assert isinstance(result, ListPolicyGenerationAssetsResponse)
+        assert result.status == 'success'
+        assert len(result.policy_generation_assets) == 0
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.list_policy_generation_assets.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ResourceNotFoundException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 404},
+            },
+            'ListPolicyGenerationAssets',
+        )
+        tools = PolicyGenerationTools(client_factory)
+        result = await tools.policy_generation_list_assets(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_generation_id='nope',
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_guide.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_guide.py
@@ -1,0 +1,120 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy guide tool."""
+
+import pytest
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.guide import (
+    POLICY_GUIDE,
+    GuideTools,
+)
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.models import (
+    PolicyGuideResponse,
+)
+
+
+class TestGetPolicyGuide:
+    """Tests for get_policy_guide tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_pydantic_model(self, mock_ctx):
+        """Returns a PolicyGuideResponse with substantial content."""
+        tools = GuideTools()
+        result = await tools.get_policy_guide(ctx=mock_ctx)
+        assert isinstance(result, PolicyGuideResponse)
+        assert len(result.guide) > 100
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_cli_commands(self, mock_ctx):
+        """Guide includes agentcore CLI commands."""
+        tools = GuideTools()
+        result = await tools.get_policy_guide(ctx=mock_ctx)
+        guide = result.guide
+        assert 'agentcore add gateway' in guide
+        assert 'agentcore deploy' in guide
+        assert 'agentcore status' in guide
+        assert '--policy-engine' in guide
+        assert '--policy-engine-mode' in guide
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_schema(self, mock_ctx):
+        """Guide includes agentcore.json schema details."""
+        assert 'policyEngines' in POLICY_GUIDE
+        assert 'policies' in POLICY_GUIDE
+        assert 'statement' in POLICY_GUIDE
+        assert 'validationMode' in POLICY_GUIDE
+        assert 'FAIL_ON_ANY_FINDINGS' in POLICY_GUIDE
+        assert 'IGNORE_ALL_FINDINGS' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_enforcement_modes(self, mock_ctx):
+        """Guide documents LOG_ONLY and ENFORCE enforcement modes."""
+        assert 'LOG_ONLY' in POLICY_GUIDE
+        assert 'ENFORCE' in POLICY_GUIDE
+        assert 'policyEngineConfiguration' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_iam(self, mock_ctx):
+        """Guide includes IAM permission references."""
+        assert 'bedrock-agentcore:CreatePolicyEngine' in POLICY_GUIDE
+        assert 'bedrock-agentcore:CreatePolicy' in POLICY_GUIDE
+        assert 'bedrock-agentcore:StartPolicyGeneration' in POLICY_GUIDE
+        assert 'bedrock-agentcore:ListPolicyGenerationAssets' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_cost_tiers(self, mock_ctx):
+        """Guide documents cost tiers for tools."""
+        assert 'Read-only tools' in POLICY_GUIDE
+        assert 'billable resources' in POLICY_GUIDE
+        assert 'Destructive tools' in POLICY_GUIDE
+        assert 'COST WARNING' not in POLICY_GUIDE  # that's in docstrings, not the guide
+        assert 'policy_generation_start' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_troubleshooting(self, mock_ctx):
+        """Guide includes troubleshooting section."""
+        assert 'Troubleshooting' in POLICY_GUIDE
+        assert 'AccessDeniedException' in POLICY_GUIDE
+        assert 'CREATE_FAILED' in POLICY_GUIDE
+        assert 'ConflictException' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_migration(self, mock_ctx):
+        """Guide includes migration notes from starter toolkit."""
+        assert 'Migration' in POLICY_GUIDE
+        assert 'starter-toolkit' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_prerequisites(self, mock_ctx):
+        """Guide documents prerequisites and CLI installation."""
+        assert 'Prerequisites' in POLICY_GUIDE
+        assert 'agentcore-cli' in POLICY_GUIDE or 'agentcore' in POLICY_GUIDE
+        assert 'do NOT need the CLI' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_generation_workflow(self, mock_ctx):
+        """Guide documents the AI-powered generation workflow."""
+        assert 'policy_generation_start' in POLICY_GUIDE
+        assert 'policyGeneration' in POLICY_GUIDE
+        assert 'VALID' in POLICY_GUIDE
+        assert 'NOT_TRANSLATABLE' in POLICY_GUIDE
+        assert '7 days' in POLICY_GUIDE
+
+    @pytest.mark.asyncio
+    async def test_guide_contains_delete_order(self, mock_ctx):
+        """Guide documents the engine-delete ordering constraint."""
+        # Engine deletion requires deleting all policies first
+        assert 'policy_delete' in POLICY_GUIDE
+        assert 'policy_engine_delete' in POLICY_GUIDE
+        assert 'zero associated policies' in POLICY_GUIDE or 'associated policies' in POLICY_GUIDE

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_init.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_init.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy tools registration."""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestRegisterPolicyTools:
+    """Tests for register_policy_tools."""
+
+    def test_registers_all_groups(self):
+        """Registers all tool groups without error."""
+        from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy import (
+            register_policy_tools,
+        )
+
+        mock_mcp = MagicMock()
+        # tool() returns a decorator, which is called with the method
+        mock_mcp.tool.return_value = lambda fn: fn
+
+        register_policy_tools(mock_mcp)
+
+        # Verify tool() was called for each of the 15 tools:
+        #   5 engine tools + 5 policy tools + 4 generation tools + 1 guide tool
+        assert mock_mcp.tool.call_count == 15
+
+    def test_raises_runtime_error_on_failure(self):
+        """Raises RuntimeError if a tool group fails to register."""
+        from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy import (
+            register_policy_tools,
+        )
+
+        mock_mcp = MagicMock()
+        mock_mcp.tool.side_effect = Exception('registration boom')
+
+        with pytest.raises(RuntimeError, match='Failed to register policy'):
+            register_policy_tools(mock_mcp)

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_policies.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_policies.py
@@ -1,0 +1,351 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy CRUD tools."""
+
+import pytest
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.models import (
+    DeletePolicyResponse,
+    ErrorResponse,
+    ListPoliciesResponse,
+    PolicyResponse,
+)
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.policies import (
+    PolicyTools,
+)
+from botocore.exceptions import ClientError
+
+
+CEDAR_DEFINITION = {'cedar': {'statement': 'permit(principal, action, resource);'}}
+
+
+class TestPolicyCreate:
+    """Tests for policy_create tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Creates policy and returns ID and status."""
+        mock_boto3_client.create_policy.return_value = {
+            'policyId': 'pol-abcdefghij',
+            'name': 'AdminAccess',
+            'status': 'CREATING',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_create(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='AdminAccess',
+            definition=CEDAR_DEFINITION,
+        )
+        assert isinstance(result, PolicyResponse)
+        assert result.status == 'success'
+        assert 'pol-abcdefghij' in result.message
+        kw = mock_boto3_client.create_policy.call_args.kwargs
+        assert kw['policyEngineId'] == 'eng-id'
+        assert kw['name'] == 'AdminAccess'
+        assert kw['definition'] == CEDAR_DEFINITION
+
+    @pytest.mark.asyncio
+    async def test_with_all_params(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes all optional params to the API."""
+        mock_boto3_client.create_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'CREATING',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_create(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='P1',
+            definition=CEDAR_DEFINITION,
+            description='A test policy',
+            validation_mode='IGNORE_ALL_FINDINGS',
+            client_token='a' * 33,
+        )
+        assert isinstance(result, PolicyResponse)
+        kw = mock_boto3_client.create_policy.call_args.kwargs
+        assert kw['description'] == 'A test policy'
+        assert kw['validationMode'] == 'IGNORE_ALL_FINDINGS'
+        assert kw['clientToken'] == 'a' * 33
+
+    @pytest.mark.asyncio
+    async def test_with_generation_reference(self, mock_ctx, client_factory, mock_boto3_client):
+        """Supports the policyGeneration union variant for definition."""
+        mock_boto3_client.create_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'CREATING',
+        }
+        gen_def = {
+            'policyGeneration': {
+                'policyGenerationId': 'gen-abcdefghij',
+                'policyGenerationAssetId': 'asset-abcdefghij',
+            }
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_create(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='FromGen',
+            definition=gen_def,
+        )
+        assert isinstance(result, PolicyResponse)
+        kw = mock_boto3_client.create_policy.call_args.kwargs
+        assert kw['definition'] == gen_def
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.create_policy.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'ValidationException',
+                    'Message': 'cedar syntax error',
+                },
+                'ResponseMetadata': {'HTTPStatusCode': 400},
+            },
+            'CreatePolicy',
+        )
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_create(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            name='Bad',
+            definition={'cedar': {'statement': 'invalid'}},
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+        assert 'cedar syntax error' in result.message
+
+
+class TestPolicyGet:
+    """Tests for policy_get tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns policy details on success."""
+        mock_boto3_client.get_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'ACTIVE',
+            'name': 'P1',
+            'definition': CEDAR_DEFINITION,
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_get(
+            ctx=mock_ctx, policy_engine_id='eng-id', policy_id='pol-id'
+        )
+        assert isinstance(result, PolicyResponse)
+        assert result.status == 'success'
+        assert result.policy['status'] == 'ACTIVE'
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse when policy not found."""
+        mock_boto3_client.get_policy.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ResourceNotFoundException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 404},
+            },
+            'GetPolicy',
+        )
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_get(
+            ctx=mock_ctx, policy_engine_id='eng-id', policy_id='nonexist'
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyUpdate:
+    """Tests for policy_update tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Updates policy and returns response."""
+        mock_boto3_client.update_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'UPDATING',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_update(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_id='pol-id',
+            definition=CEDAR_DEFINITION,
+        )
+        assert isinstance(result, PolicyResponse)
+        assert result.status == 'success'
+        kw = mock_boto3_client.update_policy.call_args.kwargs
+        assert kw['policyEngineId'] == 'eng-id'
+        assert kw['policyId'] == 'pol-id'
+        assert kw['definition'] == CEDAR_DEFINITION
+
+    @pytest.mark.asyncio
+    async def test_with_all_params(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes all optional params to the API."""
+        mock_boto3_client.update_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'UPDATING',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_update(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            policy_id='pol-id',
+            definition=CEDAR_DEFINITION,
+            description={'optionalValue': 'new desc'},
+            validation_mode='IGNORE_ALL_FINDINGS',
+        )
+        assert isinstance(result, PolicyResponse)
+        kw = mock_boto3_client.update_policy.call_args.kwargs
+        assert kw['description'] == {'optionalValue': 'new desc'}
+        assert kw['validationMode'] == 'IGNORE_ALL_FINDINGS'
+
+    @pytest.mark.asyncio
+    async def test_no_params_updates_with_just_ids(
+        self, mock_ctx, client_factory, mock_boto3_client
+    ):
+        """Omitting all optional fields sends only the IDs."""
+        mock_boto3_client.update_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'ACTIVE',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_update(
+            ctx=mock_ctx, policy_engine_id='eng-id', policy_id='pol-id'
+        )
+        assert isinstance(result, PolicyResponse)
+        kw = mock_boto3_client.update_policy.call_args.kwargs
+        assert 'definition' not in kw
+        assert 'description' not in kw
+        assert 'validationMode' not in kw
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.update_policy.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ConflictException', 'Message': 'conflict'},
+                'ResponseMetadata': {'HTTPStatusCode': 409},
+            },
+            'UpdatePolicy',
+        )
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_update(
+            ctx=mock_ctx, policy_engine_id='eng-id', policy_id='pol-id'
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyDelete:
+    """Tests for policy_delete tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Deletes policy and returns DELETING status."""
+        mock_boto3_client.delete_policy.return_value = {
+            'policyId': 'pol-id',
+            'status': 'DELETING',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_delete(
+            ctx=mock_ctx, policy_engine_id='eng-id', policy_id='pol-id'
+        )
+        assert isinstance(result, DeletePolicyResponse)
+        assert result.status == 'success'
+        assert result.policy_id == 'pol-id'
+        assert result.policy_status == 'DELETING'
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.delete_policy.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ResourceNotFoundException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 404},
+            },
+            'DeletePolicy',
+        )
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_delete(
+            ctx=mock_ctx, policy_engine_id='eng-id', policy_id='bad'
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'
+
+
+class TestPolicyList:
+    """Tests for policy_list tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns list of policies with pagination token."""
+        mock_boto3_client.list_policies.return_value = {
+            'policies': [
+                {'policyId': 'p1', 'status': 'ACTIVE'},
+                {'policyId': 'p2', 'status': 'ACTIVE'},
+            ],
+            'nextToken': 'tok123',
+        }
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_list(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, ListPoliciesResponse)
+        assert result.status == 'success'
+        assert len(result.policies) == 2
+        assert result.next_token == 'tok123'
+
+    @pytest.mark.asyncio
+    async def test_with_scope_filter(self, mock_ctx, client_factory, mock_boto3_client):
+        """Passes target_resource_scope to API."""
+        mock_boto3_client.list_policies.return_value = {'policies': []}
+        tools = PolicyTools(client_factory)
+        gateway_arn = 'arn:aws:bedrock-agentcore:us-east-1:123:gateway/gw-abcdefghij'
+        result = await tools.policy_list(
+            ctx=mock_ctx,
+            policy_engine_id='eng-id',
+            target_resource_scope=gateway_arn,
+            max_results=25,
+            next_token='prev',
+        )
+        assert isinstance(result, ListPoliciesResponse)
+        kw = mock_boto3_client.list_policies.call_args.kwargs
+        assert kw['policyEngineId'] == 'eng-id'
+        assert kw['targetResourceScope'] == gateway_arn
+        assert kw['maxResults'] == 25
+        assert kw['nextToken'] == 'prev'
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_ctx, client_factory, mock_boto3_client):
+        """Handles empty policy list."""
+        mock_boto3_client.list_policies.return_value = {'policies': []}
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_list(ctx=mock_ctx, policy_engine_id='eng-id')
+        assert isinstance(result, ListPoliciesResponse)
+        assert result.status == 'success'
+        assert len(result.policies) == 0
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, client_factory, mock_boto3_client):
+        """Returns ErrorResponse on ClientError."""
+        mock_boto3_client.list_policies.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ResourceNotFoundException', 'Message': 'x'},
+                'ResponseMetadata': {'HTTPStatusCode': 404},
+            },
+            'ListPolicies',
+        )
+        tools = PolicyTools(client_factory)
+        result = await tools.policy_list(ctx=mock_ctx, policy_engine_id='nope')
+        assert isinstance(result, ErrorResponse)
+        assert result.status == 'error'

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_policy_client.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/policy/test_unit_policy_client.py
@@ -1,0 +1,137 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Policy client wrapper."""
+
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.policy_client import (
+    MCP_USER_AGENT,
+    _policy_clients,
+    get_policy_client,
+)
+from unittest.mock import MagicMock, patch
+
+
+PATCH_SESSION = (
+    'awslabs.amazon_bedrock_agentcore_mcp_server.tools.policy.policy_client.boto3.Session'
+)
+
+
+def _extract_config(mock_session):
+    """Extract the Config object from a mock session.client() call."""
+    call_kwargs = mock_session.client.call_args
+    return call_kwargs.kwargs.get('config')
+
+
+class TestGetPolicyClient:
+    """Tests for get_policy_client."""
+
+    def setup_method(self):
+        """Clear client cache before each test."""
+        _policy_clients.clear()
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch(PATCH_SESSION)
+    def test_creates_client_with_defaults(self, mock_session_cls):
+        """Creates client with default region and correct service."""
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        client = get_policy_client()
+
+        mock_session_cls.assert_called_once_with(region_name='us-east-1')
+        mock_session.client.assert_called_once()
+        assert mock_session.client.call_args[0][0] == 'bedrock-agentcore-control'
+        assert client is mock_client
+
+    @patch.dict('os.environ', {'AWS_REGION': 'eu-west-1'}, clear=True)
+    @patch(PATCH_SESSION)
+    def test_uses_env_region(self, mock_session_cls):
+        """Uses AWS_REGION environment variable when set."""
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        get_policy_client()
+
+        mock_session_cls.assert_called_once_with(region_name='eu-west-1')
+
+    @patch(PATCH_SESSION)
+    def test_uses_explicit_region(self, mock_session_cls):
+        """Uses explicitly specified region over env var."""
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        get_policy_client(region_name='ap-southeast-1')
+
+        mock_session_cls.assert_called_once_with(region_name='ap-southeast-1')
+
+    @patch(PATCH_SESSION)
+    def test_caches_client(self, mock_session_cls):
+        """Returns cached client on subsequent calls with same region."""
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        c1 = get_policy_client(region_name='us-east-1')
+        c2 = get_policy_client(region_name='us-east-1')
+
+        assert c1 is c2
+        assert mock_session_cls.call_count == 1
+
+    @patch(PATCH_SESSION)
+    def test_different_regions_different_clients(self, mock_session_cls):
+        """Different regions produce different cached clients."""
+        mock_s1 = MagicMock()
+        mock_s2 = MagicMock()
+        mock_s1.client.return_value = MagicMock()
+        mock_s2.client.return_value = MagicMock()
+        mock_session_cls.side_effect = [mock_s1, mock_s2]
+
+        c1 = get_policy_client(region_name='us-east-1')
+        c2 = get_policy_client(region_name='us-west-2')
+
+        assert c1 is not c2
+        assert mock_session_cls.call_count == 2
+
+    @patch(PATCH_SESSION)
+    def test_user_agent_tracking(self, mock_session_cls):
+        """Policy client has the policy user-agent suffix."""
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        get_policy_client(region_name='us-east-1')
+
+        config = _extract_config(mock_session)
+        assert config is not None
+        assert config.user_agent_extra == MCP_USER_AGENT
+        assert 'policy' in config.user_agent_extra
+
+    @patch(PATCH_SESSION)
+    def test_user_agent_has_no_control_suffix(self, mock_session_cls):
+        """Single-client primitive uses plain 'policy' (no '-control' qualifier)."""
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        get_policy_client(region_name='us-east-1')
+
+        config = _extract_config(mock_session)
+        assert config is not None
+        # Plain primitive name, not 'policy-control' or 'policy-data'
+        assert 'policy-control' not in config.user_agent_extra
+        assert 'policy-data' not in config.user_agent_extra


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Adds the AgentCore **Policy** primitive to the unified
`amazon-bedrock-agentcore-mcp-server` as an operational sub-package
(Pattern A), following the same pattern as Memory, Runtime, Browser,
and Code Interpreter.

Exposes **15 MCP tools** covering all 14 public Policy control-plane
APIs plus a comprehensive static guide:

- **5 Policy Engine tools** — `policy_engine_{create,get,update,delete,list}`
- **5 Policy CRUD tools** — `policy_{create,get,update,delete,list}`
- **4 Policy Generation tools** — `policy_generation_{start,get,list,list_assets}`
- **1 Guide tool** — `get_policy_guide`

All operations go through `bedrock-agentcore-control` — Policy has no
data plane, so the sub-package uses a single cached boto3 client.

---

## Cost & Gating — Read This Before Approving

The unified MCP server autoregisters tools; AI coding agents can
discover and call any registered tool without explicit user action.
Some Policy APIs incur AWS charges, and one (policy generation) is
potentially expensive. This PR applies the same safeguards we added
after the Code Interpreter billing incident.

### Per-tool risk tier

**Billable (incur AWS charges — `COST WARNING` in docstring):**

| Tool                      | Cost driver                                        |
| ------------------------- | -------------------------------------------------- |
| `policy_engine_create`    | Provisions a policy engine (infrastructure)        |
| `policy_create`           | Invokes validation pipeline, provisions policy     |
| `policy_update`           | Re-invokes validation pipeline                     |
| `policy_generation_start` | **Foundation-model invocation** — most expensive   |

**Destructive (irreversible):**

- `policy_engine_delete` — requires zero associated policies first
- `policy_delete`

**Read-only (no cost):**

All `*_get`, `*_list`, and `get_policy_guide` — 8 tools total,
including the guide.

### How the guardrails are enforced

1. Every billable tool has `COST WARNING:` prefixed in its docstring,
   placed prominently so the LLM sees it before deciding to call.
   `policy_generation_start` explicitly calls out "typically the most
   expensive Policy operation per call."
2. The `__init__.py` module docstring groups all 15 tools by risk tier.
3. The same grouping appears in the `get_policy_guide` output under
   "Tool Cost Tiers."
4. Operators can opt out entirely via
   `AGENTCORE_DISABLE_TOOLS=policy`, and the integration test suite
   includes a `test_list_tools_policy_disabled` test asserting this
   works.

### Known limitation

`_is_service_enabled('policy')` is on by default, matching all other
primitives. There is no per-tool gating today (e.g., "disable policy
generation but keep read-only"). If we want finer-grained gating
after this lands, it should be a cross-cutting change applied to all
primitives, not a Policy-specific bolt-on.

---

## Architecture

```
awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/
├── __init__.py          # register_policy_tools(mcp) entry point
├── policy_client.py     # Cached bedrock-agentcore-control client
├── models.py            # 10 Pydantic response models
├── error_handler.py     # ClientError → ErrorResponse mapping
├── engines.py           # PolicyEngineTools (5 tools)
├── policies.py          # PolicyTools (5 tools)
├── generations.py       # PolicyGenerationTools (4 tools)
└── guide.py             # GuideTools (1 tool)
```

### Design decisions

- **Single client, not two.** All Policy APIs are control plane, so
  we use one cached `bedrock-agentcore-control` client via
  `get_policy_client()`. User-agent is `build_user_agent('policy')`
  (no `-control` suffix, matching the single-client pattern used by
  `browser` and `code-interpreter`).
- **Guide returns a Pydantic model.** `get_policy_guide` returns
  `PolicyGuideResponse(guide=...)` rather than `dict[str, str]` —
  every tool in the sub-package returns a `BaseModel`, including the
  guide.
- **No `clear_clients()` or other cleanup.** boto3 clients don't hold
  open connections; there's nothing to shut down. The sub-package
  does not hook into `server_lifespan`.
- **No PII in logs.** Logger calls only include resource IDs
  (`policy_engine_id`, `policy_id`, `policy_generation_id`), operation
  names, and counts — never user-provided Cedar statements,
  natural-language generation inputs, or descriptions.

---

## Files Changed

### New — sub-package (8 files)

```
src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/policy/
  __init__.py
  policy_client.py
  models.py
  error_handler.py
  engines.py
  policies.py
  generations.py
  guide.py
```

### New — tests (9 files)

```
src/amazon-bedrock-agentcore-mcp-server/tests/policy/
  __init__.py
  conftest.py
  test_unit_policy_client.py
  test_unit_engines.py
  test_unit_policies.py
  test_unit_generations.py
  test_unit_error_handler.py
  test_unit_init.py
  test_unit_guide.py
```

### Modified (3 files)

- **`server.py`** — adds the `_is_service_enabled('policy')` block
  with import-error fallback. Tool count logged as 15.
- **`tests/test_tools.py`** — adds `TestPolicyTool` class exercising
  the guide tool and its Pydantic response. Existing `TestMemoryTool`
  and `TestGatewayTool` are unchanged.
- **`tests/browser/test_integ_mcp_protocol.py`** — adds `POLICY_TOOLS`
  set (15 tools), registers policy in `_build_server()`, adds two
  schema tests (`test_policy_tools_require_policy_engine_id`,
  `test_policy_engine_create_has_optional_params`), a discovery opt-out
  test (`test_list_tools_policy_disabled`), and one protocol
  invocation test (`test_policy_guide_invocation`). Existing tests
  updated to include `POLICY_TOOLS` in the default-config expectation.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x ] I have performed a self-review of this change
* [x ] Changes have been tested
* [x ] Changes are documented

Is this a breaking change? N


**RFC issue number**:

Checklist:

* [ x] Migration process documented
* [x ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
