### PR TITLE
fix(redshift-mcp-server): refresh expired AWS credentials automatically

### DIFF
--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -44,8 +44,10 @@ from awslabs.redshift_mcp_server.models import (
 from awslabs.redshift_mcp_server.sql_guard import assert_executable
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from functools import partial
 from loguru import logger
 from sqlglot import exp
+from types import SimpleNamespace
 
 
 def _sql_identifier(value: str) -> str:
@@ -57,69 +59,139 @@ def _sql_identifier(value: str) -> str:
 _ACCESS_DENIED = {'AccessDeniedException', 'UnauthorizedAccess', 'AccessDenied'}
 
 
+# ClientError codes that indicate expired credentials.
+_EXPIRED_TOKEN = {'ExpiredToken', 'ExpiredTokenException'}
+
+
+def _error_code(error: ClientError) -> str | None:
+    """Return the AWS error code carried by a ClientError, if any."""
+    return error.response.get('Error', {}).get('Code')
+
+
+class _CredentialRefreshingClient:
+    """A boto3 client for one service that refreshes credentials once on ExpiredToken.
+
+    Lazily creates and caches its boto3 client. On an ExpiredToken/ExpiredTokenException
+    error it discards the cached client and retries once against a freshly built one,
+    which re-reads credentials from the default chain.
+
+    This covers credential sources botocore resolves once and never refreshes, notably
+    keys written to the shared credentials file, where a cached client keeps signing with
+    them past expiry. Sources that yield refreshable credentials (SSO, assume-role, web
+    identity, container) already refresh inside a cached client, and credentials taken
+    from environment variables cannot be refreshed in-process at all.
+    """
+
+    def __init__(
+        self,
+        service_name: str,
+        config: Config,
+        aws_region: str | None = None,
+        aws_profile: str | None = None,
+    ):
+        """Initialize for a single Redshift-family boto3 service."""
+        self._service_name = service_name
+        self._config = config
+        self._aws_region = aws_region
+        self._aws_profile = aws_profile
+        self._client = None
+
+    @property
+    def service_name(self) -> str:
+        """The boto3 service this client is bound to."""
+        return self._service_name
+
+    def _build(self):
+        """Return the live boto3 client, creating and caching it on first use."""
+        if self._client is None:
+            try:
+                # Session works with None values - uses default credentials/region chain
+                session = boto3.Session(
+                    profile_name=self._aws_profile, region_name=self._aws_region
+                )
+                self._client = session.client(self._service_name, config=self._config)
+                logger.info(
+                    f'Created {self._service_name} client with profile: {self._aws_profile or "default"}, region: {self._aws_region or "default"}'
+                )
+            except Exception as e:
+                logger.error(f'Error creating {self._service_name} client: {str(e)}')
+                raise
+
+        return self._client
+
+    def invalidate(self):
+        """Discard the cached client so the next call recreates it with fresh credentials."""
+        self._client = None
+        logger.info(f'Invalidated cached {self._service_name} client for credential refresh')
+
+    def _retry(self, description: str, call, client=None):
+        """Run call against the live client, refreshing credentials once on expiry."""
+        try:
+            return call(client if client is not None else self._build())
+        except ClientError as e:
+            if _error_code(e) not in _EXPIRED_TOKEN:
+                raise
+            logger.warning(f'Expired credentials on {description}, refreshing and retrying')
+            self.invalidate()
+            return call(self._build())
+
+    def __getattr__(self, name: str):
+        """Proxy an attribute, wrapping operations with a retry on expired credentials."""
+        if name.startswith('_'):
+            raise AttributeError(name)
+
+        client = self._build()
+        attribute = getattr(client, name)
+        if not callable(attribute):
+            return attribute
+
+        def call(*args, **kwargs):
+            return self._retry(name, lambda c: getattr(c, name)(*args, **kwargs), client)
+
+        return call
+
+    def get_paginator(self, operation: str) -> SimpleNamespace:
+        """Return an object exposing paginate(**kwargs), like a boto3 paginator."""
+        return SimpleNamespace(paginate=partial(self._paginate, operation))
+
+    def _paginate(self, operation: str, **kwargs) -> list[dict]:
+        """Return every page of the operation, retried once on expired credentials.
+
+        Pages are collected eagerly so a refresh cannot re-yield pages already handed
+        out. Both paginated listings here are small and fully materialized by callers.
+        """
+        return self._retry(
+            f'paginating {operation}',
+            lambda client: list(client.get_paginator(operation).paginate(**kwargs)),
+        )
+
+
 class RedshiftClientManager:
-    """Manages AWS clients for Redshift operations."""
+    """Builds and holds the self-refreshing clients used for Redshift operations."""
 
     def __init__(
         self, config: Config, aws_region: str | None = None, aws_profile: str | None = None
     ):
-        """Initialize the client manager."""
-        self.aws_region = aws_region
-        self.aws_profile = aws_profile
-        self._redshift_client = None
-        self._redshift_serverless_client = None
-        self._redshift_data_client = None
-        self._config = config
+        """Create one self-refreshing client per Redshift service."""
+        self._redshift = _CredentialRefreshingClient('redshift', config, aws_region, aws_profile)
+        self._redshift_serverless = _CredentialRefreshingClient(
+            'redshift-serverless', config, aws_region, aws_profile
+        )
+        self._redshift_data = _CredentialRefreshingClient(
+            'redshift-data', config, aws_region, aws_profile
+        )
 
-    def redshift_client(self):
-        """Get or create the Redshift client for provisioned clusters."""
-        if self._redshift_client is None:
-            try:
-                # Session works with None values - uses default credentials/region chain
-                session = boto3.Session(profile_name=self.aws_profile, region_name=self.aws_region)
-                self._redshift_client = session.client('redshift', config=self._config)
-                logger.info(
-                    f'Created Redshift client with profile: {self.aws_profile or "default"}, region: {self.aws_region or "default"}'
-                )
-            except Exception as e:
-                logger.error(f'Error creating Redshift client: {str(e)}')
-                raise
+    def redshift_client(self) -> _CredentialRefreshingClient:
+        """Get the Redshift client for provisioned clusters (auto-refreshes on expiry)."""
+        return self._redshift
 
-        return self._redshift_client
+    def redshift_serverless_client(self) -> _CredentialRefreshingClient:
+        """Get the Redshift Serverless client (auto-refreshes on expiry)."""
+        return self._redshift_serverless
 
-    def redshift_serverless_client(self):
-        """Get or create the Redshift Serverless client."""
-        if self._redshift_serverless_client is None:
-            try:
-                # Session works with None values - uses default credentials/region chain
-                session = boto3.Session(profile_name=self.aws_profile, region_name=self.aws_region)
-                self._redshift_serverless_client = session.client(
-                    'redshift-serverless', config=self._config
-                )
-                logger.info(
-                    f'Created Redshift Serverless client with profile: {self.aws_profile or "default"}, region: {self.aws_region or "default"}'
-                )
-            except Exception as e:
-                logger.error(f'Error creating Redshift Serverless client: {str(e)}')
-                raise
-
-        return self._redshift_serverless_client
-
-    def redshift_data_client(self):
-        """Get or create the Redshift Data API client."""
-        if self._redshift_data_client is None:
-            try:
-                # Session works with None values - uses default credentials/region chain
-                session = boto3.Session(profile_name=self.aws_profile, region_name=self.aws_region)
-                self._redshift_data_client = session.client('redshift-data', config=self._config)
-                logger.info(
-                    f'Created Redshift Data API client with profile: {self.aws_profile or "default"}, region: {self.aws_region or "default"}'
-                )
-            except Exception as e:
-                logger.error(f'Error creating Redshift Data API client: {str(e)}')
-                raise
-
-        return self._redshift_data_client
+    def redshift_data_client(self) -> _CredentialRefreshingClient:
+        """Get the Redshift Data API client (auto-refreshes on expiry)."""
+        return self._redshift_data
 
 
 class RedshiftSessionManager:
@@ -523,7 +595,7 @@ async def discover_clusters() -> list[RedshiftCluster]:
         logger.info(f'Found {len(clusters)} provisioned clusters')
 
     except ClientError as e:
-        if e.response.get('Error', {}).get('Code') not in _ACCESS_DENIED:
+        if _error_code(e) not in _ACCESS_DENIED:
             raise
         provisioned_error = e
         logger.warning(f'Skipping provisioned; IAM lacks permission: {e}')
@@ -569,7 +641,7 @@ async def discover_clusters() -> list[RedshiftCluster]:
         logger.info(f'Found {serverless_count} serverless workgroups')
 
     except ClientError as e:
-        if e.response.get('Error', {}).get('Code') not in _ACCESS_DENIED:
+        if _error_code(e) not in _ACCESS_DENIED:
             raise
         serverless_error = e
         logger.warning(f'Skipping serverless; IAM lacks permission: {e}')

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -26,6 +26,7 @@ from awslabs.redshift_mcp_server.models import RedshiftCluster
 from awslabs.redshift_mcp_server.redshift import (
     RedshiftClientManager,
     RedshiftSessionManager,
+    _CredentialRefreshingClient,
     _execute_protected_statement,
     _execute_statement,
     _sql_identifier,
@@ -54,212 +55,159 @@ def _fake_statement(statement_id='stmt-id', has_result_set=False):
     return {'Id': statement_id, 'Status': 'FINISHED', 'HasResultSet': has_result_set}
 
 
-class TestRedshiftClientManagerRedshiftClient:
-    """Tests for RedshiftClientManager redshift_client() method."""
+def _expired(operation):
+    """Build an ExpiredToken ClientError for the given operation."""
+    return ClientError({'Error': {'Code': 'ExpiredToken', 'Message': 'Token expired'}}, operation)
 
-    def test_redshift_client_creation_default_credentials(self, mocker):
-        """Test Redshift client creation with default credentials."""
+
+class TestCredentialRefreshingClientCreation:
+    """Tests for _CredentialRefreshingClient lazy boto3 client creation and caching."""
+
+    @pytest.mark.parametrize('service_name', ['redshift', 'redshift-serverless', 'redshift-data'])
+    def test_client_created_with_default_credentials(self, mocker, service_name):
+        """The first operation builds a client for the service with default credentials."""
         mock_client = mocker.Mock()
         mock_boto3_session = mocker.patch('boto3.Session')
         mock_boto3_session.return_value.client.return_value = mock_client
 
         config = Config()
-        manager = RedshiftClientManager(config)
-        client = manager.redshift_client()
+        client = _CredentialRefreshingClient(service_name, config)
+        client.describe_statement(Id='s-1')
 
-        assert client == mock_client
-
-        # Verify boto3.Session was called with correct parameters
         mock_boto3_session.assert_called_once_with(profile_name=None, region_name=None)
-        mock_boto3_session.return_value.client.assert_called_once_with('redshift', config=config)
+        mock_boto3_session.return_value.client.assert_called_once_with(service_name, config=config)
+        mock_client.describe_statement.assert_called_once_with(Id='s-1')
 
-    def test_redshift_client_creation_error(self, mocker):
-        """Test Redshift client creation error handling."""
+    def test_client_creation_error_propagates(self, mocker):
+        """Errors while creating the client propagate."""
         mock_boto3_session = mocker.patch('boto3.Session')
         mock_boto3_session.return_value.client.side_effect = Exception('AWS credentials error')
 
-        config = Config()
-        manager = RedshiftClientManager(config)
-
+        client = _CredentialRefreshingClient('redshift', Config())
         with pytest.raises(Exception, match='AWS credentials error'):
-            manager.redshift_client()
+            client.describe_statement(Id='s-1')
 
-    def test_client_caching(self, mocker):
-        """Test that clients are cached after first creation."""
+    def test_client_created_once_and_reused(self, mocker):
+        """The boto3 client is created once and reused across operations."""
         mock_client = mocker.Mock()
         mock_boto3_session = mocker.patch('boto3.Session')
         mock_boto3_session.return_value.client.return_value = mock_client
 
-        config = Config()
-        manager = RedshiftClientManager(config)
+        client = _CredentialRefreshingClient('redshift', Config())
+        client.describe_statement(Id='s-1')
+        client.describe_statement(Id='s-2')
 
-        # First call should create client
-        client1 = manager.redshift_client()
-        # Second call should return cached client
-        client2 = manager.redshift_client()
-
-        assert client1 == client2 == mock_client
-        # Session should only be called once
         mock_boto3_session.assert_called_once()
+        assert mock_client.describe_statement.call_count == 2
 
-    def test_redshift_client_creation_with_profile_and_region(self, mocker):
-        """Test Redshift client creation with AWS profile and region."""
+    def test_client_created_with_profile_and_region(self, mocker):
+        """Profile and region are passed through to the boto3 session."""
         mock_session = mocker.Mock()
-        mock_client = mocker.Mock()
-        mock_session.client.return_value = mock_client
+        mock_session.client.return_value = mocker.Mock()
         mock_session_class = mocker.patch('boto3.Session', return_value=mock_session)
 
         config = Config()
-        manager = RedshiftClientManager(config, 'us-west-2', 'test-profile')
-        client = manager.redshift_client()
+        client = _CredentialRefreshingClient('redshift-data', config, 'us-west-2', 'test-profile')
+        client.describe_statement(Id='s-1')
 
-        assert client == mock_client
-
-        # Verify session was created with profile and region
-        mock_session_class.assert_called_once_with(
-            profile_name='test-profile', region_name='us-west-2'
-        )
-        mock_session.client.assert_called_once_with('redshift', config=config)
-
-
-class TestRedshiftClientManagerServerlessClient:
-    """Tests for RedshiftClientManager redshift_serverless_client() method."""
-
-    def test_redshift_serverless_client_creation_default_credentials(self, mocker):
-        """Test Redshift Serverless client creation with default credentials."""
-        mock_client = mocker.Mock()
-        mock_boto3_session = mocker.patch('boto3.Session')
-        mock_boto3_session.return_value.client.return_value = mock_client
-
-        config = Config()
-        manager = RedshiftClientManager(config)
-        client = manager.redshift_serverless_client()
-
-        assert client == mock_client
-
-        # Verify boto3.Session was called with correct parameters
-        mock_boto3_session.assert_called_once_with(profile_name=None, region_name=None)
-        mock_boto3_session.return_value.client.assert_called_once_with(
-            'redshift-serverless', config=config
-        )
-
-    def test_redshift_serverless_client_creation_error(self, mocker):
-        """Test Redshift Serverless client creation error handling."""
-        mock_boto3_session = mocker.patch('boto3.Session')
-        mock_boto3_session.return_value.client.side_effect = Exception('Serverless client error')
-
-        config = Config()
-        manager = RedshiftClientManager(config)
-
-        with pytest.raises(Exception, match='Serverless client error'):
-            manager.redshift_serverless_client()
-
-    def test_redshift_serverless_client_creation_with_profile_and_region(self, mocker):
-        """Test Redshift Serverless client creation with AWS profile and region."""
-        mock_session = mocker.Mock()
-        mock_client = mocker.Mock()
-        mock_session.client.return_value = mock_client
-        mock_session_class = mocker.patch('boto3.Session', return_value=mock_session)
-
-        config = Config()
-        manager = RedshiftClientManager(config, 'us-west-2', 'test-profile')
-        client = manager.redshift_serverless_client()
-
-        assert client == mock_client
-
-        # Verify session was created with profile and region
-        mock_session_class.assert_called_once_with(
-            profile_name='test-profile', region_name='us-west-2'
-        )
-        mock_session.client.assert_called_once_with('redshift-serverless', config=config)
-
-    def test_redshift_serverless_client_caching(self, mocker):
-        """Test that redshift serverless client is cached after first creation."""
-        mock_client = mocker.Mock()
-        mock_boto3_session = mocker.patch('boto3.Session')
-        mock_boto3_session.return_value.client.return_value = mock_client
-
-        config = Config()
-        manager = RedshiftClientManager(config)
-
-        # First call should create client
-        client1 = manager.redshift_serverless_client()
-        # Second call should return cached client
-        client2 = manager.redshift_serverless_client()
-
-        assert client1 == client2 == mock_client
-        # Session should only be called once
-        mock_boto3_session.assert_called_once()
-
-
-class TestRedshiftClientManagerDataClient:
-    """Tests for RedshiftClientManager redshift_data_client() method."""
-
-    def test_redshift_data_client_creation_default_credentials(self, mocker):
-        """Test Redshift Data API client creation with default credentials."""
-        mock_client = mocker.Mock()
-        mock_boto3_session = mocker.patch('boto3.Session')
-        mock_boto3_session.return_value.client.return_value = mock_client
-
-        config = Config()
-        manager = RedshiftClientManager(config)
-        client = manager.redshift_data_client()
-
-        assert client == mock_client
-
-        # Verify boto3.Session was called with correct parameters
-        mock_boto3_session.assert_called_once_with(profile_name=None, region_name=None)
-        mock_boto3_session.return_value.client.assert_called_once_with(
-            'redshift-data', config=config
-        )
-
-    def test_redshift_data_client_creation_error(self, mocker):
-        """Test Redshift Data client creation error handling."""
-        mock_boto3_session = mocker.patch('boto3.Session')
-        mock_boto3_session.return_value.client.side_effect = Exception('Data client error')
-
-        config = Config()
-        manager = RedshiftClientManager(config)
-
-        with pytest.raises(Exception, match='Data client error'):
-            manager.redshift_data_client()
-
-    def test_redshift_data_client_creation_with_profile_and_region(self, mocker):
-        """Test Redshift Data API client creation with AWS profile and region."""
-        mock_session = mocker.Mock()
-        mock_client = mocker.Mock()
-        mock_session.client.return_value = mock_client
-        mock_session_class = mocker.patch('boto3.Session', return_value=mock_session)
-
-        config = Config()
-        manager = RedshiftClientManager(config, 'us-west-2', 'test-profile')
-        client = manager.redshift_data_client()
-
-        assert client == mock_client
-
-        # Verify session was created with profile and region
         mock_session_class.assert_called_once_with(
             profile_name='test-profile', region_name='us-west-2'
         )
         mock_session.client.assert_called_once_with('redshift-data', config=config)
 
-    def test_redshift_data_client_caching(self, mocker):
-        """Test that redshift data client is cached after first creation."""
-        mock_client = mocker.Mock()
+
+class TestCredentialRefreshingClientRefresh:
+    """Tests for the _CredentialRefreshingClient retry + paginator behavior."""
+
+    def test_retries_once_on_expired_token(self, mocker):
+        """An operation is retried against a freshly built client."""
+        expired, fresh = mocker.Mock(), mocker.Mock()
+        expired.describe_statement.side_effect = _expired('DescribeStatement')
+        fresh.describe_statement.return_value = {'Status': 'FINISHED'}
         mock_boto3_session = mocker.patch('boto3.Session')
-        mock_boto3_session.return_value.client.return_value = mock_client
+        mock_boto3_session.return_value.client.side_effect = [expired, fresh]
 
-        config = Config()
-        manager = RedshiftClientManager(config)
+        client = _CredentialRefreshingClient('redshift-data', Config())
 
-        # First call should create client
-        client1 = manager.redshift_data_client()
-        # Second call should return cached client
-        client2 = manager.redshift_data_client()
+        assert client.describe_statement(Id='s-1') == {'Status': 'FINISHED'}
+        # The retry ran against a client built from a second session, so from fresh credentials.
+        assert mock_boto3_session.call_count == 2
 
-        assert client1 == client2 == mock_client
-        # Session should only be called once
+    def test_does_not_retry_other_errors(self, mocker):
+        """Non-expired-token ClientErrors propagate without a refresh."""
+        raw = mocker.Mock()
+        raw.describe_statement.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}}, 'DescribeStatement'
+        )
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.return_value = raw
+
+        client = _CredentialRefreshingClient('redshift-data', Config())
+        with pytest.raises(ClientError, match='AccessDenied'):
+            client.describe_statement(Id='s-1')
+
+        assert raw.describe_statement.call_count == 1
         mock_boto3_session.assert_called_once()
+
+    def test_private_attributes_are_not_proxied(self):
+        """Private names raise AttributeError instead of returning a wrapper."""
+        client = _CredentialRefreshingClient('redshift', Config())
+        with pytest.raises(AttributeError):
+            client.__deepcopy__
+
+    def test_non_operation_attributes_are_passed_through(self, mocker):
+        """Attributes that are not operations resolve to the boto3 client's own values."""
+        raw = mocker.Mock()
+        # A plain namespace, not a Mock: Mock attributes are callable and would be wrapped.
+        raw.meta = SimpleNamespace(region_name='us-west-2')
+        raw.waiter_names = []
+        mocker.patch('boto3.Session').return_value.client.return_value = raw
+
+        client = _CredentialRefreshingClient('redshift', Config())
+
+        assert client.meta.region_name == 'us-west-2'
+        assert client.waiter_names == []
+
+    def test_paginate_retries_on_expired_token(self, mocker):
+        """Expiry while listing refreshes credentials and restarts the listing."""
+        expired, fresh = mocker.Mock(), mocker.Mock()
+        expired.get_paginator.return_value.paginate.side_effect = _expired('DescribeClusters')
+        fresh.get_paginator.return_value.paginate.return_value = [{'Clusters': [{'a': 1}]}]
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.side_effect = [expired, fresh]
+
+        client = _CredentialRefreshingClient('redshift', Config())
+        pages = client.get_paginator('describe_clusters').paginate()
+
+        assert pages == [{'Clusters': [{'a': 1}]}]
+        assert mock_boto3_session.call_count == 2
+
+    def test_paginate_forwards_arguments(self, mocker):
+        """Paginate kwargs reach the underlying paginator."""
+        raw = mocker.Mock()
+        raw.get_paginator.return_value.paginate.return_value = []
+        mocker.patch('boto3.Session').return_value.client.return_value = raw
+
+        client = _CredentialRefreshingClient('redshift-data', Config())
+        client.get_paginator('get_statement_result').paginate(Id='s-1')
+
+        raw.get_paginator.return_value.paginate.assert_called_once_with(Id='s-1')
+
+
+class TestRedshiftClientManager:
+    """Tests that the manager wires each accessor to the right service client."""
+
+    def test_accessors_return_expected_service_clients(self):
+        """Each accessor returns a client bound to the expected service."""
+        manager = RedshiftClientManager(Config())
+        assert manager.redshift_client().service_name == 'redshift'
+        assert manager.redshift_serverless_client().service_name == 'redshift-serverless'
+        assert manager.redshift_data_client().service_name == 'redshift-data'
+
+    def test_accessors_return_stable_instances(self):
+        """Accessors return the same client instance so its cached boto3 client persists."""
+        manager = RedshiftClientManager(Config())
+        assert manager.redshift_data_client() is manager.redshift_data_client()
 
 
 class TestExecuteProtectedStatement:
@@ -963,6 +911,91 @@ class TestExecuteStatement:
             await _execute_statement(
                 _fake_cluster(), 'test-cluster', 'dev', 'SELECT 1', query_poll_interval=0
             )
+
+
+class TestCredentialRefreshDuringExecution:
+    """Integration tests that credential refresh recovers without re-submitting SQL."""
+
+    @pytest.mark.asyncio
+    async def test_discover_clusters_retries_pagination(self, mocker):
+        """Expired credentials during discovery refresh and retry the listing."""
+        expired, fresh = mocker.Mock(), mocker.Mock()
+        expired.get_paginator.return_value.paginate.side_effect = _expired('DescribeClusters')
+        fresh.get_paginator.return_value.paginate.return_value = [{'Clusters': []}]
+        serverless = mocker.Mock()
+        serverless.get_paginator.return_value.paginate.return_value = [{'workgroups': []}]
+
+        mock_boto3_session = mocker.patch('boto3.Session')
+        # Provisioned discovery builds the expired client, then the fresh one after refresh
+        mock_boto3_session.return_value.client.side_effect = [expired, fresh, serverless]
+        manager = RedshiftClientManager(Config())
+        mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager', manager)
+
+        assert await discover_clusters() == []
+        # A session per build: expired provisioned, fresh provisioned, serverless
+        assert mock_boto3_session.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_expired_token_while_polling_does_not_resubmit(self, mocker):
+        """Expiry between submit and poll does not re-run the statement."""
+        raw = mocker.Mock()
+        raw.execute_statement.return_value = {'Id': 'stmt-123'}
+        raw.describe_statement.side_effect = [
+            _expired('DescribeStatement'),
+            _fake_statement('stmt-123'),
+        ]
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.return_value = raw
+        manager = RedshiftClientManager(Config())
+        mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager', manager)
+
+        result = await _execute_statement(
+            cluster_info=_fake_cluster(),
+            cluster_identifier='test-cluster',
+            database_name='dev',
+            sql='SELECT 1',
+            query_poll_interval=0,
+        )
+
+        assert result == _fake_statement('stmt-123')
+        assert raw.execute_statement.call_count == 1
+        # The client was rebuilt from a second session after the expiry
+        assert mock_boto3_session.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_expired_token_fetching_results_does_not_resubmit(self, mocker):
+        """Expiry while fetching results does not re-run the guarded SQL."""
+        raw = mocker.Mock()
+        raw.execute_statement.return_value = {'Id': 'stmt-123'}
+        raw.describe_statement.return_value = {
+            'Id': 'stmt-123',
+            'Status': 'FINISHED',
+            'HasResultSet': True,
+            'SessionId': 'session-1',
+        }
+        raw.get_statement_result.side_effect = [
+            _expired('GetStatementResult'),
+            {'Records': [], 'ColumnMetadata': []},
+        ]
+        mock_boto3_session = mocker.patch('boto3.Session')
+        mock_boto3_session.return_value.client.return_value = raw
+        manager = RedshiftClientManager(Config())
+        mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager', manager)
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[_fake_cluster()],
+        )
+
+        results, _ = await _execute_protected_statement(
+            cluster_identifier='test-cluster', database_name='dev', sql='SELECT 1'
+        )
+
+        assert results == {'Records': [], 'ColumnMetadata': []}
+        assert raw.get_statement_result.call_count == 2
+        # The client was rebuilt from a second session after the expiry
+        assert mock_boto3_session.call_count == 2
+        # The retry must not have re-run the session setup, the user SQL, or the ROLLBACK.
+        assert raw.execute_statement.call_count == 4
 
 
 class TestRedshiftSessionManager:


### PR DESCRIPTION
## Problem

`RedshiftClientManager` caches boto3 clients at first use and never refreshes them. When the underlying credentials are rotated while the MCP server is running, a cached client keeps signing requests with the stale credentials and every subsequent call fails with `ExpiredToken` until the process is restarted — a real pain point for long-running MCP server sessions.

This specifically affects credential sources that botocore resolves **once** and never refreshes on its own — most notably keys written to the **shared credentials file** (e.g. `ada` rewriting `~/.aws/credentials`). Sources that yield *refreshable* credentials (SSO, assume-role, web identity, container) already refresh inside a cached client via botocore, and environment-variable credentials cannot be refreshed in-process at all.

Related: #481, #1824

## Fix

Added **reactive** credential-refresh handling, centralized in a small per-service client so every call site is covered without per-call boilerplate.

`_CredentialRefreshingClient` wraps a single boto3 Redshift-family service client (`redshift`, `redshift-serverless`, `redshift-data`). It lazily creates and caches its client, and routes every operation through a shared retry helper: on an `ExpiredToken`/`ExpiredTokenException` error it discards the cached client and retries the call once against a freshly built one, which re-reads credentials from the default chain. Non-expiry errors propagate unchanged.

### Design decisions

- **Reactive catch-and-retry, not proactive inspection.** We catch the two documented error codes rather than inspecting private botocore internals (`_expiry_time`) — simpler and not tied to botocore implementation details.
- **Self-contained client, thin manager.** Each `_CredentialRefreshingClient` owns its own lifecycle (build, cache, invalidate, retry); `RedshiftClientManager` is a thin registry that hands out one client per service. Dependencies point inward — the manager depends on the clients, not the reverse.
- **Transparent proxy.** `__getattr__` forwards operations to the underlying client wrapped in the retry; non-callable attributes (e.g. `meta`) pass through unchanged; private names are not proxied.
- **Pagination collected eagerly under retry.** `get_paginator(...).paginate()` returns all pages as a list within a single retry. Collecting eagerly means an expiry mid-listing restarts the (idempotent, read-only) listing once with no pages already handed out — so no duplicates. Both paginated listings here are small and fully materialized by callers, so nothing is lost by not streaming.
- **Additive at the call sites.** `discover_clusters` / `_execute_statement` are unchanged from `main` — the behavior comes entirely from the client the manager hands out.

## Testing

### Unit tests

Full `redshift-mcp-server` suite passes (**202 tests**), including coverage for client creation/caching, credential invalidation, the retry helper (expired → invalidate → retry → success), non-expiry pass-through, non-operation attribute pass-through, eager pagination + retry, and — critically — that a credential refresh **never re-submits a statement** (expiry while polling and while fetching results both retry only the idempotent describe/result calls).

### E2E tests — real infrastructure (`us-east-1`, provisioned `ra3.large` + serverless 8 RPU)

Deployed via CloudFormation (provisioned cluster + serverless workgroup), tested, and torn down. Last run: 2026-08-07.

| # | Scenario | Provisioned | Serverless |
|---|----------|:-----------:|:----------:|
| 1 | discover_clusters | ✅ | ✅ |
| 2 | discover_databases | ✅ | ✅ |
| 3 | discover_schemas | ✅ | ✅ |
| 4 | discover_tables | ✅ | ✅ |
| 5 | discover_columns | ✅ | ✅ |
| 6 | execute_query (SELECT) | ✅ | ✅ |

### E2E test — credential refresh (against real infra)

| # | Scenario | Result |
|---|----------|:------:|
| 1 | Initial call establishes cached clients | ✅ |
| 2 | `invalidate()` then `execute_query` succeeds with a freshly built client | ✅ |
| 3 | Injected `ExpiredToken` at the boto3 layer → client invalidates, rebuilds, and recovers against real infra | ✅ |

CloudFormation template and E2E scripts: https://gist.github.com/scaredcat/c0465de49d7e796ac64d54aacd6285c9

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).