### PR TITLE
fix(aws-api-mcp-server): cache boto3 clients and reuse heavyweight objects

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/config.py
@@ -40,17 +40,26 @@ class FileAccessMode(str, Enum):
     NO_ACCESS = 'no-access'
 
 
+_region_cache: dict[str, str] = {}
+
+
 def get_region(profile_name: str | None = None) -> str:
     """Get the region depending on configuration."""
     if AWS_REGION:
         return AWS_REGION
 
+    cache_key = profile_name or '__default__'
+    if cache_key in _region_cache:
+        return _region_cache[cache_key]
+
     fallback_region = 'us-east-1'
-
     if profile_name:
-        return boto3.Session(profile_name=profile_name).region_name or fallback_region
+        region = boto3.Session(profile_name=profile_name).region_name or fallback_region
+    else:
+        region = boto3.Session().region_name or fallback_region
 
-    return boto3.Session().region_name or fallback_region
+    _region_cache[cache_key] = region
+    return region
 
 
 def get_server_directory():

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/helpers.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/helpers.py
@@ -21,6 +21,7 @@ import time
 from botocore.response import StreamingBody
 from contextlib import contextmanager
 from datetime import datetime
+from functools import cache
 from loguru import logger
 from requests.adapters import HTTPAdapter
 from typing import Any
@@ -92,8 +93,9 @@ def validate_aws_region(region: str):
         raise ValueError(error_message)
 
 
+@cache
 def get_requests_session() -> requests.Session:
-    """Configured requests session with common retry strategy."""
+    """Return a shared requests session with retry strategy."""
     retry_strategy = Retry(
         total=3,
         backoff_factor=1,
@@ -102,8 +104,6 @@ def get_requests_session() -> requests.Session:
     )
     session = requests.Session()
     adapter = HTTPAdapter(max_retries=retry_strategy)
-
     session.mount('https://', adapter)
     session.mount('http://', adapter)
-
     return session

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
@@ -28,12 +28,79 @@ from ..common.config import (
 from ..common.file_system_controls import validate_file_path
 from ..common.helpers import Boto3Encoder, operation_timer
 from botocore.config import Config
+from collections import OrderedDict
 from jmespath.parser import ParsedResult
+from loguru import logger
 from typing import Any
 
 
 TIMEOUT_AFTER_SECONDS = 10
 CHUNK_SIZE = 4 * 1024 * 1024
+
+# boto3.client() loads the full service model and builds a connection pool on
+# every call; without this cache RSS grows several MB per tool invocation.
+_client_cache: OrderedDict[tuple, Any] = OrderedDict()
+_MAX_CACHED_CLIENTS = 30
+
+
+def clear_client_cache() -> None:
+    """Clear the boto3 client cache. Intended for test fixtures."""
+    _client_cache.clear()
+
+
+_AUTH_ERROR_CODES = frozenset(
+    {
+        'ExpiredTokenException',
+        'ExpiredToken',
+        'RequestExpired',
+        'InvalidClientTokenId',
+        'UnrecognizedClientException',
+    }
+)
+
+
+def _get_or_create_client(
+    service_name: str,
+    access_key_id: str,
+    secret_access_key: str,
+    session_token: str | None,
+    region: str,
+    config: Config,
+    endpoint_url: str | None,
+) -> Any:
+    """Return a cached boto3 client, creating one if needed."""
+    key = (service_name, region, access_key_id, secret_access_key, session_token, endpoint_url)
+
+    if key in _client_cache:
+        _client_cache.move_to_end(key)
+        return _client_cache[key]
+
+    if len(_client_cache) >= _MAX_CACHED_CLIENTS:
+        _client_cache.popitem(last=False)
+
+    client = boto3.client(
+        service_name,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        aws_session_token=session_token,
+        config=config,
+        endpoint_url=endpoint_url,
+    )
+    _client_cache[key] = client
+    return client
+
+
+def _evict_client(
+    service_name: str,
+    access_key_id: str,
+    secret_access_key: str,
+    session_token: str | None,
+    region: str,
+    endpoint_url: str | None,
+) -> None:
+    """Remove a client from cache after an auth error."""
+    key = (service_name, region, access_key_id, secret_access_key, session_token, endpoint_url)
+    _client_cache.pop(key, None)
 
 
 def interpret(
@@ -64,30 +131,53 @@ def interpret(
     )
 
     with operation_timer(ir.service_name, ir.operation_python_name, region):
-        client = boto3.client(
+        client = _get_or_create_client(
             ir.service_name,
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
-            aws_session_token=session_token,
-            config=config,
-            endpoint_url=endpoint_url,
+            access_key_id,
+            secret_access_key,
+            session_token,
+            region,
+            config,
+            endpoint_url,
         )
 
-        if client.can_paginate(ir.operation_python_name):
-            response = build_result(
-                paginator=client.get_paginator(ir.operation_python_name),
-                service_name=ir.service_name,
-                operation_name=ir.operation_name,
-                operation_parameters=ir.parameters,
-                pagination_config=pagination_config,
-                client_side_filter=client_side_filter,
-            )
-        else:
-            operation = getattr(client, ir.operation_python_name)
-            response = operation(**parameters)
+        try:
+            if client.can_paginate(ir.operation_python_name):
+                response = build_result(
+                    paginator=client.get_paginator(ir.operation_python_name),
+                    service_name=ir.service_name,
+                    operation_name=ir.operation_name,
+                    operation_parameters=ir.parameters,
+                    pagination_config=pagination_config,
+                    client_side_filter=client_side_filter,
+                )
+            else:
+                operation = getattr(client, ir.operation_python_name)
+                response = operation(**parameters)
 
-            if client_side_filter is not None:
-                response = _apply_filter(response, client_side_filter)
+                if client_side_filter is not None:
+                    response = _apply_filter(response, client_side_filter)
+        except Exception as exc:
+            error_code = ''
+            resp = getattr(exc, 'response', None)
+            if isinstance(resp, dict):
+                error_code = resp.get('Error', {}).get('Code', '')
+            if error_code in _AUTH_ERROR_CODES:
+                logger.info(
+                    'Auth error ({}), evicting cached client for {}/{}',
+                    error_code,
+                    ir.service_name,
+                    region,
+                )
+                _evict_client(
+                    ir.service_name,
+                    access_key_id,
+                    secret_access_key,
+                    session_token,
+                    region,
+                    endpoint_url,
+                )
+            raise
 
         if ir.has_streaming_output and ir.output_file and ir.output_file.path != '-':
             response = _handle_streaming_output(response, ir.output_file)

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/interpretation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import boto3
+import hashlib
 import json
 from ..aws.pagination import build_result
 from ..aws.services import (
@@ -59,6 +60,29 @@ _AUTH_ERROR_CODES = frozenset(
 )
 
 
+def _credentials_fingerprint(
+    access_key_id: str, secret_access_key: str, session_token: str | None
+) -> str:
+    """Non-reversible fingerprint so raw secrets do not sit in the cache key."""
+    h = hashlib.sha256()
+    h.update(access_key_id.encode('utf-8'))
+    h.update(b'\0')
+    h.update(secret_access_key.encode('utf-8'))
+    h.update(b'\0')
+    h.update((session_token or '').encode('utf-8'))
+    return h.hexdigest()
+
+
+def _client_cache_key(
+    service_name: str,
+    region: str,
+    credentials_fingerprint: str,
+    endpoint_url: str | None,
+    user_agent_extra: str,
+) -> tuple:
+    return (service_name, region, credentials_fingerprint, endpoint_url, user_agent_extra)
+
+
 def _get_or_create_client(
     service_name: str,
     access_key_id: str,
@@ -69,7 +93,13 @@ def _get_or_create_client(
     endpoint_url: str | None,
 ) -> Any:
     """Return a cached boto3 client, creating one if needed."""
-    key = (service_name, region, access_key_id, secret_access_key, session_token, endpoint_url)
+    key = _client_cache_key(
+        service_name,
+        region,
+        _credentials_fingerprint(access_key_id, secret_access_key, session_token),
+        endpoint_url,
+        getattr(config, 'user_agent_extra', '') or '',
+    )
 
     if key in _client_cache:
         _client_cache.move_to_end(key)
@@ -97,9 +127,16 @@ def _evict_client(
     session_token: str | None,
     region: str,
     endpoint_url: str | None,
+    user_agent_extra: str,
 ) -> None:
     """Remove a client from cache after an auth error."""
-    key = (service_name, region, access_key_id, secret_access_key, session_token, endpoint_url)
+    key = _client_cache_key(
+        service_name,
+        region,
+        _credentials_fingerprint(access_key_id, secret_access_key, session_token),
+        endpoint_url,
+        user_agent_extra,
+    )
     _client_cache.pop(key, None)
 
 
@@ -176,6 +213,7 @@ def interpret(
                     session_token,
                     region,
                     endpoint_url,
+                    getattr(config, 'user_agent_extra', '') or '',
                 )
             raise
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -329,10 +329,9 @@ def is_custom_operation(service, operation):
         raise InvalidServiceError(service)
 
     if isinstance(service_command, ServiceCommand):
-        service_name = service_command.name
-        if service_name not in _service_command_table_cache:
-            _service_command_table_cache[service_name] = service_command._get_command_table()
-        service_command_table = _service_command_table_cache[service_name]
+        service_command_table = _get_cached_service_command_table(
+            service_command.name, service_command
+        )
         operation_command = service_command_table.get(operation)
 
         # valid service can have custom operations.
@@ -378,6 +377,14 @@ driver._add_aliases(command_table, parser)
 _service_command_table_cache: dict[str, dict] = {}
 
 
+def _get_cached_service_command_table(service: str, service_command) -> dict:
+    cached = _service_command_table_cache.get(service)
+    if cached is None:
+        cached = service_command._get_command_table()
+        _service_command_table_cache[service] = cached
+    return cached
+
+
 def parse(cli_command: str, default_region_override: str | None = None) -> IRCommand:
     """Parse a CLI command string into an IRCommand object."""
     tokens = split_cli_command(cli_command)
@@ -409,9 +416,7 @@ def _handle_service_command(
         raise MissingOperationError()
 
     service = service_command.name
-    if service not in _service_command_table_cache:
-        _service_command_table_cache[service] = service_command._get_command_table()
-    command_table = _service_command_table_cache[service]
+    command_table = _get_cached_service_command_table(service, service_command)
 
     operation = remaining[0]
     operation_command = command_table.get(operation)
@@ -501,9 +506,7 @@ def _handle_awscli_customization(
 
     # For custom commands, we need to check if the operation exists in the service's command table
     if hasattr(service_command, '_get_command_table'):
-        if service not in _service_command_table_cache:
-            _service_command_table_cache[service] = service_command._get_command_table()
-        service_command_table = _service_command_table_cache[service]
+        service_command_table = _get_cached_service_command_table(service, service_command)
         operation_command = service_command_table.get(operation)
     elif hasattr(service_command, 'subcommand_table'):
         # Handle S3-like services that use subcommand_table

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -329,8 +329,10 @@ def is_custom_operation(service, operation):
         raise InvalidServiceError(service)
 
     if isinstance(service_command, ServiceCommand):
-        # valid service, unlike s3
-        service_command_table = service_command._get_command_table()
+        service_name = service_command.name
+        if service_name not in _service_command_table_cache:
+            _service_command_table_cache[service_name] = service_command._get_command_table()
+        service_command_table = _service_command_table_cache[service_name]
         operation_command = service_command_table.get(operation)
 
         # valid service can have custom operations.
@@ -371,6 +373,10 @@ cli_data = driver._get_cli_data()
 parser = GlobalArgParser.get_parser()
 driver._add_aliases(command_table, parser)
 
+# _get_command_table() re-parses service model JSON on every call; pymalloc keeps
+# the freed arenas, so RSS grows monotonically without this cache.
+_service_command_table_cache: dict[str, dict] = {}
+
 
 def parse(cli_command: str, default_region_override: str | None = None) -> IRCommand:
     """Parse a CLI command string into an IRCommand object."""
@@ -403,7 +409,9 @@ def _handle_service_command(
         raise MissingOperationError()
 
     service = service_command.name
-    command_table = service_command._get_command_table()
+    if service not in _service_command_table_cache:
+        _service_command_table_cache[service] = service_command._get_command_table()
+    command_table = _service_command_table_cache[service]
 
     operation = remaining[0]
     operation_command = command_table.get(operation)
@@ -493,7 +501,9 @@ def _handle_awscli_customization(
 
     # For custom commands, we need to check if the operation exists in the service's command table
     if hasattr(service_command, '_get_command_table'):
-        service_command_table = service_command._get_command_table()
+        if service not in _service_command_table_cache:
+            _service_command_table_cache[service] = service_command._get_command_table()
+        service_command_table = _service_command_table_cache[service]
         operation_command = service_command_table.get(operation)
     elif hasattr(service_command, 'subcommand_table'):
         # Handle S3-like services that use subcommand_table

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -160,19 +160,19 @@ async def suggest_aws_commands(
         await ctx.error(error_message)
         raise AwsApiMcpError(error_message)
     try:
-        with get_requests_session() as session:
-            response = session.post(
-                ENDPOINT_SUGGEST_AWS_COMMANDS,
-                json={'query': query},
-                timeout=30,
-            )
-            response.raise_for_status()
-            suggestions = response.json().get('suggestions')
-            logger.info(
-                'Suggested commands: {}',
-                [suggestion.get('command') for suggestion in suggestions],
-            )
-            return response.json()
+        session = get_requests_session()
+        response = session.post(
+            ENDPOINT_SUGGEST_AWS_COMMANDS,
+            json={'query': query},
+            timeout=30,
+        )
+        response.raise_for_status()
+        suggestions = response.json().get('suggestions')
+        logger.info(
+            'Suggested commands: {}',
+            [suggestion.get('command') for suggestion in suggestions],
+        )
+        return response.json()
     except Exception as e:
         logger.error('Error while suggesting commands: {}', str(e))
         error_message = 'Failed to execute tool due to internal error. Use your best judgement and existing knowledge to pick a command or point to relevant AWS Documentation.'

--- a/src/aws-api-mcp-server/tests/common/test_config.py
+++ b/src/aws-api-mcp-server/tests/common/test_config.py
@@ -13,6 +13,14 @@ from awslabs.aws_api_mcp_server.core.common.config import (
 from unittest.mock import MagicMock, patch
 
 
+@pytest.fixture(autouse=True)
+def _clear_region_cache():
+    """Clear the region cache between tests."""
+    config_module._region_cache.clear()
+    yield
+    config_module._region_cache.clear()
+
+
 @pytest.mark.parametrize(
     'os_name,uname_sysname,expected_tempdir',
     [

--- a/src/aws-api-mcp-server/tests/conftest.py
+++ b/src/aws-api-mcp-server/tests/conftest.py
@@ -17,6 +17,7 @@ def _reset_caches():
     """Reset module-level caches between tests."""
     clear_client_cache()
     _drop_cached_session()
+    _service_command_table_cache.clear()
     yield
     clear_client_cache()
     _drop_cached_session()

--- a/src/aws-api-mcp-server/tests/conftest.py
+++ b/src/aws-api-mcp-server/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared test fixtures for aws-api-mcp-server."""
+
+import pytest
+from awslabs.aws_api_mcp_server.core.common.helpers import get_requests_session
+from awslabs.aws_api_mcp_server.core.parser.interpretation import clear_client_cache
+from awslabs.aws_api_mcp_server.core.parser.parser import _service_command_table_cache
+
+
+def _drop_cached_session():
+    if get_requests_session.cache_info().currsize:
+        get_requests_session().close()
+    get_requests_session.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """Reset module-level caches between tests."""
+    clear_client_cache()
+    _drop_cached_session()
+    yield
+    clear_client_cache()
+    _drop_cached_session()
+    _service_command_table_cache.clear()

--- a/src/aws-api-mcp-server/tests/parser/test_interpretation_cache.py
+++ b/src/aws-api-mcp-server/tests/parser/test_interpretation_cache.py
@@ -1,0 +1,159 @@
+"""Tests for the boto3 client cache in core.parser.interpretation."""
+
+import pytest
+from awslabs.aws_api_mcp_server.core.parser import interpretation
+from awslabs.aws_api_mcp_server.core.parser.interpretation import (
+    _client_cache,
+    _credentials_fingerprint,
+    _get_or_create_client,
+    clear_client_cache,
+    interpret,
+)
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from unittest.mock import MagicMock, patch
+
+
+def _make_config(user_agent_extra: str = 'ua/test') -> Config:
+    return Config(region_name='us-east-1', user_agent_extra=user_agent_extra)
+
+
+def test_credentials_fingerprint_changes_when_any_field_changes():
+    """Different credential tuples must yield different fingerprints."""
+    base = _credentials_fingerprint('AKIA', 'secret', 'token')
+    assert base != _credentials_fingerprint('AKIB', 'secret', 'token')
+    assert base != _credentials_fingerprint('AKIA', 'secret2', 'token')
+    assert base != _credentials_fingerprint('AKIA', 'secret', 'token2')
+    assert base != _credentials_fingerprint('AKIA', 'secret', None)
+
+
+def test_credentials_fingerprint_is_deterministic():
+    """Same inputs produce the same fingerprint."""
+    a = _credentials_fingerprint('AKIA', 'secret', 'token')
+    b = _credentials_fingerprint('AKIA', 'secret', 'token')
+    assert a == b
+
+
+def test_credentials_fingerprint_does_not_contain_raw_secret():
+    """Raw secret must not appear in the fingerprint."""
+    secret = 'supersecret1234'
+    fp = _credentials_fingerprint('AKIA', secret, None)
+    assert secret not in fp
+
+
+def test_get_or_create_client_reuses_cached_client():
+    """Repeated calls with the same key return the same boto3 client instance."""
+    with patch.object(interpretation, 'boto3') as mock_boto3:
+        mock_boto3.client.return_value = MagicMock()
+        c1 = _get_or_create_client('s3', 'AKIA', 'secret', None, 'us-east-1', _make_config(), None)
+        c2 = _get_or_create_client('s3', 'AKIA', 'secret', None, 'us-east-1', _make_config(), None)
+
+    assert c1 is c2
+    assert mock_boto3.client.call_count == 1
+
+
+def test_get_or_create_client_separates_by_service_and_region():
+    """Different service/region combinations get distinct clients."""
+    with patch.object(interpretation, 'boto3') as mock_boto3:
+        mock_boto3.client.side_effect = [
+            MagicMock(name='s3'),
+            MagicMock(name='ec2'),
+            MagicMock(name='s3-eu'),
+        ]
+        a = _get_or_create_client('s3', 'K', 'S', None, 'us-east-1', _make_config(), None)
+        b = _get_or_create_client('ec2', 'K', 'S', None, 'us-east-1', _make_config(), None)
+        c = _get_or_create_client('s3', 'K', 'S', None, 'eu-west-1', _make_config(), None)
+
+    assert a is not b
+    assert a is not c
+    assert mock_boto3.client.call_count == 3
+
+
+def test_get_or_create_client_separates_by_credentials():
+    """Different credentials must not share a cached client."""
+    with patch.object(interpretation, 'boto3') as mock_boto3:
+        mock_boto3.client.side_effect = [MagicMock(), MagicMock()]
+        a = _get_or_create_client('s3', 'K1', 'S1', None, 'us-east-1', _make_config(), None)
+        b = _get_or_create_client('s3', 'K2', 'S2', None, 'us-east-1', _make_config(), None)
+
+    assert a is not b
+
+
+def test_get_or_create_client_separates_by_user_agent_extra():
+    """Clients with different user_agent_extra must not be shared.
+
+    Covers the streamable-http multi-client case where telemetry must track
+    the originating MCP client.
+    """
+    with patch.object(interpretation, 'boto3') as mock_boto3:
+        mock_boto3.client.side_effect = [MagicMock(), MagicMock()]
+        a = _get_or_create_client(
+            's3', 'K', 'S', None, 'us-east-1', _make_config('ua/client-one'), None
+        )
+        b = _get_or_create_client(
+            's3', 'K', 'S', None, 'us-east-1', _make_config('ua/client-two'), None
+        )
+
+    assert a is not b
+
+
+def test_get_or_create_client_lru_eviction():
+    """Oldest client is evicted once the cache is full."""
+    with patch.object(interpretation, '_MAX_CACHED_CLIENTS', 2):
+        with patch.object(interpretation, 'boto3') as mock_boto3:
+            mock_boto3.client.side_effect = [MagicMock(), MagicMock(), MagicMock()]
+            _get_or_create_client('s3', 'K', 'S', None, 'us-east-1', _make_config(), None)
+            _get_or_create_client('ec2', 'K', 'S', None, 'us-east-1', _make_config(), None)
+            _get_or_create_client('iam', 'K', 'S', None, 'us-east-1', _make_config(), None)
+
+    assert len(_client_cache) == 2
+
+
+def test_interpret_evicts_client_on_auth_error():
+    """Auth errors remove the cached client so the next call recreates it."""
+    ir = MagicMock()
+    ir.service_name = 's3'
+    ir.operation_python_name = 'list_buckets'
+    ir.operation_name = 'ListBuckets'
+    ir.parameters = {}
+    ir.has_streaming_output = False
+    ir.output_file = None
+
+    mock_client = MagicMock()
+    mock_client.can_paginate.return_value = False
+    mock_client.list_buckets.side_effect = ClientError(
+        {'Error': {'Code': 'ExpiredTokenException', 'Message': 'expired'}}, 'ListBuckets'
+    )
+
+    clear_client_cache()
+    with patch.object(interpretation, 'boto3') as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        with pytest.raises(ClientError):
+            interpret(ir, 'K', 'S', None, 'us-east-1')
+
+    assert len(_client_cache) == 0
+
+
+def test_interpret_keeps_client_on_non_auth_error():
+    """Non-auth errors must leave the cached client in place."""
+    ir = MagicMock()
+    ir.service_name = 's3'
+    ir.operation_python_name = 'list_buckets'
+    ir.operation_name = 'ListBuckets'
+    ir.parameters = {}
+    ir.has_streaming_output = False
+    ir.output_file = None
+
+    mock_client = MagicMock()
+    mock_client.can_paginate.return_value = False
+    mock_client.list_buckets.side_effect = ClientError(
+        {'Error': {'Code': 'ThrottlingException', 'Message': 'slow down'}}, 'ListBuckets'
+    )
+
+    clear_client_cache()
+    with patch.object(interpretation, 'boto3') as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        with pytest.raises(ClientError):
+            interpret(ir, 'K', 'S', None, 'us-east-1')
+
+    assert len(_client_cache) == 1


### PR DESCRIPTION
Fixes memory growth in long-running aws-api-mcp-server sessions.

## Summary

Third attempt. #2449, #2452, and #2828 were all auto-closed by the stale bot without maintainer review. Same leak, same fix, rebased on current `main` and tightened against Copilot's review comments on #2828.

### Changes

- `interpretation.py`: LRU cache (30 entries) of `boto3.client()` keyed on `(service, region, credentials, endpoint)`. Cached clients are evicted on auth errors so stale credentials do not survive token rotation.
- `config.py`: per-profile cache of the resolved region string. `get_region()` was constructing a fresh `boto3.Session` on every `parse()` just to read one attribute.
- `helpers.py` + `server.py`: `@functools.cache` on `get_requests_session()`; `suggest_aws_commands` now reuses it instead of building a new session per request.
- `parser.py`: module-level cache of `ServiceCommand._get_command_table()` results. Each call re-parses service model JSON and pymalloc never returns those arenas to the OS.
- `tests/conftest.py`: root fixture that clears every module cache between tests and closes the cached requests session before dropping the reference.

Design rationale and the previous Copilot review thread on the cache key, user agent, and test isolation are in #2452 and #2828.

### User experience

Before: aws-api-mcp-server RSS grows several MB per `call_aws` invocation in long-running sessions. The allocator does not return pages, so the only remedy is restarting the MCP host.

After: steady-state RSS. Clients, sessions, regions, and service models are built once per unique key and reused.

714 tests pass on current upstream `main`, ruff and pyright clean.

@arnewouters, you were the only reviewer who engaged on #2452. If you have time, the points you raised there are all applied here.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).