### PR TITLE
fix(api_key_auth): truncate API key to 72 bytes before bcrypt hashing

### DIFF
--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/auth/api_key_auth.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/auth/api_key_auth.py
@@ -114,8 +114,10 @@ class ApiKeyAuthProvider(BaseAuthProvider):
             str: Hash of the API key
 
         """
-        # Create a hash of the API key to use as a cache key
-        return bcrypt.hashpw(api_key.encode('utf-8'), bcrypt.gensalt(rounds=10)).hex()
+        # Truncate API key to bcrypt's 72-byte limit before hashing
+        # The hash is only used as a cache key; the full key is used in requests
+        api_key_bytes = api_key.encode('utf-8')[:72]
+        return bcrypt.hashpw(api_key_bytes, bcrypt.gensalt(rounds=10)).hex()
 
     @cached_auth_data(ttl=3600)  # Cache for 1 hour by default
     def _generate_auth_headers(self, api_key_hash: str, api_key_name: str) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- Truncate API key to 72 bytes before passing to bcrypt.hashpw(), since bcrypt 4.x+ throws ValueError on inputs exceeding 72 bytes instead of silently truncating

## Why
Issue #3093: bcrypt.hashpw() throws ValueError for inputs over 72 bytes. The _hash_api_key() function passes the full API key to bcrypt, causing server startup crashes.

## Validation
- [x] Code review passed
- [x] Branch pushed to fork (using v2 branch name)

## Checklist
* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
