### PR TITLE
fix(aurora-dsql): case-insensitive table name matching in get_schema

### DIFF
--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/consts.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/consts.py
@@ -31,9 +31,8 @@ BEGIN_READ_ONLY_TRANSACTION_SQL = 'BEGIN TRANSACTION READ ONLY'
 COMMIT_TRANSACTION_SQL = 'COMMIT'
 ROLLBACK_TRANSACTION_SQL = 'ROLLBACK'
 BEGIN_TRANSACTION_SQL = 'BEGIN'
-GET_SCHEMA_SQL = (
-    'SELECT column_name, data_type FROM information_schema.columns WHERE table_name = %s'
-)
+GET_SCHEMA_SQL = 'SELECT column_name, data_type FROM information_schema.columns WHERE LOWER(table_name) = LOWER(%s)'
+GET_QUALIFIED_SCHEMA_SQL = 'SELECT column_name, data_type FROM information_schema.columns WHERE LOWER(table_schema) = LOWER(%s) AND LOWER(table_name) = LOWER(%s)'
 ERROR_BEGIN_READ_ONLY_TRANSACTION = 'Failed to begin read only transaction'
 INTERNAL_ERROR = 'Internal Error'
 READ_ONLY_QUERY_WRITE_ERROR = 'readonly_query does not support write operations. Use transact'

--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
@@ -43,6 +43,7 @@ from awslabs.aurora_dsql_mcp_server.consts import (
     ERROR_TRANSACT,
     ERROR_TRANSACTION_BYPASS_ATTEMPT,
     ERROR_WRITE_QUERY_PROHIBITED,
+    GET_QUALIFIED_SCHEMA_SQL,
     GET_SCHEMA_SQL,
     INTERNAL_ERROR,
     READ_ONLY_QUERY_WRITE_ERROR,
@@ -378,7 +379,11 @@ async def get_schema(
 
     try:
         conn = await get_connection(ctx)
-        return await execute_query(ctx, conn, GET_SCHEMA_SQL, [table_name])
+        if '.' in table_name:
+            schema, table = table_name.split('.', 1)
+            return await execute_query(ctx, conn, GET_QUALIFIED_SCHEMA_SQL, [schema, table])
+        else:
+            return await execute_query(ctx, conn, GET_SCHEMA_SQL, [table_name])
     except Exception as e:
         await ctx.error(f'{ERROR_GET_SCHEMA}: {str(e)}')
         raise Exception(f'{ERROR_GET_SCHEMA}: {str(e)}')

--- a/src/aurora-dsql-mcp-server/tests/test_server.py
+++ b/src/aurora-dsql-mcp-server/tests/test_server.py
@@ -27,6 +27,7 @@ from awslabs.aurora_dsql_mcp_server.consts import (
     ROLLBACK_TRANSACTION_SQL,
     BEGIN_TRANSACTION_SQL,
     GET_SCHEMA_SQL,
+    GET_QUALIFIED_SCHEMA_SQL,
     INTERNAL_ERROR,
     READ_ONLY_QUERY_WRITE_ERROR,
     ERROR_BEGIN_TRANSACTION,
@@ -237,6 +238,48 @@ async def test_get_schema_failure(mocker):
         mock_conn,
         GET_SCHEMA_SQL,
         ['table1'],
+    )
+
+
+async def test_get_schema_with_schema_qualified_name(mocker):
+    mock_get_connection = mocker.patch(
+        'awslabs.aurora_dsql_mcp_server.server.get_connection'
+    )
+    mock_conn = AsyncMock()
+    mock_get_connection.return_value = mock_conn
+    mock_execute_query = mocker.patch('awslabs.aurora_dsql_mcp_server.server.execute_query')
+    mock_execute_query.return_value = {'col1': 'integer'}
+
+    result = await get_schema('data.Associate', ctx)
+
+    assert result == {'col1': 'integer'}
+
+    mock_execute_query.assert_called_once_with(
+        ctx,
+        mock_conn,
+        GET_QUALIFIED_SCHEMA_SQL,
+        ['data', 'Associate'],
+    )
+
+
+async def test_get_schema_without_schema_uses_table_name_only(mocker):
+    mock_get_connection = mocker.patch(
+        'awslabs.aurora_dsql_mcp_server.server.get_connection'
+    )
+    mock_conn = AsyncMock()
+    mock_get_connection.return_value = mock_conn
+    mock_execute_query = mocker.patch('awslabs.aurora_dsql_mcp_server.server.execute_query')
+    mock_execute_query.return_value = {'col1': 'integer'}
+
+    result = await get_schema('Associate', ctx)
+
+    assert result == {'col1': 'integer'}
+
+    mock_execute_query.assert_called_once_with(
+        ctx,
+        mock_conn,
+        GET_SCHEMA_SQL,
+        ['Associate'],
     )
 
 


### PR DESCRIPTION
## Summary

- Apply `LOWER()` on both sides of the `WHERE` clause in `get_schema` so identifier matching follows PostgreSQL's case-folding convention. Previously, `get_schema('Associate')` returned empty results because `information_schema.columns` stores folded (lowercase) identifiers, but the query matched literally.
- Support schema-qualified table names (`schema.table`) by splitting on `.` and filtering on both `table_schema` and `table_name` via a new `GET_QUALIFIED_SCHEMA_SQL` constant. This allows `get_schema('data.associate')` to return only columns from the intended schema rather than all schemas containing a table with that name.
- Add two new tests covering both the schema-qualified and plain table name paths.

## Motivation

When an agent calls `get_schema('data.Associate')`, the tool returned empty results (3 times for 3 tables). The agent then jumped to `information_schema.tables`, saw the lowercase `associate`, concluded "DSQL is case-sensitive", and ran the lowercase version — arriving at the correct answer via an incorrect diagnosis. The root cause was the literal `WHERE table_name = %s` match in the MCP server, not DSQL case-sensitivity.

## Test plan

- [x] New unit test `test_get_schema_with_schema_qualified_name` verifies `get_schema('data.Associate')` uses `GET_QUALIFIED_SCHEMA_SQL` with split args `['data', 'Associate']`
- [x] New unit test `test_get_schema_without_schema_uses_table_name_only` verifies `get_schema('Associate')` uses `GET_SCHEMA_SQL` with `['Associate']`
- [x] Manual verification: call `get_schema` with mixed-case table names against a live DSQL cluster

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [y] I have performed a self-review of this change
* [y] Changes have been tested
* [y] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
