### PR TITLE
feat(influxdb): Adding stricter trust boundary on passed InfluxDB configs

### DIFF
--- a/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/server.py
+++ b/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/server.py
@@ -265,6 +265,10 @@ def resolve_influxdb_config(
 ) -> tuple:
     """Resolve InfluxDB configuration from parameters or environment variables.
 
+    To prevent SSRF and credential leakage, caller-supplied connection parameters
+    and server environment credentials are never mixed. Either ALL parameters come
+    from the caller, or ALL come from environment variables.
+
     Args:
         url: The URL of the InfluxDB server (optional, falls back to INFLUXDB_URL env var).
         token: The authentication token (optional, falls back to INFLUXDB_TOKEN env var).
@@ -275,24 +279,54 @@ def resolve_influxdb_config(
         A tuple of (resolved_url, resolved_token, resolved_org).
 
     Raises:
-        ValueError: If required parameters are not provided.
+        ValueError: If required parameters are not provided or if caller-supplied
+            and server credentials are mixed.
     """
-    resolved_url = url or INFLUXDB_URL
-    resolved_token = token or INFLUXDB_TOKEN
-    resolved_org = org or INFLUXDB_ORG
+    # Determine whether the caller is providing custom connection parameters.
+    # Any caller-supplied parameter signals a custom connection — in that case
+    # ALL connection parameters must come from the caller to prevent mixing
+    # server-resident credentials with attacker-controlled endpoints (SSRF).
+    caller_supplied = any(p is not None for p in (url, token, org))
 
-    if not resolved_url:
-        raise ValueError(
-            'URL must be provided either as parameter or via INFLUXDB_URL environment variable'
-        )
-    if not resolved_token:
-        raise ValueError(
-            'Token must be provided either as parameter or via INFLUXDB_TOKEN environment variable'
-        )
-    if require_org and not resolved_org:
-        raise ValueError(
-            'Organization must be provided either as parameter or via INFLUXDB_ORG environment variable'
-        )
+    if caller_supplied:
+        # Do not fall back to environment variables for any parameter.
+        resolved_url = url
+        resolved_token = token
+        resolved_org = org
+
+        if not resolved_url:
+            raise ValueError(
+                'When custom connection parameters are provided, url is required. '
+                'Server credentials cannot be mixed with caller-supplied parameters.'
+            )
+        if not resolved_token:
+            raise ValueError(
+                'When custom connection parameters are provided, token is required. '
+                'Server credentials cannot be mixed with caller-supplied parameters.'
+            )
+        if require_org and not resolved_org:
+            raise ValueError(
+                'When custom connection parameters are provided, org is required. '
+                'Server credentials cannot be mixed with caller-supplied parameters.'
+            )
+    else:
+        # All parameters come from environment variables.
+        resolved_url = INFLUXDB_URL
+        resolved_token = INFLUXDB_TOKEN
+        resolved_org = INFLUXDB_ORG
+
+        if not resolved_url:
+            raise ValueError(
+                'URL must be provided either as parameter or via INFLUXDB_URL environment variable'
+            )
+        if not resolved_token:
+            raise ValueError(
+                'Token must be provided either as parameter or via INFLUXDB_TOKEN environment variable'
+            )
+        if require_org and not resolved_org:
+            raise ValueError(
+                'Organization must be provided either as parameter or via INFLUXDB_ORG environment variable'
+            )
 
     return resolved_url, resolved_token, resolved_org
 

--- a/src/timestream-for-influxdb-mcp-server/tests/test_server.py
+++ b/src/timestream-for-influxdb-mcp-server/tests/test_server.py
@@ -2288,7 +2288,7 @@ class TestResolveInfluxDBConfig:
         with pytest.raises(ValueError) as excinfo:
             resolve_influxdb_config(url=None, token='test-token', org='test-org')
 
-        assert 'URL must be provided' in str(excinfo.value)
+        assert 'url is required' in str(excinfo.value)
 
     def test_resolve_influxdb_config_missing_token(self):
         """Test resolve_influxdb_config when token is missing."""
@@ -2297,7 +2297,7 @@ class TestResolveInfluxDBConfig:
         with pytest.raises(ValueError) as excinfo:
             resolve_influxdb_config(url='https://example.com', token=None, org='test-org')
 
-        assert 'Token must be provided' in str(excinfo.value)
+        assert 'token is required' in str(excinfo.value)
 
     def test_resolve_influxdb_config_missing_org_when_required(self):
         """Test resolve_influxdb_config when org is missing and required."""
@@ -2308,7 +2308,7 @@ class TestResolveInfluxDBConfig:
                 url='https://example.com', token='test-token', org=None, require_org=True
             )
 
-        assert 'Organization must be provided' in str(excinfo.value)
+        assert 'org is required' in str(excinfo.value)
 
     def test_resolve_influxdb_config_org_not_required(self):
         """Test resolve_influxdb_config when org is not required."""
@@ -2321,6 +2321,77 @@ class TestResolveInfluxDBConfig:
         assert url == 'https://example.com'
         assert token == 'test-token'
         assert org is None
+
+    def test_resolve_rejects_custom_url_without_token(self):
+        """Test that providing a custom URL without a token is rejected (SSRF prevention)."""
+        from awslabs.timestream_for_influxdb_mcp_server.server import resolve_influxdb_config
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_influxdb_config(url='https://evil.example.com', token=None, org=None)
+
+        assert 'token is required' in str(excinfo.value)
+        assert 'Server credentials cannot be mixed' in str(excinfo.value)
+
+    def test_resolve_rejects_custom_token_without_url(self):
+        """Test that providing a custom token without a URL is rejected (mixed trust prevention)."""
+        from awslabs.timestream_for_influxdb_mcp_server.server import resolve_influxdb_config
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_influxdb_config(url=None, token='attacker-token', org=None)
+
+        assert 'url is required' in str(excinfo.value)
+        assert 'Server credentials cannot be mixed' in str(excinfo.value)
+
+    def test_resolve_rejects_custom_org_without_url_and_token(self):
+        """Test that providing only a custom org is rejected (mixed trust prevention)."""
+        from awslabs.timestream_for_influxdb_mcp_server.server import resolve_influxdb_config
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_influxdb_config(url=None, token=None, org='attacker-org')
+
+        assert 'url is required' in str(excinfo.value)
+        assert 'Server credentials cannot be mixed' in str(excinfo.value)
+
+    def test_resolve_accepts_all_caller_supplied_params(self):
+        """Test that providing all custom params works correctly."""
+        from awslabs.timestream_for_influxdb_mcp_server.server import resolve_influxdb_config
+
+        url, token, org = resolve_influxdb_config(
+            url='https://custom.example.com', token='custom-token', org='custom-org'
+        )
+
+        assert url == 'https://custom.example.com'
+        assert token == 'custom-token'
+        assert org == 'custom-org'
+
+    @patch(
+        'awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_URL', 'https://env.example.com'
+    )
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_TOKEN', 'env-token')
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_ORG', 'env-org')
+    def test_resolve_uses_env_vars_when_no_caller_params(self):
+        """Test that env vars are used when no caller params are provided."""
+        from awslabs.timestream_for_influxdb_mcp_server.server import resolve_influxdb_config
+
+        url, token, org = resolve_influxdb_config()
+
+        assert url == 'https://env.example.com'
+        assert token == 'env-token'
+        assert org == 'env-org'
+
+    @patch(
+        'awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_URL', 'https://env.example.com'
+    )
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_TOKEN', 'env-token')
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_ORG', 'env-org')
+    def test_resolve_does_not_leak_env_token_to_custom_url(self):
+        """Test that env token is never sent to a caller-supplied URL (SSRF prevention)."""
+        from awslabs.timestream_for_influxdb_mcp_server.server import resolve_influxdb_config
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_influxdb_config(url='https://evil.example.com', token=None, org=None)
+
+        assert 'Server credentials cannot be mixed' in str(excinfo.value)
 
 
 class TestInfluxDBAsyncWriteMode:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

### Changes

> Please provide a summary of what's being changed

Fixes SSRF vulnerability in resolve_influxdb_config(). The function previously resolved url, token, and org independently with environment variable fallback, allowing a caller to supply a malicious URL while omitting the token — causing the server's INFLUXDB_TOKEN to be sent to the attacker-controlled endpoint.

The fix enforces a strict trust boundary: if the caller provides any custom connection parameter (url, token, or org), all three must come from the caller. No fallback to environment variables is allowed when caller-supplied parameters are present. When no caller parameters are provided, all values resolve from environment variables as before.


### User experience

> Please share what the user experience looks like before and after this change

Before: A caller could invoke InfluxDB tools (e.g. InfluxDBQuery, InfluxDBWritePoints) with a custom url while omitting token, causing the server's environment INFLUXDB_TOKEN to be silently sent to the caller's endpoint. This enabled credential leakage and internal network probing.

After: Any tool call that provides a custom url, token, or org must provide all required connection parameters explicitly. Partial overrides that would mix caller-supplied endpoints with server-resident credentials are rejected with a clear error message. Calls that rely entirely on environment variables continue to work unchanged.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
