### PR TITLE
feat(applicationsignalsmcp): audit banners, canary auto-discovery, and SLO console links

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
@@ -54,7 +54,12 @@ from .group_tools import (
     list_group_services,
     list_grouping_attribute_definitions,
 )
-from .service_audit_utils import normalize_service_targets, validate_and_enrich_service_targets
+from .service_audit_utils import (
+    detect_uninstrumented_targets,
+    format_uninstrumented_warning,
+    normalize_service_targets,
+    validate_and_enrich_service_targets,
+)
 from .service_tools import (
     get_service_detail,
     list_monitored_services,
@@ -414,6 +419,14 @@ async def audit_services(
             normalized_targets, applicationsignals_client, unix_start, unix_end
         )
 
+        # Detect explicitly-named uninstrumented / canary targets and build a
+        # warning block. Wildcard targets are already filtered upstream, so
+        # this only catches the case where the LLM (or user) named a canary
+        # or uninstrumented service directly.
+        uninstrumented_flagged = detect_uninstrumented_targets(
+            normalized_targets, applicationsignals_client, unix_start, unix_end
+        )
+
         # Parse auditors with service-specific defaults
         auditors_list = parse_auditors(auditors, ['slo', 'operation_metric'])
 
@@ -423,6 +436,10 @@ async def audit_services(
             f'🎯 Scope: {len(normalized_targets)} service target(s) | Region: {region}\n'
             f'⏰ Time: {unix_start}–{unix_end}\n'
         )
+
+        # Add uninstrumented-target warning at the top of the banner so it is
+        # prominent in the response.
+        banner += format_uninstrumented_warning(uninstrumented_flagged)
 
         # Add filtering statistics if services were filtered
         if filtering_stats['total_services'] > 0:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
@@ -995,8 +995,11 @@ async def audit_service_operations(
 
 
 @mcp.tool()
-async def analyze_canary_failures(canary_name: str, region: str = AWS_REGION) -> str:
+async def analyze_canary_failures(canary_name: str = '', region: str = AWS_REGION) -> str:
     """Comprehensive canary failure analysis with deep dive into issues.
+
+    **Auto-discovery**: If no canary_name is provided, automatically discovers all canaries in the account,
+    checks their last run status, and analyzes any that are currently failing.
 
     Use this tool to:
     - Deep dive into canary failures with root cause identification
@@ -1007,6 +1010,7 @@ async def analyze_canary_failures(canary_name: str, region: str = AWS_REGION) ->
     - Identify performance degradation and availability issues across service dependencies
 
     Key Features:
+    - **Auto-Discovery**: When called without a canary name, discovers and analyzes all failing canaries
     - **Failure Pattern Analysis**: Identifies recurring failure modes and temporal patterns
     - **Artifact Deep Dive**: Analyzes canary logs, screenshots, and network traces for root causes
     - **Service Correlation**: Links canary failures to upstream/downstream service issues using Application Signals
@@ -1029,7 +1033,8 @@ async def analyze_canary_failures(canary_name: str, region: str = AWS_REGION) ->
     - Historical failure patterns and recovery recommendations
 
     Args:
-        canary_name (str): Name of the CloudWatch Synthetics canary to analyze
+        canary_name (str, optional): Name of the CloudWatch Synthetics canary to analyze.
+            If empty, auto-discovers all canaries and analyzes failing ones.
         region (str, optional): AWS region where the canary is deployed.
 
     Returns:
@@ -1041,6 +1046,63 @@ async def analyze_canary_failures(canary_name: str, region: str = AWS_REGION) ->
             - Historical pattern analysis and trend insights
     """
     try:
+        # Auto-discovery: if no canary_name provided, find and analyze failing canaries
+        if not canary_name:
+            logger.info('No canary_name provided — auto-discovering canaries')
+            try:
+                describe_resp = synthetics_client.describe_canaries()
+                all_canaries = describe_resp.get('Canaries', [])
+            except Exception as e:
+                logger.error(f'Failed to describe canaries: {e}', exc_info=True)
+                return f'Error discovering canaries: {str(e)}'
+
+            if not all_canaries:
+                return 'No canaries found in this account/region. Create a canary first using CloudWatch Synthetics.'
+
+            # Check each canary's last run status
+            failing_canaries = []
+            healthy_canaries = []
+            for c in all_canaries:
+                c_name = c.get('Name', 'Unknown')
+                last_run = c.get('Status', {})
+                state = last_run.get('State', 'UNKNOWN')
+                state_reason = last_run.get('StateReason', '')
+                if state in ('ERROR', 'STOPPED') or 'error' in state_reason.lower():
+                    failing_canaries.append(c_name)
+                else:
+                    # Also check last run via get_canary_runs
+                    try:
+                        runs_resp = synthetics_client.get_canary_runs(Name=c_name, MaxResults=1)
+                        last_runs = runs_resp.get('CanaryRuns', [])
+                        if last_runs and last_runs[0].get('Status', {}).get('State') == 'FAILED':
+                            failing_canaries.append(c_name)
+                        else:
+                            healthy_canaries.append(c_name)
+                    except Exception:
+                        healthy_canaries.append(c_name)
+
+            if not failing_canaries:
+                result = f'✅ All {len(all_canaries)} canaries are healthy.\n\n'
+                result += 'Canaries checked:\n'
+                for name in healthy_canaries:
+                    result += f'  • {name} — PASSING\n'
+                return result
+
+            # Analyze each failing canary
+            result = f'🔍 Auto-Discovery: Found {len(failing_canaries)} failing canary(ies) out of {len(all_canaries)} total.\n\n'
+            if healthy_canaries:
+                result += f'✅ Healthy canaries ({len(healthy_canaries)}): {", ".join(healthy_canaries)}\n\n'
+
+            for fc_name in failing_canaries:
+                result += f'{"=" * 60}\n'
+                result += f'Analyzing failing canary: {fc_name}\n'
+                result += f'{"=" * 60}\n'
+                # Recursively call with the specific canary name
+                single_result = await analyze_canary_failures(canary_name=fc_name, region=region)
+                result += single_result + '\n\n'
+
+            return result
+
         # Get recent canary runs
         response = synthetics_client.get_canary_runs(Name=canary_name, MaxResults=5)
         runs = response.get('CanaryRuns', [])

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_audit_utils.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_audit_utils.py
@@ -229,3 +229,151 @@ def validate_and_enrich_service_targets(
         enriched_targets.append(t)
 
     return enriched_targets
+
+
+# Prefixes / instrumentation types that indicate the target is NOT an
+# instrumented application service. These deserve a warning in the audit
+# banner so the user (and the LLM) does not treat the target as equivalent
+# to an instrumented application service.
+_CANARY_PREFIX = 'cwsyn-'
+_UNINSTRUMENTED_TYPES = {'UNINSTRUMENTED', 'AWS_NATIVE'}
+
+
+def detect_uninstrumented_targets(
+    normalized_targets: List[dict],
+    applicationsignals_client,
+    unix_start: int,
+    unix_end: int,
+) -> List[dict]:
+    """Detect non-wildcard service targets that are uninstrumented or are canaries.
+
+    The wildcard expansion path already filters these out in audit_utils.
+    This helper catches the other path: the user (or LLM) explicitly names a
+    service that happens to be a CloudWatch Synthetics canary (`cwsyn-*`) or
+    carries InstrumentationType UNINSTRUMENTED / AWS_NATIVE in its
+    AttributeMaps. We do not block the call; we surface a warning so the
+    response frames the target correctly.
+
+    Args:
+        normalized_targets: Service targets after normalization + enrichment.
+        applicationsignals_client: Boto3 Application Signals client.
+        unix_start: Audit window start (unix seconds).
+        unix_end: Audit window end (unix seconds).
+
+    Returns:
+        List of dicts describing any flagged targets. Each dict has keys
+        'name', 'environment', and 'reason'. Empty list when nothing flagged.
+    """
+    # Gather target names that are not wildcards (wildcards were already
+    # expanded and filtered upstream).
+    explicit_names = []
+    for t in normalized_targets:
+        svc = (t.get('Data') or {}).get('Service') or {}
+        name = svc.get('Name') or ''
+        if name and '*' not in name:
+            explicit_names.append((name, svc.get('Environment', '')))
+
+    if not explicit_names:
+        return []
+
+    # Fast path: flag `cwsyn-*` names without any API call. These are
+    # CloudWatch Synthetics canaries by naming convention.
+    flagged: List[dict] = []
+    needs_api_check = []
+    for name, env in explicit_names:
+        if name.startswith(_CANARY_PREFIX):
+            flagged.append(
+                {
+                    'name': name,
+                    'environment': env,
+                    'reason': 'canary',
+                }
+            )
+        else:
+            needs_api_check.append((name, env))
+
+    # For the remaining targets, look them up in list_services to check
+    # InstrumentationType. We do one API call and scan its results.
+    if needs_api_check:
+        try:
+            response = applicationsignals_client.list_services(
+                StartTime=datetime.fromtimestamp(unix_start, tz=timezone.utc),
+                EndTime=datetime.fromtimestamp(unix_end, tz=timezone.utc),
+                MaxResults=100,
+            )
+            summaries = response.get('ServiceSummaries', [])
+        except Exception as e:
+            # Non-fatal: skip the uninstrumented warning if the lookup fails.
+            # The audit itself can still proceed.
+            logger.debug(f'detect_uninstrumented_targets: list_services failed: {e}')
+            return flagged
+
+        # Index summaries by name for O(1) lookup.
+        by_name = {}
+        for summary in summaries:
+            key_attrs = summary.get('KeyAttributes') or {}
+            sname = key_attrs.get('Name')
+            if sname:
+                by_name.setdefault(sname, summary)
+
+        for name, env in needs_api_check:
+            summary = by_name.get(name)
+            if not summary:
+                continue
+            attribute_maps = summary.get('AttributeMaps') or []
+            for attr_map in attribute_maps:
+                if not isinstance(attr_map, dict):
+                    continue
+                instr = attr_map.get('InstrumentationType')
+                if instr in _UNINSTRUMENTED_TYPES:
+                    flagged.append(
+                        {
+                            'name': name,
+                            'environment': env,
+                            'reason': instr.lower(),
+                        }
+                    )
+                    break
+
+    return flagged
+
+
+def format_uninstrumented_warning(flagged: List[dict]) -> str:
+    """Format the flagged-target list into a banner warning block.
+
+    Returns an empty string when nothing was flagged, so callers can
+    unconditionally concatenate the result.
+    """
+    if not flagged:
+        return ''
+
+    lines = ['⚠️  Uninstrumented or non-application targets detected:']
+    for entry in flagged:
+        name = entry.get('name', 'unknown')
+        env = entry.get('environment', '')
+        reason = entry.get('reason', 'uninstrumented')
+        env_str = f' ({env})' if env else ''
+        if reason == 'canary':
+            lines.append(
+                f"   • '{name}'{env_str} appears to be a CloudWatch Synthetics canary "
+                f'(name prefix "cwsyn-"). Its Duration metric measures canary '
+                f'execution time, NOT application latency. Do not compare its '
+                f'metrics with instrumented application services.'
+            )
+        elif reason == 'aws_native':
+            lines.append(
+                f"   • '{name}'{env_str} is AWS_NATIVE (auto-discovered AWS service, "
+                f'not explicitly instrumented). Metrics are limited.'
+            )
+        else:
+            lines.append(
+                f"   • '{name}'{env_str} is UNINSTRUMENTED (auto-discovered, not "
+                f'explicitly instrumented with Application Signals). Metrics may '
+                f'only include Duration/Errors, not application-level Latency/Fault.'
+            )
+    lines.append(
+        '   Flag this to the user in your response. If the user expected an '
+        'instrumented application service with this name, suggest they confirm '
+        'whether a separate instrumented service exists.'
+    )
+    return '\n'.join(lines) + '\n'

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/slo_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/slo_tools.py
@@ -15,7 +15,8 @@
 """CloudWatch Application Signals MCP Server - SLO-related tools."""
 
 import json
-from .aws_clients import applicationsignals_client
+from .aws_clients import AWS_REGION, applicationsignals_client
+from .utils import console_url_slo
 from botocore.exceptions import ClientError
 from loguru import logger
 from pydantic import Field
@@ -355,6 +356,7 @@ async def list_slos(
             result += f'  ARN: {slo_arn}\n'
             result += f'  Operation: {operation_name}\n'
             result += f'  Created: {created_time}\n'
+            result += f'  Console: {console_url_slo(slo_name, AWS_REGION)}\n'
 
             # Add key attributes if available
             key_attrs = slo.get('KeyAttributes', {})

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/utils.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/utils.py
@@ -17,6 +17,13 @@
 from datetime import datetime, timedelta, timezone
 from loguru import logger
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+
+def console_url_slo(slo_name: str, region: str) -> str:
+    """Generate an AWS Console deep-link to the Application Signals SLO detail page."""
+    encoded_name = quote(slo_name, safe='')
+    return f'https://{region}.console.aws.amazon.com/cloudwatch/home?region={region}#application-signals:slo?slo={encoded_name}'
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

Fixes

N/A — no open issue. These are small standalone improvements to the CloudWatch Application Signals MCP server.

## Summary

### Changes

Three independent quality-of-life improvements to the CloudWatch Application Signals MCP server, each scoped to a single tool. All three are additive, low-risk, and reviewable / revertable in isolation.

**1. Flag uninstrumented and canary targets in `audit_services` output**

`audit_services` supports both wildcard targets (`*`, `payment-*`) and explicit named targets. The wildcard expansion path already filters non-application services before auditing. The explicit-name path does not. When a caller names a target that turns out to be an auto-discovered, uninstrumented entry — or a CloudWatch Synthetics canary (`cwsyn-*`) whose name resembles a real service — the tool returns metrics for that entity with no indication the semantics are different from an instrumented application service.

For example, a canary's `Duration` metric measures canary script execution time (often seconds), not application latency (milliseconds). Comparing the two side-by-side is misleading.

Fix: two new helpers in `service_audit_utils.py`:

- `detect_uninstrumented_targets(...)` — inspects explicitly-named (non-wildcard) service targets after normalization. Flags names starting with `cwsyn-` via a fast path (no API call), and for the remaining explicit names makes one `list_services` call to check `InstrumentationType` in `AttributeMaps` for `UNINSTRUMENTED` or `AWS_NATIVE`. Non-fatal on API failure.
- `format_uninstrumented_warning(...)` — renders the flag list into a banner block explaining what the flagged target actually is and why its metrics should not be compared to instrumented application services. Returns an empty string when nothing is flagged, so output is byte-identical for clean targets.

`server.py` calls both helpers inside `audit_services` after target normalization and splices the warning at the top of the response banner. The audit itself always proceeds — the warning is informational, never blocking. Wildcard path is untouched.

**2. Auto-discover canaries when `analyze_canary_failures` is called without a name**

`analyze_canary_failures` previously required `canary_name` as a mandatory argument. A caller that does not already know a specific canary name has three bad options: ask upstream for a name, guess, or skip the tool entirely.

Fix: `canary_name` now defaults to `''`. When empty, the tool calls `synthetics_client.describe_canaries()`, classifies each by last run state (`ERROR`/`STOPPED` or last `CanaryRun.Status.State == FAILED` → failing; otherwise healthy), and either returns a healthy-summary page or recursively analyzes each failing canary with its name concatenated under a separator banner. Healthy canaries are listed by name in the header so the caller still sees the full inventory.

Existing callers that pass an explicit `canary_name` hit the unchanged code path. The signature change is additive-compatible (positional argument now has a default).

**3. Add AWS console deep-link per SLO in `list_slos` output**

`list_slos` renders each SLO with name, ARN, operation, creation timestamp, and key attributes. Drilling into a specific SLO in the console required manual navigation.

Fix: new `console_url_slo(slo_name, region)` helper in `utils.py` returns a deterministic deep-link URL:

```
https://{region}.console.aws.amazon.com/cloudwatch/home?region={region}#application-signals:slo?slo={url_encoded_name}
```


`list_slos` imports `AWS_REGION` and the new helper, and renders `Console: <url>` on a new line per SLO, right after `Created: ...`.

Purely additive text. No schema, signature, or behavior change for any caller. URLs are deterministic — no network calls, no API dependency.

### User experience

**Before**

- `audit_services` with a canary or uninstrumented target name returned metrics with no flag indicating the target was a canary or uninstrumented. A client interpreting the response could present a canary's `Duration` alongside an application service's `Latency` as if they were comparable.
- `analyze_canary_failures` required a canary name up front. A client without one either asked the user, invented a name, or skipped the tool.
- `list_slos` showed SLO names as plain text. Drilling into a specific SLO required manually constructing a console URL or navigating there.

**After**

- `audit_services` prepends a clearly-labelled warning to the response banner when a named target is a canary (`cwsyn-*`) or has `InstrumentationType: UNINSTRUMENTED` / `AWS_NATIVE`, so the response can frame the target correctly.
- `analyze_canary_failures` can be called with no arguments. It lists the full inventory, classifies each canary as healthy or failing, and analyzes only the failing ones.
- `list_slos` shows a `Console:` line per SLO with a direct deep-link to the SLO detail page.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [] Changes are documented

Is this a breaking change? **N**

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
