### PR TITLE
feat: Add cost allocation tags and cost category tools

### DIFF
--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -52,6 +52,16 @@ MCP server for accessing AWS Billing and Cost Management capabilities.
 - **Pricing rules and plans**: List pricing rules (MARKUP, DISCOUNT, TIERING) and pricing plans with their associations
 - **Custom line items**: List custom cost allocations including support fees, shared service costs, taxes, credits, and RI/SP distribution
 
+### Cost Allocation Tags
+
+- **Tag activation status**: List cost allocation tags with filters by status (Active/Inactive), type (AWSGenerated/UserDefined), and specific tag keys
+- **Backfill history**: Retrieve the history of tag backfill requests that retroactively apply activation status to historical billing data
+
+### Cost Category Definitions
+
+- **Describe cost categories**: Get the full definition of a cost category including rules, split charge rules, and processing status
+- **List cost categories**: List all cost category definitions in the account with summary metadata and filtering by effective date or supported resource types
+
 ### Specialized Cost Optimization Prompts
 
 - **Graviton migration analysis**: Guided analysis to identify EC2 instances suitable for AWS Graviton migration
@@ -206,6 +216,14 @@ Cost Explorer:
 - ce:GetTags
 - ce:GetCostCategories
 
+Cost Allocation Tags:
+- ce:ListCostAllocationTags
+- ce:ListCostAllocationTagBackfillHistory
+
+Cost Category Definitions:
+- ce:DescribeCostCategoryDefinition
+- ce:ListCostCategoryDefinitions
+
 Cost Optimization Hub:
 - cost-optimization-hub:GetRecommendation
 - cost-optimization-hub:ListRecommendations
@@ -359,3 +377,11 @@ The server currently supports the following AWS services
    - list_custom_line_items
    - list_custom_line_item_versions
    - list_resources_associated_to_custom_line_item
+
+10. **Cost Allocation Tags**
+    - list_cost_allocation_tags
+    - list_cost_allocation_tag_backfill_history
+
+11. **Cost Category Definitions**
+    - describe_cost_category_definition
+    - list_cost_category_definitions

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -41,7 +41,13 @@ from awslabs.billing_cost_management_mcp_server.tools.bvs_tools import bvs_serve
 from awslabs.billing_cost_management_mcp_server.tools.compute_optimizer_tools import (
     compute_optimizer_server,
 )
+from awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools import (
+    cost_allocation_tags_server,
+)
 from awslabs.billing_cost_management_mcp_server.tools.cost_anomaly_tools import cost_anomaly_server
+from awslabs.billing_cost_management_mcp_server.tools.cost_category_tools import (
+    cost_category_server,
+)
 from awslabs.billing_cost_management_mcp_server.tools.cost_comparison_tools import (
     cost_comparison_server,
 )
@@ -104,6 +110,8 @@ TOOLS:
 - session-sql: Execute SQL queries on the session database
 - billing-conductor: AWS Billing Conductor tools for AWS Proforma billing (billing groups and associated accounts and cost reports, pricing rules/plans, custom line items)
 - billing-view: AWS Billing View tools for managing and querying billing views (get-billing-view, list-billing-views, list-source-views-for-billing-view, get-resource-policy)
+- cost-allocation-tags: List cost allocation tags and backfill history (list-cost-allocation-tags, list-cost-allocation-tag-backfill-history)
+- cost-category: Describe and list cost category definitions (describe-cost-category-definition, list-cost-category-definitions)
 
 PROMPTS:
 - savings_plans: Analyzes AWS usage and identifies opportunities for Savings Plans purchases
@@ -158,6 +166,8 @@ async def setup():
     await mcp.import_server(unified_sql_server)
     await mcp.import_server(billing_conductor_server)
     await mcp.import_server(bvs_server)
+    await mcp.import_server(cost_allocation_tags_server)
+    await mcp.import_server(cost_category_server)
 
     await register_prompts()
 
@@ -194,6 +204,10 @@ async def setup():
         'list-billing-views',
         'list-source-views-for-billing-view',
         'get-resource-policy',
+        'list-cost-allocation-tags',
+        'list-cost-allocation-tag-backfill-history',
+        'describe-cost-category-definition',
+        'list-cost-category-definitions',
     ]
     for tool in tools:
         logger.info(f'- {tool}')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_allocation_tags_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_allocation_tags_tools.py
@@ -1,0 +1,205 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cost Allocation Tags tools for the AWS Billing and Cost Management MCP server."""
+
+import json
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, Optional
+
+
+cost_allocation_tags_server = FastMCP(
+    name='cost-allocation-tags-tools',
+    instructions='Tools for managing AWS Cost Allocation Tags',
+)
+
+
+@cost_allocation_tags_server.tool(
+    name='list-cost-allocation-tags',
+    description="""Lists cost allocation tags in the account using the ListCostAllocationTags API.
+
+Cost allocation tags must be activated before they appear in Cost Explorer, CUR, and budgets.
+There are two types: AWSGenerated (auto-created by AWS services like aws:createdBy) and
+UserDefined (created by customers via resource tagging APIs).
+
+The tool returns CostAllocationTag objects containing:
+- TagKey, Type (AWSGenerated/UserDefined), Status (Active/Inactive)
+- LastUpdatedDate (when activation status last changed)
+- LastUsedDate (last month the tag appeared on a billed resource, for identifying stale tags)
+
+You can filter tags by:
+- status: Active or Inactive
+- tag_keys: JSON array of tag key strings to look up (max 100, case-sensitive).
+  Example: '["Environment", "Team", "CostCenter"]'
+- tag_type: AWSGenerated or UserDefined
+- max_results: Results per page (1-1000, default 100)
+- max_pages: Max pages to auto-paginate through
+
+Limits: 500 active cost allocation tag keys per payer account (adjustable via Service Quotas
+up to 1,000). Max 20 tags per UpdateCostAllocationTagsStatus request.
+
+Example 1 - List active user-defined tags: {"status": "Active", "tag_type": "UserDefined"}
+Example 2 - Check specific tag keys: {"tag_keys": "[\"Environment\", \"Team\"]"}
+Example 3 - List all tags with no filters: {}""",
+)
+async def list_cost_allocation_tags(
+    ctx: Context,
+    status: Optional[str] = None,
+    tag_keys: Optional[str] = None,
+    tag_type: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List cost allocation tags.
+
+    Args:
+        ctx: The MCP context object
+        status: Filter by tag status (Active, Inactive)
+        tag_keys: JSON array of tag key strings to filter by (max 100)
+        tag_type: Filter by tag type (AWSGenerated, UserDefined)
+        max_results: Max results per page (1-1000, default 100)
+        next_token: Pagination token from previous response
+        max_pages: Max pages to auto-paginate through
+
+    Returns:
+        Dict containing the list of cost allocation tags
+    """
+    await ctx.info('Calling ListCostAllocationTags API')
+
+    try:
+        ce_client = create_aws_client('ce')
+        params: Dict[str, Any] = {}
+
+        if status:
+            params['Status'] = status
+        if tag_keys:
+            try:
+                params['TagKeys'] = json.loads(tag_keys)
+            except json.JSONDecodeError as e:
+                return format_response('error', {
+                    'message': f'Invalid JSON for tag_keys parameter: {e}',
+                })
+        if tag_type:
+            params['Type'] = tag_type
+        if max_results is not None:
+            params['MaxResults'] = max_results
+
+        if next_token:
+            params['NextToken'] = next_token
+        if next_token or max_pages:
+            results, pagination = await paginate_aws_response(
+                ctx,
+                'ListCostAllocationTags',
+                lambda **p: ce_client.list_cost_allocation_tags(**p),
+                params,
+                'CostAllocationTags',
+                max_pages=max_pages,
+            )
+            return format_response('success', {
+                'CostAllocationTags': results,
+                'Pagination': pagination,
+            })
+
+        response = ce_client.list_cost_allocation_tags(**params)
+        return format_response('success', response)
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'ListCostAllocationTags', 'Cost Explorer')
+
+
+@cost_allocation_tags_server.tool(
+    name='list-cost-allocation-tag-backfill-history',
+    description="""Retrieves the history of cost allocation tag backfill requests using the
+ListCostAllocationTagBackfillHistory API.
+
+Backfill retroactively applies the current tag activation status to historical billing data.
+Without backfill, tag activation only affects future billing periods.
+
+Backfill requests progress through these states:
+- SCHEDULED: Initial state when the backfill is requested
+- PROCESSING: System is rewriting historical tag data and reprocessing bills
+- SUCCEEDED: Backfill completed, historical data updated
+- FAILED: Processing error occurred (can be retried)
+
+Constraints: Only one backfill can run at a time. There is a 24-hour cooldown between
+requests. Maximum lookback is 12 months. BackfillFrom must be the first day of a month
+at 00:00:00 UTC.
+
+The tool returns CostAllocationTagBackfillRequest objects containing:
+- BackfillFrom (start date, first of month UTC)
+- BackfillStatus (SUCCEEDED, PROCESSING, or FAILED)
+- RequestedAt, CompletedAt (null if still processing), LastUpdatedAt
+
+You can control pagination with:
+- max_results: Results per page (1-1000)
+- max_pages: Max pages to auto-paginate through
+
+Example 1 - Get latest backfill request: {"max_results": 1}
+Example 2 - Get full backfill history: {"max_pages": 10}""",
+)
+async def list_cost_allocation_tag_backfill_history(
+    ctx: Context,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List cost allocation tag backfill history.
+
+    Args:
+        ctx: The MCP context object
+        max_results: Max results per page (1-1000)
+        next_token: Pagination token from previous response
+        max_pages: Max pages to auto-paginate through
+
+    Returns:
+        Dict containing the list of backfill requests
+    """
+    await ctx.info('Calling ListCostAllocationTagBackfillHistory API')
+
+    try:
+        ce_client = create_aws_client('ce')
+        params: Dict[str, Any] = {}
+
+        if max_results is not None:
+            params['MaxResults'] = max_results
+
+        if next_token:
+            params['NextToken'] = next_token
+        if next_token or max_pages:
+            results, pagination = await paginate_aws_response(
+                ctx,
+                'ListCostAllocationTagBackfillHistory',
+                lambda **p: ce_client.list_cost_allocation_tag_backfill_history(**p),
+                params,
+                'BackfillRequests',
+                max_pages=max_pages,
+            )
+            return format_response('success', {
+                'BackfillRequests': results,
+                'Pagination': pagination,
+            })
+
+        response = ce_client.list_cost_allocation_tag_backfill_history(**params)
+        return format_response('success', response)
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'ListCostAllocationTagBackfillHistory', 'Cost Explorer')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_allocation_tags_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_allocation_tags_tools.py
@@ -15,7 +15,6 @@
 """Cost Allocation Tags tools for the AWS Billing and Cost Management MCP server."""
 
 import json
-
 from ..utilities.aws_service_base import (
     create_aws_client,
     format_response,
@@ -95,9 +94,12 @@ async def list_cost_allocation_tags(
             try:
                 params['TagKeys'] = json.loads(tag_keys)
             except json.JSONDecodeError as e:
-                return format_response('error', {
-                    'message': f'Invalid JSON for tag_keys parameter: {e}',
-                })
+                return format_response(
+                    'error',
+                    {
+                        'message': f'Invalid JSON for tag_keys parameter: {e}',
+                    },
+                )
         if tag_type:
             params['Type'] = tag_type
         if max_results is not None:
@@ -114,10 +116,13 @@ async def list_cost_allocation_tags(
                 'CostAllocationTags',
                 max_pages=max_pages,
             )
-            return format_response('success', {
-                'CostAllocationTags': results,
-                'Pagination': pagination,
-            })
+            return format_response(
+                'success',
+                {
+                    'CostAllocationTags': results,
+                    'Pagination': pagination,
+                },
+            )
 
         response = ce_client.list_cost_allocation_tags(**params)
         return format_response('success', response)
@@ -193,13 +198,18 @@ async def list_cost_allocation_tag_backfill_history(
                 'BackfillRequests',
                 max_pages=max_pages,
             )
-            return format_response('success', {
-                'BackfillRequests': results,
-                'Pagination': pagination,
-            })
+            return format_response(
+                'success',
+                {
+                    'BackfillRequests': results,
+                    'Pagination': pagination,
+                },
+            )
 
         response = ce_client.list_cost_allocation_tag_backfill_history(**params)
         return format_response('success', response)
 
     except Exception as e:
-        return await handle_aws_error(ctx, e, 'ListCostAllocationTagBackfillHistory', 'Cost Explorer')
+        return await handle_aws_error(
+            ctx, e, 'ListCostAllocationTagBackfillHistory', 'Cost Explorer'
+        )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_category_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_category_tools.py
@@ -1,0 +1,194 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cost Category tools for the AWS Billing and Cost Management MCP server.
+
+Dedicated tools for Cost Category management APIs:
+- DescribeCostCategoryDefinition
+- ListCostCategoryDefinitions
+"""
+
+import json
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, Optional
+
+
+cost_category_server = FastMCP(
+    name='cost-category-tools',
+    instructions='Tools for managing AWS Cost Categories',
+)
+
+
+@cost_category_server.tool(
+    name='describe-cost-category-definition',
+    description="""Returns the full definition of a cost category using the DescribeCostCategoryDefinition API.
+
+Cost categories group AWS costs using rule-based expressions that match line items by
+dimensions (SERVICE, LINKED_ACCOUNT, USAGE_TYPE), resource tags, or other cost category
+values. Each matched line item is assigned a category value such as "Production" or
+"Development". Rules can be REGULAR (explicit match) or INHERITED_VALUE (dynamic value
+from a tag key or account name). A DefaultValue catches costs that do not match any rule.
+
+The tool returns a CostCategory object containing:
+- Name (1-50 chars, unique per account, case-sensitive), CostCategoryArn
+- RuleVersion (always "CostCategoryExpression.v1")
+- Rules array with Value, Rule expression (Dimensions/Tags/CostCategories with And/Or/Not), and Type
+- DefaultValue, SplitChargeRules (PROPORTIONAL, FIXED, or EVEN allocation methods)
+- EffectiveStart/EffectiveEnd (null if still active)
+- ProcessingStatus: APPLIED (rules reflected in data) or PROCESSING (backfill in progress)
+
+Linked accounts can describe cost categories from their management account.
+
+Required parameters:
+- cost_category_arn: ARN of the cost category (arn:aws:ce::<account_id>:costcategory/<uuid>).
+  Use list-cost-category-definitions to discover ARNs.
+
+Optional parameters:
+- effective_on: ISO 8601 datetime (e.g., 2024-01-01T00:00:00Z) to retrieve the version
+  active at that time. Defaults to the current version.
+
+Example 1 - Get current definition:
+  {"cost_category_arn": "arn:aws:ce::123456789012:costcategory/abcd-1234"}
+Example 2 - Get historical version:
+  {"cost_category_arn": "arn:aws:ce::123456789012:costcategory/abcd-1234", "effective_on": "2024-06-01T00:00:00Z"}""",
+)
+async def describe_cost_category_definition(
+    ctx: Context,
+    cost_category_arn: str,
+    effective_on: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Describe a cost category definition.
+
+    Args:
+        ctx: The MCP context object
+        cost_category_arn: ARN of the cost category to describe
+        effective_on: Optional ISO 8601 datetime to retrieve a historical version
+
+    Returns:
+        Dict containing the cost category definition
+    """
+    await ctx.info(f'Calling DescribeCostCategoryDefinition for {cost_category_arn}')
+
+    try:
+        ce_client = create_aws_client('ce')
+        params: Dict[str, Any] = {'CostCategoryArn': cost_category_arn}
+
+        if effective_on:
+            params['EffectiveOn'] = effective_on
+
+        response = ce_client.describe_cost_category_definition(**params)
+        return format_response('success', response)
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'DescribeCostCategoryDefinition', 'Cost Explorer')
+
+
+@cost_category_server.tool(
+    name='list-cost-category-definitions',
+    description="""Lists all cost category definitions in the account using the ListCostCategoryDefinitions API.
+
+Returns lightweight references for each cost category, not full rule definitions. Use
+describe-cost-category-definition with the returned ARN to get the complete rule set.
+
+The tool returns CostCategoryReference objects containing:
+- CostCategoryArn, Name (unique, case-sensitive), NumberOfRules
+- EffectiveStart, EffectiveEnd (null if current)
+- DefaultValue, Values (all category values defined in the rules)
+- ProcessingStatus: APPLIED or PROCESSING
+- SupportedResourceTypes
+
+You can filter and paginate with:
+- effective_on: ISO 8601 datetime to return only categories active at that time.
+  Defaults to current date.
+- supported_resource_types: JSON array to filter by resource type support.
+  Valid values: "billing:rispgroupsharing", "billing:billingview"
+  Example: '["billing:billingview"]'
+  Returns only categories supporting all specified types.
+- max_results: Results per page (1-100, default 20)
+- max_pages: Max pages to auto-paginate through
+
+Limits: 50 cost categories per management account, 500 rules per category (API),
+100 rules per category (console), 10 split charge rules per category.
+
+Example 1 - List all current categories: {}
+Example 2 - List categories active on a date: {"effective_on": "2024-06-01T00:00:00Z"}
+Example 3 - Filter by billing view support: {"supported_resource_types": "[\"billing:billingview\"]"}""",
+)
+async def list_cost_category_definitions(
+    ctx: Context,
+    effective_on: Optional[str] = None,
+    supported_resource_types: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List cost category definitions.
+
+    Args:
+        ctx: The MCP context object
+        effective_on: Optional ISO 8601 datetime to filter by active date
+        supported_resource_types: Optional JSON array of resource type strings
+        max_results: Max results per page (1-100, default 20)
+        next_token: Pagination token from previous response
+        max_pages: Max pages to auto-paginate through
+
+    Returns:
+        Dict containing the list of cost category references
+    """
+    await ctx.info('Calling ListCostCategoryDefinitions API')
+
+    try:
+        ce_client = create_aws_client('ce')
+        params: Dict[str, Any] = {}
+
+        if effective_on:
+            params['EffectiveOn'] = effective_on
+        if supported_resource_types:
+            try:
+                params['SupportedResourceTypes'] = json.loads(supported_resource_types)
+            except json.JSONDecodeError as e:
+                return format_response('error', {
+                    'message': f'Invalid JSON for supported_resource_types parameter: {e}',
+                })
+        if max_results is not None:
+            params['MaxResults'] = max_results
+
+        if next_token:
+            params['NextToken'] = next_token
+        if next_token or max_pages:
+            results, pagination = await paginate_aws_response(
+                ctx,
+                'ListCostCategoryDefinitions',
+                lambda **p: ce_client.list_cost_category_definitions(**p),
+                params,
+                'CostCategoryReferences',
+                max_pages=max_pages,
+            )
+            return format_response('success', {
+                'CostCategoryReferences': results,
+                'Pagination': pagination,
+            })
+
+        response = ce_client.list_cost_category_definitions(**params)
+        return format_response('success', response)
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'ListCostCategoryDefinitions', 'Cost Explorer')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_category_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_category_tools.py
@@ -20,7 +20,6 @@ Dedicated tools for Cost Category management APIs:
 """
 
 import json
-
 from ..utilities.aws_service_base import (
     create_aws_client,
     format_response,
@@ -165,9 +164,12 @@ async def list_cost_category_definitions(
             try:
                 params['SupportedResourceTypes'] = json.loads(supported_resource_types)
             except json.JSONDecodeError as e:
-                return format_response('error', {
-                    'message': f'Invalid JSON for supported_resource_types parameter: {e}',
-                })
+                return format_response(
+                    'error',
+                    {
+                        'message': f'Invalid JSON for supported_resource_types parameter: {e}',
+                    },
+                )
         if max_results is not None:
             params['MaxResults'] = max_results
 
@@ -182,10 +184,13 @@ async def list_cost_category_definitions(
                 'CostCategoryReferences',
                 max_pages=max_pages,
             )
-            return format_response('success', {
-                'CostCategoryReferences': results,
-                'Pagination': pagination,
-            })
+            return format_response(
+                'success',
+                {
+                    'CostCategoryReferences': results,
+                    'Pagination': pagination,
+                },
+            )
 
         response = ce_client.list_cost_category_definitions(**params)
         return format_response('success', response)

--- a/src/billing-cost-management-mcp-server/tests/test_server.py
+++ b/src/billing-cost-management-mcp-server/tests/test_server.py
@@ -55,6 +55,8 @@ def test_server_tool_imports():
     assert hasattr(server, 'compute_optimizer_server')
     assert hasattr(server, 'cost_anomaly_server')
     assert hasattr(server, 'cost_comparison_server')
+    assert hasattr(server, 'cost_allocation_tags_server')
+    assert hasattr(server, 'cost_category_server')
 
 
 @patch.dict(os.environ, {'AWS_REGION': 'us-west-2'})

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_allocation_tags_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_allocation_tags_tools.py
@@ -1,0 +1,372 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the cost_allocation_tags_tools module.
+
+These tests verify the functionality of the Cost Allocation Tags API tools, including:
+- Listing cost allocation tags with various filters
+- Listing cost allocation tag backfill history
+- Pagination handling
+- Error handling for API exceptions and invalid inputs
+"""
+
+import fastmcp
+import importlib
+import json
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools import (
+    cost_allocation_tags_server,
+)
+from botocore.exceptions import ClientError
+from fastmcp import Context
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _reload_with_identity_decorator():
+    """Reload module with FastMCP.tool patched to return the original function."""
+    from awslabs.billing_cost_management_mcp_server.tools import (
+        cost_allocation_tags_tools as mod,
+    )
+
+    def _identity_tool(self, *args, **kwargs):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+    with patch.object(fastmcp.FastMCP, 'tool', _identity_tool):
+        importlib.reload(mod)
+        return mod
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context."""
+    context = MagicMock(spec=Context)
+    context.info = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def mock_ce_client():
+    """Create a mock Cost Explorer boto3 client."""
+    mock_client = MagicMock()
+
+    mock_client.list_cost_allocation_tags.return_value = {
+        'CostAllocationTags': [
+            {
+                'TagKey': 'Environment',
+                'Type': 'UserDefined',
+                'Status': 'Active',
+                'LastUpdatedDate': '2024-01-15',
+                'LastUsedDate': '2024-03-01',
+            },
+            {
+                'TagKey': 'aws:createdBy',
+                'Type': 'AWSGenerated',
+                'Status': 'Active',
+                'LastUpdatedDate': '2024-02-01',
+                'LastUsedDate': '2024-03-01',
+            },
+        ],
+    }
+
+    mock_client.list_cost_allocation_tag_backfill_history.return_value = {
+        'BackfillRequests': [
+            {
+                'BackfillFrom': '2024-01-01T00:00:00Z',
+                'RequestedAt': '2024-03-15T10:00:00Z',
+                'CompletedAt': '2024-03-15T12:00:00Z',
+                'LastUpdatedAt': '2024-03-15T12:00:00Z',
+                'BackfillStatus': 'SUCCEEDED',
+            },
+        ],
+    }
+
+    return mock_client
+
+
+def test_cost_allocation_tags_server_initialization():
+    """Test that the cost_allocation_tags_server is properly initialized."""
+    assert cost_allocation_tags_server.name == 'cost-allocation-tags-tools'
+    instructions = cost_allocation_tags_server.instructions
+    assert instructions is not None
+    assert 'Cost Allocation Tags' in instructions if instructions else False
+
+
+@pytest.mark.asyncio
+class TestListCostAllocationTags:
+    """Tests for list_cost_allocation_tags function."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools.create_aws_client'
+    )
+    async def test_list_tags_no_filters(self, mock_create_client, mock_context, mock_ce_client):
+        """Test listing tags with no filters."""
+        mod = _reload_with_identity_decorator()
+        mock_create_client.return_value = mock_ce_client
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tags(mock_context)
+
+        assert result['status'] == 'success'
+        assert len(result['data']['CostAllocationTags']) == 2
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools.create_aws_client'
+    )
+    async def test_list_tags_with_status_filter(
+        self, mock_create_client, mock_context, mock_ce_client
+    ):
+        """Test listing tags filtered by status."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tags(mock_context, status='Active')
+
+        mock_ce_client.list_cost_allocation_tags.assert_called_once_with(Status='Active')
+        assert result['status'] == 'success'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools.create_aws_client'
+    )
+    async def test_list_tags_with_type_filter(
+        self, mock_create_client, mock_context, mock_ce_client
+    ):
+        """Test listing tags filtered by type."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tags(mock_context, tag_type='UserDefined')
+
+        mock_ce_client.list_cost_allocation_tags.assert_called_once_with(Type='UserDefined')
+        assert result['status'] == 'success'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools.create_aws_client'
+    )
+    async def test_list_tags_with_tag_keys_filter(
+        self, mock_create_client, mock_context, mock_ce_client
+    ):
+        """Test listing tags filtered by specific tag keys."""
+        mod = _reload_with_identity_decorator()
+        tag_keys = json.dumps(['Environment', 'Team'])
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tags(mock_context, tag_keys=tag_keys)
+
+        mock_ce_client.list_cost_allocation_tags.assert_called_once_with(
+            TagKeys=['Environment', 'Team']
+        )
+        assert result['status'] == 'success'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools.create_aws_client'
+    )
+    async def test_list_tags_with_max_results(
+        self, mock_create_client, mock_context, mock_ce_client
+    ):
+        """Test listing tags with max_results parameter."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tags(mock_context, max_results=50)
+
+        mock_ce_client.list_cost_allocation_tags.assert_called_once_with(MaxResults=50)
+        assert result['status'] == 'success'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools.create_aws_client'
+    )
+    async def test_list_tags_with_all_filters(
+        self, mock_create_client, mock_context, mock_ce_client
+    ):
+        """Test listing tags with all filters combined."""
+        mod = _reload_with_identity_decorator()
+        tag_keys = json.dumps(['Environment'])
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tags(
+                mock_context,
+                status='Active',
+                tag_keys=tag_keys,
+                tag_type='UserDefined',
+                max_results=10,
+            )
+
+        mock_ce_client.list_cost_allocation_tags.assert_called_once_with(
+            Status='Active',
+            TagKeys=['Environment'],
+            Type='UserDefined',
+            MaxResults=10,
+        )
+        assert result['status'] == 'success'
+
+    async def test_list_tags_with_max_pages(self, mock_context, mock_ce_client):
+        """Test listing tags with auto-pagination via max_pages."""
+        mod = _reload_with_identity_decorator()
+        mock_paginate = AsyncMock(
+            return_value=(
+                [
+                    {'TagKey': 'Environment', 'Type': 'UserDefined', 'Status': 'Active'},
+                    {'TagKey': 'Team', 'Type': 'UserDefined', 'Status': 'Active'},
+                ],
+                {'total_results': 2, 'pages_fetched': 1},
+            )
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
+            mod, 'paginate_aws_response', mock_paginate
+        ):
+            result = await mod.list_cost_allocation_tags(mock_context, max_pages=5)
+
+        mock_paginate.assert_called_once()
+        assert result['status'] == 'success'
+        assert len(result['data']['CostAllocationTags']) == 2
+        assert result['data']['Pagination']['total_results'] == 2
+
+    async def test_list_tags_with_next_token(self, mock_context, mock_ce_client):
+        """Test listing tags with next_token triggers pagination."""
+        mod = _reload_with_identity_decorator()
+        mock_paginate = AsyncMock(
+            return_value=(
+                [{'TagKey': 'CostCenter', 'Type': 'UserDefined', 'Status': 'Active'}],
+                {'total_results': 1, 'pages_fetched': 1},
+            )
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
+            mod, 'paginate_aws_response', mock_paginate
+        ):
+            result = await mod.list_cost_allocation_tags(mock_context, next_token='abc123')
+
+        mock_paginate.assert_called_once()
+        assert result['status'] == 'success'
+
+    async def test_list_tags_error(self, mock_context):
+        """Test error handling for exceptions."""
+        mod = _reload_with_identity_decorator()
+        error = ClientError(
+            {'Error': {'Code': 'LimitExceededException', 'Message': 'Too many tags'}},
+            'ListCostAllocationTags',
+        )
+        mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'Too many tags'})
+
+        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
+            mod, 'handle_aws_error', mock_handle
+        ):
+            result = await mod.list_cost_allocation_tags(mock_context)
+
+        mock_handle.assert_called_once_with(
+            mock_context, error, 'ListCostAllocationTags', 'Cost Explorer'
+        )
+        assert result['status'] == 'error'
+
+    async def test_list_tags_invalid_tag_keys_json(self, mock_context):
+        """Test error handling for invalid JSON in tag_keys."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=MagicMock()):
+            result = await mod.list_cost_allocation_tags(mock_context, tag_keys='not valid json')
+
+        assert result['status'] == 'error'
+        assert 'Invalid JSON for tag_keys parameter' in result['data']['message']
+
+
+@pytest.mark.asyncio
+class TestListCostAllocationTagBackfillHistory:
+    """Tests for list_cost_allocation_tag_backfill_history function."""
+
+    async def test_list_backfill_no_filters(self, mock_context, mock_ce_client):
+        """Test listing backfill history with no filters."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tag_backfill_history(mock_context)
+
+        mock_ce_client.list_cost_allocation_tag_backfill_history.assert_called_once_with()
+        assert result['status'] == 'success'
+        assert len(result['data']['BackfillRequests']) == 1
+
+    async def test_list_backfill_with_max_results(self, mock_context, mock_ce_client):
+        """Test listing backfill history with max_results."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_allocation_tag_backfill_history(
+                mock_context, max_results=1
+            )
+
+        mock_ce_client.list_cost_allocation_tag_backfill_history.assert_called_once_with(
+            MaxResults=1
+        )
+        assert result['status'] == 'success'
+
+    async def test_list_backfill_with_max_pages(self, mock_context, mock_ce_client):
+        """Test listing backfill history with auto-pagination."""
+        mod = _reload_with_identity_decorator()
+        mock_paginate = AsyncMock(
+            return_value=(
+                [{'BackfillFrom': '2024-01-01T00:00:00Z', 'BackfillStatus': 'SUCCEEDED'}],
+                {'total_results': 1, 'pages_fetched': 1},
+            )
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
+            mod, 'paginate_aws_response', mock_paginate
+        ):
+            result = await mod.list_cost_allocation_tag_backfill_history(
+                mock_context, max_pages=10
+            )
+
+        mock_paginate.assert_called_once()
+        assert result['status'] == 'success'
+        assert len(result['data']['BackfillRequests']) == 1
+
+    async def test_list_backfill_with_next_token(self, mock_context, mock_ce_client):
+        """Test listing backfill history with next_token triggers pagination."""
+        mod = _reload_with_identity_decorator()
+        mock_paginate = AsyncMock(
+            return_value=(
+                [{'BackfillFrom': '2024-02-01T00:00:00Z', 'BackfillStatus': 'PROCESSING'}],
+                {'total_results': 1, 'pages_fetched': 1},
+            )
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
+            mod, 'paginate_aws_response', mock_paginate
+        ):
+            result = await mod.list_cost_allocation_tag_backfill_history(
+                mock_context, next_token='token123'
+            )
+
+        mock_paginate.assert_called_once()
+        assert result['status'] == 'success'
+
+    async def test_list_backfill_error(self, mock_context):
+        """Test error handling for backfill history."""
+        mod = _reload_with_identity_decorator()
+        error = Exception('API error')
+        mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'API error'})
+
+        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
+            mod, 'handle_aws_error', mock_handle
+        ):
+            result = await mod.list_cost_allocation_tag_backfill_history(mock_context)
+
+        mock_handle.assert_called_once_with(
+            mock_context, error, 'ListCostAllocationTagBackfillHistory', 'Cost Explorer'
+        )
+        assert result['status'] == 'error'

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_allocation_tags_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_allocation_tags_tools.py
@@ -30,10 +30,11 @@ from awslabs.billing_cost_management_mcp_server.tools.cost_allocation_tags_tools
 )
 from botocore.exceptions import ClientError
 from fastmcp import Context
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-def _reload_with_identity_decorator():
+def _reload_with_identity_decorator() -> Any:
     """Reload module with FastMCP.tool patched to return the original function."""
     from awslabs.billing_cost_management_mcp_server.tools import (
         cost_allocation_tags_tools as mod,
@@ -227,8 +228,9 @@ class TestListCostAllocationTags:
             )
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
-            mod, 'paginate_aws_response', mock_paginate
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_ce_client),
+            patch.object(mod, 'paginate_aws_response', mock_paginate),
         ):
             result = await mod.list_cost_allocation_tags(mock_context, max_pages=5)
 
@@ -247,8 +249,9 @@ class TestListCostAllocationTags:
             )
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
-            mod, 'paginate_aws_response', mock_paginate
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_ce_client),
+            patch.object(mod, 'paginate_aws_response', mock_paginate),
         ):
             result = await mod.list_cost_allocation_tags(mock_context, next_token='abc123')
 
@@ -264,8 +267,9 @@ class TestListCostAllocationTags:
         )
         mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'Too many tags'})
 
-        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
-            mod, 'handle_aws_error', mock_handle
+        with (
+            patch.object(mod, 'create_aws_client', side_effect=error),
+            patch.object(mod, 'handle_aws_error', mock_handle),
         ):
             result = await mod.list_cost_allocation_tags(mock_context)
 
@@ -324,8 +328,9 @@ class TestListCostAllocationTagBackfillHistory:
             )
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
-            mod, 'paginate_aws_response', mock_paginate
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_ce_client),
+            patch.object(mod, 'paginate_aws_response', mock_paginate),
         ):
             result = await mod.list_cost_allocation_tag_backfill_history(
                 mock_context, max_pages=10
@@ -345,8 +350,9 @@ class TestListCostAllocationTagBackfillHistory:
             )
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
-            mod, 'paginate_aws_response', mock_paginate
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_ce_client),
+            patch.object(mod, 'paginate_aws_response', mock_paginate),
         ):
             result = await mod.list_cost_allocation_tag_backfill_history(
                 mock_context, next_token='token123'
@@ -361,8 +367,9 @@ class TestListCostAllocationTagBackfillHistory:
         error = Exception('API error')
         mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'API error'})
 
-        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
-            mod, 'handle_aws_error', mock_handle
+        with (
+            patch.object(mod, 'create_aws_client', side_effect=error),
+            patch.object(mod, 'handle_aws_error', mock_handle),
         ):
             result = await mod.list_cost_allocation_tag_backfill_history(mock_context)
 

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_category_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_category_tools.py
@@ -1,0 +1,339 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the cost_category_tools module.
+
+These tests verify the functionality of the Cost Category API tools, including:
+- Describing cost category definitions
+- Listing cost category definitions with various filters
+- Pagination handling
+- Error handling for API exceptions and invalid inputs
+"""
+
+import fastmcp
+import importlib
+import json
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.cost_category_tools import (
+    cost_category_server,
+)
+from botocore.exceptions import ClientError
+from fastmcp import Context
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+COST_CATEGORY_ARN = 'arn:aws:ce::123456789012:costcategory/abcd-1234-efgh-5678'
+
+
+def _reload_with_identity_decorator():
+    """Reload module with FastMCP.tool patched to return the original function."""
+    from awslabs.billing_cost_management_mcp_server.tools import cost_category_tools as mod
+
+    def _identity_tool(self, *args, **kwargs):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+    with patch.object(fastmcp.FastMCP, 'tool', _identity_tool):
+        importlib.reload(mod)
+        return mod
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context."""
+    context = MagicMock(spec=Context)
+    context.info = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def mock_ce_client():
+    """Create a mock Cost Explorer boto3 client."""
+    mock_client = MagicMock()
+
+    mock_client.describe_cost_category_definition.return_value = {
+        'CostCategory': {
+            'CostCategoryArn': COST_CATEGORY_ARN,
+            'Name': 'Environment',
+            'RuleVersion': 'CostCategoryExpression.v1',
+            'Rules': [
+                {
+                    'Value': 'Production',
+                    'Rule': {
+                        'Tags': {
+                            'Key': 'Environment',
+                            'Values': ['prod', 'production'],
+                            'MatchOptions': ['EQUALS'],
+                        }
+                    },
+                    'Type': 'REGULAR',
+                },
+            ],
+            'DefaultValue': 'Other',
+            'EffectiveStart': '2024-01-01T00:00:00Z',
+            'EffectiveEnd': None,
+            'ProcessingStatus': [{'Component': 'COST_EXPLORER', 'Status': 'APPLIED'}],
+        },
+    }
+
+    mock_client.list_cost_category_definitions.return_value = {
+        'CostCategoryReferences': [
+            {
+                'CostCategoryArn': COST_CATEGORY_ARN,
+                'Name': 'Environment',
+                'NumberOfRules': 3,
+                'EffectiveStart': '2024-01-01T00:00:00Z',
+                'EffectiveEnd': None,
+                'DefaultValue': 'Other',
+                'Values': ['Production', 'Development', 'Other'],
+                'ProcessingStatus': [{'Component': 'COST_EXPLORER', 'Status': 'APPLIED'}],
+            },
+        ],
+    }
+
+    return mock_client
+
+
+def test_cost_category_server_initialization():
+    """Test that the cost_category_server is properly initialized."""
+    assert cost_category_server.name == 'cost-category-tools'
+    instructions = cost_category_server.instructions
+    assert instructions is not None
+    assert 'Cost Categories' in instructions if instructions else False
+
+
+@pytest.mark.asyncio
+class TestDescribeCostCategoryDefinition:
+    """Tests for describe_cost_category_definition function."""
+
+    async def test_describe_success(self, mock_context, mock_ce_client):
+        """Test successful describe of a cost category."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.describe_cost_category_definition(mock_context, COST_CATEGORY_ARN)
+
+        mock_ce_client.describe_cost_category_definition.assert_called_once_with(
+            CostCategoryArn=COST_CATEGORY_ARN
+        )
+        assert result['status'] == 'success'
+        assert result['data']['CostCategory']['Name'] == 'Environment'
+        assert result['data']['CostCategory']['DefaultValue'] == 'Other'
+
+    async def test_describe_with_effective_on(self, mock_context, mock_ce_client):
+        """Test describe with effective_on parameter."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.describe_cost_category_definition(
+                mock_context, COST_CATEGORY_ARN, effective_on='2024-06-01T00:00:00Z'
+            )
+
+        mock_ce_client.describe_cost_category_definition.assert_called_once_with(
+            CostCategoryArn=COST_CATEGORY_ARN,
+            EffectiveOn='2024-06-01T00:00:00Z',
+        )
+        assert result['status'] == 'success'
+
+    async def test_describe_not_found(self, mock_context):
+        """Test error handling when cost category is not found."""
+        mod = _reload_with_identity_decorator()
+        error = ClientError(
+            {
+                'Error': {
+                    'Code': 'ResourceNotFoundException',
+                    'Message': 'Cost category not found',
+                }
+            },
+            'DescribeCostCategoryDefinition',
+        )
+        mock_client = MagicMock()
+        mock_client.describe_cost_category_definition.side_effect = error
+        mock_handle = AsyncMock(
+            return_value={'status': 'error', 'message': 'Cost category not found'}
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_client), patch.object(
+            mod, 'handle_aws_error', mock_handle
+        ):
+            result = await mod.describe_cost_category_definition(mock_context, COST_CATEGORY_ARN)
+
+        mock_handle.assert_called_once_with(
+            mock_context, error, 'DescribeCostCategoryDefinition', 'Cost Explorer'
+        )
+        assert result['status'] == 'error'
+
+    async def test_describe_generic_exception(self, mock_context):
+        """Test error handling for generic exceptions."""
+        mod = _reload_with_identity_decorator()
+        error = Exception('Unexpected error')
+        mock_handle = AsyncMock(
+            return_value={'status': 'error', 'message': 'Unexpected error'}
+        )
+
+        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
+            mod, 'handle_aws_error', mock_handle
+        ):
+            result = await mod.describe_cost_category_definition(mock_context, COST_CATEGORY_ARN)
+
+        mock_handle.assert_called_once_with(
+            mock_context, error, 'DescribeCostCategoryDefinition', 'Cost Explorer'
+        )
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestListCostCategoryDefinitions:
+    """Tests for list_cost_category_definitions function."""
+
+    async def test_list_no_filters(self, mock_context, mock_ce_client):
+        """Test listing categories with no filters."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_category_definitions(mock_context)
+
+        mock_ce_client.list_cost_category_definitions.assert_called_once_with()
+        assert result['status'] == 'success'
+        assert len(result['data']['CostCategoryReferences']) == 1
+
+    async def test_list_with_effective_on(self, mock_context, mock_ce_client):
+        """Test listing categories filtered by effective date."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_category_definitions(
+                mock_context, effective_on='2024-06-01T00:00:00Z'
+            )
+
+        mock_ce_client.list_cost_category_definitions.assert_called_once_with(
+            EffectiveOn='2024-06-01T00:00:00Z'
+        )
+        assert result['status'] == 'success'
+
+    async def test_list_with_supported_resource_types(self, mock_context, mock_ce_client):
+        """Test listing categories filtered by supported resource types."""
+        mod = _reload_with_identity_decorator()
+        resource_types = json.dumps(['billing:billingview'])
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_category_definitions(
+                mock_context, supported_resource_types=resource_types
+            )
+
+        mock_ce_client.list_cost_category_definitions.assert_called_once_with(
+            SupportedResourceTypes=['billing:billingview']
+        )
+        assert result['status'] == 'success'
+
+    async def test_list_with_max_results(self, mock_context, mock_ce_client):
+        """Test listing categories with max_results."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_category_definitions(mock_context, max_results=10)
+
+        mock_ce_client.list_cost_category_definitions.assert_called_once_with(MaxResults=10)
+        assert result['status'] == 'success'
+
+    async def test_list_with_all_filters(self, mock_context, mock_ce_client):
+        """Test listing categories with all filters combined."""
+        mod = _reload_with_identity_decorator()
+        resource_types = json.dumps(['billing:billingview'])
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client):
+            result = await mod.list_cost_category_definitions(
+                mock_context,
+                effective_on='2024-06-01T00:00:00Z',
+                supported_resource_types=resource_types,
+                max_results=5,
+            )
+
+        mock_ce_client.list_cost_category_definitions.assert_called_once_with(
+            EffectiveOn='2024-06-01T00:00:00Z',
+            SupportedResourceTypes=['billing:billingview'],
+            MaxResults=5,
+        )
+        assert result['status'] == 'success'
+
+    async def test_list_with_max_pages(self, mock_context, mock_ce_client):
+        """Test listing categories with auto-pagination."""
+        mod = _reload_with_identity_decorator()
+        mock_paginate = AsyncMock(
+            return_value=(
+                [{'CostCategoryArn': COST_CATEGORY_ARN, 'Name': 'Environment'}],
+                {'total_results': 1, 'pages_fetched': 1},
+            )
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
+            mod, 'paginate_aws_response', mock_paginate
+        ):
+            result = await mod.list_cost_category_definitions(mock_context, max_pages=5)
+
+        mock_paginate.assert_called_once()
+        assert result['status'] == 'success'
+        assert len(result['data']['CostCategoryReferences']) == 1
+
+    async def test_list_with_next_token(self, mock_context, mock_ce_client):
+        """Test listing categories with next_token triggers pagination."""
+        mod = _reload_with_identity_decorator()
+        mock_paginate = AsyncMock(
+            return_value=(
+                [{'CostCategoryArn': COST_CATEGORY_ARN, 'Name': 'Environment'}],
+                {'total_results': 1, 'pages_fetched': 1},
+            )
+        )
+
+        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
+            mod, 'paginate_aws_response', mock_paginate
+        ):
+            result = await mod.list_cost_category_definitions(mock_context, next_token='token456')
+
+        mock_paginate.assert_called_once()
+        assert result['status'] == 'success'
+
+    async def test_list_client_error(self, mock_context):
+        """Test error handling for ClientError."""
+        mod = _reload_with_identity_decorator()
+        error = ClientError(
+            {'Error': {'Code': 'ServiceException', 'Message': 'Service error'}},
+            'ListCostCategoryDefinitions',
+        )
+        mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'Service error'})
+
+        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
+            mod, 'handle_aws_error', mock_handle
+        ):
+            result = await mod.list_cost_category_definitions(mock_context)
+
+        mock_handle.assert_called_once_with(
+            mock_context, error, 'ListCostCategoryDefinitions', 'Cost Explorer'
+        )
+        assert result['status'] == 'error'
+
+    async def test_list_invalid_resource_types_json(self, mock_context):
+        """Test error handling for invalid JSON in supported_resource_types."""
+        mod = _reload_with_identity_decorator()
+
+        with patch.object(mod, 'create_aws_client', return_value=MagicMock()):
+            result = await mod.list_cost_category_definitions(
+                mock_context, supported_resource_types='not valid json'
+            )
+
+        assert result['status'] == 'error'
+        assert 'Invalid JSON for supported_resource_types parameter' in result['data']['message']

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_category_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_category_tools.py
@@ -30,13 +30,14 @@ from awslabs.billing_cost_management_mcp_server.tools.cost_category_tools import
 )
 from botocore.exceptions import ClientError
 from fastmcp import Context
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
 COST_CATEGORY_ARN = 'arn:aws:ce::123456789012:costcategory/abcd-1234-efgh-5678'
 
 
-def _reload_with_identity_decorator():
+def _reload_with_identity_decorator() -> Any:
     """Reload module with FastMCP.tool patched to return the original function."""
     from awslabs.billing_cost_management_mcp_server.tools import cost_category_tools as mod
 
@@ -167,8 +168,9 @@ class TestDescribeCostCategoryDefinition:
             return_value={'status': 'error', 'message': 'Cost category not found'}
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_client), patch.object(
-            mod, 'handle_aws_error', mock_handle
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_client),
+            patch.object(mod, 'handle_aws_error', mock_handle),
         ):
             result = await mod.describe_cost_category_definition(mock_context, COST_CATEGORY_ARN)
 
@@ -181,12 +183,11 @@ class TestDescribeCostCategoryDefinition:
         """Test error handling for generic exceptions."""
         mod = _reload_with_identity_decorator()
         error = Exception('Unexpected error')
-        mock_handle = AsyncMock(
-            return_value={'status': 'error', 'message': 'Unexpected error'}
-        )
+        mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'Unexpected error'})
 
-        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
-            mod, 'handle_aws_error', mock_handle
+        with (
+            patch.object(mod, 'create_aws_client', side_effect=error),
+            patch.object(mod, 'handle_aws_error', mock_handle),
         ):
             result = await mod.describe_cost_category_definition(mock_context, COST_CATEGORY_ARN)
 
@@ -280,8 +281,9 @@ class TestListCostCategoryDefinitions:
             )
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
-            mod, 'paginate_aws_response', mock_paginate
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_ce_client),
+            patch.object(mod, 'paginate_aws_response', mock_paginate),
         ):
             result = await mod.list_cost_category_definitions(mock_context, max_pages=5)
 
@@ -299,8 +301,9 @@ class TestListCostCategoryDefinitions:
             )
         )
 
-        with patch.object(mod, 'create_aws_client', return_value=mock_ce_client), patch.object(
-            mod, 'paginate_aws_response', mock_paginate
+        with (
+            patch.object(mod, 'create_aws_client', return_value=mock_ce_client),
+            patch.object(mod, 'paginate_aws_response', mock_paginate),
         ):
             result = await mod.list_cost_category_definitions(mock_context, next_token='token456')
 
@@ -316,8 +319,9 @@ class TestListCostCategoryDefinitions:
         )
         mock_handle = AsyncMock(return_value={'status': 'error', 'message': 'Service error'})
 
-        with patch.object(mod, 'create_aws_client', side_effect=error), patch.object(
-            mod, 'handle_aws_error', mock_handle
+        with (
+            patch.object(mod, 'create_aws_client', side_effect=error),
+            patch.object(mod, 'handle_aws_error', mock_handle),
         ):
             result = await mod.list_cost_category_definitions(mock_context)
 


### PR DESCRIPTION
## Summary

### Changes

Add 4 new read-only MCP tools to the billing-cost-management-mcp-server for Cost Allocation Tags and Cost Categories APIs:

Cost Allocation Tags:
- list-cost-allocation-tags — List cost allocation tags with filters by status (Active/Inactive), type (AWSGenerated/UserDefined), and specific tag keys
- list-cost-allocation-tag-backfill-history — Retrieve the history of tag backfill requests that retroactively apply activation status to historical billing data

Cost Category Definitions:
- describe-cost-category-definition — Get the full definition of a cost category including rules, split charge rules, and processing status
- list-cost-category-definitions — List all cost category definitions in the account with summary metadata and filtering by effective date or supported resource types

All tools follow existing patterns: shared utility layer (create_aws_client, format_response, handle_aws_error, paginate_aws_response), separate FastMCP sub-server instances, and JSON string
parameters for list inputs.

Also updates:
- server.py — imports and registers the two new sub-servers, adds tool names to the logging list and server instructions
- README.md — documents new tools, required IAM permissions (ce:ListCostAllocationTags, ce:ListCostAllocationTagBackfillHistory, ce:DescribeCostCategoryDefinition,
ce:ListCostCategoryDefinitions), and tool listing
- test_server.py — verifies new server imports

### User experience

Before: Users had no way to query cost allocation tag status or cost category definitions through the MCP server. They would need to use the AWS CLI or console directly.

After: Users can ask the LLM to list their active cost allocation tags, check backfill history, describe cost category rules, or list all cost categories — all through natural language via
the MCP server. Examples:
- "What cost allocation tags are active in my account?"
- "Show me the rules for my Environment cost category"
- "List all cost categories and their processing status"

#### Sample Conversation

```
what cost categories, cost allocation tags, cost allocation tag backfills do I have available? can you also describe one of the available cost categories to me.

  Let me fetch all of that information in parallel.
● list-cost-category-definitions
● list-cost-allocation-tags
● list-cost-allocation-tag-backfill-history

  Now let me describe the "Environment" cost category since it looks like the most meaningful one with clear Production/Development values.
● describe-cost-category-definition
    ╰ cost_category_arn=arn:aws:ce::437838858178:costcategory/735f8952-67c0-48d2-9c2b-d02d84fa6cf5
    {
      "content": [
        {
    ...+69 lines (ctrl+o to toggle)

  Here's a summary of everything:

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  Cost Categories (5 total)

  ┌──────────────┬─────────────────────────────────────────────┬─────────┬─────────────────┬─────────┬─────────────────────┐
  │ Name         │ Values                                      │ # Rules │ Effective Start │ Status  │ Supports            │
  ├──────────────┼─────────────────────────────────────────────┼─────────┼─────────────────┼─────────┼─────────────────────┤
  │ 5j6npaxhqp   │ UpdatedValue                                │ 1       │ 2026-04-01      │ APPLIED │ RI/SP group sharing │
  │ Environment  │ Production, Development (default: Untagged) │ 2       │ 2026-04-01      │ APPLIED │ Billing views       │
  │ department   │ ld9nu4ecru                                  │ 1       │ 2026-03-01      │ APPLIED │ Billing views       │
  │ organization │ IT, billing, finance                        │ 3       │ 2025-09-01      │ APPLIED │ Billing views       │
  │ test11111    │ Group1                                      │ 3       │ 2026-03-01      │ APPLIED │ —                   │
  └──────────────┴─────────────────────────────────────────────┴─────────┴─────────────────┴─────────┴─────────────────────┘

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  Cost Allocation Tags (71 total)

  - 38 Active (25 UserDefined, 13 AWSGenerated)
  - 33 Inactive

  Notable active tags include: Name, Organization, SoftwareType, TargetAlias, account1, accountTag/* family, aws:createdBy, aws:cloudformation:* family, aws:eks:* family, aws-cdk:subnet-*,
  organization, mytag, test, and others.

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  Cost Allocation Tag Backfill History (10 requests, all SUCCEEDED)

  ┌───────────────┬────────────┬────────────┐
  │ Backfill From │ Requested  │ Completed  │
  ├───────────────┼────────────┼────────────┤
  │ 2025-01-01    │ 2025-11-13 │ 2025-11-13 │
  │ 2025-10-01    │ 2025-11-04 │ 2025-11-04 │
  │ 2024-11-01    │ 2025-08-29 │ 2025-08-29 │
  │ 2024-07-01    │ 2025-03-25 │ 2025-03-25 │
  │ 2024-02-01    │ 2025-02-12 │ 2025-02-13 │
  │ 2024-02-01    │ 2024-11-14 │ 2024-11-14 │
  │ 2023-03-01    │ 2024-03-27 │ 2024-03-27 │
  │ 2024-02-01    │ 2024-03-19 │ 2024-03-19 │
  │ 2023-12-01    │ 2024-03-14 │ 2024-03-14 │
  │ 2024-02-01    │ 2024-03-13 │ 2024-03-13 │
  └───────────────┴────────────┴────────────┘

  All backfills completed successfully. The most recent one backfilled from 2025-01-01 and was requested on 2025-11-13.

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  Environment Cost Category — Detailed Description

  The "Environment" cost category (effective since 2026-04-01, status: APPLIED) classifies costs into three buckets:

  1. Production — Matches resources where the Name tag equals prod, production, or Prod (case-insensitive match).
  2. Development — Matches resources where the Name tag is absent (i.e., no Name tag at all).
  3. Untagged (default) — Catches everything else that doesn't match either rule above.

  This category supports billing views (billing:billingview), so it can be used as a filter dimension in custom billing views.
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

RFC issue number:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).