### PR TITLE
fix(agentcore): remove Unix-only signal handler crashing server on Windows

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/CHANGELOG.md
+++ b/src/amazon-bedrock-agentcore-mcp-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Server crash on Windows due to `asyncio.loop.add_signal_handler` being unsupported on the default `ProactorEventLoop` (#2752). Removed the redundant signal handler from `server_lifespan` — cleanup is already handled by the context manager's `finally` block on every graceful shutdown path (stdin EOF, SIGINT via default `KeyboardInterrupt`, HTTP shutdown via uvicorn's own signal handling).
+
 ### Added
 
 - Initial project setup

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import os
-import signal
 from .tools import docs, gateway
 from .utils import cache
 from collections.abc import AsyncIterator
@@ -107,13 +106,6 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
     graceful shutdown.
     """
     if _browser_cm is not None and _browser_sm is not None:
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(
-                sig,
-                lambda cm=_browser_cm: asyncio.ensure_future(cm.cleanup()),
-            )
-
         from .tools.browser import cleanup_stale_sessions
 
         task = asyncio.create_task(cleanup_stale_sessions(_browser_cm, _browser_sm))

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_server.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_server.py
@@ -306,9 +306,7 @@ class TestServerLifespan:
                 'awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser.cleanup_stale_sessions',
                 side_effect=fake_cleanup_stale,
             ),
-            patch('asyncio.get_running_loop') as mock_loop,
         ):
-            mock_loop.return_value = MagicMock()
             mock_server = MagicMock()
 
             async with server.server_lifespan(mock_server):
@@ -316,6 +314,44 @@ class TestServerLifespan:
 
         mock_cm.cleanup.assert_awaited_once()
         ci_cleanup.assert_awaited_once()
+
+    async def test_lifespan_does_not_call_add_signal_handler(self):
+        """Regression for #2752: lifespan must not call loop.add_signal_handler.
+
+        On Windows the default ProactorEventLoop raises NotImplementedError from
+        add_signal_handler, which crashed the server on startup. This test
+        simulates that by making add_signal_handler raise and asserts the
+        lifespan still completes — ensuring no future change reintroduces the
+        unconditional call.
+        """
+        mock_cm = MagicMock()
+        mock_cm.cleanup = AsyncMock()
+
+        async def fake_cleanup_stale(cm, sm):
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                return
+
+        loop = asyncio.get_running_loop()
+        with (
+            patch.object(server, '_browser_cm', mock_cm),
+            patch.object(server, '_browser_sm', MagicMock()),
+            patch.object(server, '_code_interpreter_cleanup', None),
+            patch(
+                'awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser.cleanup_stale_sessions',
+                side_effect=fake_cleanup_stale,
+            ),
+            patch.object(
+                loop,
+                'add_signal_handler',
+                side_effect=NotImplementedError('simulated ProactorEventLoop'),
+            ),
+        ):
+            async with server.server_lifespan(MagicMock()):
+                pass
+
+        mock_cm.cleanup.assert_awaited_once()
 
     async def test_lifespan_browser_without_code_interpreter(self):
         """Lifespan manages browser cleanup when code interpreter is not registered."""
@@ -337,9 +373,7 @@ class TestServerLifespan:
                 'awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser.cleanup_stale_sessions',
                 side_effect=fake_cleanup_stale,
             ),
-            patch('asyncio.get_running_loop') as mock_loop,
         ):
-            mock_loop.return_value = MagicMock()
             mock_server = MagicMock()
 
             async with server.server_lifespan(mock_server):


### PR DESCRIPTION
## Issue, if available
Fixes #2752

## Description of changes
On Windows, `amazon-bedrock-agentcore-mcp-server` crashes during startup with `NotImplementedError: loop.add_signal_handler()`. The default Windows `ProactorEventLoop` does not implement `add_signal_handler` ([Python docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.add_signal_handler)), but `server_lifespan` called it unconditionally.

This PR removes the signal handler block entirely rather than guarding it with `sys.platform != "win32"`, because the handler is also redundant and subtly wrong on Unix:

1. **Cleanup is already covered by `finally`.** The `async with` lifespan has `finally: await _browser_cm.cleanup()` at [server.py:120](https://github.com/awslabs/mcp/blob/main/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/server.py#L120), which runs on every graceful shutdown path:
   - **stdio transport** (how Claude Code and most MCP clients run this server): parent closes stdin → anyio sees EOF → `stdio_server()` context exits → lifespan `finally` runs. No signal involved.
   - **Ctrl+C**: Python's default `SIGINT` handler raises `KeyboardInterrupt`, which unwinds the lifespan and runs `finally`.
   - **HTTP/SSE**: FastMCP delegates to uvicorn, which [installs its own signal handlers](https://github.com/encode/uvicorn/blob/master/uvicorn/server.py) that trigger graceful shutdown — a user-installed handler here would fight uvicorn.

2. **The handler was fire-and-forget**, so it did not reliably complete cleanup even on Unix. `asyncio.ensure_future(cm.cleanup())` schedules a task and returns immediately; the signal handler callback does not await. If the process exits promptly after the signal, cleanup is dropped. The `finally` block is strictly more reliable because it awaits.

3. **Installing a custom SIGINT handler replaced asyncio's default** `KeyboardInterrupt`-raising handler ([CPython `asyncio/runners.py` `_on_sigint`](https://github.com/python/cpython/blob/main/Lib/asyncio/runners.py)), meaning the lifespan's `finally` block did **not** actually run on Ctrl+C before this fix — the handler ran the fire-and-forget task instead. Removing the handler restores proper unwind.

The only shutdown paths that skip `finally` after this change are `SIGKILL` / `taskkill /F` / segfaults — none of which a Python-level handler could catch anyway. Cloud browser sessions also have a server-side idle timeout as a backstop.

## User experience
**Before:** server crashes on Windows with `NotImplementedError` on every startup; unusable.
**After:** server starts and runs on Windows. Cleanup behavior on Unix is unchanged for normal shutdowns and improved for Ctrl+C (now actually unwinds the lifespan instead of abandoning it as a background task).

## Checklist
- [x] Please read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Please read the [design guidelines](/DESIGN_GUIDELINES.md)
- [x] My code follows the style of this project
- [x] My change requires a change to the documentation — `CHANGELOG.md` updated
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes — existing lifespan tests updated to drop now-unnecessary `asyncio.get_running_loop` mocking; all 17 tests in `test_server.py` pass locally
- [x] All new and existing tests passed

### Local validation

- `pytest tests/test_server.py` — 17 passed.
- Simulated Windows `ProactorEventLoop` by patching `asyncio.get_running_loop` to return a loop whose `add_signal_handler` raises `NotImplementedError`; on `main` this reproduces the crash, on this branch the lifespan completes and `_browser_cm.cleanup()` is awaited as expected.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).*
