### PR TITLE
fix(cloudwatch): rename tool to comply with Bedrock 64-char limit

### DIFF
--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/observability_admin/tools.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/observability_admin/tools.py
@@ -43,7 +43,7 @@ class ObservabilityAdminTools:
         mcp.tool(name='get_telemetry_evaluation_status')(self.get_telemetry_evaluation_status)
         mcp.tool(name='start_telemetry_evaluation')(self.start_telemetry_evaluation)
         mcp.tool(name='stop_telemetry_evaluation')(self.stop_telemetry_evaluation)
-        mcp.tool(name='get_telemetry_evaluation_status_for_organization')(
+        mcp.tool(name='awslabs_cloudwatch_get_telemetry_eval_status_for_org')(
             self.get_telemetry_evaluation_status_for_organization
         )
         mcp.tool(name='start_telemetry_evaluation_for_organization')(

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
@@ -290,12 +290,41 @@ class K8sHandler:
                 resource['metadata'].pop('managedFields')
         return resource
 
+    def redact_secret_data(self, resource: Dict[str, Any]) -> Dict[str, Any]:
+        """Redact Secret data values with HIDDEN_FOR_SECURITY_REASONS.
+
+        This implements the documented redaction behavior for Kubernetes Secrets.
+
+        Args:
+            resource: The Kubernetes resource dictionary
+
+        Returns:
+            The resource with Secret data values redacted
+        """
+        kind = resource.get('kind', '').lower()
+        if kind != 'secret':
+            return resource
+
+        # Redact .data fields (base64-encoded secret values)
+        if 'data' in resource and isinstance(resource['data'], dict):
+            for key in resource['data']:
+                resource['data'][key] = 'HIDDEN_FOR_SECURITY_REASONS'
+
+        # Redact .stringData fields (plaintext secrets)
+        if 'stringData' in resource and isinstance(resource['stringData'], dict):
+            for key in resource['stringData']:
+                resource['stringData'][key] = 'HIDDEN_FOR_SECURITY_REASONS'
+
+        return resource
+
     def cleanup_resource_response(self, resource: Any) -> Any:
         """Clean up a Kubernetes resource response by removing managed fields and null values.
 
         This method:
         1. Removes metadata.managed_fields which is typically large and not useful
-        2. Recursively removes null values to reduce response size
+        2. Redacts Secret data with HIDDEN_FOR_SECURITY_REASONS when
+           allow_sensitive_data_access is False
+        3. Recursively removes null values to reduce response size
 
         Args:
             resource: The Kubernetes resource to clean up
@@ -305,6 +334,10 @@ class K8sHandler:
         """
         # First remove managed fields
         resource = self.remove_managed_fields(resource)
+
+        # Redact Secret data if sensitive data access is not allowed
+        if not self.allow_sensitive_data_access:
+            resource = self.redact_secret_data(resource)
 
         # Then filter out null values
         return self.filter_null_values(resource)


### PR DESCRIPTION
Backport of awslabs/mcp#3264 rebased onto latest main

## DCO

I, Xiaowei Hu (1176843521@qq.com), hereby agree to the Developer Certificate of Origin (DCO) version 1.1. I certify that my contributions are made under the terms of the DCO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).