### PR TITLE
fix(billing): omit Granularity when GroupBy set in get_reservation_coverage

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/ri_performance_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/ri_performance_tools.py
@@ -174,10 +174,14 @@ async def get_reservation_coverage(
         )
 
         # Prepare the request parameters
-        request_params = {
+        # IMPORTANT: GroupBy and Granularity are mutually exclusive for coverage.
+        # When group_by is provided, granularity is automatically omitted from the coverage request.
+        request_params: Dict[str, Any] = {
             'TimePeriod': {'Start': start, 'End': end},
-            'Granularity': granularity,
         }
+
+        if not group_by:
+            request_params['Granularity'] = granularity
 
         # Add optional parameters if provided
         if metrics:

--- a/src/billing-cost-management-mcp-server/tests/tools/test_ri_performance_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_ri_performance_tools.py
@@ -407,6 +407,53 @@ class TestGetReservationCoverage:
         assert request_params['Filter'] == mock_filter
         assert request_params['SortBy'] == mock_sort_by
         assert request_params['MaxResults'] == 50
+        # Granularity must be absent when group_by is specified (mutually exclusive)
+        assert 'Granularity' not in request_params
+
+        assert result['status'] == 'success'
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.ri_performance_tools.get_date_range')
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.ri_performance_tools.paginate_aws_response'
+    )
+    @patch('awslabs.billing_cost_management_mcp_server.tools.ri_performance_tools.parse_json')
+    async def test_get_reservation_coverage_group_by_omits_granularity(
+        self,
+        mock_parse_json,
+        mock_paginate_response,
+        mock_get_date_range,
+        mock_context,
+        mock_ce_client,
+    ):
+        """Test that Granularity is omitted when group_by is specified (they are mutually exclusive)."""
+        # Setup
+        mock_get_date_range.return_value = ('2026-03-01', '2026-04-01')
+        mock_paginate_response.return_value = (
+            mock_ce_client.get_reservation_coverage.return_value['CoveragesByTime'],
+            {'NextPageToken': None},
+        )
+
+        mock_group_by = [{'Type': 'DIMENSION', 'Key': 'INSTANCE_TYPE'}]
+        mock_parse_json.return_value = mock_group_by
+
+        # Execute
+        result = await get_reservation_coverage(
+            mock_context,
+            mock_ce_client,
+            '2026-03-01',
+            '2026-04-01',
+            'DAILY',
+            None,  # metrics
+            'group_by_json',  # group_by
+            None,  # filter_expr
+            None,  # sort_by
+            None,  # max_results
+        )
+
+        # Assert: Granularity must NOT be in request params when group_by is present
+        request_params = mock_paginate_response.call_args[1]['request_params']
+        assert 'Granularity' not in request_params
+        assert request_params['GroupBy'] == mock_group_by
 
         assert result['status'] == 'success'
 


### PR DESCRIPTION
## Summary

- The `get_reservation_coverage` function always included `Granularity` in the AWS `GetReservationCoverage` API request, even when `GroupBy` was specified.
- The AWS API treats `Granularity` and `GroupBy` as mutually exclusive, returning a `ValidationException: Granularity is not supported when specifying groupBy` error.
- Fix: only add `Granularity` to the request params when `group_by` is not provided.

## Test plan

- Updated `test_get_reservation_coverage_with_options` to assert `Granularity` is absent when `group_by` is present.
- Added `test_get_reservation_coverage_group_by_omits_granularity` which directly tests the mutual exclusion behavior.
- All 14 existing tests pass.

Fixes #2933

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).