### PR TITLE
feat(aws-healthomics-mcp-server): add dark theme contrast to timeline

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/run_timeline.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/run_timeline.py
@@ -38,6 +38,9 @@ VALID_TIME_UNITS = ['sec', 'min', 'hr', 'day']
 # Valid output formats
 VALID_OUTPUT_FORMATS = ['svg', 'base64']
 
+# Valid themes
+VALID_THEMES = ['light', 'dark']
+
 # Default region for cost analysis
 DEFAULT_REGION = 'us-east-1'
 
@@ -76,6 +79,13 @@ async def generate_run_timeline(
             'will be written. When provided, the response contains only summary '
             'metadata instead of the full SVG content. Recommended for complex '
             'workflows to avoid context window overflow.'
+        ),
+    ),
+    theme: str = Field(
+        default='light',
+        description=(
+            'Color theme for the timeline visualization. Valid values: light, dark. '
+            'Use dark for better legibility on dark backgrounds. Defaults to light.'
         ),
     ),
     expected_bucket_owner: Optional[str] = Field(
@@ -121,6 +131,7 @@ async def generate_run_timeline(
         region: AWS region for pricing lookups
         output_format: Output format (svg or base64)
         output_path: Optional file path or S3 URI to write SVG to
+        theme: Color theme for the visualization ('light' or 'dark')
         expected_bucket_owner: AWS account ID for S3 bucket owner verification
         aws_profile: Optional AWS profile name override
         aws_region: Optional AWS region override
@@ -145,6 +156,12 @@ async def generate_run_timeline(
                 f"Invalid output_format '{output_format}'. "
                 f'Valid values are: {", ".join(VALID_OUTPUT_FORMATS)}'
             )
+            await ctx.error(error_msg)
+            return error_msg
+
+        # Validate theme
+        if theme not in VALID_THEMES:
+            error_msg = f"Invalid theme '{theme}'. Valid values are: {', '.join(VALID_THEMES)}"
             await ctx.error(error_msg)
             return error_msg
 
@@ -235,6 +252,7 @@ Please verify the run ID and ensure the run has completed successfully.
             tasks=all_tasks,
             run_info=run_info,
             time_unit=time_unit,
+            theme=theme,
         )
 
         logger.info(f'Generated timeline with {len(all_tasks)} tasks')

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/visualization/gantt_generator.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/visualization/gantt_generator.py
@@ -38,6 +38,14 @@ class GanttGenerator:
     }
     PENDING_COLOR = '#D3D3D3'  # lightgrey
 
+    # Dark mode uses brighter variants for better contrast on dark backgrounds
+    STATUS_COLORS_DARK = {
+        'COMPLETED': '#7AAFFF',  # brighter blue
+        'FAILED': '#FF6B6B',  # brighter red
+        'CANCELLED': '#FFD166',  # brighter orange
+    }
+    PENDING_COLOR_DARK = '#555555'  # medium grey visible on dark background
+
     TIME_SCALES = {
         'sec': 1,
         'min': 1 / 60,
@@ -52,6 +60,7 @@ class GanttGenerator:
         time_unit: str = 'hr',
         width: int = 960,
         height: int = 800,
+        theme: str = 'light',
     ) -> str:
         """Generate SVG Gantt chart for tasks.
 
@@ -72,17 +81,18 @@ class GanttGenerator:
             time_unit: Time unit for axis (sec, min, hr, day). Defaults to 'hr'.
             width: Chart width in pixels. Defaults to 960.
             height: Chart height in pixels. Defaults to 800.
+            theme: Color theme ('light' or 'dark'). Defaults to 'light'.
 
         Returns:
             SVG string representing the Gantt chart
         """
         if not tasks:
-            return self._empty_chart_svg(width, height)
+            return self._empty_chart_svg(width, height, theme)
 
         # Filter tasks with valid timing data (need at least creationTime and stopTime)
         valid_tasks = [t for t in tasks if t.get('creationTime') and t.get('stopTime')]
         if not valid_tasks:
-            return self._empty_chart_svg(width, height)
+            return self._empty_chart_svg(width, height, theme)
 
         # Calculate time reference (earliest creation time)
         tare = min(self._parse_time(t['creationTime']) for t in valid_tasks)
@@ -136,7 +146,7 @@ class GanttGenerator:
         # Build SVG - omit labels if more than 100 tasks
         show_labels = len(valid_tasks) <= 100
         return self._build_svg(
-            chart_data, run_info, max_time, time_unit, width, height, show_labels
+            chart_data, run_info, max_time, time_unit, width, height, show_labels, theme
         )
 
     def _parse_time(self, time_str: Union[str, datetime]) -> datetime:
@@ -200,6 +210,7 @@ class GanttGenerator:
         width: int,
         height: int,
         show_labels: bool,
+        theme: str = 'light',
     ) -> str:
         """Build SVG string from chart data.
 
@@ -211,11 +222,17 @@ class GanttGenerator:
             width: Chart width in pixels
             height: Chart height in pixels
             show_labels: Whether to show task name labels
+            theme: Color theme ('light' or 'dark')
 
         Returns:
             SVG string
         """
-        builder = SVGBuilder(width, height)
+        builder = SVGBuilder(width, height, theme=theme)
+
+        # Select colors based on theme
+        is_dark = theme == 'dark'
+        status_colors = self.STATUS_COLORS_DARK if is_dark else self.STATUS_COLORS
+        pending_color = self.PENDING_COLOR_DARK if is_dark else self.PENDING_COLOR
 
         # Add title
         run_id = run_info.get('runId', 'Unknown')
@@ -259,13 +276,13 @@ class GanttGenerator:
                     y=y,
                     width=pending_width,
                     height=bar_height,
-                    fill=self.PENDING_COLOR,
+                    fill=pending_color,
                     tooltip=pending_tooltip,
                 )
 
             # Running bar (colored by status)
             running_width = (task['running_end'] - task['pending_end']) * x_scale
-            color = self.STATUS_COLORS.get(task['status'], '#6495ED')
+            color = status_colors.get(task['status'], status_colors['COMPLETED'])
 
             # Build tooltip with task details including timing
             start_str = task['start_time'].strftime('%Y-%m-%d %H:%M:%S')
@@ -305,19 +322,23 @@ class GanttGenerator:
 
         return builder.build()
 
-    def _empty_chart_svg(self, width: int, height: int) -> str:
+    def _empty_chart_svg(self, width: int, height: int, theme: str = 'light') -> str:
         """Return SVG for empty chart.
 
         Args:
             width: Chart width in pixels
             height: Chart height in pixels
+            theme: Color theme ('light' or 'dark')
 
         Returns:
             SVG string with "no data" message
         """
+        colors = SVGBuilder.THEMES.get(theme, SVGBuilder.THEMES['light'])
         return (
             f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">\n'
-            f'<text x="{width / 2}" y="{height / 2}" text-anchor="middle">'
+            f'<rect width="{width}" height="{height}" fill="{colors["background"]}"/>\n'
+            f'<text x="{width / 2}" y="{height / 2}" text-anchor="middle" '
+            f'fill="{colors["text"]}">'
             f'No task data available</text>\n'
             f'</svg>'
         )

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/visualization/svg_builder.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/visualization/svg_builder.py
@@ -25,17 +25,36 @@ class SVGBuilder:
     that does not require external JavaScript libraries.
     """
 
-    def __init__(self, width: int, height: int):
+    # Theme color definitions
+    THEMES = {
+        'light': {
+            'background': '#FFFFFF',
+            'text': '#000000',
+            'axis': '#000000',
+            'grid': '#E0E0E0',
+        },
+        'dark': {
+            'background': '#1E1E1E',
+            'text': '#E0E0E0',
+            'axis': '#E0E0E0',
+            'grid': '#444444',
+        },
+    }
+
+    def __init__(self, width: int, height: int, theme: str = 'light'):
         """Initialize SVG builder.
 
         Args:
             width: SVG canvas width in pixels
             height: SVG canvas height in pixels
+            theme: Color theme ('light' or 'dark'). Defaults to 'light'.
         """
         self.width = width
         self.height = height
         self.elements: list[str] = []
         self.defs: list[str] = []
+        self.theme = theme if theme in self.THEMES else 'light'
+        self._colors = self.THEMES[self.theme]
 
     def add_title(self, text: str, x: Optional[int] = None, y: int = 30) -> None:
         """Add title text to SVG.
@@ -48,7 +67,8 @@ class SVGBuilder:
         x = x if x is not None else self.width // 2
         self.elements.append(
             f'<text x="{x}" y="{y}" text-anchor="middle" '
-            f'font-family="sans-serif" font-size="14" font-weight="bold">'
+            f'font-family="sans-serif" font-size="14" font-weight="bold" '
+            f'fill="{self._colors["text"]}">'
             f'{self._escape(text)}</text>'
         )
 
@@ -103,6 +123,7 @@ class SVGBuilder:
         self.elements.append(
             f'<text x="{x:.2f}" y="{y:.2f}" text-anchor="{anchor}" '
             f'font-family="sans-serif" font-size="{font_size}" '
+            f'fill="{self._colors["text"]}" '
             f'dominant-baseline="middle">{self._escape(text)}</text>'
         )
 
@@ -112,7 +133,7 @@ class SVGBuilder:
         y1: float,
         x2: float,
         y2: float,
-        stroke: str = '#000',
+        stroke: Optional[str] = None,
         stroke_width: float = 1,
     ) -> None:
         """Add line element.
@@ -122,9 +143,10 @@ class SVGBuilder:
             y1: Start Y position
             x2: End X position
             y2: End Y position
-            stroke: Stroke color
+            stroke: Stroke color (defaults to theme axis color)
             stroke_width: Stroke width
         """
+        stroke = stroke if stroke is not None else self._colors['axis']
         self.elements.append(
             f'<line x1="{x1:.2f}" y1="{y1:.2f}" x2="{x2:.2f}" y2="{y2:.2f}" '
             f'stroke="{stroke}" stroke-width="{stroke_width}"/>'
@@ -205,10 +227,12 @@ class SVGBuilder:
         Returns:
             Complete SVG document as string
         """
+        bg_color = self._colors['background']
         svg_parts = [
             f'<svg width="{self.width}" height="{self.height}" '
             f'xmlns="http://www.w3.org/2000/svg">',
             '<style>rect:hover { opacity: 0.8; cursor: pointer; }</style>',
+            f'<rect width="{self.width}" height="{self.height}" fill="{bg_color}"/>',
         ]
 
         if self.defs:

--- a/src/aws-healthomics-mcp-server/tests/test_gantt_generator.py
+++ b/src/aws-healthomics-mcp-server/tests/test_gantt_generator.py
@@ -305,13 +305,14 @@ class TestGanttGeneratorPropertyBased:
 
         # Property: For each task, there should be at least one rectangle
         # (pending phase may have zero width if start == creation)
+        # +1 accounts for the background rectangle added by SVGBuilder
         num_tasks = len(tasks)
-        # Each task has at most 2 rects (pending + running), at least 1 (running)
-        assert len(rects) >= num_tasks, (
-            f'Expected at least {num_tasks} rectangles for {num_tasks} tasks, got {len(rects)}'
+        # Each task has at most 2 rects (pending + running), at least 1 (running), plus background
+        assert len(rects) >= num_tasks + 1, (
+            f'Expected at least {num_tasks + 1} rectangles for {num_tasks} tasks (including background), got {len(rects)}'
         )
-        assert len(rects) <= num_tasks * 2, (
-            f'Expected at most {num_tasks * 2} rectangles for {num_tasks} tasks, got {len(rects)}'
+        assert len(rects) <= num_tasks * 2 + 1, (
+            f'Expected at most {num_tasks * 2 + 1} rectangles for {num_tasks} tasks (including background), got {len(rects)}'
         )
 
         # Property: Running phase rectangles have correct status colors
@@ -395,3 +396,178 @@ class TestGanttGeneratorPropertyBased:
 
         # Property: The pending color also appears (for the pending phase)
         assert GanttGenerator.PENDING_COLOR in svg, 'Expected pending color in SVG'
+
+
+class TestGanttGeneratorTheme:
+    """Tests for GanttGenerator dark/light theme support."""
+
+    def test_dark_theme_uses_dark_status_colors(self):
+        """Test that dark theme uses brighter status colors for contrast."""
+        generator = GanttGenerator()
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+        for status, expected_color in GanttGenerator.STATUS_COLORS_DARK.items():
+            tasks = [
+                {
+                    'taskName': f'Task_{status}',
+                    'creationTime': base_time.isoformat(),
+                    'startTime': (base_time + timedelta(seconds=10)).isoformat(),
+                    'stopTime': (base_time + timedelta(minutes=1)).isoformat(),
+                    'status': status,
+                }
+            ]
+            run_info = {'runName': 'TestRun'}
+            svg = generator.generate_chart(tasks, run_info, theme='dark')
+            assert expected_color in svg, (
+                f'Expected dark color {expected_color} for status {status}'
+            )
+
+    def test_dark_theme_uses_dark_pending_color(self):
+        """Test that dark theme uses the dark pending color."""
+        generator = GanttGenerator()
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        tasks = [
+            {
+                'taskName': 'Task1',
+                'creationTime': base_time.isoformat(),
+                'startTime': (base_time + timedelta(minutes=1)).isoformat(),
+                'stopTime': (base_time + timedelta(minutes=5)).isoformat(),
+                'status': 'COMPLETED',
+            }
+        ]
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart(tasks, run_info, theme='dark')
+
+        assert GanttGenerator.PENDING_COLOR_DARK in svg
+        # Light pending color should NOT be present
+        assert GanttGenerator.PENDING_COLOR not in svg
+
+    def test_dark_theme_has_dark_background(self):
+        """Test that dark theme SVG has a dark background."""
+        generator = GanttGenerator()
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        tasks = [
+            {
+                'taskName': 'Task1',
+                'creationTime': base_time.isoformat(),
+                'startTime': (base_time + timedelta(seconds=10)).isoformat(),
+                'stopTime': (base_time + timedelta(minutes=1)).isoformat(),
+                'status': 'COMPLETED',
+            }
+        ]
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart(tasks, run_info, theme='dark')
+
+        assert '#1E1E1E' in svg  # Dark background color
+
+    def test_dark_theme_has_light_text(self):
+        """Test that dark theme SVG uses light-colored text."""
+        generator = GanttGenerator()
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        tasks = [
+            {
+                'taskName': 'Task1',
+                'creationTime': base_time.isoformat(),
+                'startTime': (base_time + timedelta(seconds=10)).isoformat(),
+                'stopTime': (base_time + timedelta(minutes=1)).isoformat(),
+                'status': 'COMPLETED',
+            }
+        ]
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart(tasks, run_info, theme='dark')
+
+        assert 'fill="#E0E0E0"' in svg  # Light text color
+
+    def test_light_theme_does_not_use_dark_colors(self):
+        """Test that light theme does not use dark theme colors."""
+        generator = GanttGenerator()
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        tasks = [
+            {
+                'taskName': 'Task1',
+                'creationTime': base_time.isoformat(),
+                'startTime': (base_time + timedelta(seconds=10)).isoformat(),
+                'stopTime': (base_time + timedelta(minutes=1)).isoformat(),
+                'status': 'COMPLETED',
+            }
+        ]
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart(tasks, run_info, theme='light')
+
+        # Should use light mode colors, not dark mode
+        assert GanttGenerator.STATUS_COLORS['COMPLETED'] in svg
+        assert GanttGenerator.STATUS_COLORS_DARK['COMPLETED'] not in svg
+
+    def test_empty_chart_dark_theme(self):
+        """Test that empty chart with dark theme has correct background and text colors."""
+        generator = GanttGenerator()
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart([], run_info, theme='dark')
+
+        assert '#1E1E1E' in svg  # Dark background
+        assert '#E0E0E0' in svg  # Light text
+        assert 'No task data available' in svg
+
+    def test_empty_chart_light_theme(self):
+        """Test that empty chart with light theme has correct background and text colors."""
+        generator = GanttGenerator()
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart([], run_info, theme='light')
+
+        assert '#FFFFFF' in svg  # White background
+        assert '#000000' in svg  # Dark text
+        assert 'No task data available' in svg
+
+    def test_filtered_empty_tasks_dark_theme(self):
+        """Test dark theme when all tasks are filtered out (no valid timing data)."""
+        generator = GanttGenerator()
+        # Tasks without stopTime will be filtered out
+        tasks = [
+            {
+                'taskName': 'InvalidTask',
+                'creationTime': '2024-01-01T10:00:00Z',
+                # No stopTime
+            }
+        ]
+        run_info = {'runName': 'TestRun'}
+        svg = generator.generate_chart(tasks, run_info, theme='dark')
+
+        assert '#1E1E1E' in svg  # Dark background
+        assert '#E0E0E0' in svg  # Light text
+        assert 'No task data available' in svg
+
+    def test_dark_theme_produces_valid_xml(self):
+        """Test that dark theme Gantt chart is valid XML."""
+        generator = GanttGenerator()
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        tasks = [
+            {
+                'taskName': 'Task1',
+                'creationTime': base_time.isoformat(),
+                'startTime': (base_time + timedelta(seconds=30)).isoformat(),
+                'stopTime': (base_time + timedelta(minutes=5)).isoformat(),
+                'status': 'COMPLETED',
+                'allocatedCpus': 4,
+                'allocatedMemoryGiB': 8,
+                'instanceType': 'omics.m.xlarge',
+                'estimatedUSD': 0.05,
+            },
+            {
+                'taskName': 'Task2',
+                'creationTime': (base_time + timedelta(minutes=1)).isoformat(),
+                'startTime': (base_time + timedelta(minutes=2)).isoformat(),
+                'stopTime': (base_time + timedelta(minutes=10)).isoformat(),
+                'status': 'FAILED',
+                'allocatedCpus': 8,
+                'allocatedMemoryGiB': 16,
+                'instanceType': 'omics.r.2xlarge',
+                'estimatedUSD': 0.12,
+            },
+        ]
+        run_info = {'runName': 'TestRun', 'runId': 'run-123'}
+        svg = generator.generate_chart(tasks, run_info, theme='dark')
+
+        try:
+            ET.fromstring(svg)
+        except ET.ParseError as e:
+            pytest.fail(f'Dark theme Gantt chart is not valid XML: {e}')

--- a/src/aws-healthomics-mcp-server/tests/test_run_timeline.py
+++ b/src/aws-healthomics-mcp-server/tests/test_run_timeline.py
@@ -132,6 +132,7 @@ class TestGenerateRunTimeline:
             output_format='svg',
             region=None,
             output_path=None,
+            theme='light',
             expected_bucket_owner=None,
         )
 
@@ -148,7 +149,7 @@ class TestGenerateRunTimeline:
         ctx.error = AsyncMock()
 
         result = await generate_run_timeline(
-            ctx, run_id='test-run', time_unit='invalid', output_format='svg'
+            ctx, run_id='test-run', time_unit='invalid', output_format='svg', theme='light'
         )
 
         assert 'Invalid time_unit' in result
@@ -173,7 +174,7 @@ class TestGenerateRunTimeline:
         ctx.error = AsyncMock()
 
         result = await generate_run_timeline(
-            ctx, run_id='test-run', time_unit='hr', output_format='svg'
+            ctx, run_id='test-run', time_unit='hr', output_format='svg', theme='light'
         )
 
         assert 'Unable to retrieve task data' in result
@@ -194,7 +195,7 @@ class TestGenerateRunTimeline:
         ctx.error = AsyncMock()
 
         result = await generate_run_timeline(
-            ctx, run_id='test-run', time_unit='hr', output_format='svg'
+            ctx, run_id='test-run', time_unit='hr', output_format='svg', theme='light'
         )
 
         assert 'No UUID found' in result
@@ -209,7 +210,7 @@ class TestGenerateRunTimeline:
         ctx.error = AsyncMock()
 
         result = await generate_run_timeline(
-            ctx, run_id='test-run', time_unit='hr', output_format='svg'
+            ctx, run_id='test-run', time_unit='hr', output_format='svg', theme='light'
         )
 
         assert 'Error generating timeline' in result
@@ -246,6 +247,7 @@ class TestGenerateRunTimeline:
             output_format='base64',
             region=None,
             output_path=None,
+            theme='light',
             expected_bucket_owner=None,
         )
 
@@ -265,8 +267,64 @@ class TestGenerateRunTimeline:
         ctx.error = AsyncMock()
 
         result = await generate_run_timeline(
-            ctx, run_id='test-run', time_unit='hr', output_format='invalid'
+            ctx, run_id='test-run', time_unit='hr', output_format='invalid', theme='light'
         )
 
         assert 'Invalid output_format' in result
         ctx.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.aws_healthomics_mcp_server.tools.run_timeline.get_omics_client')
+    async def test_generate_timeline_invalid_theme(self, mock_get_omics_client):
+        """Test timeline generation with invalid theme value."""
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        result = await generate_run_timeline(
+            ctx, run_id='test-run', time_unit='hr', output_format='svg', theme='neon'
+        )
+
+        assert 'Invalid theme' in result
+        assert 'light, dark' in result
+        ctx.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.aws_healthomics_mcp_server.tools.run_timeline.get_omics_client')
+    @patch('awslabs.aws_healthomics_mcp_server.tools.run_timeline.get_run_manifest_logs_internal')
+    async def test_generate_timeline_dark_theme(self, mock_get_logs, mock_get_omics_client):
+        """Test timeline generation with dark theme produces dark background and light text."""
+        mock_client = MagicMock()
+        mock_client.get_run.return_value = {
+            'uuid': 'test-uuid',
+            'name': 'TestRun',
+            'arn': 'arn:aws:omics:us-east-1:123456789012:run/test-run',
+        }
+        mock_get_omics_client.return_value = mock_client
+
+        mock_get_logs.return_value = {
+            'events': [
+                {
+                    'message': '{"name": "Task1", "cpus": 4, "memory": 8, "instanceType": "omics.m.xlarge", "creationTime": "2024-01-01T10:00:00Z", "startTime": "2024-01-01T10:01:00Z", "stopTime": "2024-01-01T10:05:00Z", "status": "COMPLETED", "metrics": {}}'
+                },
+            ]
+        }
+
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        result = await generate_run_timeline(
+            ctx,
+            run_id='test-run',
+            time_unit='hr',
+            output_format='svg',
+            region=None,
+            output_path=None,
+            theme='dark',
+            expected_bucket_owner=None,
+        )
+
+        # Verify result is SVG with dark theme colors
+        assert '<svg' in result
+        assert '</svg>' in result
+        assert '#1E1E1E' in result  # Dark background
+        assert '#E0E0E0' in result  # Light text color

--- a/src/aws-healthomics-mcp-server/tests/test_svg_builder.py
+++ b/src/aws-healthomics-mcp-server/tests/test_svg_builder.py
@@ -295,3 +295,88 @@ class TestSVGBuilderPropertyBased:
             ET.fromstring(svg)
         except ET.ParseError as e:
             pytest.fail(f'SVG with x-axis is not valid XML: {e}')
+
+
+class TestSVGBuilderTheme:
+    """Tests for SVGBuilder dark/light theme support."""
+
+    def test_light_theme_default(self):
+        """Test that light theme is the default."""
+        builder = SVGBuilder(800, 600)
+        assert builder.theme == 'light'
+        assert builder._colors == SVGBuilder.THEMES['light']
+
+    def test_dark_theme_initialization(self):
+        """Test SVGBuilder initialization with dark theme."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        assert builder.theme == 'dark'
+        assert builder._colors == SVGBuilder.THEMES['dark']
+
+    def test_invalid_theme_falls_back_to_light(self):
+        """Test that an invalid theme falls back to light."""
+        builder = SVGBuilder(800, 600, theme='invalid')
+        assert builder.theme == 'light'
+        assert builder._colors == SVGBuilder.THEMES['light']
+
+    def test_dark_theme_background_in_build(self):
+        """Test that dark theme produces a dark background rect."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        svg = builder.build()
+        # Background rect should use dark background color
+        assert 'fill="#1E1E1E"' in svg
+
+    def test_light_theme_background_in_build(self):
+        """Test that light theme produces a white background rect."""
+        builder = SVGBuilder(800, 600, theme='light')
+        svg = builder.build()
+        assert 'fill="#FFFFFF"' in svg
+
+    def test_dark_theme_title_text_color(self):
+        """Test that dark theme title uses light text color."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        builder.add_title('Dark Title')
+        assert 'fill="#E0E0E0"' in builder.elements[0]
+
+    def test_light_theme_title_text_color(self):
+        """Test that light theme title uses dark text color."""
+        builder = SVGBuilder(800, 600, theme='light')
+        builder.add_title('Light Title')
+        assert 'fill="#000000"' in builder.elements[0]
+
+    def test_dark_theme_text_color(self):
+        """Test that dark theme add_text uses light text color."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        builder.add_text(10, 20, 'Hello')
+        assert 'fill="#E0E0E0"' in builder.elements[0]
+
+    def test_dark_theme_line_default_stroke(self):
+        """Test that dark theme lines default to light axis color."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        builder.add_line(0, 0, 100, 100)
+        assert 'stroke="#E0E0E0"' in builder.elements[0]
+
+    def test_light_theme_line_default_stroke(self):
+        """Test that light theme lines default to dark axis color."""
+        builder = SVGBuilder(800, 600, theme='light')
+        builder.add_line(0, 0, 100, 100)
+        assert 'stroke="#000000"' in builder.elements[0]
+
+    def test_line_explicit_stroke_overrides_theme(self):
+        """Test that an explicit stroke color overrides the theme default."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        builder.add_line(0, 0, 100, 100, stroke='#FF0000')
+        assert 'stroke="#FF0000"' in builder.elements[0]
+
+    def test_dark_theme_produces_valid_xml(self):
+        """Test that dark theme SVG output is valid XML."""
+        builder = SVGBuilder(800, 600, theme='dark')
+        builder.add_title('Dark Chart')
+        builder.add_rect(10, 10, 100, 50, '#7AAFFF')
+        builder.add_text(50, 100, 'Label')
+        builder.add_line(0, 0, 100, 100)
+        svg = builder.build()
+
+        try:
+            ET.fromstring(svg)
+        except ET.ParseError as e:
+            pytest.fail(f'Dark theme SVG is not valid XML: {e}')


### PR DESCRIPTION
- Add theme parameter to generate_run_timeline function with light/dark options
- Introduce VALID_THEMES constant and theme validation logic
- Add dark mode color palette to GanttGenerator with brighter variants for contrast
- Update SVGBuilder to support theme-aware styling with background colors
- Pass theme parameter through visualization pipeline (gantt_generator → svg_builder)
- Update empty chart SVG generation to respect theme settings
- Add comprehensive test coverage for theme validation and dark mode rendering
- Improve accessibility by providing better legibility options for different backgrounds


## Summary

Timeline plots were generated with a transparent background and black text which didn't display in browsers or IDEs in 'dark mode'. This update adds `light` (default) and `dark` themes with white and black backgrounds and appropriately contrasting colors.

### Changes

Adds theme support to timeline plot generation

### User experience

Timelines are now visible with appropriate contrast for the preferred background. Light mode is default and dark mode is supported.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
