### PR TITLE
fix(agentcore-mcp-server): fix URL allowlist bypass via prefix matching

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/doc_fetcher.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/doc_fetcher.py
@@ -15,11 +15,10 @@
 import html
 import re
 import urllib.request
-from urllib.parse import urljoin
-
 from ..config import doc_config
 from .url_validator import URLValidationError, validate_urls
 from pydantic import BaseModel, Field
+from urllib.parse import urljoin
 
 
 # Example: "[Quickstart](https://strandsagents.com/.../index.md)" or "[Quickstart](/path/to/doc.md)"

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/doc_fetcher.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/doc_fetcher.py
@@ -15,6 +15,8 @@
 import html
 import re
 import urllib.request
+from urllib.parse import urljoin
+
 from ..config import doc_config
 from .url_validator import URLValidationError, validate_urls
 from pydantic import BaseModel, Field
@@ -78,6 +80,9 @@ def parse_llms_txt(url: str) -> list[tuple[str, str]]:
     for match in _MD_LINK.finditer(txt):
         title = match.group(1).strip() or match.group(2).strip()
         doc_url = match.group(2).strip()
+
+        if not doc_url.startswith(('http://', 'https://')):
+            doc_url = urljoin(url, doc_url)
 
         try:
             validated_urls = validate_urls(doc_url)

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
@@ -55,9 +55,15 @@ class URLValidator:
         if not url or not isinstance(url, str):
             return False
 
+        if any(c in url for c in '\r\n\x00'):
+            return False
+
         parsed = urlparse(url)
 
         if parsed.scheme != 'https':
+            return False
+
+        if '@' in parsed.netloc:
             return False
 
         hostname = parsed.hostname or ''

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
@@ -14,7 +14,9 @@
 
 """URL validation for domain restriction."""
 
+import posixpath
 from typing import List
+from urllib.parse import urlparse
 
 
 class URLValidationError(Exception):
@@ -23,48 +25,49 @@ class URLValidationError(Exception):
     pass
 
 
+class _AllowedOrigin:
+    """Parsed representation of an allowed URL prefix for structural matching."""
+
+    def __init__(self, raw: str):
+        parsed = urlparse(raw)
+        self.scheme = parsed.scheme
+        self.hostname = parsed.hostname or ''
+        self.path = parsed.path.rstrip('/')
+
+    def matches(self, scheme: str, hostname: str, normalized_path: str) -> bool:
+        if self.scheme != scheme or self.hostname != hostname:
+            return False
+        if not self.path:
+            return True
+        return normalized_path == self.path or normalized_path.startswith(self.path + '/')
+
+
 class URLValidator:
     """Validates URLs against a list of allowed domain prefixes."""
 
     def __init__(self, allowed_domain_prefixes: List[str]):
-        """Initialize the URL validator with allowed domain prefixes.
-
-        Args:
-            allowed_domain_prefixes: List of allowed domain prefixes
-        """
         self.allowed_domain_prefixes = set(allowed_domain_prefixes)
+        self._allowed_origins = [_AllowedOrigin(p) for p in allowed_domain_prefixes]
 
     def is_url_allowed(self, url: str) -> bool:
-        """Check if a URL is allowed based on domain prefixes.
-
-        Args:
-            url: The URL to validate
-
-        Returns:
-            True if the URL is allowed, False otherwise
-        """
         if not url or not isinstance(url, str):
             return False
 
-        # Check if URL starts with any of the allowed prefixes
-        for allowed_prefix in self.allowed_domain_prefixes:
-            if url.startswith(allowed_prefix):
+        parsed = urlparse(url)
+
+        if parsed.scheme != 'https':
+            return False
+
+        hostname = parsed.hostname or ''
+        normalized_path = posixpath.normpath(parsed.path or '/')
+
+        for origin in self._allowed_origins:
+            if origin.matches(parsed.scheme, hostname, normalized_path):
                 return True
 
         return False
 
     def validate_urls(self, urls) -> List[str]:
-        """Validate URLs and return valid ones.
-
-        Args:
-            urls: Single URL string or list of URLs to validate
-
-        Returns:
-            List of validated URLs (single URL wrapped in list if input was string)
-
-        Raises:
-            URLValidationError: If any URL is not allowed
-        """
         if isinstance(urls, str):
             urls = [urls]
 
@@ -113,15 +116,15 @@ def validate_urls(urls, allowed_domains: list[str] | None = None) -> list[str]:
     if isinstance(urls, str):
         urls = [urls]
 
-    # Convert relative URLs to absolute URLs
-    processed_urls = []
     for url in urls:
         if not url.startswith(('http://', 'https://')):
-            url = 'https://aws.github.io/bedrock-agentcore-starter-toolkit' + url
-        processed_urls.append(url)
+            raise URLValidationError(
+                f'Relative URLs are not allowed: {url}. '
+                f'All URLs must use an absolute https:// scheme.'
+            )
 
     if allowed_domains is None:
-        return default_validator.validate_urls(processed_urls)
+        return default_validator.validate_urls(urls)
     else:
         validator = URLValidator(allowed_domains)
-        return validator.validate_urls(processed_urls)
+        return validator.validate_urls(urls)

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
@@ -46,10 +46,12 @@ class URLValidator:
     """Validates URLs against a list of allowed domain prefixes."""
 
     def __init__(self, allowed_domain_prefixes: List[str]):
+        """Initialize the URL validator with allowed domain prefixes."""
         self.allowed_domain_prefixes = set(allowed_domain_prefixes)
         self._allowed_origins = [_AllowedOrigin(p) for p in allowed_domain_prefixes]
 
     def is_url_allowed(self, url: str | None) -> bool:
+        """Check if a URL is allowed based on structural matching against allowed origins."""
         if not url or not isinstance(url, str):
             return False
 
@@ -68,6 +70,7 @@ class URLValidator:
         return False
 
     def validate_urls(self, urls) -> List[str]:
+        """Validate URLs and return valid ones, raising URLValidationError for any disallowed URL."""
         if isinstance(urls, str):
             urls = [urls]
 

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/url_validator.py
@@ -49,7 +49,7 @@ class URLValidator:
         self.allowed_domain_prefixes = set(allowed_domain_prefixes)
         self._allowed_origins = [_AllowedOrigin(p) for p in allowed_domain_prefixes]
 
-    def is_url_allowed(self, url: str) -> bool:
+    def is_url_allowed(self, url: str | None) -> bool:
         if not url or not isinstance(url, str):
             return False
 

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
@@ -97,9 +97,7 @@ class TestURLValidator:
     def test_rejects_domain_suffix_attack(self):
         """PoC vector 2: prefix match must not approve a longer hostname."""
         with pytest.raises(URLValidationError):
-            validate_urls(
-                'https://aws.github.io/bedrock-agentcore-starter-toolkit.evil.com/steal'
-            )
+            validate_urls('https://aws.github.io/bedrock-agentcore-starter-toolkit.evil.com/steal')
 
     def test_rejects_relative_url_with_query(self):
         """PoC vector 3: /evil?test=1 must be rejected as a relative URL."""

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
@@ -39,16 +39,19 @@ class TestURLValidator:
         allowed_domains = [
             'https://docs.aws.amazon.com',
             'https://github.com',
-            'http://docs.aws.amazon.com',
         ]
         validator = URLValidator(allowed_domains)
 
         assert validator.is_url_allowed('https://docs.aws.amazon.com/bedrock/agentcore/')
         assert validator.is_url_allowed('https://github.com/awslabs/mcp/blob/main/README.md')
-        assert validator.is_url_allowed('http://docs.aws.amazon.com/bedrock/')
 
         assert not validator.is_url_allowed('https://example.com/page')
         assert not validator.is_url_allowed('https://malicious-site.com/evil')
+
+    def test_is_url_allowed_rejects_http(self):
+        """http:// scheme must be rejected even if the domain matches."""
+        validator = URLValidator(['https://docs.aws.amazon.com'])
+        assert not validator.is_url_allowed('http://docs.aws.amazon.com/bedrock/')
 
     def test_validate_urls_all_valid(self):
         """Test validate_urls with all valid URLs."""
@@ -74,7 +77,6 @@ class TestURLValidator:
             validator.validate_urls(urls)
         assert 'https://example.com/page' in str(e.value)
 
-        # Default validator
         with pytest.raises(URLValidationError) as e:
             validate_urls(urls)
         assert 'https://example.com/page' in str(e.value)
@@ -84,3 +86,96 @@ class TestURLValidator:
         validator = URLValidator(['https://docs.aws.amazon.com'])
         result = validator.validate_urls([])
         assert result == []
+
+    # --- Bypass vector tests (P415493054) ---
+
+    def test_rejects_relative_url_path_traversal(self):
+        """PoC vector 1: /../../attacker-path must be rejected as a relative URL."""
+        with pytest.raises(URLValidationError, match='Relative URLs are not allowed'):
+            validate_urls('/../../attacker-path')
+
+    def test_rejects_domain_suffix_attack(self):
+        """PoC vector 2: prefix match must not approve a longer hostname."""
+        with pytest.raises(URLValidationError):
+            validate_urls(
+                'https://aws.github.io/bedrock-agentcore-starter-toolkit.evil.com/steal'
+            )
+
+    def test_rejects_relative_url_with_query(self):
+        """PoC vector 3: /evil?test=1 must be rejected as a relative URL."""
+        with pytest.raises(URLValidationError, match='Relative URLs are not allowed'):
+            validate_urls('/evil?test=1')
+
+    def test_rejects_path_traversal_in_absolute_url(self):
+        """Path traversal via .. in an absolute URL must not escape the allowed path prefix."""
+        with pytest.raises(URLValidationError):
+            validate_urls(
+                'https://aws.github.io/bedrock-agentcore-starter-toolkit/../../other-repo/secrets'
+            )
+
+    def test_rejects_plain_relative_path(self):
+        """Any relative URL must be rejected outright."""
+        for path in ['/foo', 'bar', '../up', './here']:
+            with pytest.raises(URLValidationError, match='Relative URLs are not allowed'):
+                validate_urls(path)
+
+    def test_rejects_non_https_scheme(self):
+        """Only https is permitted."""
+        with pytest.raises(URLValidationError):
+            validate_urls('http://docs.aws.amazon.com/something')
+
+        with pytest.raises(URLValidationError):
+            validate_urls('file:///etc/passwd')
+
+        with pytest.raises(URLValidationError):
+            validate_urls('ftp://docs.aws.amazon.com/')
+
+    def test_allows_valid_default_domain_urls(self):
+        """Legitimate URLs for all default allowed domains must still pass."""
+        valid = [
+            'https://aws.github.io/bedrock-agentcore-starter-toolkit/quickstart',
+            'https://aws.github.io/bedrock-agentcore-starter-toolkit/docs/guide.html',
+            'https://strandsagents.com/latest/user-guide/',
+            'https://docs.aws.amazon.com/bedrock/latest/userguide/',
+            'https://boto3.amazonaws.com/v1/documentation/api/latest/index.html',
+        ]
+        result = validate_urls(valid)
+        assert result == valid
+
+    def test_path_boundary_enforcement(self):
+        """Allowed path prefix must match on / boundaries, not arbitrary substrings."""
+        validator = URLValidator(['https://example.com/app'])
+
+        assert validator.is_url_allowed('https://example.com/app')
+        assert validator.is_url_allowed('https://example.com/app/')
+        assert validator.is_url_allowed('https://example.com/app/sub/page')
+        assert not validator.is_url_allowed('https://example.com/application')
+        assert not validator.is_url_allowed('https://example.com/app-extra')
+
+    def test_hostname_exact_match(self):
+        """Hostname must match exactly, not as a prefix/suffix."""
+        validator = URLValidator(['https://docs.aws.amazon.com'])
+
+        assert validator.is_url_allowed('https://docs.aws.amazon.com/page')
+        assert not validator.is_url_allowed('https://docs.aws.amazon.com.evil.com/page')
+        assert not validator.is_url_allowed('https://evil-docs.aws.amazon.com/page')
+
+    def test_validate_urls_with_custom_allowed_domains(self):
+        """Custom allowed_domains parameter must override defaults."""
+        custom = ['https://internal.example.com/docs']
+        result = validate_urls('https://internal.example.com/docs/page', allowed_domains=custom)
+        assert result == ['https://internal.example.com/docs/page']
+
+        with pytest.raises(URLValidationError):
+            validate_urls('https://docs.aws.amazon.com/', allowed_domains=custom)
+
+    def test_string_input_wrapped_in_list(self):
+        """A single string URL input should be treated as a one-element list."""
+        result = validate_urls('https://docs.aws.amazon.com/test')
+        assert result == ['https://docs.aws.amazon.com/test']
+
+    def test_empty_and_none_urls(self):
+        """Empty/None values must be rejected."""
+        validator = URLValidator(['https://docs.aws.amazon.com'])
+        assert not validator.is_url_allowed('')
+        assert not validator.is_url_allowed(None)

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
@@ -172,6 +172,17 @@ class TestURLValidator:
         result = validate_urls('https://docs.aws.amazon.com/test')
         assert result == ['https://docs.aws.amazon.com/test']
 
+    def test_rejects_control_characters(self):
+        """URLs with control characters (CRLF injection) must be rejected."""
+        validator = URLValidator(['https://docs.aws.amazon.com'])
+        assert not validator.is_url_allowed('https://docs.aws.amazon.com/\r\ninjection')
+        assert not validator.is_url_allowed('https://docs.aws.amazon.com/\x00null')
+
+    def test_rejects_userinfo_in_url(self):
+        """URLs with userinfo (user@host) must be rejected."""
+        validator = URLValidator(['https://docs.aws.amazon.com'])
+        assert not validator.is_url_allowed('https://attacker.com@docs.aws.amazon.com/page')
+
     def test_empty_and_none_urls(self):
         """Empty/None values must be rejected."""
         validator = URLValidator(['https://docs.aws.amazon.com'])

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
@@ -178,4 +178,4 @@ class TestURLValidator:
         """Empty/None values must be rejected."""
         validator = URLValidator(['https://docs.aws.amazon.com'])
         assert not validator.is_url_allowed('')
-        assert not validator.is_url_allowed(None)
+        assert not validator.is_url_allowed(None)  # type: ignore[arg-type]

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_url_validator.py
@@ -178,4 +178,4 @@ class TestURLValidator:
         """Empty/None values must be rejected."""
         validator = URLValidator(['https://docs.aws.amazon.com'])
         assert not validator.is_url_allowed('')
-        assert not validator.is_url_allowed(None)  # type: ignore[arg-type]
+        assert not validator.is_url_allowed(None)


### PR DESCRIPTION
Fixes URL allowlist bypass vulnerability in `amazon-bedrock-agentcore-mcp-server/utils/url_validator.py`.

## Summary

### Changes

The `validate_urls()` function used weak string prefix checks (`startswith`) combined with automatic rewriting of relative URLs, allowing bypass of the intended allowlist of trusted AWS documentation domains.

This PR replaces the string-based prefix matching with structural URL validation:

- **`url_validator.py`**: Uses `urlparse` + `posixpath.normpath` for proper URL parsing. Enforces exact hostname matching, `/`-boundary path prefix checks, `https`-only scheme, and path normalization to resolve `..` traversal. Relative URLs are now rejected outright instead of silently rewritten.
- **`doc_fetcher.py`**: Moves relative link resolution to the caller using `urllib.parse.urljoin` to resolve relative links in llms.txt files against the base URL before validation.
- **`test_url_validator.py`**: Adds 12 new test cases covering all reported bypass vectors, path traversal, scheme enforcement, hostname boundary matching, and path boundary matching.

### User experience

**Before:** Malicious URLs like `/../../attacker-path`, `https://aws.github.io/bedrock-agentcore-starter-toolkit.evil.com/steal`, and `/evil?test=1` bypassed the allowlist.

**After:** All three vectors are rejected. Legitimate URLs for all default allowed domains continue to work as expected.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

N — The only behavioral change is that relative URLs passed directly to `validate_urls()` now raise an error instead of being silently rewritten. The caller (`doc_fetcher.py`) has been updated to resolve relative URLs before validation, preserving existing functionality.

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).