### PR TITLE
fix(mcp-lambda-handler): return 202 no body for notification-only POSTs

### DIFF
--- a/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/mcp-lambda-handler/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -435,13 +435,15 @@ class MCPLambdaHandler:
                 logger.debug(f'Parsed request body: {body}')
                 request_id = body.get('id') if isinstance(body, dict) else None
 
-                # Check if this is a notification (no id field)
+                # Check if this is a notification (no id field).
+                # Per MCP Streamable HTTP spec, notification-only POSTs must
+                # receive HTTP 202 Accepted with no body.
                 if isinstance(body, dict) and 'id' not in body:
                     logger.debug('Request is a notification')
                     return {
                         'statusCode': 202,
                         'body': '',
-                        'headers': {'Content-Type': 'application/json', 'MCP-Version': '0.6'},
+                        'headers': {'MCP-Version': '0.6'},
                     }
 
                 # Validate basic JSON-RPC structure

--- a/src/mcp-lambda-handler/tests/test_lambda_handler.py
+++ b/src/mcp-lambda-handler/tests/test_lambda_handler.py
@@ -422,7 +422,25 @@ def test_handle_request_notification():
     resp = handler.handle_request(event, context)
     assert resp['statusCode'] == 202
     assert resp['body'] == ''
-    assert resp['headers']['Content-Type'] == 'application/json'
+    assert 'Content-Type' not in resp['headers']
+
+
+def test_handle_request_initialized_notification():
+    """Test that notifications/initialized returns 202 Accepted with no body.
+
+    Per MCP Streamable HTTP spec, notification-only POSTs must receive
+    HTTP 202 Accepted with no body.  Strict clients (e.g. rmcp-based
+    Codex adapter) reject any 200 application/json response that cannot
+    be parsed as a JSON-RPC message, so returning 200 null here would
+    break the handshake.
+    """
+    handler = MCPLambdaHandler('test-server')
+    req = {'jsonrpc': '2.0', 'method': 'notifications/initialized'}
+    event = make_lambda_event(req)
+    resp = handler.handle_request(event, None)
+    assert resp['statusCode'] == 202
+    assert resp['body'] == ''
+    assert 'Content-Type' not in resp['headers']
 
 
 def test_handle_request_ping():


### PR DESCRIPTION
## Summary

- Remove the spurious `Content-Type: application/json` header from the 202 notification response in `mcp-lambda-handler` — per the MCP Streamable HTTP spec a notification-only POST MUST return `HTTP 202 Accepted` with **no body**, so advertising a JSON content-type with an empty body is misleading and can confuse strict clients
- Add an explicit test for `notifications/initialized` (the exact notification that breaks rmcp-based Codex clients) to document and guard the correct behaviour

## Background

`https://knowledge-mcp.global.api.aws` currently returns `HTTP 200 application/json null` for `notifications/initialized`. Strict `StreamableHttpClient` adapters (e.g. the one used by OpenAI Codex, built on `rmcp`) attempt to deserialise every `200 application/json` response as a JSON-RPC message, fail on `null`, and abort the handshake.

The `mcp-lambda-handler` already short-circuits to `202` for any request without an `id` field, but the response included a `Content-Type: application/json` header that implied there was parseable JSON content. This patch removes that header and adds a regression test pinning the `notifications/initialized` path.

## Test plan

- [ ] `pytest src/mcp-lambda-handler/tests/test_lambda_handler.py` — all 82 tests pass, including the new `test_handle_request_initialized_notification`

Fixes #3295

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).