### PR TITLE
fix(amazon-qindex-mcp-server): use URL Mode Elicitation for AuthorizeQIndex per MCP 2025-11-25 spec

### DIFF
--- a/src/amazon-qindex-mcp-server/README.md
+++ b/src/amazon-qindex-mcp-server/README.md
@@ -21,7 +21,6 @@ For Amazon Q Business application owners, direct integration support is not yet 
   - isv_redirect_url (str): Redirect URL registered during ISV registration
   - oauth_state (str): Random string for CSRF protection
   - idc_application_arn (str): Amazon Q Business application ID
-- Returns: Authorization URL for user authentication
 
 #### CreateTokenWithIAM
 - Creates authentication token using authorization code through IAM

--- a/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/server.py
+++ b/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/server.py
@@ -137,7 +137,7 @@ async def authorize_qindex(
     idc_application_arn: str = Field(
         description='The Amazon Q Business application ID provided by the customer'
     ),
-) -> Dict:
+) -> None:
     """Generate the OIDC authorization URL for Q index authentication.
 
     This tool generates the URL that users need to visit to authenticate with their
@@ -149,11 +149,8 @@ async def authorize_qindex(
         oauth_state (str): Random string to prevent CSRF attacks
         idc_application_arn (str): The Amazon Q Business application ID provided by the customer
 
-    Returns:
-        Dict: Response containing the authorization URL
-        {
-            'authorization_url': 'string'
-        }
+    Raises:
+        ValueError: Always raised; the message embeds the authorization URL.
     """
     auth_url = (
         f'https://oidc.{idc_region}.amazonaws.com/authorize'

--- a/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/server.py
+++ b/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/server.py
@@ -20,6 +20,8 @@ import sys
 from awslabs.amazon_qindex_mcp_server.clients import QBusinessClient, QBusinessClientError
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import UrlElicitationRequiredError
+from mcp.types import ElicitRequestURLParams
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, Dict, List, Optional
 
@@ -150,7 +152,7 @@ async def authorize_qindex(
         idc_application_arn (str): The Amazon Q Business application ID provided by the customer
 
     Raises:
-        ValueError: Always raised; the message embeds the authorization URL.
+        UrlElicitationRequiredError: Always raised; carries the authorization URL.
     """
     auth_url = (
         f'https://oidc.{idc_region}.amazonaws.com/authorize'
@@ -161,10 +163,21 @@ async def authorize_qindex(
     )
 
     # Ask the user to visit the URL and provide the authorization code
-    raise ValueError(
+    auth_message = (
         f'Please visit this URL to sign in: {auth_url}\n'
         'After signing in, you will be redirected to your redirect URL.\n'
         'Please provide the authorization code from the redirect URL to continue.'
+    )
+    raise UrlElicitationRequiredError(
+        [
+            ElicitRequestURLParams(
+                mode='url',
+                url=auth_url,
+                elicitationId=oauth_state,
+                message=auth_message,
+            )
+        ],
+        message=auth_message,
     )
 
 

--- a/src/amazon-qindex-mcp-server/tests/test_server.py
+++ b/src/amazon-qindex-mcp-server/tests/test_server.py
@@ -24,6 +24,7 @@ from awslabs.amazon_qindex_mcp_server.server import (
     create_token_with_iam,
     mcp,
 )
+from mcp.shared.exceptions import UrlElicitationRequiredError
 
 
 class TestMCPServer:
@@ -74,7 +75,7 @@ class TestAuthorizeQIndex:
             f'&client_id={self.TEST_DATA["idc_application_arn"]}'
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(UrlElicitationRequiredError) as exc_info:
             await authorize_qindex(
                 idc_region=self.TEST_DATA['idc_region'],
                 isv_redirect_url=self.TEST_DATA['isv_redirect_url'],
@@ -82,7 +83,12 @@ class TestAuthorizeQIndex:
                 idc_application_arn=self.TEST_DATA['idc_application_arn'],
             )
 
-        assert expected_url in str(exc_info.value)
+        elicitation = exc_info.value.elicitations[0]
+        assert elicitation.url == expected_url
+        assert elicitation.elicitationId == self.TEST_DATA['oauth_state']
+        # Wire-level back-compat: top-level error.message preserves the previous
+        # ValueError text so legacy consumers reading error.message keep working.
+        assert expected_url in exc_info.value.error.message
 
 
 class TestCreateTokenWithIAM:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #3327 

## Summary

### Changes

`AuthorizeQIndex` initiates an OAuth flow (the MCP server is the OAuth client to AWS Q Business / IAM Identity Center). The previous implementation raised `ValueError` to convey the auth URL; the docstring and README also promised a Dict return that was never produced.

Two atomic commits:

- **`docs(...)`** — `-> Dict` becomes `-> None`; `Returns:` docstring section becomes `Raises:`; the redundant "Returns: Authorization URL..." README bullet is dropped (the preceding "Generates ..." bullet already describes the tool). No behavioral change.
- **`refactor(...)`** — replace `raise ValueError(URL...)` with `UrlElicitationRequiredError` (JSON-RPC `-32042`) carrying an `ElicitRequestURLParams` payload. The original message string is also passed as `message=`, so consumers parsing the URL out of the error text keep working.

Per the [MCP 2025-11-25 Elicitation spec](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#user-interaction-model), servers **MUST** use URL mode for sensitive credential flows (passwords, **access tokens**, payment credentials). OAuth authorization yields an access token; the spec dedicates a [URL Mode Elicitation for OAuth Flows](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-elicitation-for-oauth-flows) subsection to this exact pattern. Sibling `aws-api-mcp-server` already uses elicitation primitives; `AuthorizeQIndex` was the lone outlier.

The `mcp[cli]>=1.23.0` pin and `uv.lock` are left untouched — dep bumps are routed through this repo's auto-release process; sibling servers' lockfiles are at mcp 1.25+ via that path.

### User experience

- **mcp `< 1.25`**: wire shape unchanged; FastMCP wraps both old and new exception identically.
- **mcp `>= 1.25`**: client receives `McpError(code=-32042)` with structured `error.data.elicitations[0]` (typed URL, `elicitationId`, message). The URL substring is preserved at `error.message` for consumers that previously parsed it out of the error text. Empirically verified via in-process MCP client/server roundtrip.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested — `uv run --frozen pytest --cov` (34 passed, 94% coverage); pre-commit + pyright clean
* [x] Changes are documented (docstring + commit messages cite the spec)

Is this a breaking change? **Mostly N.** Fully back-compat on mcp `< 1.25`. On mcp `>= 1.25` the wire result type changes from `CallToolResult(isError=true)` to `McpError(-32042)`, but the URL substring is preserved at `error.message`. The only consumer that needs a one-line change is one explicitly switching on `CallToolResult(isError=true)` for this tool.

**RFC issue number**:

Checklist:

* [x] Migration process documented — see breaking-change line above.
* [x] Implement warnings (if it can live side by side) — wire-level coexistence: `message=` preserves the URL+instruction string at `error.message`. (`DeprecationWarning` does not reach JSON-RPC consumers.)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
