### PR TITLE
fix(openapi-mcp-server): pass auth headers when fetching OpenAPI spec URL

### DIFF
--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -126,7 +126,7 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         openapi_spec = load_openapi_spec(
             url=config.api_spec_url,
             path=config.api_spec_path,
-            headers=auth_headers,
+            headers=auth_provider.get_auth_headers(),
         )
 
         # Validate the OpenAPI spec
@@ -278,7 +278,9 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                     logger.info(f'Loading additional spec: {extra_name}')
                     try:
                         extra_spec = load_openapi_spec(
-                            url=entry.get('spec_url', ''), path=entry.get('spec_path', '')
+                            url=entry.get('spec_url', ''),
+                            path=entry.get('spec_path', ''),
+                            headers=auth_provider.get_auth_headers(),
                         )
                     except Exception as e:
                         logger.warning(f'Failed to load additional spec {extra_name}: {e}')

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -88,21 +88,9 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
             logger.error('No API spec URL or path provided')
             raise ValueError('Either api_spec_url or api_spec_path must be provided')
 
-        logger.debug(
-            f'Loading OpenAPI spec from URL: {config.api_spec_url} or path: {config.api_spec_path}'
-        )
-        openapi_spec = load_openapi_spec(url=config.api_spec_url, path=config.api_spec_path)
-
-        # Validate the OpenAPI spec
-        if not validate_openapi_spec(openapi_spec):
-            logger.warning('OpenAPI specification validation failed, but continuing anyway')
-
-        # Create a client for the API
-        if not config.api_base_url:
-            logger.error('No API base URL provided')
-            raise ValueError('API base URL must be provided')
-
         # Configure authentication using the auth factory
+        # Auth is initialized before loading the spec so that the Bearer token
+        # can be passed when fetching a spec URL that requires authentication.
         from awslabs.openapi_mcp_server.auth import get_auth_provider, is_auth_type_available
 
         # Import and register the specific auth provider
@@ -131,6 +119,24 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         _ = auth_provider.get_auth_params()
         auth_cookies = auth_provider.get_auth_cookies()
         httpx_auth = auth_provider.get_httpx_auth()
+
+        logger.debug(
+            f'Loading OpenAPI spec from URL: {config.api_spec_url} or path: {config.api_spec_path}'
+        )
+        openapi_spec = load_openapi_spec(
+            url=config.api_spec_url,
+            path=config.api_spec_path,
+            headers=auth_headers,
+        )
+
+        # Validate the OpenAPI spec
+        if not validate_openapi_spec(openapi_spec):
+            logger.warning('OpenAPI specification validation failed, but continuing anyway')
+
+        # Create a client for the API
+        if not config.api_base_url:
+            logger.error('No API base URL provided')
+            raise ValueError('API base URL must be provided')
 
         # Helper function to handle authentication configuration errors
         def handle_auth_error(auth_type, error_message):

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -114,7 +114,6 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         auth_provider = get_auth_provider(config)
 
         # Get authentication components
-        auth_headers = auth_provider.get_auth_headers()
         # Get auth params (not used directly but may be needed in the future)
         _ = auth_provider.get_auth_params()
         auth_cookies = auth_provider.get_auth_cookies()
@@ -123,10 +122,12 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         logger.debug(
             f'Loading OpenAPI spec from URL: {config.api_spec_url} or path: {config.api_spec_path}'
         )
+        # Fetch headers right before first use so the token is as fresh as possible
+        auth_headers = auth_provider.get_auth_headers()
         openapi_spec = load_openapi_spec(
             url=config.api_spec_url,
             path=config.api_spec_path,
-            headers=auth_provider.get_auth_headers(),
+            headers=auth_headers,
         )
 
         # Validate the OpenAPI spec

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -119,26 +119,6 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         auth_cookies = auth_provider.get_auth_cookies()
         httpx_auth = auth_provider.get_httpx_auth()
 
-        logger.debug(
-            f'Loading OpenAPI spec from URL: {config.api_spec_url} or path: {config.api_spec_path}'
-        )
-        # Fetch headers right before first use so the token is as fresh as possible
-        auth_headers = auth_provider.get_auth_headers()
-        openapi_spec = load_openapi_spec(
-            url=config.api_spec_url,
-            path=config.api_spec_path,
-            headers=auth_headers,
-        )
-
-        # Validate the OpenAPI spec
-        if not validate_openapi_spec(openapi_spec):
-            logger.warning('OpenAPI specification validation failed, but continuing anyway')
-
-        # Create a client for the API
-        if not config.api_base_url:
-            logger.error('No API base URL provided')
-            raise ValueError('API base URL must be provided')
-
         # Helper function to handle authentication configuration errors
         def handle_auth_error(auth_type, error_message):
             """Handle authentication configuration errors.
@@ -181,6 +161,26 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                 logger.warning(
                     'Continuing with incomplete authentication configuration. This may cause API requests to fail.'
                 )
+
+        logger.debug(
+            f'Loading OpenAPI spec from URL: {config.api_spec_url} or path: {config.api_spec_path}'
+        )
+        # Fetch headers right before first use so the token is as fresh as possible
+        auth_headers = auth_provider.get_auth_headers()
+        openapi_spec = load_openapi_spec(
+            url=config.api_spec_url,
+            path=config.api_spec_path,
+            headers=auth_headers,
+        )
+
+        # Validate the OpenAPI spec
+        if not validate_openapi_spec(openapi_spec):
+            logger.warning('OpenAPI specification validation failed, but continuing anyway')
+
+        # Create a client for the API
+        if not config.api_base_url:
+            logger.error('No API base URL provided')
+            raise ValueError('API base URL must be provided')
 
         # Log authentication info
         if config.auth_type != 'none':

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/cache_provider.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/cache_provider.py
@@ -214,24 +214,33 @@ def create_cache_provider(ttl_seconds: Optional[int] = None) -> CacheProvider:
     return InMemoryCacheProvider(ttl_seconds=ttl_seconds)
 
 
-def cached(ttl_seconds: Optional[int] = None) -> Callable:
+def cached(
+    ttl_seconds: Optional[int] = None,
+    exclude_from_key: Optional[set] = None,
+) -> Callable:
     """Cache function results.
 
     Args:
         ttl_seconds: Time-to-live in seconds for cache entries (defaults to config value)
+        exclude_from_key: Set of kwarg names to omit from the cache key. Useful for
+            arguments like auth headers whose values should not affect cache identity
+            (e.g. the same spec URL should map to the same cache entry regardless of
+            which token was used to fetch it).
 
     Returns:
         Callable: Decorated function with caching
 
     """
     cache = create_cache_provider(ttl_seconds=ttl_seconds)
+    _exclude = exclude_from_key or set()
 
     def decorator(func: Callable) -> Callable:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Create a cache key from the function name and arguments
+            # Create a cache key from the function name and arguments,
+            # omitting any kwargs listed in exclude_from_key.
             key_parts = [func.__name__]
             key_parts.extend(str(arg) for arg in args)
-            key_parts.extend(f'{k}={v}' for k, v in sorted(kwargs.items()))
+            key_parts.extend(f'{k}={v}' for k, v in sorted(kwargs.items()) if k not in _exclude)
             cache_key = ':'.join(key_parts)
 
             # Try to get from cache first

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/cache_provider.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/cache_provider.py
@@ -22,7 +22,7 @@ import time
 from abc import ABC, abstractmethod
 from awslabs.openapi_mcp_server import logger
 from awslabs.openapi_mcp_server.utils.config import CACHE_MAXSIZE, CACHE_TTL, USE_CACHETOOLS
-from typing import Any, Callable, Dict, Generic, Optional, TypeVar
+from typing import Any, Callable, Dict, Generic, Optional, Set, TypeVar
 
 
 # Type variable for generic cache implementation
@@ -216,7 +216,7 @@ def create_cache_provider(ttl_seconds: Optional[int] = None) -> CacheProvider:
 
 def cached(
     ttl_seconds: Optional[int] = None,
-    exclude_from_key: Optional[set] = None,
+    exclude_from_key: Optional[Set[str]] = None,
 ) -> Callable:
     """Cache function results.
 
@@ -232,7 +232,7 @@ def cached(
 
     """
     cache = create_cache_provider(ttl_seconds=ttl_seconds)
-    _exclude = exclude_from_key or set()
+    _exclude = set(exclude_from_key) if exclude_from_key else set()
 
     def decorator(func: Callable) -> Callable:
         def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -103,7 +103,9 @@ def load_openapi_spec(
         # Use retry logic for network resilience
         for attempt in range(3):
             try:
-                response = httpx.get(url, timeout=10.0, headers=headers or {})
+                response = httpx.get(
+                    url, timeout=10.0, headers=headers or {}, follow_redirects=False
+                )
                 response.raise_for_status()
 
                 if PRANCE_AVAILABLE:

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -65,7 +65,7 @@ except ImportError:
 
 @cached(
     ttl_seconds=3600, exclude_from_key={'headers'}
-)  # Cache by URL/path only; headers excluded so token rotation doesn't fragment the cache
+)  # Cache OpenAPI specs for 1 hour; headers excluded from key so token rotation doesn't fragment the cache
 def load_openapi_spec(
     url: str = '',
     path: str = '',

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -63,7 +63,9 @@ except ImportError:
     logger.warning('Prance library not found. Reference resolution will be limited.')
 
 
-@cached(ttl_seconds=3600)  # Cache OpenAPI specs for 1 hour
+@cached(
+    ttl_seconds=3600, exclude_from_key={'headers'}
+)  # Cache by URL/path only; headers excluded so token rotation doesn't fragment the cache
 def load_openapi_spec(
     url: str = '',
     path: str = '',

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -64,7 +64,11 @@ except ImportError:
 
 
 @cached(ttl_seconds=3600)  # Cache OpenAPI specs for 1 hour
-def load_openapi_spec(url: str = '', path: str = '') -> Dict[str, Any]:
+def load_openapi_spec(
+    url: str = '',
+    path: str = '',
+    headers: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
     """Load an OpenAPI specification from a URL or file path.
 
     If prance is available, it will be used to resolve references in the OpenAPI spec.
@@ -73,6 +77,7 @@ def load_openapi_spec(url: str = '', path: str = '') -> Dict[str, Any]:
     Args:
         url: URL to the OpenAPI specification
         path: Path to the OpenAPI specification file
+        headers: Optional HTTP headers to include when fetching the spec (e.g. Authorization)
 
     Returns:
         Dict[str, Any]: The parsed OpenAPI specification
@@ -96,7 +101,7 @@ def load_openapi_spec(url: str = '', path: str = '') -> Dict[str, Any]:
         # Use retry logic for network resilience
         for attempt in range(3):
             try:
-                response = httpx.get(url, timeout=10.0)
+                response = httpx.get(url, timeout=10.0, headers=headers or {})
                 response.raise_for_status()
 
                 if PRANCE_AVAILABLE:

--- a/src/openapi-mcp-server/tests/test_new_features.py
+++ b/src/openapi-mcp-server/tests/test_new_features.py
@@ -107,7 +107,7 @@ async def _create_server(config, spec=None, extra_spec=None):
         patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', headers=None):
             if extra_spec and url != config.api_spec_url:
                 return extra_spec
             return spec
@@ -459,7 +459,7 @@ async def test_additional_specs_load_failure_skipped():
         patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', headers=None):
             if url == 'http://x':
                 raise ValueError('bad spec')
             return PETSTORE_SPEC
@@ -516,7 +516,7 @@ async def test_additional_specs_validation_failure_continues():
         patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', headers=None):
             return PETSTORE_SPEC if url != 'http://payments/spec' else EXTRA_SPEC
 
         def validate_side_effect(spec):

--- a/src/openapi-mcp-server/tests/test_server.py
+++ b/src/openapi-mcp-server/tests/test_server.py
@@ -71,7 +71,7 @@ def test_create_mcp_server_basic(
     assert result == mock_server
     mock_fastmcp.assert_called_once()
     mock_load_spec.assert_called_once_with(
-        url=mock_config.api_spec_url, path=mock_config.api_spec_path
+        url=mock_config.api_spec_url, path=mock_config.api_spec_path, headers={}
     )
     mock_validate.assert_called_once()
     mock_create_client.assert_called_once()

--- a/src/openapi-mcp-server/tests/test_server_auth_errors.py
+++ b/src/openapi-mcp-server/tests/test_server_auth_errors.py
@@ -1,5 +1,6 @@
 """Tests for authentication error handling in server.py."""
 
+import pytest
 from awslabs.openapi_mcp_server.api.config import Config
 from awslabs.openapi_mcp_server.server import create_mcp_server
 from unittest.mock import MagicMock, patch
@@ -8,7 +9,7 @@ from unittest.mock import MagicMock, patch
 class TestServerAuthErrors:
     """Tests for authentication error handling in server.py."""
 
-    @patch('sys.exit')
+    @patch('sys.exit', side_effect=SystemExit(1))
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     def test_bearer_auth_not_configured(self, mock_get_auth, mock_exit):
         """Test handling of bearer auth not configured."""
@@ -28,12 +29,13 @@ class TestServerAuthErrors:
         )
 
         # Call create_mcp_server, which should handle the auth error
-        create_mcp_server(config)
+        with pytest.raises(SystemExit):
+            create_mcp_server(config)
 
         # Verify sys.exit was called
         mock_exit.assert_called_once_with(1)
 
-    @patch('sys.exit')
+    @patch('sys.exit', side_effect=SystemExit(1))
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     def test_basic_auth_not_configured(self, mock_get_auth, mock_exit):
         """Test handling of basic auth not configured."""
@@ -54,12 +56,13 @@ class TestServerAuthErrors:
         )
 
         # Call create_mcp_server, which should handle the auth error
-        create_mcp_server(config)
+        with pytest.raises(SystemExit):
+            create_mcp_server(config)
 
         # Verify sys.exit was called
         mock_exit.assert_called_once_with(1)
 
-    @patch('sys.exit')
+    @patch('sys.exit', side_effect=SystemExit(1))
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     def test_api_key_auth_not_configured(self, mock_get_auth, mock_exit):
         """Test handling of API key auth not configured."""
@@ -79,12 +82,13 @@ class TestServerAuthErrors:
         )
 
         # Call create_mcp_server, which should handle the auth error
-        create_mcp_server(config)
+        with pytest.raises(SystemExit):
+            create_mcp_server(config)
 
         # Verify sys.exit was called
         mock_exit.assert_called_once_with(1)
 
-    @patch('sys.exit')
+    @patch('sys.exit', side_effect=SystemExit(1))
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     def test_cognito_auth_not_configured(self, mock_get_auth, mock_exit):
         """Test handling of Cognito auth not configured."""
@@ -106,12 +110,13 @@ class TestServerAuthErrors:
         )
 
         # Call create_mcp_server, which should handle the auth error
-        create_mcp_server(config)
+        with pytest.raises(SystemExit):
+            create_mcp_server(config)
 
         # Verify sys.exit was called
         mock_exit.assert_called_once_with(1)
 
-    @patch('sys.exit')
+    @patch('sys.exit', side_effect=SystemExit(1))
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     def test_unknown_auth_not_configured(self, mock_get_auth, mock_exit):
         """Test handling of unknown auth type not configured."""
@@ -130,7 +135,8 @@ class TestServerAuthErrors:
         )
 
         # Call create_mcp_server, which should handle the auth error
-        create_mcp_server(config)
+        with pytest.raises(SystemExit):
+            create_mcp_server(config)
 
         # Verify sys.exit was called
         mock_exit.assert_called_once_with(1)

--- a/src/openapi-mcp-server/tests/test_server_coverage_boost.py
+++ b/src/openapi-mcp-server/tests/test_server_coverage_boost.py
@@ -9,11 +9,12 @@ class TestServerCoverageBoost:
     """Tests to improve coverage for server.py - adding one test at a time."""
 
     @patch('awslabs.openapi_mcp_server.auth.register.register_provider_by_type')
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
     @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     def test_create_mcp_server_with_auth_type_registration(
-        self, mock_fastmcp, mock_validate, mock_load_spec, mock_register
+        self, mock_fastmcp, mock_validate, mock_load_spec, mock_get_auth, mock_register
     ):
         """Test create_mcp_server registers auth provider by type."""
         # Mock dependencies with a valid OpenAPI spec
@@ -32,6 +33,13 @@ class TestServerCoverageBoost:
         mock_validate.return_value = True
         mock_server_instance = MagicMock()
         mock_fastmcp.return_value = mock_server_instance
+        mock_auth_provider = MagicMock()
+        mock_auth_provider.get_auth_headers.return_value = {}
+        mock_auth_provider.get_auth_params.return_value = {}
+        mock_auth_provider.get_auth_cookies.return_value = {}
+        mock_auth_provider.get_httpx_auth.return_value = None
+        mock_auth_provider.provider_name = 'bearer'
+        mock_get_auth.return_value = mock_auth_provider
 
         # Create a config with auth_type
         config = Config(

--- a/src/openapi-mcp-server/tests/test_server_part1.py
+++ b/src/openapi-mcp-server/tests/test_server_part1.py
@@ -71,7 +71,7 @@ def test_create_mcp_server_basic(
     assert result == mock_server
     mock_fastmcp.assert_called_once()
     mock_load_spec.assert_called_once_with(
-        url=mock_config.api_spec_url, path=mock_config.api_spec_path
+        url=mock_config.api_spec_url, path=mock_config.api_spec_path, headers={}
     )
     mock_validate.assert_called_once()
     mock_create_client.assert_called_once()

--- a/src/openapi-mcp-server/tests/utils/test_cache_provider.py
+++ b/src/openapi-mcp-server/tests/utils/test_cache_provider.py
@@ -138,6 +138,32 @@ def test_cached_decorator():
     assert call_count == 2  # Function called again
 
 
+def test_cached_decorator_with_exclude_from_key():
+    """Test that excluded kwargs do not affect the cache key."""
+    call_count = 0
+
+    @cached(ttl_seconds=60, exclude_from_key={'headers'})
+    def fetch(url='', headers=None):
+        nonlocal call_count
+        call_count += 1
+        return f'result:{url}'
+
+    # First call
+    result = fetch(url='http://example.com', headers={'Authorization': 'Bearer token_a'})
+    assert result == 'result:http://example.com'
+    assert call_count == 1
+
+    # Same URL, different headers → cache HIT (headers excluded from key)
+    result = fetch(url='http://example.com', headers={'Authorization': 'Bearer token_b'})
+    assert result == 'result:http://example.com'
+    assert call_count == 1
+
+    # Different URL → cache MISS (url is part of the key)
+    result = fetch(url='http://other.com', headers={'Authorization': 'Bearer token_a'})
+    assert result == 'result:http://other.com'
+    assert call_count == 2
+
+
 def test_cached_decorator_with_complex_args():
     """Test the cached decorator with complex arguments."""
     # Create a test function


### PR DESCRIPTION
## Summary

- Moves auth provider initialization before the OpenAPI spec is loaded, so that a Bearer token is available when fetching the spec
- Adds an optional `headers` parameter to `load_openapi_spec()` and passes auth headers through when fetching from a URL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

## Motivation

Some APIs gate their OpenAPI spec URL behind the same authentication as the API itself (e.g. SSO/OAuth-protected spec endpoints). Without this change, the server would attempt to fetch the spec before obtaining a token, causing an authentication redirect or 401.

## Test plan

- [ ] Existing tests pass (`uv run pytest tests/`)
- [ ] Server starts successfully with a spec URL that requires authentication
- [ ] Log output shows auth initialized before `Loading OpenAPI spec from URL`