### PR TITLE
chore: Updating content recommendations endpoint in Docs MCP

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -43,7 +43,7 @@ from typing import List, Optional
 
 
 SEARCH_API_URL = 'https://proxy.search.docs.aws.com/search'
-RECOMMENDATIONS_API_URL = 'https://contentrecs-api.docs.aws.amazon.com/v1/recommendations'
+RECOMMENDATIONS_API_URL = 'https://api.contentrecs.docs.aws.com/v1/recommendations'
 SESSION_UUID = str(uuid.uuid4())
 
 

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -870,7 +870,7 @@ class TestRecommend:
             assert '?path=' in called_url
             assert '&session=' in called_url
             assert called_url.startswith(
-                'https://contentrecs-api.docs.aws.amazon.com/v1/recommendations?path=https://docs.aws.amazon.com/test&session='
+                'https://api.contentrecs.docs.aws.com/v1/recommendations?path=https://docs.aws.amazon.com/test&session='
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Updating content recommendations endpoint

### Changes

New content recommendations endpoint is being rolled out, need to update Docs MCP + tests accordingly

### User experience

Experience is unchanged, endpoint behavior is the same

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
