### PR TITLE
chore(healthlake-mcp-server): align user-agent format with AWS metada…

### DIFF
--- a/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/fhir_operations.py
+++ b/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/fhir_operations.py
@@ -242,7 +242,9 @@ class HealthLakeClient:
             self.healthlake_client = self.session.client(
                 'healthlake',
                 region_name=region_name,
-                config=Config(user_agent_extra=f'awslabs/mcp/healthlake-mcp-server/{__version__}'),
+                config=Config(
+                    user_agent_extra=f'md/awslabs#mcp#healthlake-mcp-server#{__version__}'
+                ),
             )
             self.region = region_name or self.session.region_name or 'us-east-1'
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
  Fixes N/A

  ## Summary

  Aligns the `healthlake-mcp-server` boto3 User-Agent suffix with the `md/` metadata convention
  already used across most MCP servers in this repository (e.g., `iam-mcp-server`,
  `ecs-mcp-server`, `eks-mcp-server`, `cloudwatch-mcp-server`, `aws-pricing-mcp-server`,
  `billing-cost-management-mcp-server`, `sagemaker-ai-mcp-server`, etc.).

  This is a small, internal telemetry/identification change. There is no change to FHIR
  behavior, tools, inputs, outputs, authentication, or permissions.

  ### Changes

  Single-line change in
  `src/healthlake-mcp-server/awslabs/healthlake_mcp_server/fhir_operations.py`:

  ```diff
  - config=Config(user_agent_extra=f'awslabs/mcp/healthlake-mcp-server/{__version__}'),
  + config=Config(user_agent_extra=f'md/awslabs#mcp#healthlake-mcp-server#{__version__}'),
  ```
  The previous value embedded / separators, which conflicts with the standard User-Agent
  product-token grammar. The new value uses the md/ (metadata) prefix with # as the delimiter,
  matching the AWS SDK convention and the pattern used by sibling MCP servers, so requests are
  consistently attributable in service-side telemetry.

  ## User experience

  No user-visible change.

  - Before: Outgoing HealthLake API requests carried a User-Agent suffix of
  awslabs/mcp/healthlake-mcp-server/<version>.
  - After: Outgoing HealthLake API requests carry a User-Agent suffix of
  md/awslabs#mcp#healthlake-mcp-server#<version>, matching the convention used by the rest of
  the MCP server suite.

  Tool behavior, responses, and configuration are identical.

  ## Checklist

  - [x] I have reviewed the contributing guidelines
  (https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
  - [x] I have performed a self-review of this change
  - [x] Changes have been tested (existing unit tests pass; change is a string-literal format
  update in the boto3 client config)
  - [ ] Changes are documented (no user-facing docs affected)

  Is this a breaking change? N

  RFC issue number: N/A

  - [ ] Migration process documented
  - [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).