### PR TITLE
chore: release/2026.05.20260505222206

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.0.19'
+__version__ = '0.0.20'

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.19"
+version = "0.0.20"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.3.33'
+__version__ = '1.3.34'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.33"
+version = "1.3.34"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.3.33"
+version = "1.3.34"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-healthomics-mcp-server"""
 
-__version__ = '0.0.36'
+__version__ = '0.0.37'

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-healthomics-mcp-server"
-version = "0.0.36"
+version = "0.0.37"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-healthomics-mcp-server"
-version = "0.0.36"
+version = "0.0.37"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/__init__.py
+++ b/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS HealthLake MCP Server."""
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'

--- a/src/healthlake-mcp-server/pyproject.toml
+++ b/src/healthlake-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.healthlake-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.13"
+version = "0.0.14"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for healthlake"
 readme = "README.md"

--- a/src/healthlake-mcp-server/uv.lock
+++ b/src/healthlake-mcp-server/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-healthlake-mcp-server"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
@@ -19,6 +19,6 @@ from importlib.metadata import version
 try:
     __version__ = version('awslabs.postgres-mcp-server')
 except Exception:  # pragma: no cover
-    __version__ = '1.1.1'
+    __version__ = '1.1.2'
 
 __user_agent__ = f'md/awslabs#mcp#postgres-mcp-server#{__version__}'

--- a/src/postgres-mcp-server/pyproject.toml
+++ b/src/postgres-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.postgres-mcp-server"
-version = "1.1.1"
+version = "1.1.2"
 description = "An AWS Labs Model Context Protocol (MCP) server for postgres"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/postgres-mcp-server/uv.lock
+++ b/src/postgres-mcp-server/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-postgres-mcp-server"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },


### PR DESCRIPTION
# release/2026.05.20260505222206

Triggered Release Branch (initiated) by @aws-steve for @aws-steve

## Changes
* amazon-bedrock-agentcore-mcp-server
* aws-api-mcp-server
* aws-healthomics-mcp-server
* aws-knowledge-mcp-server
* healthlake-mcp-server
* postgres-mcp-server

## Checklist
- [ ] Code changes have been reviewed
- [ ] Distribution packages have been built and tested
- [ ] Documentation has been updated if applicable

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).