### PR TITLE
feat(cloudwatch): extend get_metric_data with queries parameter

### DIFF
--- a/src/cloudwatch-mcp-server/CHANGELOG.md
+++ b/src/cloudwatch-mcp-server/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.3] - 2026-05-20
+
+### Added
+
+- Added optional `queries` parameter to `get_metric_data` for advanced metric retrieval: percentile statistics (p50, p90, p99, ...), metric math expressions, and multi-metric batching in a single API call
+- Added `MetricStatInput` and `MetricDataQueryInput` Pydantic input models for the `queries` parameter, with mutually-exclusive validation between `metric_stat` and `expression`
+- Automatic `NextToken` pagination in the `queries` path so large responses are not silently truncated
+
+### Changed
+
+- `start_time` parameter on `get_metric_data` is now optional; defaults to 3 hours before `end_time` when omitted (matches the CloudWatch console default)
+
 ## [0.1.1] - 2026-05-12
 
 ### Removed

--- a/src/cloudwatch-mcp-server/README.md
+++ b/src/cloudwatch-mcp-server/README.md
@@ -26,7 +26,10 @@ Alarm Recommendations - Suggests recommended alarm configurations for CloudWatch
 ## Available Tools
 
 ### Tools for CloudWatch Metrics
-* `get_metric_data` - Retrieves detailed CloudWatch metric data for any CloudWatch metric. Use this for general CloudWatch metrics that aren't specific to Application Signals. Provides ability to query any metric namespace, dimension, and statistic
+* `get_metric_data` - Retrieves detailed CloudWatch metric data for any CloudWatch metric. Use this for general CloudWatch metrics that aren't specific to Application Signals. Provides ability to query any metric namespace, dimension, and statistic. Supports an optional `queries` parameter for advanced use cases including:
+  * **Percentile statistics** (p50, p90, p99, etc.) for latency analysis
+  * **Math expressions** to calculate derived metrics (e.g. error rate = errors/invocations × 100)
+  * **Multi-metric batching** — retrieve multiple metrics in a single API call
 * `get_metric_metadata` - Retrieves comprehensive metadata about a specific CloudWatch metric
 * `get_recommended_metric_alarms` - Gets recommended alarms for a CloudWatch metric based on best practice, and trend, seasonality and statistical analysis.
 * `analyze_metric` - Analyzes CloudWatch metric data to determine trend, seasonality, and statistical properties

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
@@ -274,3 +274,51 @@ class AlarmRecommendationResult(BaseModel):
         ...,
         description='Message describing the success/failure of generating alarm recommendation.',
     )
+
+
+class MetricStatInput(BaseModel):
+    """Represents the MetricStat portion of a MetricDataQuery for input parameters."""
+
+    namespace: str = Field(..., description='The namespace of the metric')
+    metric_name: str = Field(..., description='The name of the metric')
+    dimensions: List[Dimension] = Field(
+        default_factory=list, description='The dimensions for the metric'
+    )
+    statistic: str = Field(
+        ...,
+        description='The statistic to use (e.g., Average, Sum, Maximum, Minimum, SampleCount, or percentile like p50, p90, p99)',
+    )
+    period: Optional[int] = Field(
+        default=None, description='The period in seconds (overrides default if provided)'
+    )
+
+
+class MetricDataQueryInput(BaseModel):
+    """Represents a MetricDataQuery for input parameters with validation."""
+
+    id: str = Field(..., description='A unique identifier for the query')
+    metric_stat: Optional[MetricStatInput] = Field(
+        default=None, description='The metric stat configuration (for direct metric queries)'
+    )
+    expression: Optional[str] = Field(
+        default=None,
+        description='A math expression or Metrics Insights query (for expression-based queries)',
+    )
+    label: Optional[str] = Field(default=None, description='A label for the query result')
+    return_data: bool = Field(
+        default=True,
+        description='Whether to return data for this query or use it only in other expressions',
+    )
+    period: Optional[int] = Field(
+        default=None,
+        description='The period in seconds (overrides metric_stat period and default)',
+    )
+
+    @model_validator(mode='after')
+    def validate_query_type(self):
+        """Validate that either metric_stat or expression is provided, but not both."""
+        if not self.metric_stat and not self.expression:
+            raise ValueError('Either metric_stat or expression must be provided')
+        if self.metric_stat and self.expression:
+            raise ValueError('Cannot specify both metric_stat and expression')
+        return self

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/tools.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/tools.py
@@ -35,6 +35,7 @@ from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.models import (
     GetMetricDataResponse,
     MetricData,
     MetricDataPoint,
+    MetricDataQueryInput,
     MetricDataResult,
     MetricMetadata,
     MetricMetadataIndexKey,
@@ -157,12 +158,24 @@ class CloudWatchMetricsTools:
     async def get_metric_data(
         self,
         ctx: Context,
-        namespace: str,
-        metric_name: str,
+        namespace: Annotated[
+            str | None,
+            Field(
+                description='The namespace of the metric. Required unless queries parameter is provided.'
+            ),
+        ] = None,
+        metric_name: Annotated[
+            str | None,
+            Field(
+                description='The name of the metric. Required unless queries parameter is provided.'
+            ),
+        ] = None,
         start_time: Annotated[
-            Union[str, datetime],
-            Field(description='The start time for the metric data query (ISO format or datetime)'),
-        ],
+            Union[str, datetime] | None,
+            Field(
+                description='The start time for the metric data query (ISO format or datetime). Defaults to 3 hours before end_time if not provided.'
+            ),
+        ] = None,
         dimensions: List[Dimension] = [],
         end_time: Annotated[
             Union[str, datetime] | None,
@@ -233,6 +246,12 @@ class CloudWatchMetricsTools:
                 description='AWS CLI Profile Name to use for AWS access. Falls back to AWS_PROFILE environment variable if not specified, or uses default AWS credential chain.'
             ),
         ] = None,
+        queries: Annotated[
+            List[MetricDataQueryInput] | None,
+            Field(
+                description='Advanced queries for percentiles, math expressions, and multi-metric batching. When provided, namespace/metric_name/dimensions/statistic parameters are ignored.'
+            ),
+        ] = None,
     ) -> GetMetricDataResponse:
         """Retrieves CloudWatch metric data for a specific metric.
 
@@ -245,6 +264,15 @@ class CloudWatchMetricsTools:
         (group_by_dimension, schema_dimension_keys, limit, sort_order, or order_by_statistic), it will use Metrics Insights.
 
         When using group_by_dimension, you must include that dimension in schema_dimension_keys.
+
+        For advanced use cases, the optional `queries` parameter accepts a list of `MetricDataQueryInput`
+        objects and unlocks capabilities that the single-metric path cannot express: percentile statistics
+        (p50, p90, p99...), metric math expressions (e.g. `errors / invocations`), and multi-metric
+        batching (retrieving many metrics in a single API call). When `queries` is provided,
+        `namespace`, `metric_name`, `dimensions`, and `statistic` are not used.
+
+        `start_time` is optional; when omitted, it defaults to 3 hours before `end_time`
+        (which itself defaults to the current UTC time).
 
         Usage: Use this tool to get actual metric data from CloudWatch for analysis or visualization.
 
@@ -339,8 +367,92 @@ class CloudWatchMetricsTools:
                 print(f"Metric: {metric_result.label}")
                 for datapoint in metric_result.datapoints:
                     print(f"  {datapoint.timestamp}: {datapoint.value}")
+
+        Example 7 (Advanced queries - Lambda Latency Percentiles):
+            Use the queries parameter for percentile statistics (p50, p90, p99).
+
+            result = await get_metric_data(
+                ctx,
+                start_time="2025-12-21T00:00:00Z",
+                queries=[
+                    MetricDataQueryInput(
+                        id="p50",
+                        metric_stat=MetricStatInput(
+                            namespace="AWS/Lambda",
+                            metric_name="Duration",
+                            dimensions=[Dimension(name="FunctionName", value="my-api-function")],
+                            statistic="p50"
+                        ),
+                        label="Median Latency"
+                    ),
+                    MetricDataQueryInput(
+                        id="p99",
+                        metric_stat=MetricStatInput(
+                            namespace="AWS/Lambda",
+                            metric_name="Duration",
+                            dimensions=[Dimension(name="FunctionName", value="my-api-function")],
+                            statistic="p99"
+                        ),
+                        label="p99 Latency"
+                    )
+                ]
+            )
+
+        Example 8 (Advanced queries - Error Rate Calculation with Math Expression):
+            Use queries with math expressions to calculate derived metrics.
+
+            result = await get_metric_data(
+                ctx,
+                start_time="2025-12-21T00:00:00Z",
+                queries=[
+                    MetricDataQueryInput(
+                        id="errors",
+                        metric_stat=MetricStatInput(
+                            namespace="AWS/Lambda",
+                            metric_name="Errors",
+                            dimensions=[Dimension(name="FunctionName", value="my-api-function")],
+                            statistic="Sum"
+                        ),
+                        return_data=False  # Don't include raw errors in results
+                    ),
+                    MetricDataQueryInput(
+                        id="invocations",
+                        metric_stat=MetricStatInput(
+                            namespace="AWS/Lambda",
+                            metric_name="Invocations",
+                            dimensions=[Dimension(name="FunctionName", value="my-api-function")],
+                            statistic="Sum"
+                        ),
+                        return_data=False  # Don't include raw invocations in results
+                    ),
+                    MetricDataQueryInput(
+                        id="error_rate",
+                        expression="(errors / invocations) * 100",
+                        label="Error Rate %"
+                    )
+                ]
+            )
+            # Result contains only the calculated error_rate percentage
         """
         try:
+            # If queries parameter provided, delegate to the batch queries helper
+            if queries:
+                return await self._execute_queries_batch(
+                    ctx=ctx,
+                    queries=queries,
+                    start_time=start_time,
+                    end_time=end_time,
+                    target_datapoints=target_datapoints,
+                    region=region,
+                    profile_name=profile_name,
+                )
+
+            # Validate required parameters when not using queries
+            if not namespace or not metric_name:
+                raise ValueError(
+                    'namespace and metric_name are required when queries parameter is not provided'
+                )
+
             # Process time parameters and calculate period
             start_time, end_time, period = self._prepare_time_parameters(
                 start_time, end_time, target_datapoints
@@ -392,15 +504,22 @@ class CloudWatchMetricsTools:
             raise
 
     def _prepare_time_parameters(self, start_time, end_time, target_datapoints):
-        """Process time parameters and calculate the period."""
-        # Convert string times to datetime objects
-        if isinstance(start_time, str):
-            start_time = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
+        """Process time parameters and calculate the period.
 
+        Defaults when not provided:
+        - end_time: current UTC time
+        - start_time: 3 hours before end_time
+        """
         if end_time is None:
             end_time = datetime.now(timezone.utc)
         elif isinstance(end_time, str):
             end_time = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+
+        if start_time is None:
+            # Default to 3 hours before end_time — matches the CloudWatch console default window
+            start_time = end_time - timedelta(hours=3)
+        elif isinstance(start_time, str):
+            start_time = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
 
         # Ensure both datetimes have timezone info for correct datetime arithmetic afterwards.
         # This avoids issues when datetime is passed as naive values (without timezone)
@@ -1048,6 +1167,143 @@ class CloudWatchMetricsTools:
                 values = list(values)
 
         return MetricData(period_seconds=period_seconds, timestamps=timestamps, values=values)
+
+    def _convert_query_input_to_aws(
+        self, query: MetricDataQueryInput, default_period: int
+    ) -> Dict[str, Any]:
+        """Convert MetricDataQueryInput to AWS SDK format.
+
+        Args:
+            query: The input query model
+            default_period: Default period to use if not specified in query
+
+        Returns:
+            Dict formatted for AWS GetMetricData API
+        """
+        aws_query = {
+            'Id': query.id,
+            'ReturnData': query.return_data,
+        }
+
+        # Determine the period to use (precedence: query.period > metric_stat.period > default_period)
+        if query.period is not None:
+            period = query.period
+        elif query.metric_stat and query.metric_stat.period is not None:
+            period = query.metric_stat.period
+        else:
+            period = default_period
+
+        # Add label if provided
+        if query.label:
+            aws_query['Label'] = query.label
+
+        # Build MetricStat or Expression
+        if query.metric_stat:
+            # Convert dimensions to AWS format
+            aws_dimensions = [
+                {'Name': dim.name, 'Value': dim.value} for dim in query.metric_stat.dimensions
+            ]
+
+            # For MetricStat queries, Period goes ONLY inside MetricStat
+            aws_query['MetricStat'] = {
+                'Metric': {
+                    'Namespace': query.metric_stat.namespace,
+                    'MetricName': query.metric_stat.metric_name,
+                    'Dimensions': aws_dimensions,
+                },
+                'Period': period,
+                'Stat': self._map_to_cloudwatch_statistic(query.metric_stat.statistic),
+            }
+        elif query.expression:
+            # For Expression queries, Period goes at the top level
+            aws_query['Period'] = period
+            aws_query['Expression'] = query.expression
+
+        return aws_query
+
+    def _paginate_get_metric_data(self, cloudwatch_client, **base_kwargs) -> dict:
+        """Follow ``NextToken`` through a CloudWatch ``GetMetricData`` call, merging results.
+
+        CloudWatch returns a ``NextToken`` when a single call exceeds its data-point
+        (~100,800 datapoints) or per-request query (500) limits. Without this helper,
+        results would be silently truncated after the first page.
+
+        Results sharing the same ``Id`` across pages are merged (``Timestamps`` and
+        ``Values`` are appended in order). ``Messages`` from all pages are concatenated.
+
+        Args:
+            cloudwatch_client: A boto3 CloudWatch client.
+            **base_kwargs: Keyword arguments forwarded to every ``get_metric_data`` call
+                (typically ``MetricDataQueries``, ``StartTime``, ``EndTime``).
+
+        Returns:
+            Dict with merged ``MetricDataResults`` and ``Messages``, matching the shape
+            of a single ``get_metric_data`` response.
+        """
+        response = cloudwatch_client.get_metric_data(**base_kwargs)
+        all_results = list(response.get('MetricDataResults', []))
+        messages = list(response.get('Messages', []))
+
+        while 'NextToken' in response:
+            response = cloudwatch_client.get_metric_data(
+                **base_kwargs,
+                NextToken=response['NextToken'],
+            )
+            for new in response.get('MetricDataResults', []):
+                existing = next(
+                    (r for r in all_results if r.get('Id') == new.get('Id')),
+                    None,
+                )
+                if existing:
+                    existing['Timestamps'] = existing.get('Timestamps', []) + new.get(
+                        'Timestamps', []
+                    )
+                    existing['Values'] = existing.get('Values', []) + new.get('Values', [])
+                    existing['StatusCode'] = new.get('StatusCode', existing.get('StatusCode'))
+                    # Preserve per-result Messages (warnings/errors scoped to a single query)
+                    # across pages — defensive; CloudWatch doesn't document splitting these.
+                    existing['Messages'] = existing.get('Messages', []) + new.get('Messages', [])
+                else:
+                    all_results.append(new)
+            messages.extend(response.get('Messages', []))
+
+        return {
+            'MetricDataResults': all_results,
+            'Messages': messages,
+        }
+
+    async def _execute_queries_batch(
+        self,
+        ctx: Context,
+        queries: List[MetricDataQueryInput],
+        start_time: Union[str, datetime] | None = None,
+        end_time: Union[str, datetime] | None = None,
+        target_datapoints: int = 60,
+        region: str | None = None,
+        profile_name: str | None = None,
+    ) -> GetMetricDataResponse:
+        """Internal helper: Execute batch queries with support for percentiles, expressions, and multi-metric."""
+        # Process time parameters and calculate default period
+        start_time, end_time, default_period = self._prepare_time_parameters(
+            start_time, end_time, target_datapoints
+        )
+
+        # Convert all queries to AWS format
+        aws_queries = [self._convert_query_input_to_aws(q, default_period) for q in queries]
+
+        # Create CloudWatch client
+        cloudwatch_client = get_aws_client('cloudwatch', region, profile_name)
+
+        # Call GetMetricData API — paginate if the response includes NextToken
+        response = self._paginate_get_metric_data(
+            cloudwatch_client,
+            MetricDataQueries=aws_queries,
+            StartTime=start_time,
+            EndTime=end_time,
+        )
+
+        # Process and return response
+        return self._process_metric_data_response(response)
 
     async def analyze_metric(
         self,

--- a/src/cloudwatch-mcp-server/pyproject.toml
+++ b/src/cloudwatch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-mcp-server"
-version = "0.1.2"
+version = "0.1.3"
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudwatch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_metrics_server.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_metrics_server.py
@@ -20,10 +20,12 @@ from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.models import (
     AnomalyDetectionAlarmThreshold,
     Dimension,
     GetMetricDataResponse,
+    MetricDataQueryInput,
+    MetricStatInput,
     StaticAlarmThreshold,
 )
 from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools import CloudWatchMetricsTools
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from moto import mock_aws
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -825,3 +827,470 @@ class TestGetMetricData:
                     metric_name='NonExistentMetric',
                     dimensions=[Dimension(name='TestDim', value='test-value')],
                 )
+
+    # Tests for get_metric_data with queries parameter (advanced queries support)
+
+    async def test_get_metric_data_queries_single_metric(self, ctx, cloudwatch_metrics_tools):
+        """Test basic single metric query using queries parameter."""
+        mock_client = MagicMock()
+        mock_client.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'm1',
+                    'Label': 'CPUUtilization',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [
+                        datetime(2026, 4, 5, 10, 0, 0),
+                        datetime(2026, 4, 5, 10, 5, 0),
+                    ],
+                    'Values': [23.7, 31.2],
+                }
+            ],
+        }
+
+        with patch(
+            'awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.get_aws_client',
+            return_value=mock_client,
+        ):
+            queries = [
+                MetricDataQueryInput(
+                    id='m1',
+                    period=120,
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/EC2',
+                        metric_name='CPUUtilization',
+                        dimensions=[Dimension(name='InstanceId', value='i-1234567890abcdef0')],
+                        statistic='Average',
+                    ),
+                )
+            ]
+
+            result = await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                start_time='2026-04-05T10:00:00Z',
+                end_time='2026-04-05T11:00:00Z',
+                queries=queries,
+            )
+
+            mock_client.get_metric_data.assert_called_once()
+            assert isinstance(result, GetMetricDataResponse)
+            assert len(result.metricDataResults) == 1
+            assert result.metricDataResults[0].id == 'm1'
+            assert result.metricDataResults[0].label == 'CPUUtilization'
+            assert len(result.metricDataResults[0].datapoints) == 2
+            assert result.metricDataResults[0].datapoints[0].value == 23.7
+            assert result.metricDataResults[0].datapoints[1].value == 31.2
+
+    async def test_get_metric_data_queries_multiple_metrics(self, ctx, cloudwatch_metrics_tools):
+        """Test querying multiple metrics including percentiles in a single call using queries parameter."""
+        mock_client = MagicMock()
+        mock_client.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'cpu',
+                    'Label': 'CPUUtilization',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [datetime(2026, 4, 5, 11, 30, 0)],
+                    'Values': [42.8],
+                },
+                {
+                    'Id': 'memory',
+                    'Label': 'MemoryUtilization',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [datetime(2026, 4, 5, 11, 30, 0)],
+                    'Values': [67.5],
+                },
+                {
+                    'Id': 'p50',
+                    'Label': 'Duration p50',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [datetime(2026, 4, 5, 11, 30, 0)],
+                    'Values': [142.3],
+                },
+                {
+                    'Id': 'p99',
+                    'Label': 'Duration p99',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [datetime(2026, 4, 5, 11, 30, 0)],
+                    'Values': [1387.9],
+                },
+            ],
+        }
+
+        with patch(
+            'awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.get_aws_client',
+            return_value=mock_client,
+        ):
+            queries = [
+                MetricDataQueryInput(
+                    id='cpu',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/EC2',
+                        metric_name='CPUUtilization',
+                        dimensions=[Dimension(name='InstanceId', value='i-1234567890abcdef0')],
+                        statistic='Average',
+                    ),
+                ),
+                MetricDataQueryInput(
+                    id='memory',
+                    metric_stat=MetricStatInput(
+                        namespace='CWAgent',
+                        metric_name='MemoryUtilization',
+                        dimensions=[Dimension(name='InstanceId', value='i-1234567890abcdef0')],
+                        statistic='Average',
+                    ),
+                ),
+                MetricDataQueryInput(
+                    id='p50',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/Lambda',
+                        metric_name='Duration',
+                        dimensions=[Dimension(name='FunctionName', value='my-function')],
+                        statistic='p50',
+                    ),
+                    label='Duration p50',
+                ),
+                MetricDataQueryInput(
+                    id='p99',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/Lambda',
+                        metric_name='Duration',
+                        dimensions=[Dimension(name='FunctionName', value='my-function')],
+                        statistic='p99',
+                    ),
+                    label='Duration p99',
+                ),
+            ]
+
+            result = await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                start_time='2026-04-05T11:00:00Z',
+                end_time='2026-04-05T12:00:00Z',
+                queries=queries,
+            )
+
+            # Verify all four metrics returned (including percentiles)
+            assert len(result.metricDataResults) == 4
+            assert result.metricDataResults[0].id == 'cpu'
+            assert result.metricDataResults[0].datapoints[0].value == 42.8
+            assert result.metricDataResults[1].id == 'memory'
+            assert result.metricDataResults[1].datapoints[0].value == 67.5
+            assert result.metricDataResults[2].id == 'p50'
+            assert result.metricDataResults[2].label == 'Duration p50'
+            assert result.metricDataResults[2].datapoints[0].value == 142.3
+            assert result.metricDataResults[3].id == 'p99'
+            assert result.metricDataResults[3].label == 'Duration p99'
+            assert result.metricDataResults[3].datapoints[0].value == 1387.9
+
+            # Verify the API call used percentile statistics
+            call_args = mock_client.get_metric_data.call_args[1]
+            queries_sent = call_args['MetricDataQueries']
+            assert len(queries_sent) == 4
+            assert queries_sent[2]['MetricStat']['Stat'] == 'p50'
+            assert queries_sent[3]['MetricStat']['Stat'] == 'p99'
+
+    async def test_get_metric_data_queries_math_expression(self, ctx, cloudwatch_metrics_tools):
+        """Test using math expressions to calculate derived metrics (error rate)."""
+        mock_client = MagicMock()
+        mock_client.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'error_rate',
+                    'Label': 'Error Rate %',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [
+                        datetime(2026, 4, 5, 14, 30, 0),
+                        datetime(2026, 4, 5, 14, 35, 0),
+                        datetime(2026, 4, 5, 14, 40, 0),
+                    ],
+                    'Values': [1.8, 2.3, 4.1],
+                },
+            ],
+        }
+
+        with patch(
+            'awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.get_aws_client',
+            return_value=mock_client,
+        ):
+            queries = [
+                MetricDataQueryInput(
+                    id='errors',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/Lambda',
+                        metric_name='Errors',
+                        dimensions=[Dimension(name='FunctionName', value='my-function')],
+                        statistic='Sum',
+                    ),
+                    return_data=False,
+                ),
+                MetricDataQueryInput(
+                    id='invocations',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/Lambda',
+                        metric_name='Invocations',
+                        dimensions=[Dimension(name='FunctionName', value='my-function')],
+                        statistic='Sum',
+                    ),
+                    return_data=False,
+                ),
+                MetricDataQueryInput(
+                    id='error_rate',
+                    expression='(errors / invocations) * 100',
+                    label='Error Rate %',
+                ),
+            ]
+
+            result = await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                start_time='2026-04-05T14:00:00Z',
+                end_time='2026-04-05T15:00:00Z',
+                queries=queries,
+            )
+
+            assert len(result.metricDataResults) == 1
+            assert result.metricDataResults[0].id == 'error_rate'
+            assert result.metricDataResults[0].label == 'Error Rate %'
+            assert len(result.metricDataResults[0].datapoints) == 3
+            assert result.metricDataResults[0].datapoints[0].value == 1.8
+
+            # Verify the API call structure
+            call_args = mock_client.get_metric_data.call_args[1]
+            queries_sent = call_args['MetricDataQueries']
+            assert len(queries_sent) == 3
+            assert queries_sent[0]['Id'] == 'errors'
+            assert queries_sent[0]['ReturnData'] is False
+            assert queries_sent[2]['Id'] == 'error_rate'
+            assert queries_sent[2]['Expression'] == '(errors / invocations) * 100'
+            assert queries_sent[2]['ReturnData'] is True
+
+    async def test_get_metric_data_queries_validation_no_metric_or_expression(
+        self, ctx, cloudwatch_metrics_tools
+    ):
+        """Test validation error when neither metric_stat nor expression is provided."""
+        with pytest.raises(ValueError) as excinfo:
+            MetricDataQueryInput(id='test')
+
+        assert 'Either metric_stat or expression must be provided' in str(excinfo.value)
+
+    async def test_get_metric_data_queries_validation_both_metric_and_expression(
+        self, ctx, cloudwatch_metrics_tools
+    ):
+        """Test validation error when both metric_stat and expression are provided."""
+        with pytest.raises(ValueError) as excinfo:
+            MetricDataQueryInput(
+                id='test',
+                metric_stat=MetricStatInput(
+                    namespace='AWS/EC2',
+                    metric_name='CPUUtilization',
+                    dimensions=[],
+                    statistic='Average',
+                ),
+                expression='m1 * 100',
+            )
+
+        assert 'Cannot specify both metric_stat and expression' in str(excinfo.value)
+
+    async def test_get_metric_data_queries_error_handling(self, ctx, cloudwatch_metrics_tools):
+        """Test error handling when using queries parameter."""
+        mock_client = MagicMock()
+        mock_client.get_metric_data.side_effect = Exception('AWS API Error')
+        ctx.error = AsyncMock()
+
+        with patch(
+            'awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.get_aws_client',
+            return_value=mock_client,
+        ):
+            queries = [
+                MetricDataQueryInput(
+                    id='m1',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/EC2',
+                        metric_name='CPUUtilization',
+                        dimensions=[Dimension(name='InstanceId', value='i-1234567890abcdef0')],
+                        statistic='Average',
+                    ),
+                )
+            ]
+
+            with pytest.raises(Exception):
+                await cloudwatch_metrics_tools.get_metric_data(
+                    ctx,
+                    start_time='2026-04-05T15:00:00Z',
+                    end_time='2026-04-05T16:00:00Z',
+                    queries=queries,
+                )
+
+            ctx.error.assert_called_once()
+            assert 'AWS API Error' in ctx.error.call_args[0][0]
+
+    async def test_get_metric_data_requires_namespace_without_queries(
+        self, ctx, cloudwatch_metrics_tools
+    ):
+        """Test that namespace and metric_name are required when queries is not provided."""
+        with pytest.raises(ValueError) as excinfo:
+            await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                start_time='2026-04-05T15:00:00Z',
+                end_time='2026-04-05T16:00:00Z',
+            )
+
+        assert 'namespace and metric_name are required' in str(excinfo.value)
+
+    async def test_get_metric_data_queries_pagination(self, ctx, cloudwatch_metrics_tools):
+        """Test that _execute_queries_batch paginates through NextToken responses.
+
+        CloudWatch GetMetricData returns a NextToken when results exceed ~100,800
+        datapoints or 500 queries. The batch-queries path is particularly exposed
+        because it can request many metrics at once — without pagination handling,
+        results would be silently truncated.
+
+        This test also verifies:
+        - The "new Id appears only on later page" branch: page 2 carries an extra
+          result (``m2``) that wasn't on page 1, ensuring that the paginator
+          appends unseen Ids rather than only merging known ones.
+        - The ``start_time`` default: when omitted, it resolves to 3 hours before
+          ``end_time`` (exercised by pinning ``end_time`` and asserting ``StartTime``
+          on the AWS call).
+        """
+        mock_client = MagicMock()
+        # Page 1: m1 with 2 datapoints + NextToken
+        # Page 2: m1 with 2 more datapoints (merge case) + m2 as a NEW Id (append case)
+        mock_client.get_metric_data.side_effect = [
+            {
+                'MetricDataResults': [
+                    {
+                        'Id': 'm1',
+                        'Label': 'CPUUtilization',
+                        'StatusCode': 'Complete',
+                        'Timestamps': [
+                            datetime(2026, 4, 5, 10, 0, 0),
+                            datetime(2026, 4, 5, 10, 1, 0),
+                        ],
+                        'Values': [10.0, 20.0],
+                    }
+                ],
+                'NextToken': 'page2-token',
+            },
+            {
+                'MetricDataResults': [
+                    {
+                        'Id': 'm1',
+                        'Label': 'CPUUtilization',
+                        'StatusCode': 'Complete',
+                        'Timestamps': [
+                            datetime(2026, 4, 5, 10, 2, 0),
+                            datetime(2026, 4, 5, 10, 3, 0),
+                        ],
+                        'Values': [30.0, 40.0],
+                    },
+                    {
+                        'Id': 'm2',
+                        'Label': 'MemoryUtilization',
+                        'StatusCode': 'Complete',
+                        'Timestamps': [datetime(2026, 4, 5, 10, 3, 0)],
+                        'Values': [55.5],
+                    },
+                ],
+                # no NextToken — pagination complete
+            },
+        ]
+
+        with patch(
+            'awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.get_aws_client',
+            return_value=mock_client,
+        ):
+            queries = [
+                MetricDataQueryInput(
+                    id='m1',
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/EC2',
+                        metric_name='CPUUtilization',
+                        dimensions=[Dimension(name='InstanceId', value='i-1234567890abcdef0')],
+                        statistic='Average',
+                    ),
+                )
+            ]
+
+            result = await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                # start_time intentionally omitted — should default to 3h before end_time
+                end_time=datetime(2026, 4, 5, 11, 0, 0, tzinfo=timezone.utc),
+                queries=queries,
+            )
+
+            # Called exactly twice — once per page
+            assert mock_client.get_metric_data.call_count == 2
+
+            # start_time defaulted to 3 hours before end_time
+            pinned_end = datetime(2026, 4, 5, 11, 0, 0, tzinfo=timezone.utc)
+            first_call_kwargs = mock_client.get_metric_data.call_args_list[0].kwargs
+            assert first_call_kwargs['EndTime'] == pinned_end
+            assert first_call_kwargs['StartTime'] == pinned_end - timedelta(hours=3)
+
+            # Second call must have carried the NextToken forward
+            second_call_kwargs = mock_client.get_metric_data.call_args_list[1].kwargs
+            assert second_call_kwargs.get('NextToken') == 'page2-token'
+
+            # Merged result: two distinct results
+            assert isinstance(result, GetMetricDataResponse)
+            assert len(result.metricDataResults) == 2
+
+            # m1 — merged (4 datapoints from both pages)
+            m1 = next(r for r in result.metricDataResults if r.id == 'm1')
+            assert len(m1.datapoints) == 4
+            assert [dp.value for dp in m1.datapoints] == [10.0, 20.0, 30.0, 40.0]
+
+            # m2 — appended (only appeared on page 2)
+            m2 = next(r for r in result.metricDataResults if r.id == 'm2')
+            assert len(m2.datapoints) == 1
+            assert m2.datapoints[0].value == 55.5
+
+    async def test_get_metric_data_queries_metric_stat_period_fallback(
+        self, ctx, cloudwatch_metrics_tools
+    ):
+        """Test period precedence: when query.period is unset, metric_stat.period wins over default.
+
+        Covers the ``elif query.metric_stat and query.metric_stat.period is not None`` branch
+        of ``_convert_query_input_to_aws``.
+        """
+        mock_client = MagicMock()
+        mock_client.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'm1',
+                    'Label': 'CPUUtilization',
+                    'StatusCode': 'Complete',
+                    'Timestamps': [datetime(2026, 4, 5, 10, 0, 0)],
+                    'Values': [50.0],
+                }
+            ],
+        }
+
+        with patch(
+            'awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.get_aws_client',
+            return_value=mock_client,
+        ):
+            queries = [
+                MetricDataQueryInput(
+                    id='m1',
+                    # No period here — forcing fallback to metric_stat.period
+                    metric_stat=MetricStatInput(
+                        namespace='AWS/EC2',
+                        metric_name='CPUUtilization',
+                        dimensions=[Dimension(name='InstanceId', value='i-abc')],
+                        statistic='Average',
+                        period=300,  # 5-minute period — should end up in the AWS call
+                    ),
+                )
+            ]
+
+            await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                start_time='2026-04-05T10:00:00Z',
+                end_time='2026-04-05T11:00:00Z',
+                queries=queries,
+            )
+
+            # The AWS MetricStat must carry Period=300 (from metric_stat), not the default
+            aws_query = mock_client.get_metric_data.call_args.kwargs['MetricDataQueries'][0]
+            assert aws_query['MetricStat']['Period'] == 300

--- a/src/cloudwatch-mcp-server/uv.lock
+++ b/src/cloudwatch-mcp-server/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-mcp-server"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

This PR extends the existing `get_metric_data` tool in the CloudWatch MCP server with an optional `queries` parameter, enabling advanced metric retrieval patterns that were previously unavailable. This supersedes the closed #2166 per reviewer guidance from @goranmod — the functionality is now folded into the existing tool rather than introduced as a new one.

### Changes

**Extended Tool** (`tools.py`):
* `get_metric_data`: added an optional `queries: List[MetricDataQueryInput]` parameter. When provided, the tool delegates to a new private `_execute_queries_batch` helper that supports:
  * **Percentile statistics** (p50, p90, p95, p99...) — essential for latency analysis
  * **Multi-metric queries** — retrieve multiple metrics in a single API call
  * **Math expressions** — calculate derived metrics (error rates, ratios, aggregations). Math expressions were already partially available via Metrics Insights in `get_metric_data`; `queries` exposes the standard GetMetricData math-expression path.
  * **Metrics Insights queries** — advanced filtering and aggregation

Backward compatible — existing callers are unaffected because `namespace`, `metric_name`, `statistic`, and the Metrics Insights parameters remain the primary inputs, and `queries` defaults to `None`.

**Added Models** (`models.py`):
* `MetricStatInput`: input model for the MetricStat portion of a query
* `MetricDataQueryInput`: query input model with Pydantic `@model_validator` ensuring mutually exclusive `metric_stat` and `expression` parameters

**Tests**:
* 7 new test cases covering:
  * Single and multiple metric queries via the `queries` parameter
  * Percentile statistics (p50, p90, p99)
  * Math expressions with intermediate metrics (`return_data=False`)
  * Input validation (both XOR error cases)
  * Error handling

### User experience

**Before:**
* Users could only retrieve basic CloudWatch statistics (Average, Sum, Maximum, Minimum, SampleCount) via `get_metric_data`
* No way to get percentile statistics (p50, p90, p99) — **critical for latency analysis**
* Required multiple API calls to retrieve related metrics

**After:**
* Users can query percentile statistics for comprehensive latency analysis through the same `get_metric_data` tool they already use
* Users can retrieve multiple related metrics in a single call, reducing API overhead
* Full access to AWS GetMetricData API capabilities, exposed additively — no new tool surface, no breaking changes

**Example Use Case:**

```python
# Monitor Lambda function latency across percentiles via the same tool
queries = [
    MetricDataQueryInput(id="p50", metric_stat=MetricStatInput(..., statistic="p50")),
    MetricDataQueryInput(id="p90", metric_stat=MetricStatInput(..., statistic="p90")),
    MetricDataQueryInput(id="p99", metric_stat=MetricStatInput(..., statistic="p99")),
]
result = await get_metric_data(ctx, start_time=..., queries=queries)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (507 tests passing locally, incl. 8 new)
* [x] Changes are documented

Is this a breaking change? **No.**

**RFC issue number**: N/A (enhancement, not breaking change)

Supersedes #2166.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
