### PR TITLE
 feat(amazon-keyspaces-mcp-server): add SSL support and configurable …

### DIFF
--- a/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/client.py
+++ b/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/client.py
@@ -92,14 +92,36 @@ class UnifiedCassandraClient:
 
         logger.info('Using password authentication with Apache Cassandra ...')
 
-        cluster = Cluster(
-            contact_points=[self.database_config.cassandra_contact_points],
-            port=self.database_config.cassandra_port,
-            auth_provider=auth_provider,
-            protocol_version=4,  # Use protocol version 4 for better compatibility
-            control_connection_timeout=CONTROL_CONNECTION_TIMEOUT,
-            connect_timeout=int(CONNECTION_TIMEOUT),
-        )
+        cluster_kwargs: Dict[str, Any] = {
+            'contact_points': [self.database_config.cassandra_contact_points],
+            'port': self.database_config.cassandra_port,
+            'auth_provider': auth_provider,
+            'protocol_version': self.database_config.cassandra_protocol_version,
+            'control_connection_timeout': CONTROL_CONNECTION_TIMEOUT,
+            'connect_timeout': int(CONNECTION_TIMEOUT),
+        }
+
+        if self.database_config.use_ssl:
+            ssl_context = ssl.create_default_context()
+            cert_path = self.database_config.ssl_cert_path
+            if cert_path:
+                try:
+                    ssl_context.load_verify_locations(cafile=cert_path)
+                    logger.info(f'Loaded SSL certificate from {cert_path}')
+                except Exception as e:
+                    logger.warning(f'Failed to load SSL certificate from {cert_path}: {e}')
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
+            if HAS_SSL_OPTIONS:
+                ssl_options = SSLOptions(ssl_context=ssl_context)
+                cluster_kwargs['ssl_options'] = ssl_options
+            else:
+                cluster_kwargs['ssl_context'] = ssl_context
+
+            logger.info('SSL enabled for Cassandra connection')
+
+        cluster = Cluster(**cluster_kwargs)
 
         cluster.connection_class = AsyncoreConnection
 

--- a/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/config.py
+++ b/src/amazon-keyspaces-mcp-server/awslabs/amazon_keyspaces_mcp_server/config.py
@@ -14,7 +14,7 @@
 """Configuration module for Keyspaces MCP Server."""
 
 import os
-from .consts import CASSANDRA_DEFAULT_PORT, ENV_DIRECTORY, ENV_FILENAME
+from .consts import CASSANDRA_DEFAULT_PORT, ENV_DIRECTORY, ENV_FILENAME, PROTOCOL_VERSION
 from dataclasses import dataclass
 from dotenv import load_dotenv
 
@@ -37,6 +37,11 @@ class DatabaseConfig:
     cassandra_local_datacenter: str
     cassandra_username: str
     cassandra_password: str
+    cassandra_protocol_version: int
+
+    # SSL configuration (for plain Cassandra connections)
+    use_ssl: bool
+    ssl_cert_path: str
 
     # Keyspaces configuration
     keyspaces_endpoint: str
@@ -52,6 +57,11 @@ class DatabaseConfig:
             cassandra_local_datacenter=os.getenv('DB_CASSANDRA_LOCAL_DATACENTER', 'datacenter1'),
             cassandra_username=os.getenv('DB_CASSANDRA_USERNAME', ''),
             cassandra_password=os.getenv('DB_CASSANDRA_PASSWORD', ''),
+            cassandra_protocol_version=int(
+                os.getenv('DB_CASSANDRA_PROTOCOL_VERSION', str(PROTOCOL_VERSION))
+            ),
+            use_ssl=os.getenv('DB_USE_SSL', 'false').lower() == 'true',
+            ssl_cert_path=os.getenv('DB_SSL_CERT_PATH', ''),
             keyspaces_endpoint=os.getenv(
                 'DB_KEYSPACES_ENDPOINT', 'cassandra.us-east-1.amazonaws.com'
             ),

--- a/src/amazon-keyspaces-mcp-server/tests/test_client.py
+++ b/src/amazon-keyspaces-mcp-server/tests/test_client.py
@@ -33,6 +33,9 @@ class TestUnifiedCassandraClient(unittest.TestCase):
             cassandra_username='',
             cassandra_password='',
             cassandra_local_datacenter='datacenter1',
+            cassandra_protocol_version=4,
+            use_ssl=False,
+            ssl_cert_path='',
             keyspaces_endpoint='',
             keyspaces_region='',
         )
@@ -45,6 +48,9 @@ class TestUnifiedCassandraClient(unittest.TestCase):
             cassandra_username='',
             cassandra_password='',
             cassandra_local_datacenter='',
+            cassandra_protocol_version=4,
+            use_ssl=False,
+            ssl_cert_path='',
             keyspaces_endpoint='cassandra.us-west-2.amazonaws.com',
             keyspaces_region='us-west-2',
         )


### PR DESCRIPTION
 ## Summary

 - Add optional SSL/TLS support for plain Apache Cassandra connections, controlled by `DB_USE_SSL=true` and optional `DB_SSL_CERT_PATH` env
  vars
 - Add compatibility shim so both newer cassandra-driver (`SSLOptions`) and older driver (`ssl_context`) are supported
 - Make the Cassandra protocol version configurable via `DB_CASSANDRA_PROTOCOL_VERSION` (defaults to `4` from `PROTOCOL_VERSION` constant)
 - Update `DatabaseConfig` dataclass and existing unit test fixtures to include the new fields

 ## New environment variables

 | Variable | Default | Description |
 |---|---|---|
 | `DB_USE_SSL` | `false` | Enable SSL for plain Cassandra connections |
 | `DB_SSL_CERT_PATH` | `` | Path to a CA certificate file (optional) |
 | `DB_CASSANDRA_PROTOCOL_VERSION` | `4` | Cassandra native protocol version |

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
