### PR TITLE
refactor(aws-documentation-server): remove check for abstract from Intelligent Summaries

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -408,13 +408,11 @@ async def search_documentation(
                 text_suggestion = suggestion['textExcerptSuggestion']
                 context = None
 
-                # Use SEO abstract if available, as it is designed for this task explicitly. If that is not available,
-                # Try using Intelligent Summary Abstract, then fallback to authored summary and finally content body
+                # Use SEO abstract if available, as it is designed for this task explicitly.
+                # Fallback to authored summary and finally content body
                 metadata = text_suggestion.get('metadata', {})
                 if 'seo_abstract' in metadata:
                     context = metadata['seo_abstract']
-                elif 'abstract' in metadata:
-                    context = metadata['abstract']
                 elif 'summary' in text_suggestion:
                     context = text_suggestion['summary']
                 elif 'suggestionBody' in text_suggestion:

--- a/src/aws-documentation-mcp-server/tests/test_metadata_handling.py
+++ b/src/aws-documentation-mcp-server/tests/test_metadata_handling.py
@@ -66,8 +66,8 @@ class TestMetadataHandling:
             assert results[0].context == 'SEO optimized abstract'
 
     @pytest.mark.asyncio
-    async def test_abstract_fallback(self):
-        """Test that abstract is used when seo_abstract is not available."""
+    async def test_summary_fallback_when_no_seo_abstract(self):
+        """Test that summary is used when seo_abstract is not available."""
         ctx = MockContext()
 
         mock_response = MagicMock()
@@ -82,7 +82,6 @@ class TestMetadataHandling:
                         'summary': 'Regular summary',
                         'suggestionBody': 'Suggestion body text',
                         'metadata': {
-                            'abstract': 'Regular abstract',
                             'summary': 'Metadata summary',
                         },
                     }
@@ -98,7 +97,7 @@ class TestMetadataHandling:
             )
             results = response.search_results
             assert len(results) == 1
-            assert results[0].context == 'Regular abstract'
+            assert results[0].context == 'Regular summary'
 
     @pytest.mark.asyncio
     async def test_summary_fallback(self):
@@ -247,7 +246,7 @@ class TestMetadataHandling:
                         'link': 'https://docs.aws.amazon.com/test2',
                         'title': 'Test Page 2',
                         'summary': 'Regular summary 2',
-                        'metadata': {'abstract': 'Regular abstract 2'},
+                        'metadata': {},
                     }
                 },
                 {
@@ -278,7 +277,7 @@ class TestMetadataHandling:
             results = response.search_results
             assert len(results) == 4
             assert results[0].context == 'SEO abstract 1'
-            assert results[1].context == 'Regular abstract 2'
+            assert results[1].context == 'Regular summary 2'
             assert results[2].context == 'Regular summary 3'
             assert results[3].context == 'Suggestion body 4'
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Remove the `abstract` metadata field check from the search result context waterfall in `server_aws.py`. This field was sourced from the Intelligent Summary feature group, which is being removed from the search metadata enrichment.

The context selection waterfall now goes:
1. `metadata['seo_abstract']` (SEO-optimized abstract)
2. `text_suggestion['summary']` (authored summary)
3. `text_suggestion['suggestionBody']` (content body)

### User experience

No user-facing change. The `seo_abstract` field (step 1) is populated for the vast majority of search results and is the preferred context source. The removed `abstract` field was a fallback that is no longer populated by the search backend.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
