### PR TITLE
docs: add missing Migration & Modernization entry to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A suite of specialized MCP servers that help you get the most out of AWS, wherev
     - [🏗️ Infrastructure \& Deployment](#️-infrastructure--deployment)
       - [Container Platforms](#container-platforms)
       - [Serverless \& Functions](#serverless--functions)
+      - [Migration \& Modernization](#migration--modernization)
       - [Support](#support)
     - [🤖 AI \& Machine Learning](#-ai--machine-learning)
     - [📊 Data \& Analytics](#-data--analytics)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes missing Table of Contents entry for "Migration & Modernization" section

## Summary

### Changes

The Table of Contents in README.md is missing the "Migration & Modernization" subsection entry under "Infrastructure & Deployment". The section exists in the document body (as `#### Migration & Modernization`) but was never added to the TOC. This PR adds the missing entry in the correct position between "Serverless & Functions" and "Support".

### User experience

**Before:** Readers using the TOC to navigate cannot find or jump to the "Migration & Modernization" section. The TOC is inconsistent with the actual document structure.

**After:** The TOC accurately reflects all subsections under "Infrastructure & Deployment", and readers can click through to the Migration & Modernization section directly.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
