### PR TITLE
fix: postgres-mcp-server add host validation during connect to DB API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -973,7 +973,7 @@
         "filename": "src/postgres-mcp-server/tests/test_server_internal_functions.py",
         "hashed_secret": "43b5a7ccc96b402d0fc814b5e03f8e23c2d9d1d8",
         "is_verified": false,
-        "line_number": 123,
+        "line_number": 124,
         "is_secret": false
       }
     ],

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
@@ -21,6 +21,7 @@ from botocore.exceptions import ClientError
 from loguru import logger
 from typing import Any, Dict, List, Optional, Tuple
 
+
 DEFAULT_POSTGRES_PORT = 5432
 
 def internal_create_rds_client(region: str):

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
@@ -54,8 +54,14 @@ def internal_get_cluster_valid_endpoints(
         region: AWS region (used to fetch member instance endpoints).
 
     Returns:
-        List of (host, port) tuples. Never None; may be empty if the
-        cluster has no advertised endpoints.
+        Non-empty list of (host, port) tuples.
+
+    Raises:
+        ValueError: If no valid endpoints could be resolved. A real Aurora
+            cluster always has at least a writer endpoint with a port, so
+            an empty result indicates malformed cluster properties or a
+            transient API state; we treat it as an error rather than
+            silently accepting any caller-supplied endpoint.
     """
     endpoints: List[Tuple[str, int]] = []
 
@@ -102,6 +108,20 @@ def internal_get_cluster_valid_endpoints(
                     f"Failed to fetch endpoint for member instance '{instance_id}': "
                     f'{e.response["Error"]["Code"]} - {e.response["Error"]["Message"]}'
                 )
+
+    if not endpoints:
+        # A real Aurora cluster always advertises at least a writer endpoint
+        # with a valid port. An empty result here means either the cluster
+        # properties dict was malformed (missing/invalid Port, missing
+        # Endpoint) or every describe_db_instances call failed. Treat as an
+        # error so the caller doesn't build a connection string from caller
+        # input.
+        raise ValueError(
+            f'Cluster has no valid connection endpoints. '
+            f'Endpoint={cluster_properties.get("Endpoint")!r}, '
+            f'ReaderEndpoint={cluster_properties.get("ReaderEndpoint")!r}, '
+            f'Port={cluster_properties.get("Port")!r}'
+        )
 
     return endpoints
 

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 DEFAULT_POSTGRES_PORT = 5432
 
+
 def internal_create_rds_client(region: str):
     """Create an RDS client with custom user agent configuration."""
     return boto3.client('rds', region_name=region, config=Config(user_agent_extra=__user_agent__))
@@ -85,7 +86,9 @@ def internal_get_cluster_valid_endpoints(
             endpoints.append((custom_endpoint, cluster_port))
 
     members = cluster_properties.get('DBClusterMembers', []) or []
-    instance_ids = [m.get('DBInstanceIdentifier') for m in members if m.get('DBInstanceIdentifier')]
+    instance_ids = [
+        m.get('DBInstanceIdentifier') for m in members if m.get('DBInstanceIdentifier')
+    ]
     if instance_ids:
         rds_client = internal_create_rds_client(region=region)
         for instance_id in instance_ids:

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
@@ -19,12 +19,90 @@ from awslabs.postgres_mcp_server import __user_agent__
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from loguru import logger
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def internal_create_rds_client(region: str):
     """Create an RDS client with custom user agent configuration."""
     return boto3.client('rds', region_name=region, config=Config(user_agent_extra=__user_agent__))
+
+
+def internal_get_cluster_valid_endpoints(
+    cluster_properties: Dict[str, Any], region: str
+) -> List[Tuple[str, int]]:
+    """Return the list of valid (host, port) connection endpoints for a cluster.
+
+    A caller-supplied db_endpoint/port is considered legitimate only if it
+    matches one of the endpoints returned here. This is used to prevent
+    connection strings from pointing at arbitrary hosts (e.g. an
+    attacker-controlled FQDN / IP) that could capture DB credentials or
+    IAM auth tokens.
+
+    The returned list includes, where present:
+      - Writer endpoint (cluster.Endpoint)
+      - Reader endpoint (cluster.ReaderEndpoint)
+      - Custom endpoints (cluster.CustomEndpoints)
+      - Each member instance endpoint (from describe_db_instances)
+
+    Host comparison should be case-insensitive (DNS is case-insensitive);
+    this function returns hosts as reported by AWS without normalization.
+
+    Args:
+        cluster_properties: Cluster properties previously fetched via
+            internal_get_cluster_properties.
+        region: AWS region (used to fetch member instance endpoints).
+
+    Returns:
+        List of (host, port) tuples. Never None; may be empty if the
+        cluster has no advertised endpoints.
+    """
+    endpoints: List[Tuple[str, int]] = []
+
+    cluster_port_raw = cluster_properties.get('Port')
+    try:
+        cluster_port = int(cluster_port_raw) if cluster_port_raw is not None else 0
+    except (TypeError, ValueError):
+        cluster_port = 0
+
+    writer_endpoint = cluster_properties.get('Endpoint')
+    if writer_endpoint and cluster_port:
+        endpoints.append((writer_endpoint, cluster_port))
+
+    reader_endpoint = cluster_properties.get('ReaderEndpoint')
+    if reader_endpoint and cluster_port:
+        endpoints.append((reader_endpoint, cluster_port))
+
+    for custom_endpoint in cluster_properties.get('CustomEndpoints', []) or []:
+        if custom_endpoint and cluster_port:
+            endpoints.append((custom_endpoint, cluster_port))
+
+    members = cluster_properties.get('DBClusterMembers', []) or []
+    instance_ids = [m.get('DBInstanceIdentifier') for m in members if m.get('DBInstanceIdentifier')]
+    if instance_ids:
+        rds_client = internal_create_rds_client(region=region)
+        for instance_id in instance_ids:
+            try:
+                response = rds_client.describe_db_instances(DBInstanceIdentifier=instance_id)
+                for instance in response.get('DBInstances', []):
+                    instance_endpoint = instance.get('Endpoint', {})
+                    host = instance_endpoint.get('Address')
+                    port_raw = instance_endpoint.get('Port')
+                    try:
+                        port = int(port_raw) if port_raw is not None else 0
+                    except (TypeError, ValueError):
+                        port = 0
+                    if host and port:
+                        endpoints.append((host, port))
+            except ClientError as e:
+                # Don't fail the whole validation if a single instance lookup
+                # fails; log and continue. The caller still has to match one of
+                # the endpoints we successfully resolved.
+                logger.warning(
+                    f"Failed to fetch endpoint for member instance '{instance_id}': "
+                    f'{e.response["Error"]["Code"]} - {e.response["Error"]["Message"]}'
+                )
+
+    return endpoints
 
 
 def internal_get_instance_properties(target_endpoint: str, region: str) -> Dict[str, Any]:

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
@@ -21,6 +21,7 @@ from botocore.exceptions import ClientError
 from loguru import logger
 from typing import Any, Dict, List, Optional, Tuple
 
+DEFAULT_POSTGRES_PORT = 5432
 
 def internal_create_rds_client(region: str):
     """Create an RDS client with custom user agent configuration."""
@@ -62,7 +63,7 @@ def internal_get_cluster_valid_endpoints(
     try:
         cluster_port = int(cluster_port_raw) if cluster_port_raw is not None else 0
     except (TypeError, ValueError):
-        cluster_port = 0
+        cluster_port = DEFAULT_POSTGRES_PORT
 
     writer_endpoint = cluster_properties.get('Endpoint')
     if writer_endpoint and cluster_port:

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -21,13 +21,13 @@ import sys
 import threading
 from awslabs.postgres_mcp_server.connection.abstract_db_connection import AbstractDBConnection
 from awslabs.postgres_mcp_server.connection.cp_api_connection import (
+    DEFAULT_POSTGRES_PORT,
     internal_create_express_cluster,
     internal_create_serverless_cluster,
     internal_get_cluster_properties,
     internal_get_cluster_valid_endpoints,
     internal_get_instance_properties,
     setup_aurora_iam_policy_for_current_user,
-    DEFAULT_POSTGRES_PORT
 )
 from awslabs.postgres_mcp_server.connection.db_connection_map import (
     ConnectionMethod,

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -27,6 +27,7 @@ from awslabs.postgres_mcp_server.connection.cp_api_connection import (
     internal_get_cluster_valid_endpoints,
     internal_get_instance_properties,
     setup_aurora_iam_policy_for_current_user,
+    DEFAULT_POSTGRES_PORT
 )
 from awslabs.postgres_mcp_server.connection.db_connection_map import (
     ConnectionMethod,
@@ -671,7 +672,7 @@ def internal_create_connection(
         try:
             cluster_port = int(cluster_properties.get('Port') or 0)
         except (TypeError, ValueError):
-            cluster_port = 0
+            cluster_port = DEFAULT_POSTGRES_PORT
 
         if not db_endpoint:
             # No endpoint supplied: default to the cluster's writer endpoint/port
@@ -723,7 +724,7 @@ def internal_create_connection(
         try:
             resolved_port = int(instance_endpoint.get('Port') or 0)
         except (TypeError, ValueError):
-            resolved_port = 0
+            resolved_port = DEFAULT_POSTGRES_PORT
         if resolved_host:
             db_endpoint = resolved_host
         if resolved_port:

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -24,6 +24,7 @@ from awslabs.postgres_mcp_server.connection.cp_api_connection import (
     internal_create_express_cluster,
     internal_create_serverless_cluster,
     internal_get_cluster_properties,
+    internal_get_cluster_valid_endpoints,
     internal_get_instance_properties,
     setup_aurora_iam_policy_for_current_user,
 )
@@ -666,16 +667,67 @@ def internal_create_connection(
         cluster_arn = cluster_properties.get('DBClusterArn', '')
         secret_arn = cluster_properties.get('MasterUserSecret', {}).get('SecretArn')
 
+        cluster_writer_endpoint = cluster_properties.get('Endpoint', '')
+        try:
+            cluster_port = int(cluster_properties.get('Port') or 0)
+        except (TypeError, ValueError):
+            cluster_port = 0
+
         if not db_endpoint:
-            # if db_endpoint not set, we will use cluster's endpoint
-            db_endpoint = cluster_properties.get('Endpoint', '')
-            port = int(cluster_properties.get('Port', ''))
+            # No endpoint supplied: default to the cluster's writer endpoint/port
+            # sourced directly from AWS. Caller never influences the host string.
+            db_endpoint = cluster_writer_endpoint
+            port = cluster_port
+        else:
+            # Endpoint supplied: validate (host, port) against the cluster's
+            # advertised endpoints (writer, reader, custom, members). If the
+            # caller-supplied pair does not match any legitimate endpoint,
+            # refuse the connection — this prevents directing credentials or
+            # IAM auth tokens at an attacker-controlled host.
+            #
+            # On match, we overwrite the local db_endpoint/port with the
+            # AWS-sourced strings so the connection string is never built
+            # from caller input.
+            valid_endpoints = internal_get_cluster_valid_endpoints(
+                cluster_properties=cluster_properties, region=region
+            )
+
+            requested_host = db_endpoint.strip().lower()
+            matched: Optional[Tuple[str, int]] = None
+            for valid_host, valid_port in valid_endpoints:
+                if valid_host.lower() == requested_host and valid_port == port:
+                    matched = (valid_host, valid_port)
+                    break
+
+            if matched is None:
+                valid_repr = ', '.join(f'{h}:{p}' for h, p in valid_endpoints) or '<none>'
+                err = (
+                    f"db_endpoint '{db_endpoint}:{port}' does not match any endpoint of "
+                    f"cluster '{cluster_identifier}'. Valid endpoints: {valid_repr}"
+                )
+                logger.error(err)
+                raise ValueError(err)
+
+            db_endpoint, port = matched
     else:
-        # Must be RPG instance only deployment case (i.e. without cluster)
+        # Must be RPG instance only deployment case (i.e. without cluster).
+        # internal_get_instance_properties already verifies that the supplied
+        # endpoint matches an actual RDS instance endpoint in the account.
+        # We still overwrite db_endpoint/port with the AWS-sourced values so
+        # the connection string never comes from the caller-supplied string.
         instance_properties = internal_get_instance_properties(db_endpoint, region)
         masteruser = instance_properties.get('MasterUsername', '')
         secret_arn = instance_properties.get('MasterUserSecret', {}).get('SecretArn')
-        port = int(instance_properties.get('Endpoint', {}).get('Port'))
+        instance_endpoint = instance_properties.get('Endpoint', {}) or {}
+        resolved_host = instance_endpoint.get('Address', '')
+        try:
+            resolved_port = int(instance_endpoint.get('Port') or 0)
+        except (TypeError, ValueError):
+            resolved_port = 0
+        if resolved_host:
+            db_endpoint = resolved_host
+        if resolved_port:
+            port = resolved_port
 
     logger.info(
         f'About to create internal DB connections with:'

--- a/src/postgres-mcp-server/tests/e2e/e2e_integration_test.py
+++ b/src/postgres-mcp-server/tests/e2e/e2e_integration_test.py
@@ -31,6 +31,7 @@ from awslabs.postgres_mcp_server.server import (
     get_database_connection_info,
     get_job_status,
     get_table_schema,
+    internal_create_connection,
     is_database_connected,
     run_query,
 )
@@ -366,6 +367,118 @@ async def run_test_suite(config: ClusterConfig, table_suffix: str) -> TestResult
     return result
 
 
+def run_endpoint_validation_suite(
+    cluster_identifier: str,
+    region: str,
+    database: str,
+    valid_endpoint: str,
+    port: int,
+) -> TestResult:
+    """Test the endpoint-validation security check in internal_create_connection.
+
+    Positive case: caller-supplied db_endpoint matches the cluster's writer
+    endpoint → connection succeeds, resolved endpoint in the response matches
+    what AWS reports for the cluster.
+
+    Negative case: caller-supplied db_endpoint is an arbitrary host that is
+    not owned by the cluster → internal_create_connection must raise
+    ValueError and no connection is created.
+
+    The DB connection created here is cached in server.db_connection_map and
+    reused by the main test suite that follows, so these checks don't add
+    extra cluster warm-up cost.
+    """
+    result = TestResult(
+        cluster_identifier=cluster_identifier,
+        connection_method_name='endpoint_validation',
+        passed=[],
+        failed=[],
+    )
+
+    logger.info(f'\n{"=" * 60}')
+    logger.info(f'Running endpoint validation suite on cluster: {cluster_identifier}')
+    logger.info(f'{"=" * 60}')
+
+    def record(step, ok, detail=''):
+        """Record a test step result as passed or failed."""
+        log_step(step, 'PASS' if ok else 'FAIL', detail)
+        if ok:
+            result.passed.append(step)
+        else:
+            result.failed.append((step, detail))
+
+    # Positive case — db_endpoint matches the cluster's writer endpoint.
+    step = 'endpoint_validation_positive(writer endpoint accepted)'
+    try:
+        db_conn, llm_response = internal_create_connection(
+            region=region,
+            database_type=DatabaseType.APG,
+            connection_method=ConnectionMethod.RDS_API,
+            cluster_identifier=cluster_identifier,
+            db_endpoint=valid_endpoint,
+            port=port,
+            database=database,
+        )
+        resp_dict = json.loads(llm_response)
+        # The response echoes the resolved (AWS-sourced) endpoint/port. For the
+        # writer endpoint we just passed, host should match case-insensitively
+        # and port should round-trip.
+        host_ok = resp_dict.get('db_endpoint', '').lower() == valid_endpoint.lower()
+        port_ok = int(resp_dict.get('port') or 0) == port
+        ok = db_conn is not None and host_ok and port_ok
+        record(
+            step,
+            ok,
+            f'resolved={resp_dict.get("db_endpoint")}:{resp_dict.get("port")}',
+        )
+    except Exception as e:
+        record(step, False, str(e))
+
+    # Negative case — arbitrary host that does not belong to the cluster.
+    step = 'endpoint_validation_negative(bogus endpoint rejected)'
+    bogus_endpoint = 'attacker.example.com'
+    try:
+        internal_create_connection(
+            region=region,
+            database_type=DatabaseType.APG,
+            connection_method=ConnectionMethod.RDS_API,
+            cluster_identifier=cluster_identifier,
+            db_endpoint=bogus_endpoint,
+            port=port,
+            database=database,
+        )
+        record(step, False, f'Expected ValueError for endpoint {bogus_endpoint}, got success')
+    except ValueError as e:
+        msg = str(e)
+        ok = bogus_endpoint in msg and cluster_identifier in msg
+        record(step, ok, msg)
+    except Exception as e:
+        record(step, False, f'Expected ValueError, got {type(e).__name__}: {e}')
+
+    # Negative case — valid host with a wrong port.
+    step = 'endpoint_validation_negative(wrong port rejected)'
+    wrong_port = port + 1
+    try:
+        internal_create_connection(
+            region=region,
+            database_type=DatabaseType.APG,
+            connection_method=ConnectionMethod.RDS_API,
+            cluster_identifier=cluster_identifier,
+            db_endpoint=valid_endpoint,
+            port=wrong_port,
+            database=database,
+        )
+        record(step, False, f'Expected ValueError for port {wrong_port}, got success')
+    except ValueError as e:
+        msg = str(e)
+        ok = str(wrong_port) in msg and cluster_identifier in msg
+        record(step, ok, msg)
+    except Exception as e:
+        record(step, False, f'Expected ValueError, got {type(e).__name__}: {e}')
+
+    return result
+
+
 def print_summary(results: list[TestResult]):
     """Print a formatted summary of all test results. Returns True if all passed."""
     logger.info(f'\n{"=" * 60}')
@@ -431,6 +544,20 @@ async def main_async(args):
             engine_version=args.engine_version,
         )
         clusters_to_delete.append(serverless_id)
+
+        # Phase 2a: Endpoint validation (positive + negative). Runs before the
+        # main suite so the db_connection_map starts clean for this cluster
+        # and we genuinely exercise the validation path rather than the
+        # existing-connection short-circuit.
+        results.append(
+            run_endpoint_validation_suite(
+                cluster_identifier=serverless_id,
+                region=args.region,
+                database=args.database,
+                valid_endpoint=serverless_endpoint,
+                port=args.port,
+            )
+        )
 
         connection_methods = [
             (ConnectionMethod.RDS_API, 'RDS_API'),

--- a/src/postgres-mcp-server/tests/test_cp_api_connection.py
+++ b/src/postgres-mcp-server/tests/test_cp_api_connection.py
@@ -7,6 +7,7 @@ from awslabs.postgres_mcp_server.connection.cp_api_connection import (
     internal_create_serverless_cluster,
     internal_delete_cluster,
     internal_get_cluster_properties,
+    internal_get_cluster_valid_endpoints,
 )
 from botocore.exceptions import ClientError, WaiterError
 from typing import Dict, List, Optional
@@ -1291,3 +1292,267 @@ class TestInternalDeleteCluster:
 
         mock_rds.delete_db_instance.assert_not_called()
         mock_rds.delete_db_cluster.assert_called_once()
+
+
+# =============================================================================
+# TESTS FOR: internal_get_cluster_valid_endpoints
+# =============================================================================
+
+
+class TestInternalGetClusterValidEndpoints:
+    """Tests for internal_get_cluster_valid_endpoints function.
+
+    Covers cluster-level dict parsing (writer, reader, custom endpoints, port
+    parsing) and the member-instance lookup branch that queries
+    describe_db_instances. Tests that don't exercise the member-instance
+    branch don't need to patch the RDS client because the function only
+    reaches AWS when DBClusterMembers contains an identifier.
+    """
+
+    def test_writer_and_reader_endpoints_included(self):
+        """Writer and reader endpoints are both returned with the cluster port."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'ReaderEndpoint': 'cluster.reader.rds.amazonaws.com',
+            'Port': 5432,
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert ('cluster.writer.rds.amazonaws.com', 5432) in result
+        assert ('cluster.reader.rds.amazonaws.com', 5432) in result
+        assert len(result) == 2
+
+    def test_custom_endpoints_included(self):
+        """Custom endpoints are included alongside writer/reader."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'ReaderEndpoint': 'cluster.reader.rds.amazonaws.com',
+            'CustomEndpoints': [
+                'cluster.custom-a.rds.amazonaws.com',
+                'cluster.custom-b.rds.amazonaws.com',
+            ],
+            'Port': 5432,
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert ('cluster.custom-a.rds.amazonaws.com', 5432) in result
+        assert ('cluster.custom-b.rds.amazonaws.com', 5432) in result
+        assert len(result) == 4
+
+    def test_custom_endpoints_none_is_treated_as_empty(self):
+        """Explicit CustomEndpoints=None does not crash and yields no custom entries."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'ReaderEndpoint': 'cluster.reader.rds.amazonaws.com',
+            'CustomEndpoints': None,
+            'Port': 5432,
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert len(result) == 2
+
+    def test_custom_endpoints_empty_list_yields_no_extras(self):
+        """An empty CustomEndpoints list contributes nothing."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'ReaderEndpoint': 'cluster.reader.rds.amazonaws.com',
+            'CustomEndpoints': [],
+            'Port': 5432,
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert len(result) == 2
+
+    def test_port_as_string_parses(self):
+        """Port returned as a string (as the RDS API sometimes does) is parsed as int."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': '5432',
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert ('cluster.writer.rds.amazonaws.com', 5432) in result
+
+    def test_missing_port_raises_value_error(self):
+        """Missing Port suppresses all cluster-level endpoints, yielding an empty list → ValueError."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'ReaderEndpoint': 'cluster.reader.rds.amazonaws.com',
+        }
+
+        with pytest.raises(ValueError, match='no valid connection endpoints'):
+            internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+    def test_invalid_port_string_falls_back_to_default(self):
+        """Unparseable Port falls back to DEFAULT_POSTGRES_PORT (5432)."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': 'not-a-number',
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert ('cluster.writer.rds.amazonaws.com', 5432) in result
+
+    def test_empty_cluster_properties_raises_value_error(self):
+        """Empty cluster properties yield no endpoints and must raise ValueError."""
+        with pytest.raises(ValueError, match='no valid connection endpoints'):
+            internal_get_cluster_valid_endpoints({}, 'us-east-1')
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_members_included_when_describe_succeeds(self, mock_create_client):
+        """Each member instance's endpoint is included in the valid list."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+        mock_rds.describe_db_instances.side_effect = [
+            {
+                'DBInstances': [
+                    {
+                        'Endpoint': {
+                            'Address': 'instance-1.abc.us-east-1.rds.amazonaws.com',
+                            'Port': 5432,
+                        }
+                    }
+                ]
+            },
+            {
+                'DBInstances': [
+                    {
+                        'Endpoint': {
+                            'Address': 'instance-2.abc.us-east-1.rds.amazonaws.com',
+                            'Port': 5432,
+                        }
+                    }
+                ]
+            },
+        ]
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': 5432,
+            'DBClusterMembers': [
+                {'DBInstanceIdentifier': 'instance-1'},
+                {'DBInstanceIdentifier': 'instance-2'},
+            ],
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert ('instance-1.abc.us-east-1.rds.amazonaws.com', 5432) in result
+        assert ('instance-2.abc.us-east-1.rds.amazonaws.com', 5432) in result
+        assert mock_rds.describe_db_instances.call_count == 2
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_member_clienterror_is_logged_and_skipped(self, mock_create_client):
+        """ClientError on one member does not abort processing of others."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+        mock_rds.describe_db_instances.side_effect = [
+            ClientError(
+                {'Error': {'Code': 'AccessDenied', 'Message': 'denied'}},
+                'DescribeDBInstances',
+            ),
+            {
+                'DBInstances': [
+                    {
+                        'Endpoint': {
+                            'Address': 'instance-2.abc.us-east-1.rds.amazonaws.com',
+                            'Port': 5432,
+                        }
+                    }
+                ]
+            },
+        ]
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': 5432,
+            'DBClusterMembers': [
+                {'DBInstanceIdentifier': 'instance-1'},
+                {'DBInstanceIdentifier': 'instance-2'},
+            ],
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        # Writer endpoint is still there, and the second member's endpoint
+        # is present even though the first member's lookup failed.
+        assert ('cluster.writer.rds.amazonaws.com', 5432) in result
+        assert ('instance-2.abc.us-east-1.rds.amazonaws.com', 5432) in result
+        assert mock_rds.describe_db_instances.call_count == 2
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_member_missing_endpoint_fields_skipped(self, mock_create_client):
+        """Member instance responses missing Address or Port are skipped."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+        mock_rds.describe_db_instances.side_effect = [
+            # No Endpoint at all
+            {'DBInstances': [{}]},
+            # Endpoint with no Address
+            {'DBInstances': [{'Endpoint': {'Port': 5432}}]},
+            # Endpoint with Address but no Port
+            {
+                'DBInstances': [
+                    {'Endpoint': {'Address': 'instance-3.abc.us-east-1.rds.amazonaws.com'}}
+                ]
+            },
+        ]
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': 5432,
+            'DBClusterMembers': [
+                {'DBInstanceIdentifier': 'instance-1'},
+                {'DBInstanceIdentifier': 'instance-2'},
+                {'DBInstanceIdentifier': 'instance-3'},
+            ],
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        # Writer endpoint is still present, but none of the malformed members
+        # contributed entries.
+        assert result == [('cluster.writer.rds.amazonaws.com', 5432)]
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_member_invalid_port_string_skipped(self, mock_create_client):
+        """A member instance with an unparseable Port string is skipped."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+        mock_rds.describe_db_instances.return_value = {
+            'DBInstances': [
+                {
+                    'Endpoint': {
+                        'Address': 'instance-1.abc.us-east-1.rds.amazonaws.com',
+                        'Port': 'not-a-number',
+                    }
+                }
+            ]
+        }
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': 5432,
+            'DBClusterMembers': [{'DBInstanceIdentifier': 'instance-1'}],
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        # Writer endpoint is the only survivor; the member's bad port was rejected.
+        assert result == [('cluster.writer.rds.amazonaws.com', 5432)]
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_members_without_identifier_are_skipped(self, mock_create_client):
+        """DBClusterMembers entries lacking DBInstanceIdentifier trigger no API call."""
+        cluster_properties = {
+            'Endpoint': 'cluster.writer.rds.amazonaws.com',
+            'Port': 5432,
+            'DBClusterMembers': [{}, {'SomeOtherField': 'x'}],
+        }
+
+        result = internal_get_cluster_valid_endpoints(cluster_properties, 'us-east-1')
+
+        assert ('cluster.writer.rds.amazonaws.com', 5432) in result
+        mock_create_client.assert_not_called()

--- a/src/postgres-mcp-server/tests/test_server_internal_functions.py
+++ b/src/postgres-mcp-server/tests/test_server_internal_functions.py
@@ -17,6 +17,7 @@ import json
 import pytest
 from awslabs.postgres_mcp_server.connection.db_connection_map import ConnectionMethod, DatabaseType
 from awslabs.postgres_mcp_server.server import (
+    DEFAULT_POSTGRES_PORT,
     MAX_IDENTIFIER_BYTES,
     _parse_identifier_parts,
     create_cluster_worker,
@@ -278,6 +279,253 @@ class TestInternalCreateConnection:
             response_dict = json.loads(response)
             assert response_dict['db_endpoint'] == 'cluster.endpoint.com'
             assert response_dict['port'] == 5432
+
+    def test_rejects_endpoint_not_in_cluster(self):
+        """Caller-supplied endpoint that doesn't match any cluster endpoint raises ValueError."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_cluster_properties'
+            ) as mock_props,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'HttpEndpointEnabled': False,
+                'MasterUsername': 'postgres',
+                'DBClusterArn': 'arn:aws:rds:us-east-1:123456789012:cluster:test',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': 'legitimate.endpoint.com',
+                'ReaderEndpoint': 'legitimate.reader.endpoint.com',
+                'Port': 5432,
+            }
+
+            with pytest.raises(ValueError) as exc_info:
+                internal_create_connection(
+                    region='us-east-1',
+                    database_type=DatabaseType.APG,
+                    connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                    cluster_identifier='test-cluster',
+                    db_endpoint='attacker.example.com',
+                    port=5432,
+                    database='testdb',
+                )
+
+            msg = str(exc_info.value)
+            assert 'attacker.example.com' in msg
+            assert 'test-cluster' in msg
+            # Error message should list the legitimate endpoints so the caller
+            # knows which hosts are acceptable.
+            assert 'legitimate.endpoint.com' in msg
+
+    def test_rejects_endpoint_with_wrong_port(self):
+        """Caller supplies correct host but wrong port → ValueError."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_cluster_properties'
+            ) as mock_props,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'HttpEndpointEnabled': False,
+                'MasterUsername': 'postgres',
+                'DBClusterArn': 'arn:aws:rds:us-east-1:123456789012:cluster:test',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': 'test.endpoint.com',
+                'Port': 5432,
+            }
+
+            with pytest.raises(ValueError, match='does not match any endpoint'):
+                internal_create_connection(
+                    region='us-east-1',
+                    database_type=DatabaseType.APG,
+                    connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                    cluster_identifier='test-cluster',
+                    db_endpoint='test.endpoint.com',
+                    port=9999,
+                    database='testdb',
+                )
+
+    def test_endpoint_match_is_case_insensitive(self):
+        """Hostname comparison against cluster endpoints is case-insensitive (DNS is)."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_cluster_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'HttpEndpointEnabled': False,
+                'MasterUsername': 'postgres',
+                'DBClusterArn': 'arn:aws:rds:us-east-1:123456789012:cluster:test',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': 'test.endpoint.com',
+                'Port': 5432,
+            }
+            mock_pg_conn.return_value = MagicMock()
+
+            conn, response = internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.APG,
+                connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                cluster_identifier='test-cluster',
+                # Mixed-case host should still validate against the lowercase
+                # cluster endpoint.
+                db_endpoint='TEST.Endpoint.COM',
+                port=5432,
+                database='testdb',
+            )
+
+            # The resolved (AWS-sourced) host is what's returned and what the
+            # underlying connection pool is built with — never the caller's
+            # mixed-case input.
+            response_dict = json.loads(response)
+            assert response_dict['db_endpoint'] == 'test.endpoint.com'
+            call_kwargs = mock_pg_conn.call_args[1]
+            assert call_kwargs['host'] == 'test.endpoint.com'
+
+    def test_caller_endpoint_string_is_never_used_for_connection(self):
+        """On successful match, the connection is built from the AWS-sourced host string."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_cluster_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+        ):
+            mock_map.get.return_value = None
+            # Note: writer endpoint intentionally has different capitalization
+            # than the caller will supply, proving we don't echo caller input
+            # back into the connection string.
+            mock_props.return_value = {
+                'HttpEndpointEnabled': False,
+                'MasterUsername': 'postgres',
+                'DBClusterArn': 'arn:aws:rds:us-east-1:123456789012:cluster:test',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': 'canonical.endpoint.com',
+                'Port': 5432,
+            }
+            mock_pg_conn.return_value = MagicMock()
+
+            internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.APG,
+                connection_method=ConnectionMethod.PG_WIRE_IAM_PROTOCOL,
+                cluster_identifier='test-cluster',
+                db_endpoint='  Canonical.Endpoint.COM  ',  # extra whitespace + mixed case
+                port=5432,
+                database='testdb',
+            )
+
+            call_kwargs = mock_pg_conn.call_args[1]
+            assert call_kwargs['host'] == 'canonical.endpoint.com'
+
+    def test_cluster_invalid_port_falls_back_to_default(self):
+        """Unparseable cluster Port falls back to DEFAULT_POSTGRES_PORT."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_cluster_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.RDSDataAPIConnection') as mock_rds_conn,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'HttpEndpointEnabled': True,
+                'MasterUsername': 'postgres',
+                'DBClusterArn': 'arn:aws:rds:us-east-1:123456789012:cluster:test',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': 'cluster.endpoint.com',
+                'Port': 'not-a-number',
+            }
+            mock_rds_conn.return_value = MagicMock()
+
+            conn, response = internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.APG,
+                connection_method=ConnectionMethod.RDS_API,
+                cluster_identifier='test-cluster',
+                db_endpoint='',  # Take the cluster-default path
+                port=0,
+                database='testdb',
+            )
+
+            response_dict = json.loads(response)
+            # Port round-trips through the default fallback rather than crashing.
+            assert response_dict['port'] == DEFAULT_POSTGRES_PORT
+
+    def test_rpg_instance_uses_aws_sourced_host(self):
+        """RPG instance path: db_endpoint passed to connection comes from AWS, not the caller."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_instance_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'MasterUsername': 'postgres',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': {
+                    'Address': 'resolved.instance.endpoint.com',
+                    'Port': 5432,
+                },
+            }
+            mock_pg_conn.return_value = MagicMock()
+
+            internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.RPG,
+                connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                cluster_identifier='',
+                db_endpoint='caller.supplied.endpoint.com',
+                port=5432,
+                database='testdb',
+            )
+
+            # internal_get_instance_properties is the gatekeeper for RPG
+            # instances — it already rejects arbitrary endpoints. Once it
+            # returns, we rebuild the connection string from its Address so
+            # the caller's input never reaches the connection pool.
+            call_kwargs = mock_pg_conn.call_args[1]
+            assert call_kwargs['host'] == 'resolved.instance.endpoint.com'
+            assert call_kwargs['port'] == 5432
+
+    def test_rpg_instance_invalid_port_falls_back_to_default(self):
+        """Unparseable instance Port falls back to DEFAULT_POSTGRES_PORT."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_instance_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'MasterUsername': 'postgres',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': {
+                    'Address': 'resolved.instance.endpoint.com',
+                    'Port': 'not-a-number',
+                },
+            }
+            mock_pg_conn.return_value = MagicMock()
+
+            internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.RPG,
+                connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                cluster_identifier='',
+                db_endpoint='caller.supplied.endpoint.com',
+                port=5432,
+                database='testdb',
+            )
+
+            call_kwargs = mock_pg_conn.call_args[1]
+            assert call_kwargs['port'] == DEFAULT_POSTGRES_PORT
 
 
 class TestCreateClusterWorker:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Add host validation during DB connection API

### User experience

If the host parameter specified by MCP user doesn't match the cluster/instance configuration, it will be rejected.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ x] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
