### PR TITLE
feat: auth conflict detection and structured recovery

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/config_store.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/config_store.py
@@ -194,6 +194,14 @@ class ConfigStore:
         """Clear the current FES connection config."""
         self._config = None
 
+    def delete_persisted_config(self) -> None:
+        """Delete the persisted config file from disk and clear in-memory state."""
+        self._config = None
+        try:
+            os.remove(self._config_file)
+        except FileNotFoundError:
+            pass
+
     # ── Persistence ─────────────────────────────────────────────────────
 
     def persist_config(self) -> None:
@@ -352,8 +360,8 @@ def is_sigv4_fes_available() -> bool:
     return _sigv4_fes_available is True
 
 
-def set_sigv4_region(region: str) -> None:
-    """Store the selected SigV4 region."""
+def set_sigv4_region(region: str | None) -> None:
+    """Store the selected SigV4 region, or None to clear it."""
     global _sigv4_region
     _sigv4_region = region
 
@@ -397,6 +405,11 @@ def is_configured() -> bool:
 def clear_config() -> None:
     """Clear the current FES connection config."""
     _default_store.clear_config()
+
+
+def delete_persisted_config() -> None:
+    """Delete the persisted config file from disk and clear in-memory state."""
+    _default_store.delete_persisted_config()
 
 
 def persist_config() -> None:

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/server.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/server.py
@@ -80,6 +80,7 @@ If `get_status` shows a valid connection (any method), do NOT call `configure`.
 
 - `configure` and `get_status` always work without auth.
 - `get_status` shows which auth method is active and whether the connection is healthy.
+- `configure(authMode="reset")` clears a stale session and re-probes AWS credentials.
 - `accept_connector` requires AWS credentials (for STS + TCP calls).
 
 # Tool Selection
@@ -115,6 +116,9 @@ may still be generating.
   (1) AWS Credentials: set AWS_PROFILE + AWS_REGION in MCP client env and restart,
   (2) SSO: run `configure` with authMode "sso",
   (3) Cookie: run `configure` with authMode "cookie".
+- `AUTH_CONFLICT` → the saved session is stale but AWS credentials exist.
+  Run `configure(authMode="reset")` to clear the stale session and switch to
+  AWS credential auth. Or run `configure(authMode="sso")` to re-authenticate.
 - AWS credential errors → Set `AWS_PROFILE` in your MCP client config env
   block and restart. Use `get_status` to verify credentials are working.
 - `INSTRUCTIONS_REQUIRED` → run `load_instructions` for the job.
@@ -162,11 +166,11 @@ def _register_handlers(mcp: FastMCP) -> None:
 
 
 async def _startup() -> None:
-    """Load persisted config and probe API credential auth if needed."""
+    """Load persisted config and probe API credential auth unconditionally."""
     loaded = await load_persisted_config()
     if not loaded:
         clear_config()
-        await _probe_sigv4_transform_api()
+    await _probe_sigv4_transform_api()
 
 
 async def _probe_sigv4_transform_api() -> None:
@@ -206,6 +210,7 @@ async def _probe_sigv4_transform_api() -> None:
         set_sigv4_fes_available(True)
         logger.info('Credential probe succeeded — auto-selected region {}', regions[0])
     else:
+        set_sigv4_region(None)
         set_sigv4_regions(regions)
         set_sigv4_fes_available(True)
         logger.info(

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
@@ -180,7 +180,32 @@ def failure_result(error: Exception, hint: Optional[str] = None) -> Dict[str, An
     If *error* carries ``status_code`` and ``body`` attributes (e.g. an HttpError),
     those are included in the response.
     """
-    from awslabs.aws_transform_mcp_server.transform_api_client import ProfileSelectionRequired
+    from awslabs.aws_transform_mcp_server.transform_api_client import (
+        AuthConflict,
+        ProfileSelectionRequired,
+    )
+
+    if isinstance(error, AuthConflict):
+        return text_result(
+            {
+                'success': False,
+                'error': {
+                    'code': 'AUTH_CONFLICT',
+                    'message': (
+                        f'{error.failed_method.upper()} auth failed: {error.original_error}. '
+                        f'Alternative auth methods are available.'
+                    ),
+                    'suggestedAction': (
+                        'Run configure(authMode="reset") to clear the stale session and '
+                        'switch to AWS credential auth, or configure(authMode="sso") to '
+                        're-authenticate with IAM Identity Center.'
+                    ),
+                },
+                'failedMethod': error.failed_method,
+                'availableMethods': error.available_methods,
+            },
+            is_error=True,
+        )
 
     if isinstance(error, ProfileSelectionRequired):
         from awslabs.aws_transform_mcp_server.config_store import derive_transform_api_endpoint

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/configure.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/configure.py
@@ -23,6 +23,7 @@ from awslabs.aws_transform_mcp_server.config_store import (
     build_bearer_config,
     build_cookie_config,
     clear_config,
+    delete_persisted_config,
     derive_transform_api_endpoint,
     extract_region_from_origin,
     get_config,
@@ -54,7 +55,7 @@ from awslabs.aws_transform_mcp_server.transform_api_client import (
 from loguru import logger
 from mcp.server.fastmcp import Context
 from pydantic import BaseModel, Field
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Literal, Optional
 
 
 async def _discover_profiles(
@@ -211,12 +212,13 @@ class ConfigureHandler:
         self,
         ctx: Context,
         authMode: Annotated[
-            str,
+            Literal['cookie', 'sso', 'reset'],
             Field(
                 description=(
                     'Authentication method. '
                     '"cookie" — requires: origin, sessionCookie. '
-                    '"sso" — requires: startUrl, idcRegion. Opens a browser for login.'
+                    '"sso" — requires: startUrl, idcRegion. Opens a browser for login. '
+                    '"reset" — clears saved session and switches to AWS credential auth if available.'
                 ),
             ),
         ],
@@ -282,6 +284,47 @@ class ConfigureHandler:
 
         [CRITICAL] SSO mode opens the user's default browser. Ensure the user expects this.
         """
+        # ── Reset ───────────────────────────────────────────────────────
+        if authMode == 'reset':
+            from awslabs.aws_transform_mcp_server.server import _probe_sigv4_transform_api
+
+            delete_persisted_config()
+            await _probe_sigv4_transform_api()
+            if is_sigv4_fes_available():
+                region = get_sigv4_region()
+                return text_result(
+                    {
+                        'success': True,
+                        'message': (
+                            f'Session cleared. Switched to AWS credential auth (region: {region}).'
+                        ),
+                        'authMode': 'sigv4',
+                        'region': region,
+                    },
+                )
+            from awslabs.aws_transform_mcp_server.aws_helper import AwsHelper
+
+            session = AwsHelper.create_session()
+            has_creds = session.get_credentials() is not None
+            if has_creds:
+                message = (
+                    'Session cleared. AWS credentials were found but your account '
+                    'does not have access to the Transform API via IAM. '
+                    'Use configure(authMode="sso") to authenticate with IAM Identity Center.'
+                )
+            else:
+                message = (
+                    'Session cleared. No AWS credentials detected. '
+                    'Use configure(authMode="sso") to authenticate, or set '
+                    'AWS_PROFILE in the MCP client env block and restart.'
+                )
+            return text_result(
+                {
+                    'success': True,
+                    'message': message,
+                },
+            )
+
         # ── Cookie auth ─────────────────────────────────────────────────
         if authMode == 'cookie':
             if not sessionCookie:
@@ -747,13 +790,24 @@ class ConfigureHandler:
             }
 
         # ── AWS credential API status ──────────────────────────────────
+        if is_sigv4_fes_available():
+            sigv4_api_message = (
+                'AWS credential auth enabled — all API tools work without configure.'
+            )
+        elif status.get('sigv4', {}).get('configured'):
+            sigv4_api_message = (
+                'AWS credentials detected but your account does not have access to '
+                'the Transform API. Use configure(authMode="sso") to authenticate '
+                'with IAM Identity Center instead.'
+            )
+        else:
+            sigv4_api_message = (
+                'No AWS credentials detected. Set AWS_PROFILE in the MCP client env '
+                'block and restart, or use configure(authMode="sso") to authenticate.'
+            )
         status['sigv4AwsTransformAPI'] = {
             'available': is_sigv4_fes_available(),
-            'message': (
-                'AWS credential auth enabled — all API tools work without configure.'
-                if is_sigv4_fes_available()
-                else 'AWS credential auth not available. Use configure to connect.'
-            ),
+            'message': sigv4_api_message,
         }
 
         fes_status = status.get('connection', {})

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
@@ -58,6 +58,21 @@ class ProfileSelectionRequired(Exception):
         super().__init__('Multiple regions available. Please choose one.')
 
 
+class AuthConflict(Exception):
+    """Raised when configured auth fails but alternative auth methods are available."""
+
+    def __init__(  # noqa: D107
+        self, failed_method: str, available_methods: list[str], original_error: str
+    ) -> None:
+        self.failed_method = failed_method
+        self.available_methods = available_methods
+        self.original_error = original_error
+        super().__init__(
+            f'{failed_method} auth failed ({original_error}). '
+            f'Alternative auth available: {", ".join(available_methods)}.'
+        )
+
+
 # ── boto3 client helpers ────────────────────────────────────────────────
 
 
@@ -327,7 +342,27 @@ async def call_transform_api(
     else:
         _inject_bearer_auth(client, config.bearer_token or '', config.origin)
 
-    return await asyncio.to_thread(_call_boto3, client, operation, body)
+    try:
+        return await asyncio.to_thread(_call_boto3, client, operation, body)
+    except HttpError as exc:
+        if exc.status_code == 403 and 'Invalid request origin' in str(exc):
+            available = []
+            if config_store.is_sigv4_fes_available():
+                available.append('sigv4')
+            else:
+                try:
+                    session = AwsHelper.create_session()
+                    if session.get_credentials() is not None:
+                        available.append('sigv4')
+                except Exception:
+                    pass
+            if available:
+                raise AuthConflict(
+                    failed_method=config.auth_mode,
+                    available_methods=available,
+                    original_error=str(exc),
+                ) from exc
+        raise
 
 
 async def _ensure_fresh_token(config: 'ConnectionConfig') -> 'ConnectionConfig':

--- a/src/aws-transform-mcp-server/tests/test_auth_conflict.py
+++ b/src/aws-transform-mcp-server/tests/test_auth_conflict.py
@@ -1,0 +1,325 @@
+import pytest
+from awslabs.aws_transform_mcp_server.http_utils import HttpError
+from awslabs.aws_transform_mcp_server.transform_api_client import AuthConflict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestAuthConflict:  # noqa: D101
+    def test_exception_stores_available_methods(self):
+        exc = AuthConflict(
+            failed_method='bearer',
+            available_methods=['sigv4'],
+            original_error='HTTP 403: Invalid request origin',
+        )
+        assert exc.failed_method == 'bearer'
+        assert exc.available_methods == ['sigv4']
+        assert exc.original_error == 'HTTP 403: Invalid request origin'
+        assert 'Invalid request origin' in str(exc)
+
+
+class TestCallTransformApiAuthConflict:  # noqa: D101
+    @pytest.mark.asyncio
+    async def test_raises_auth_conflict_on_origin_403_with_sigv4_available(self):
+        """When bearer path gets 403 origin error and SigV4 is available, raise AuthConflict."""
+        mock_config = MagicMock()
+        mock_config.auth_mode = 'bearer'
+        mock_config.bearer_token = 'token'
+        mock_config.origin = 'https://tenant.transform.us-east-1.on.aws'
+        mock_config.region = 'us-east-1'
+        mock_config.token_expiry = 9999999999
+        mock_config.refresh_token = None
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.transform_api_client.config_store') as mock_cs,
+            patch('awslabs.aws_transform_mcp_server.transform_api_client._create_unsigned_client'),
+            patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client._call_boto3',
+                side_effect=HttpError(
+                    403, {'Message': 'Invalid request origin'}, 'HTTP 403: Invalid request origin'
+                ),
+            ),
+        ):
+            mock_cs.get_config.return_value = mock_config
+            mock_cs.is_sigv4_fes_available.return_value = True
+
+            from awslabs.aws_transform_mcp_server.transform_api_client import call_transform_api
+
+            with pytest.raises(AuthConflict) as exc_info:
+                await call_transform_api('ListWorkspaces', {})
+
+            assert exc_info.value.failed_method == 'bearer'
+            assert 'sigv4' in exc_info.value.available_methods
+            assert 'Invalid request origin' in exc_info.value.original_error
+
+    @pytest.mark.asyncio
+    async def test_raises_auth_conflict_when_creds_exist_but_sigv4_not_probed(self):
+        """When bearer gets 403 and sigv4 not probed but creds exist, still raise AuthConflict."""
+        mock_config = MagicMock()
+        mock_config.auth_mode = 'bearer'
+        mock_config.bearer_token = 'token'
+        mock_config.origin = 'https://tenant.transform.us-east-1.on.aws'
+        mock_config.region = 'us-east-1'
+        mock_config.token_expiry = 9999999999
+        mock_config.refresh_token = None
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.transform_api_client.config_store') as mock_cs,
+            patch('awslabs.aws_transform_mcp_server.transform_api_client._create_unsigned_client'),
+            patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client._call_boto3',
+                side_effect=HttpError(
+                    403, {'Message': 'Invalid request origin'}, 'HTTP 403: Invalid request origin'
+                ),
+            ),
+        ):
+            mock_cs.get_config.return_value = mock_config
+            mock_cs.is_sigv4_fes_available.return_value = False
+
+            mock_session = MagicMock()
+            mock_session.get_credentials.return_value = MagicMock()
+
+            with patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client.AwsHelper'
+            ) as mock_helper:
+                mock_helper.create_session.return_value = mock_session
+
+                from awslabs.aws_transform_mcp_server.transform_api_client import (
+                    call_transform_api,
+                )
+
+                with pytest.raises(AuthConflict) as exc_info:
+                    await call_transform_api('ListWorkspaces', {})
+
+                assert 'sigv4' in exc_info.value.available_methods
+
+    @pytest.mark.asyncio
+    async def test_raises_http_error_on_origin_403_without_creds(self):
+        """When bearer gets 403 but no AWS creds exist, raise HttpError as before."""
+        mock_config = MagicMock()
+        mock_config.auth_mode = 'bearer'
+        mock_config.bearer_token = 'token'
+        mock_config.origin = 'https://tenant.transform.us-east-1.on.aws'
+        mock_config.region = 'us-east-1'
+        mock_config.token_expiry = 9999999999
+        mock_config.refresh_token = None
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.transform_api_client.config_store') as mock_cs,
+            patch('awslabs.aws_transform_mcp_server.transform_api_client._create_unsigned_client'),
+            patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client._call_boto3',
+                side_effect=HttpError(
+                    403, {'Message': 'Invalid request origin'}, 'HTTP 403: Invalid request origin'
+                ),
+            ),
+        ):
+            mock_cs.get_config.return_value = mock_config
+            mock_cs.is_sigv4_fes_available.return_value = False
+
+            mock_session = MagicMock()
+            mock_session.get_credentials.return_value = None
+
+            with patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client.AwsHelper'
+            ) as mock_helper:
+                mock_helper.create_session.return_value = mock_session
+
+                from awslabs.aws_transform_mcp_server.transform_api_client import (
+                    call_transform_api,
+                )
+
+                with pytest.raises(HttpError) as exc_info:
+                    await call_transform_api('ListWorkspaces', {})
+
+                assert exc_info.value.status_code == 403
+
+
+class TestDeletePersistedConfig:  # noqa: D101
+    def test_deletes_config_file(self):
+        import os
+        import tempfile
+        from awslabs.aws_transform_mcp_server.config_store import ConfigStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ConfigStore(config_dir=tmpdir)
+            config_file = os.path.join(tmpdir, 'config.json')
+            with open(config_file, 'w') as f:
+                f.write('{}')
+            os.chmod(config_file, 0o600)
+            assert os.path.exists(config_file)
+
+            store.delete_persisted_config()
+
+            assert not os.path.exists(config_file)
+
+    def test_no_error_when_file_missing(self):
+        import tempfile
+        from awslabs.aws_transform_mcp_server.config_store import ConfigStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ConfigStore(config_dir=tmpdir)
+            store.delete_persisted_config()
+
+
+class TestConfigureReset:  # noqa: D101
+    @pytest.mark.asyncio
+    async def test_reset_clears_config_and_reports_sigv4(self):
+        import json
+        from awslabs.aws_transform_mcp_server.tools.configure import ConfigureHandler
+
+        handler = ConfigureHandler(MagicMock())
+        ctx = MagicMock()
+
+        with (
+            patch(
+                'awslabs.aws_transform_mcp_server.tools.configure.delete_persisted_config'
+            ) as mock_delete,
+            patch(
+                'awslabs.aws_transform_mcp_server.server._probe_sigv4_transform_api',
+                new_callable=AsyncMock,
+            ),
+            patch(
+                'awslabs.aws_transform_mcp_server.tools.configure.is_sigv4_fes_available',
+                return_value=True,
+            ),
+            patch(
+                'awslabs.aws_transform_mcp_server.tools.configure.get_sigv4_region',
+                return_value='us-east-1',
+            ),
+        ):
+            result = await handler.configure(ctx, authMode='reset')
+
+        mock_delete.assert_called_once()
+        parsed = json.loads(result['content'][0]['text'])
+        assert parsed['success'] is True
+        assert 'cleared' in parsed['message'].lower()
+        assert parsed['authMode'] == 'sigv4'
+
+    @pytest.mark.asyncio
+    async def test_reset_no_creds_reports_instructions(self):
+        import json
+        from awslabs.aws_transform_mcp_server.tools.configure import ConfigureHandler
+
+        handler = ConfigureHandler(MagicMock())
+        ctx = MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = None
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.tools.configure.delete_persisted_config'),
+            patch(
+                'awslabs.aws_transform_mcp_server.server._probe_sigv4_transform_api',
+                new_callable=AsyncMock,
+            ),
+            patch(
+                'awslabs.aws_transform_mcp_server.tools.configure.is_sigv4_fes_available',
+                return_value=False,
+            ),
+            patch(
+                'awslabs.aws_transform_mcp_server.aws_helper.AwsHelper.create_session',
+                return_value=mock_session,
+            ),
+        ):
+            result = await handler.configure(ctx, authMode='reset')
+
+        parsed = json.loads(result['content'][0]['text'])
+        assert parsed['success'] is True
+        assert 'no aws credentials' in parsed['message'].lower()
+
+    @pytest.mark.asyncio
+    async def test_reset_creds_exist_but_no_transform_access(self):
+        import json
+        from awslabs.aws_transform_mcp_server.tools.configure import ConfigureHandler
+
+        handler = ConfigureHandler(MagicMock())
+        ctx = MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = MagicMock()
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.tools.configure.delete_persisted_config'),
+            patch(
+                'awslabs.aws_transform_mcp_server.server._probe_sigv4_transform_api',
+                new_callable=AsyncMock,
+            ),
+            patch(
+                'awslabs.aws_transform_mcp_server.tools.configure.is_sigv4_fes_available',
+                return_value=False,
+            ),
+            patch(
+                'awslabs.aws_transform_mcp_server.aws_helper.AwsHelper.create_session',
+                return_value=mock_session,
+            ),
+        ):
+            result = await handler.configure(ctx, authMode='reset')
+
+        parsed = json.loads(result['content'][0]['text'])
+        assert parsed['success'] is True
+        assert 'does not have access' in parsed['message'].lower()
+
+
+class TestFailureResultAuthConflict:  # noqa: D101
+    def test_returns_structured_choice_on_auth_conflict(self):
+        import json
+        from awslabs.aws_transform_mcp_server.tool_utils import failure_result
+
+        exc = AuthConflict(
+            failed_method='bearer',
+            available_methods=['sigv4'],
+            original_error='HTTP 403: Invalid request origin',
+        )
+        result = failure_result(exc)
+        parsed = json.loads(result['content'][0]['text'])
+
+        assert parsed['success'] is False
+        assert parsed['error']['code'] == 'AUTH_CONFLICT'
+        assert 'Invalid request origin' in parsed['error']['message']
+        assert 'suggestedAction' in parsed['error']
+        assert 'configure' in parsed['error']['suggestedAction']
+        assert parsed['failedMethod'] == 'bearer'
+        assert 'sigv4' in parsed['availableMethods']
+        assert result['isError'] is True
+
+
+class TestAuthConflictEndToEnd:  # noqa: D101
+    @pytest.mark.asyncio
+    async def test_origin_403_with_creds_produces_structured_choice(self):
+        """Full flow: call_transform_api raises AuthConflict, failure_result formats it."""
+        import json
+        from awslabs.aws_transform_mcp_server.tool_utils import failure_result
+
+        mock_config = MagicMock()
+        mock_config.auth_mode = 'bearer'
+        mock_config.bearer_token = 'token'
+        mock_config.origin = 'https://tenant.transform.us-east-1.on.aws'
+        mock_config.region = 'us-east-1'
+        mock_config.token_expiry = 9999999999
+        mock_config.refresh_token = None
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.transform_api_client.config_store') as mock_cs,
+            patch('awslabs.aws_transform_mcp_server.transform_api_client._create_unsigned_client'),
+            patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client._call_boto3',
+                side_effect=HttpError(
+                    403, {'Message': 'Invalid request origin'}, 'HTTP 403: Invalid request origin'
+                ),
+            ),
+        ):
+            mock_cs.get_config.return_value = mock_config
+            mock_cs.is_sigv4_fes_available.return_value = True
+            mock_cs.get_sigv4_region.return_value = 'us-east-1'
+
+            from awslabs.aws_transform_mcp_server.transform_api_client import call_transform_api
+
+            with pytest.raises(AuthConflict) as exc_info:
+                await call_transform_api('ListWorkspaces', {})
+
+        result = failure_result(exc_info.value)
+        parsed = json.loads(result['content'][0]['text'])
+
+        assert parsed['error']['code'] == 'AUTH_CONFLICT'
+        assert 'configure' in parsed['error']['suggestedAction']
+        assert 'sigv4' in parsed['availableMethods']

--- a/src/aws-transform-mcp-server/tests/test_auth_conflict.py
+++ b/src/aws-transform-mcp-server/tests/test_auth_conflict.py
@@ -133,6 +133,44 @@ class TestCallTransformApiAuthConflict:  # noqa: D101
 
                 assert exc_info.value.status_code == 403
 
+    @pytest.mark.asyncio
+    async def test_credential_check_exception_does_not_mask_403(self):
+        """When AwsHelper.create_session() throws, original 403 is still raised."""
+        mock_config = MagicMock()
+        mock_config.auth_mode = 'bearer'
+        mock_config.bearer_token = 'token'
+        mock_config.origin = 'https://tenant.transform.us-east-1.on.aws'
+        mock_config.region = 'us-east-1'
+        mock_config.token_expiry = 9999999999
+        mock_config.refresh_token = None
+
+        with (
+            patch('awslabs.aws_transform_mcp_server.transform_api_client.config_store') as mock_cs,
+            patch('awslabs.aws_transform_mcp_server.transform_api_client._create_unsigned_client'),
+            patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client._call_boto3',
+                side_effect=HttpError(
+                    403, {'Message': 'Invalid request origin'}, 'HTTP 403: Invalid request origin'
+                ),
+            ),
+        ):
+            mock_cs.get_config.return_value = mock_config
+            mock_cs.is_sigv4_fes_available.return_value = False
+
+            with patch(
+                'awslabs.aws_transform_mcp_server.transform_api_client.AwsHelper'
+            ) as mock_helper:
+                mock_helper.create_session.side_effect = Exception('ProfileNotFound')
+
+                from awslabs.aws_transform_mcp_server.transform_api_client import (
+                    call_transform_api,
+                )
+
+                with pytest.raises(HttpError) as exc_info:
+                    await call_transform_api('ListWorkspaces', {})
+
+                assert exc_info.value.status_code == 403
+
 
 class TestDeletePersistedConfig:  # noqa: D101
     def test_deletes_config_file(self):

--- a/src/aws-transform-mcp-server/tests/test_credential_auth.py
+++ b/src/aws-transform-mcp-server/tests/test_credential_auth.py
@@ -284,7 +284,7 @@ class TestProbeSigv4Fes:
             await _probe_sigv4_transform_api()
 
         mock_set_available.assert_called_once_with(True)
-        mock_set_region.assert_not_called()
+        mock_set_region.assert_called_once_with(None)
         mock_set_regions.assert_called_once_with(['us-east-1', 'eu-central-1'])
 
     @pytest.mark.asyncio
@@ -344,7 +344,7 @@ class TestStartup:
             await _startup()
 
         mock_clear.assert_not_called()
-        mock_probe.assert_not_called()
+        mock_probe.assert_called_once()
 
 
 # ── derive_transform_api_endpoint validation ───────────────────────────────────────


### PR DESCRIPTION

  ## Summary

  ### Changes

  When a stale SSO/cookie config exists but valid AWS credentials are available, the server previously returned a cryptic `HTTP 403: Invalid request origin` error. This PR
  adds structured error detection and recovery:

  1. **Auth conflict detection** — `call_transform_api` catches 403 "Invalid request origin" errors and checks if alternative AWS credentials are available. If so, raises `AuthConflict` which surfaces a structured response with available auth methods and actionable instructions.

  2. **`configure(authMode="reset")`** — New action that clears persisted config from disk and re-probes SigV4 credentials, so users can recover from stale sessions without manually deleting `~/.aws-transform-mcp/config.json`.

  3. **Improved status messages** — Differentiates "no AWS credentials detected" from "credentials exist but account lacks Transform API access" so LLM clients don't misinterpret the error.

  ### User experience

  **Before:** User with a stale SSO session and valid AWS credentials calls `list_resources` → gets `HTTP 403: Invalid request origin`. The LLM doesn't know what to do. User must manually delete `~/.aws-transform-mcp/config.json` to recover.

  **After:** Same scenario → gets structured `AUTH_CONFLICT` response:
  ```json
  {
    "error": {
      "code": "AUTH_CONFLICT",
      "message": "BEARER auth failed: HTTP 403: Invalid request origin. Alternative auth methods are available.",
      "suggestedAction": "Run configure(authMode=\"reset\") to clear the stale session and switch to AWS credential auth, or configure(authMode=\"sso\") to re-authenticate
  with IAM Identity Center."
    },
    "failedMethod": "bearer",
    "availableMethods": ["sigv4"]
  }
```
  LLM client can then run configure(authMode="reset") to clear the stale session and switch to credential auth automatically.
  Checklist

  - I have reviewed the contributing guidelines
  - I have performed a self-review of this change
  - Changes have been tested
  - Changes are documented

  Is this a breaking change? N

  RFC issue number: N/A

  Checklist:

  - Migration process documented
  - Implement warnings (if it can live side by side)

  Acknowledgment

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).