### PR TITLE
fix(aws-transform-mcp-server): align MainframeAssessmentConfiguration…

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/hitl_output_schemas.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/hitl_output_schemas.py
@@ -4036,8 +4036,9 @@ OUTPUT_SCHEMA_META: Dict[str, OutputSchemaMeta] = {
         merge_with_artifact=False,
         examples=[
             {
-                'sourceCodeS3Path': 's3://my-bucket/mainframe/source-code/',
-                'smfRecordsS3Path': 's3://my-bucket/mainframe/smf-records/',
+                'legacyCodeS3Path': 's3://my-bucket/mainframe/source-code/',
+                'sourceCodeS3Path': 's3://my-bucket/mainframe/data/',
+                'scrtFileS3Path': 's3://my-bucket/mainframe/scrt-file/',
             }
         ],
         json_schema={
@@ -4048,23 +4049,29 @@ OUTPUT_SCHEMA_META: Dict[str, OutputSchemaMeta] = {
             'type': 'object',
             'examples': [
                 {
-                    'sourceCodeS3Path': 's3://my-bucket/mainframe/source-code/',
-                    'smfRecordsS3Path': 's3://my-bucket/mainframe/smf-records/',
+                    'legacyCodeS3Path': 's3://my-bucket/mainframe/source-code/',
+                    'sourceCodeS3Path': 's3://my-bucket/mainframe/data/',
+                    'scrtFileS3Path': 's3://my-bucket/mainframe/scrt-file/',
                 }
             ],
             'properties': {
-                'sourceCodeS3Path': {
+                'legacyCodeS3Path': {
                     'type': 'string',
                     'description': "S3 URI pointing to the mainframe source code location. Must start with 's3://'.",
                     'pattern': '^s3://',
                 },
-                'smfRecordsS3Path': {
+                'sourceCodeS3Path': {
                     'type': 'string',
-                    'description': "S3 URI pointing to the SMF records location. Must start with 's3://'.",
+                    'description': "S3 URI pointing to the SMF records location (named sourceCodeS3Path for compatibility with SMFConfigureComponent). Must start with 's3://'.",
+                    'pattern': '^s3://',
+                },
+                'scrtFileS3Path': {
+                    'type': 'string',
+                    'description': "S3 URI pointing to the SCRT file location. Must start with 's3://'.",
                     'pattern': '^s3://',
                 },
             },
-            'required': ['sourceCodeS3Path'],
+            'required': ['legacyCodeS3Path'],
             'additionalProperties': True,
         },
     ),

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/hitl_schemas.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/hitl_schemas.py
@@ -528,10 +528,11 @@ CUSTOMIZATIONS: Dict[str, ComponentCustomization] = {
     # ── Mainframe S3 path input components ─────────────────────────
     'MainframeAssessmentConfigurationComponent': ComponentCustomization(
         template={
-            'sourceCodeS3Path': 's3://bucket/source/',
-            'smfRecordsS3Path': 's3://bucket/smf/',
+            'legacyCodeS3Path': 's3://bucket/source-code/',
+            'sourceCodeS3Path': 's3://bucket/smf-records/',
+            'scrtFileS3Path': 's3://bucket/scrt-file/',
         },
-        hint='Provide S3 paths for source code and SMF records. Only include fields you want to change.',
+        hint='Provide S3 paths for source code (required), SMF records (optional), and SCRT file (optional). Only include fields you want to change.',
         merge_with_artifact=True,
     ),
     'MainframeSMFConfigureComponent': ComponentCustomization(


### PR DESCRIPTION
## Summary

The HITL output schema, input template, and response hint for `MainframeAssessmentConfigurationComponent` diverge from the authoritative schema in `ElasticGumbyUIComponents/schemaRegistry`. This causes legitimate submissions to be rejected because `legacyCodeS3Path` (the real required field) is left empty, resulting in a confusing duplicate Configure task.

## Upstream Schema

- [MainframeAssessmentConfigurationComponent.schema.json](https://code.amazon.com/packages/ElasticGumbyUIComponents/blobs/mainline/--/schemaRegistry/MainframeAssessmentConfigurationComponent.schema.json)
- [MainframeAssessmentConfigurationComponent.output.schema.json](https://code.amazon.com/packages/ElasticGumbyUIComponents/blobs/mainline/--/schemaRegistry/MainframeAssessmentConfigurationComponent.output.schema.json)

Upstream defines:

| Field | Purpose | Required |
|-------|---------|----------|
| `legacyCodeS3Path` | Mainframe source code archive | ✅ |
| `sourceCodeS3Path` | SMF records (misnamed for compat with `SMFConfigureComponent`) | — |
| `scrtFileS3Path` | SCRT file | — |

## Changes

- **`hitl_output_schemas.py`** — replace `smfRecordsS3Path` with `legacyCodeS3Path` + `scrtFileS3Path`; change `required` from `['sourceCodeS3Path']` to `['legacyCodeS3Path']`; document the `sourceCodeS3Path` → SMF records mapping in descriptions.
- **`hitl_schemas.py`** — update template to include all three real fields; rewrite `_responseHint` to describe inputs by purpose ("source code", "SMF records", "SCRT file") rather than internal field names.

## Verification

End-to-end tested against a gamma tenant in us-west-2:
- Submission accepted on the first attempt
- No duplicate Configure task
- Task status: `CLOSED`
- `_outputSchema`, `_responseTemplate`, and `_responseHint` all reflect the upstream shape at runtime.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
