### PR TITLE
fix: client app id header

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
@@ -76,6 +76,15 @@ class AuthConflict(Exception):
 # ── boto3 client helpers ────────────────────────────────────────────────
 
 
+def _register_client_app_id(client):
+    """Register event handler to inject clientAppId on every request."""
+
+    def add_client_app_id(params, **kwargs):
+        params['headers'][HEADER_CLIENT_APP_ID] = CLIENT_APP_ID
+
+    client.meta.events.register('before-call.elasticgumbyfrontend.*', add_client_app_id)
+
+
 def _create_unsigned_client(
     endpoint: str,
     region: str = 'us-east-1',
@@ -84,7 +93,7 @@ def _create_unsigned_client(
 ):
     """Create a boto3 FES client with UNSIGNED config (no SigV4)."""
     session = create_session()
-    return session.client(
+    client = session.client(
         'elasticgumbyfrontendservice',
         region_name=region,
         endpoint_url=endpoint,
@@ -96,6 +105,8 @@ def _create_unsigned_client(
             read_timeout=timeout,
         ),
     )
+    _register_client_app_id(client)
+    return client
 
 
 def _create_sigv4_client(
@@ -120,7 +131,7 @@ def _create_sigv4_client(
         loader.search_paths.insert(0, _MODEL_DIR)
 
     session = boto3.Session(botocore_session=core)
-    return session.client(
+    client = session.client(
         'elasticgumbyfrontendservice',
         region_name=region,
         endpoint_url=endpoint,
@@ -131,6 +142,8 @@ def _create_sigv4_client(
             read_timeout=timeout,
         ),
     )
+    _register_client_app_id(client)
+    return client
 
 
 def _inject_cookie_auth(client, origin: str, cookie: str):
@@ -148,7 +161,6 @@ def _inject_bearer_auth(client, token: str, origin: Optional[str] = None):
 
     def add_headers(params, model, **kwargs):
         params['headers']['Authorization'] = f'Bearer {token}'
-        params['headers'][HEADER_CLIENT_APP_ID] = CLIENT_APP_ID
         params['headers']['Content-Encoding'] = 'amz-1.0'
         params['headers']['X-Amz-Target'] = f'{FES_TARGET_BEARER}.{model.name}'
         if origin and model.name != 'ListAvailableProfiles':

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
@@ -84,6 +84,11 @@ def _register_client_app_id(client):
 
     client.meta.events.register('before-call.elasticgumbyfrontend.*', add_client_app_id)
 
+    def _log_outgoing_headers(request, **kwargs):
+        logger.info('Outgoing headers: {}', dict(request.headers))
+
+    client.meta.events.register('before-send', _log_outgoing_headers)
+
 
 def _create_unsigned_client(
     endpoint: str,

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
@@ -84,11 +84,6 @@ def _register_client_app_id(client):
 
     client.meta.events.register('before-call.elasticgumbyfrontend.*', add_client_app_id)
 
-    def _log_outgoing_headers(request, **kwargs):
-        logger.info('Outgoing headers: {}', dict(request.headers))
-
-    client.meta.events.register('before-send', _log_outgoing_headers)
-
 
 def _create_unsigned_client(
     endpoint: str,

--- a/src/aws-transform-mcp-server/tests/test_client_app_id.py
+++ b/src/aws-transform-mcp-server/tests/test_client_app_id.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_transform_mcp_server.consts import CLIENT_APP_ID, HEADER_CLIENT_APP_ID
+from awslabs.aws_transform_mcp_server.transform_api_client import _create_unsigned_client
+
+
+class TestClientAppIdHeader:  # noqa: D101
+    def test_unsigned_client_injects_client_app_id(self):
+        """Verify _create_unsigned_client registers clientAppId on all requests."""
+        client = _create_unsigned_client('https://fake.endpoint.com')
+
+        captured = {}
+
+        def capture_request(request, **kwargs):
+            captured.update(
+                {k: v.decode() if isinstance(v, bytes) else v for k, v in request.headers.items()}
+            )
+
+        client.meta.events.register('before-send', capture_request)
+
+        try:
+            client.list_workspaces()
+        except Exception:
+            pass
+
+        assert captured.get(HEADER_CLIENT_APP_ID) == CLIENT_APP_ID


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
  ## Summary

  ### Changes

  Move `x-amzn-atx-clientAppId` header injection from `_inject_bearer_auth` to a shared `_register_client_app_id` function called at client creation time (`_create_unsigned_client` and `_create_sigv4_client`). All FES requests now send `clientAppId = "atx-mcp"` regardless of auth method.

  Previously only the bearer auth path set this header. Cookie auth requests defaulted to `atx-webapp`

  ### User experience

  **Before:** Jobs created via cookie or SigV4 auth show `clientAppId = "atx-webapp"` or `"atx-ide"` in FES. MCP-specific gating cannot distinguish MCP clients from web app or IDE users.

  **After:** All requests from the MCP server identify as `clientAppId = "atx-mcp"` regardless of auth method. MCP gating works correctly across all auth paths.

  ## Testing

  Manual validation: confirmed `x-amzn-atx-clientAppId: atx-mcp` present in outgoing headers on both cookie and SigV4 paths via botocore `before-send` event logging against gamma (us-east-1).

  ## Checklist

  * [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
  * [x] I have performed a self-review of this change
  * [x] Changes have been tested
  * [x] Changes are documented

  Is this a breaking change? N

  **RFC issue number**: N/A

  Checklist:

  * [ ] Migration process documented
  * [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
