### PR TITLE
fix(aws-transform-mcp-server): clarify targetRegions is required for connector

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/connector.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/connector.py
@@ -95,7 +95,8 @@ class ConnectorHandler:
         targetRegions: Annotated[
             Optional[list],
             Field(
-                description='Optional list of target AWS regions (e.g. ["us-east-1", "us-west-2"])',
+                description='List of target AWS regions (e.g. ["us-east-1", "us-west-2"]). '
+                'Required for containerization and infra_provisioning connector types.',
             ),
         ] = None,
     ) -> dict:


### PR DESCRIPTION
  ## Summary

  ### Changes

  Clarify that `targetRegions` is required (not optional) for containerization and infra_provisioning connector types in the `create_connector` tool description.

Previously the description said "Optional list of target AWS regions" which caused agents to omit it. Without `targetRegions`, the connector is created but the workspace agent rejects it as missing a target region, forcing users out of the IDE to the web UI.

  ### User experience

**Before:** Agent calls `create_connector` for a containerization job without `targetRegions`. Connector is created in PENDING state, user approves it, but the agent then rejects it because no target region is configured. User must leave the IDE and use the web UI to set the region.

**After:** Agent sees the tool description states `targetRegions` is required for containerization/infra_provisioning types, includes it in the call, and the full flow completes without leaving the IDE.

  ## Checklist

  If your change doesn't seem to apply, please leave them unchecked.

  * [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
  * [x] I have performed a self-review of this change
  * [x] Changes have been tested
  * [x] Changes are documented

  Is this a breaking change? N

  **RFC issue number**: N/A

  Checklist:

  * [ ] Migration process documented
  * [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
