### PR TITLE
feat(postgres-mcp-server): auto-detect and route through RDS Proxy

### DIFF
--- a/src/postgres-mcp-server/README.md
+++ b/src/postgres-mcp-server/README.md
@@ -155,6 +155,16 @@ The MCP server supports connecting to multiple database endpoints using differen
 - RDS Data API must be enabled on the Aurora PostgreSQL cluster
 - Appropriate IAM permissions for Data API access
 
+#### RDS Proxy auto-detection (RPG only)
+
+For standalone RDS PostgreSQL instances (`database_type: RPG` without a `cluster_identifier`), the server automatically checks whether an RDS Proxy fronts the target instance and routes the connection through the proxy endpoint when one is found. The proxy uses the same Secrets Manager secret on its backend, so no additional configuration is required.
+
+This lookup is best-effort: if the IAM permissions below are missing or the API call fails, the server logs a warning and falls back to a direct instance connection.
+
+Optional IAM permissions for proxy auto-detection:
+- `rds:DescribeDBProxies`
+- `rds:DescribeDBProxyTargets`
+
 ### AWS Authentication
 
 The MCP server uses the AWS profile specified in the `AWS_PROFILE` environment variable. If not provided, it defaults to the "default" profile in your AWS configuration file.

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/cp_api_connection.py
@@ -130,6 +130,74 @@ def internal_get_cluster_valid_endpoints(
     return endpoints
 
 
+def find_proxy_for_instance(db_instance_id: str, region: str) -> Optional[str]:
+    """Check if an RDS Proxy fronts the given DB instance and return its endpoint.
+
+    Iterates all available RDS Proxies in the region, then inspects each proxy's
+    targets to see if any reference the given DBInstanceIdentifier.
+
+    Args:
+        db_instance_id: The RDS DB instance identifier to look up.
+        region: AWS region (e.g., 'us-east-1').
+
+    Returns:
+        The proxy endpoint string if a proxy is found for the instance, or None.
+    """
+    logger.info(f"Looking for RDS Proxy fronting instance '{db_instance_id}' in region '{region}'")
+
+    try:
+        rds_client = internal_create_rds_client(region=region)
+
+        # Paginate through all proxies in the region
+        proxy_paginator = rds_client.get_paginator('describe_db_proxies')
+        for proxy_page in proxy_paginator.paginate():
+            for proxy in proxy_page.get('DBProxies', []):
+                proxy_name = proxy.get('DBProxyName', '')
+                proxy_status = proxy.get('Status', '')
+
+                if proxy_status != 'available':
+                    logger.debug(f"Skipping proxy '{proxy_name}' with status '{proxy_status}'")
+                    continue
+
+                # Check if this proxy targets our instance
+                try:
+                    targets_paginator = rds_client.get_paginator('describe_db_proxy_targets')
+                    for targets_page in targets_paginator.paginate(DBProxyName=proxy_name):
+                        for target in targets_page.get('Targets', []):
+                            target_id = target.get('RdsResourceId', '')
+                            if target_id == db_instance_id:
+                                proxy_endpoint = proxy.get('Endpoint', '')
+                                logger.info(
+                                    f"Found RDS Proxy '{proxy_name}' "
+                                    f'(endpoint: {proxy_endpoint}) '
+                                    f"fronting instance '{db_instance_id}'"
+                                )
+                                return proxy_endpoint
+                except ClientError as e:
+                    logger.warning(
+                        f"Failed to describe targets for proxy '{proxy_name}': "
+                        f'{e.response["Error"]["Code"]} - {e.response["Error"]["Message"]}'
+                    )
+                    continue
+
+        logger.info(f"No RDS Proxy found for instance '{db_instance_id}' in region '{region}'")
+        return None
+
+    except ClientError as e:
+        logger.warning(
+            f"Failed to look up RDS Proxies in region '{region}': "
+            f'{e.response["Error"]["Code"]} - {e.response["Error"]["Message"]}. '
+            f'Falling back to direct instance connection.'
+        )
+        return None
+    except Exception as e:
+        logger.warning(
+            f"Unexpected error during RDS Proxy lookup in region '{region}': "
+            f'{type(e).__name__}: {e}. Falling back to direct instance connection.'
+        )
+        return None
+
+
 def internal_get_instance_properties(target_endpoint: str, region: str) -> Dict[str, Any]:
     """Retrieve RDS instance properties from AWS."""
     rds_client = internal_create_rds_client(region=region)

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -22,6 +22,7 @@ import threading
 from awslabs.postgres_mcp_server.connection.abstract_db_connection import AbstractDBConnection
 from awslabs.postgres_mcp_server.connection.cp_api_connection import (
     DEFAULT_POSTGRES_PORT,
+    find_proxy_for_instance,
     internal_create_express_cluster,
     internal_create_serverless_cluster,
     internal_get_cluster_properties,
@@ -729,6 +730,22 @@ def internal_create_connection(
             db_endpoint = resolved_host
         if resolved_port:
             port = resolved_port
+
+        # Check if an RDS Proxy fronts this instance and route through it if so
+        db_instance_id = instance_properties.get('DBInstanceIdentifier', '')
+        if db_instance_id:
+            proxy_endpoint = find_proxy_for_instance(db_instance_id, region)
+            if proxy_endpoint:
+                logger.info(
+                    f"Routing connection through RDS Proxy endpoint '{proxy_endpoint}' "
+                    f"instead of direct instance endpoint '{db_endpoint}'"
+                )
+                db_endpoint = proxy_endpoint
+            else:
+                logger.info(
+                    f"No RDS Proxy detected for instance '{db_instance_id}', "
+                    f"using direct instance endpoint '{db_endpoint}'"
+                )
 
     logger.info(
         f'About to create internal DB connections with:'

--- a/src/postgres-mcp-server/tests/test_cp_api_connection.py
+++ b/src/postgres-mcp-server/tests/test_cp_api_connection.py
@@ -2,6 +2,7 @@
 
 import pytest
 from awslabs.postgres_mcp_server.connection.cp_api_connection import (
+    find_proxy_for_instance,
     internal_create_express_cluster,
     internal_create_rds_client,
     internal_create_serverless_cluster,
@@ -1556,3 +1557,371 @@ class TestInternalGetClusterValidEndpoints:
 
         assert ('cluster.writer.rds.amazonaws.com', 5432) in result
         mock_create_client.assert_not_called()
+
+
+# =============================================================================
+# TESTS FOR: find_proxy_for_instance
+# =============================================================================
+
+
+class TestFindProxyForInstance:
+    """Tests for find_proxy_for_instance function."""
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_returns_endpoint_when_proxy_found(self, mock_create_client):
+        """Test that the proxy endpoint is returned when a matching proxy is found."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        # Setup proxy paginator
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'my-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'my-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    }
+                ]
+            }
+        ]
+
+        # Setup targets paginator
+        targets_paginator = MagicMock()
+        targets_paginator.paginate.return_value = [
+            {
+                'Targets': [
+                    {'RdsResourceId': 'my-instance'},
+                ]
+            }
+        ]
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                return targets_paginator
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result == 'my-proxy.proxy-abc123.us-east-1.rds.amazonaws.com'
+        mock_create_client.assert_called_once_with(region='us-east-1')
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_returns_none_when_no_proxies_exist(self, mock_create_client):
+        """Test that None is returned when no proxies exist in the region."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [{'DBProxies': []}]
+        mock_rds.get_paginator.return_value = proxy_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result is None
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_returns_none_when_proxy_targets_different_instance(self, mock_create_client):
+        """Test that None is returned when proxy targets a different instance."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'other-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'other-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    }
+                ]
+            }
+        ]
+
+        targets_paginator = MagicMock()
+        targets_paginator.paginate.return_value = [
+            {
+                'Targets': [
+                    {'RdsResourceId': 'different-instance'},
+                ]
+            }
+        ]
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                return targets_paginator
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result is None
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_skips_unavailable_proxies(self, mock_create_client):
+        """Test that proxies with non-available status are skipped."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'creating-proxy',
+                        'Status': 'creating',
+                        'Endpoint': 'creating-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    },
+                    {
+                        'DBProxyName': 'available-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'available-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    },
+                ]
+            }
+        ]
+
+        targets_paginator = MagicMock()
+        targets_paginator.paginate.return_value = [
+            {
+                'Targets': [
+                    {'RdsResourceId': 'my-instance'},
+                ]
+            }
+        ]
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                return targets_paginator
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        # Should find the available proxy, not the creating one
+        assert result == 'available-proxy.proxy-abc123.us-east-1.rds.amazonaws.com'
+        # describe_db_proxy_targets should only be called for the available proxy
+        targets_paginator.paginate.assert_called_once_with(DBProxyName='available-proxy')
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_continues_on_describe_targets_client_error(self, mock_create_client):
+        """Test that a ClientError on describe_db_proxy_targets is handled gracefully."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'error-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'error-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    },
+                    {
+                        'DBProxyName': 'good-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'good-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    },
+                ]
+            }
+        ]
+
+        # First proxy's targets call raises ClientError, second succeeds
+        error_targets_paginator = MagicMock()
+        error_targets_paginator.paginate.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Not authorized'}},
+            'DescribeDBProxyTargets',
+        )
+
+        good_targets_paginator = MagicMock()
+        good_targets_paginator.paginate.return_value = [
+            {
+                'Targets': [
+                    {'RdsResourceId': 'my-instance'},
+                ]
+            }
+        ]
+
+        call_count = {'n': 0}
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                call_count['n'] += 1
+                if call_count['n'] == 1:
+                    return error_targets_paginator
+                return good_targets_paginator
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        # Should skip the errored proxy and find the good one
+        assert result == 'good-proxy.proxy-abc123.us-east-1.rds.amazonaws.com'
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_returns_none_on_describe_proxies_client_error(self, mock_create_client):
+        """Test that a ClientError on describe_db_proxies returns None gracefully."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Not authorized'}},
+            'DescribeDBProxies',
+        )
+        mock_rds.get_paginator.return_value = proxy_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result is None
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_returns_none_on_unexpected_exception(self, mock_create_client):
+        """Test that an unexpected exception returns None gracefully."""
+        mock_create_client.side_effect = RuntimeError('Unexpected failure')
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result is None
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_paginates_across_multiple_proxy_pages(self, mock_create_client):
+        """Test that pagination works across multiple pages of proxies."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'proxy-page1',
+                        'Status': 'available',
+                        'Endpoint': 'proxy-page1.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    }
+                ]
+            },
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'proxy-page2',
+                        'Status': 'available',
+                        'Endpoint': 'proxy-page2.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    }
+                ]
+            },
+        ]
+
+        # First proxy targets a different instance, second matches
+        page1_targets = MagicMock()
+        page1_targets.paginate.return_value = [{'Targets': [{'RdsResourceId': 'other-instance'}]}]
+
+        page2_targets = MagicMock()
+        page2_targets.paginate.return_value = [{'Targets': [{'RdsResourceId': 'my-instance'}]}]
+
+        call_count = {'n': 0}
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                call_count['n'] += 1
+                if call_count['n'] == 1:
+                    return page1_targets
+                return page2_targets
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result == 'proxy-page2.proxy-abc123.us-east-1.rds.amazonaws.com'
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_paginates_across_multiple_target_pages(self, mock_create_client):
+        """Test that pagination works across multiple pages of targets."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'my-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'my-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    }
+                ]
+            }
+        ]
+
+        targets_paginator = MagicMock()
+        targets_paginator.paginate.return_value = [
+            {'Targets': [{'RdsResourceId': 'other-instance-1'}]},
+            {'Targets': [{'RdsResourceId': 'my-instance'}]},
+        ]
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                return targets_paginator
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result == 'my-proxy.proxy-abc123.us-east-1.rds.amazonaws.com'
+
+    @patch('awslabs.postgres_mcp_server.connection.cp_api_connection.internal_create_rds_client')
+    def test_empty_targets_list(self, mock_create_client):
+        """Test handling of a proxy with no targets."""
+        mock_rds = MagicMock()
+        mock_create_client.return_value = mock_rds
+
+        proxy_paginator = MagicMock()
+        proxy_paginator.paginate.return_value = [
+            {
+                'DBProxies': [
+                    {
+                        'DBProxyName': 'empty-proxy',
+                        'Status': 'available',
+                        'Endpoint': 'empty-proxy.proxy-abc123.us-east-1.rds.amazonaws.com',
+                    }
+                ]
+            }
+        ]
+
+        targets_paginator = MagicMock()
+        targets_paginator.paginate.return_value = [{'Targets': []}]
+
+        def get_paginator(operation):
+            if operation == 'describe_db_proxies':
+                return proxy_paginator
+            elif operation == 'describe_db_proxy_targets':
+                return targets_paginator
+            return MagicMock()
+
+        mock_rds.get_paginator.side_effect = get_paginator
+
+        result = find_proxy_for_instance('my-instance', 'us-east-1')
+
+        assert result is None

--- a/src/postgres-mcp-server/tests/test_server_internal_functions.py
+++ b/src/postgres-mcp-server/tests/test_server_internal_functions.py
@@ -222,13 +222,16 @@ class TestInternalCreateConnection:
                 'awslabs.postgres_mcp_server.server.internal_get_instance_properties'
             ) as mock_props,
             patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+            patch('awslabs.postgres_mcp_server.server.find_proxy_for_instance') as mock_proxy,
         ):
             mock_map.get.return_value = None
             mock_props.return_value = {
                 'MasterUsername': 'postgres',
                 'MasterUserSecret': {'SecretArn': 'arn:secret'},
                 'Endpoint': {'Port': 5432},
+                'DBInstanceIdentifier': 'my-instance',
             }
+            mock_proxy.return_value = None
             mock_connection = MagicMock()
             mock_pg_conn.return_value = mock_connection
 
@@ -244,6 +247,114 @@ class TestInternalCreateConnection:
 
             assert conn == mock_connection
             mock_props.assert_called_once()
+            mock_proxy.assert_called_once_with('my-instance', 'us-east-1')
+
+    def test_rpg_instance_routes_through_proxy_when_found(self):
+        """Test that connection routes through RDS Proxy when one is found."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_instance_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+            patch('awslabs.postgres_mcp_server.server.find_proxy_for_instance') as mock_proxy,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'MasterUsername': 'postgres',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': {'Port': 5432},
+                'DBInstanceIdentifier': 'my-instance',
+            }
+            mock_proxy.return_value = 'my-proxy.proxy-abc123.us-east-1.rds.amazonaws.com'
+            mock_connection = MagicMock()
+            mock_pg_conn.return_value = mock_connection
+
+            conn, response = internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.RPG,
+                connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                cluster_identifier='',
+                db_endpoint='instance.endpoint.com',
+                port=5432,
+                database='testdb',
+            )
+
+            assert conn == mock_connection
+            mock_proxy.assert_called_once_with('my-instance', 'us-east-1')
+            # Verify the proxy endpoint was used instead of the direct endpoint
+            call_kwargs = mock_pg_conn.call_args[1]
+            assert call_kwargs['host'] == 'my-proxy.proxy-abc123.us-east-1.rds.amazonaws.com'
+
+    def test_rpg_instance_uses_direct_endpoint_when_no_proxy(self):
+        """Test that direct endpoint is used when no RDS Proxy is found."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_instance_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+            patch('awslabs.postgres_mcp_server.server.find_proxy_for_instance') as mock_proxy,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'MasterUsername': 'postgres',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': {'Port': 5432},
+                'DBInstanceIdentifier': 'my-instance',
+            }
+            mock_proxy.return_value = None
+            mock_connection = MagicMock()
+            mock_pg_conn.return_value = mock_connection
+
+            conn, response = internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.RPG,
+                connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                cluster_identifier='',
+                db_endpoint='instance.endpoint.com',
+                port=5432,
+                database='testdb',
+            )
+
+            assert conn == mock_connection
+            # Verify the original direct endpoint was used
+            call_kwargs = mock_pg_conn.call_args[1]
+            assert call_kwargs['host'] == 'instance.endpoint.com'
+
+    def test_rpg_instance_skips_proxy_lookup_when_no_instance_id(self):
+        """Test that proxy lookup is skipped when DBInstanceIdentifier is empty."""
+        with (
+            patch('awslabs.postgres_mcp_server.server.db_connection_map') as mock_map,
+            patch(
+                'awslabs.postgres_mcp_server.server.internal_get_instance_properties'
+            ) as mock_props,
+            patch('awslabs.postgres_mcp_server.server.PsycopgPoolConnection') as mock_pg_conn,
+            patch('awslabs.postgres_mcp_server.server.find_proxy_for_instance') as mock_proxy,
+        ):
+            mock_map.get.return_value = None
+            mock_props.return_value = {
+                'MasterUsername': 'postgres',
+                'MasterUserSecret': {'SecretArn': 'arn:secret'},
+                'Endpoint': {'Port': 5432},
+                'DBInstanceIdentifier': '',
+            }
+            mock_connection = MagicMock()
+            mock_pg_conn.return_value = mock_connection
+
+            conn, response = internal_create_connection(
+                region='us-east-1',
+                database_type=DatabaseType.RPG,
+                connection_method=ConnectionMethod.PG_WIRE_PROTOCOL,
+                cluster_identifier='',
+                db_endpoint='instance.endpoint.com',
+                port=5432,
+                database='testdb',
+            )
+
+            assert conn == mock_connection
+            # Proxy lookup should not have been called
+            mock_proxy.assert_not_called()
 
     def test_uses_cluster_endpoint_when_not_provided(self):
         """Test that cluster endpoint is used when db_endpoint is not provided."""


### PR DESCRIPTION
Fixes #3338

<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Adds RDS Proxy awareness to the standalone RDS PostgreSQL (RPG) connection path
in postgres-mcp-server. When `connect_to_database` is called with
`database_type=RPG` and no `cluster_identifier`, the server now checks whether
an RDS Proxy fronts the target instance and, if so, routes the connection
through the proxy endpoint instead of connecting directly to the instance.

- `connection/cp_api_connection.py`: New `find_proxy_for_instance(db_instance_id, region)`
  function. Paginates `describe_db_proxies`, filters to proxies in `available`
  status, and for each one paginates `describe_db_proxy_targets` looking for a
  target whose `RdsResourceId` matches the given DB instance identifier. Returns
  the proxy `Endpoint` on match, or `None` otherwise. All `ClientError` and
  unexpected exceptions are caught, logged at warning level, and the function
  returns `None` so the caller falls back to the direct instance endpoint.

- `server.py`: In `internal_create_connection`, in the RPG-without-cluster
  branch, after `internal_get_instance_properties` succeeds (and the new
  upstream endpoint validation runs) the new function is called with the
  resolved `DBInstanceIdentifier`. If a proxy endpoint comes back,
  `db_endpoint` is swapped to the proxy endpoint before the
  `PsycopgPoolConnection` is created. Credentials (`MasterUserSecret`,
  `MasterUsername`) still come from the instance — RDS Proxy uses the same
  Secrets Manager secret on its backend.

- `README.md`: Documents the new behavior under "Prerequisites by Connection
  Method" and lists the optional `rds:DescribeDBProxies` and
  `rds:DescribeDBProxyTargets` IAM permissions required for proxy
  auto-detection.

- `tests/`: 9 unit tests for `find_proxy_for_instance` covering the success
  path, no-proxy and no-match paths, status filtering, pagination across
  multiple proxy and target pages, and graceful degradation on `ClientError`
  and unexpected exceptions. 3 integration tests for the
  `internal_create_connection` RPG branch covering proxy-found, no-proxy-found,
  and missing-`DBInstanceIdentifier` paths.

The change is scoped to the RPG (standalone instance) path. The Aurora and
RPG-multi-AZ-cluster branches are untouched, since Aurora already has its own
endpoint abstraction and auto-swapping there could conflict with built-in
routing.

### User experience

**Before:** A user with an RDS Proxy in front of their RDS PostgreSQL instance
calls `connect_to_database` with the instance endpoint. The MCP server connects
directly to the instance, bypassing the proxy and any connection pooling,
failover, or IAM auth benefits it provides.

**After:** Same call. The MCP server resolves the instance, discovers the proxy
fronting it, and transparently connects through the proxy endpoint. Logs make
it clear which path was taken:
- `Found RDS Proxy '<name>' (endpoint: <endpoint>) fronting instance '<id>'`
- `Routing connection through RDS Proxy endpoint '<proxy>' instead of direct instance endpoint '<instance>'`
- Or, when no proxy exists or the lookup fails: `No RDS Proxy detected for instance '<id>', using direct instance endpoint '<instance>'`

If `rds:DescribeDBProxies` or `rds:DescribeDBProxyTargets` permissions are
missing, the lookup degrades gracefully: a warning is logged and the original
direct-instance behavior is preserved. The new IAM permissions are optional.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? **N**

**RFC issue number**:  #3338

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
