### PR TITLE
docs(aws-transform-mcp-server): add PyPI download badges to README

### DIFF
--- a/src/aws-transform-mcp-server/README.md
+++ b/src/aws-transform-mcp-server/README.md
@@ -1,5 +1,7 @@
 # AWS Transform MCP Server
 
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/awslabs-aws-transform-mcp-server?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/awslabs-aws-transform-mcp-server) [![PyPI Downloads/month](https://static.pepy.tech/personalized-badge/awslabs-aws-transform-mcp-server?period=month&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads/month)](https://pepy.tech/projects/awslabs-aws-transform-mcp-server)
+
 An MCP server for [AWS Transform](https://aws.amazon.com/transform/) that enables AI assistants to manage transformation workspaces, jobs, connectors, human-in-the-loop (HITL) tasks, artifacts, and chat directly from the IDE.
 
 AWS Transform accelerates migration and modernization of enterprise workloads using specialized AI agents across discovery, planning, and execution. This MCP server exposes the Transform lifecycle through 19 tools, supporting mainframe modernization, VMware migration, .NET modernization, and custom code transformations.


### PR DESCRIPTION

  ## Summary

  ### Changes

Add PyPI download badges (total and monthly) from pepy.tech to the aws-transform-mcp-server README. Badges are placed after the title and before the description, consistent with the pattern used by other servers in this repo (e.g., ecs-mcp-server, well-architected-security-mcp-server).


  User experience

  Before: The aws-transform-mcp-server README had no package metrics visible at a glance.

  After: Visitors immediately see two badges showing total and monthly download counts, providing a quick signal of adoption and activity.

  Checklist

  - I have reviewed the contributing guidelines
  - I have performed a self-review of this change
  - Changes have been tested
  - Changes are documented

  Is this a breaking change? N

  RFC issue number: N/A
 
Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
