### PR TITLE
fix: Set isError on CallToolResult for API failures per MCP spec

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -29,6 +29,7 @@ if __name__ == '__main__':
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
 
+import mcp.types as mcp_types
 from awslabs.billing_cost_management_mcp_server.tools.aws_pricing_tools import aws_pricing_server
 from awslabs.billing_cost_management_mcp_server.tools.bcm_pricing_calculator_tools import (
     bcm_pricing_calculator_server,
@@ -73,10 +74,49 @@ from awslabs.billing_cost_management_mcp_server.tools.storage_lens_tools import 
 from awslabs.billing_cost_management_mcp_server.tools.unified_sql_tools import unified_sql_server
 from awslabs.billing_cost_management_mcp_server.utilities.logging_utils import get_logger
 from fastmcp import FastMCP
+from fastmcp.server.middleware import Middleware
+from fastmcp.tools.tool import ToolResult
 
 
 # Configure logger for server
 logger = get_logger(__name__)
+
+
+class _ErrorToolResult(ToolResult):
+    """A ToolResult that serializes to a CallToolResult with isError=True."""
+
+    def to_mcp_result(self):
+        return mcp_types.CallToolResult(
+            content=self.content,
+            structuredContent=self.structured_content,
+            isError=True,
+            _meta=self.meta,
+        )
+
+
+class ErrorSignalingMiddleware(Middleware):
+    """Middleware that sets isError=True when a tool returns an error response.
+
+    Per the MCP spec, tools should signal errors via isError on CallToolResult.
+    This middleware intercepts tool results that contain status='error' in their
+    response body and returns a result with isError=True, preserving the original
+    content and structuredContent for backward compatibility.
+    """
+
+    async def on_call_tool(self, context, call_next):
+        """Intercept tool results and set isError for error responses."""
+        result = await call_next(context)
+        if (
+            isinstance(result, ToolResult)
+            and isinstance(result.structured_content, dict)
+            and result.structured_content.get('status') == 'error'
+        ):
+            return _ErrorToolResult(
+                content=result.content,
+                structured_content=result.structured_content,
+                meta=result.meta,
+            )
+        return result
 
 
 # Main MCP server instance
@@ -135,6 +175,9 @@ For multi-account environments:
 - Specify accountIds parameter for compute-optimizer and cost-optimization tools
 """,
 )
+
+# Register middleware to signal errors via isError per MCP spec
+mcp.add_middleware(ErrorSignalingMiddleware())
 
 
 async def register_prompts():

--- a/src/billing-cost-management-mcp-server/tests/test_error_signaling_middleware.py
+++ b/src/billing-cost-management-mcp-server/tests/test_error_signaling_middleware.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ErrorSignalingMiddleware."""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.server import (
+    ErrorSignalingMiddleware,
+    _ErrorToolResult,
+)
+from fastmcp.tools.tool import ToolResult
+from mcp.types import CallToolResult, TextContent
+from unittest.mock import AsyncMock, MagicMock
+
+
+@pytest.fixture
+def middleware():
+    """Create an ErrorSignalingMiddleware instance."""
+    return ErrorSignalingMiddleware()
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock middleware context."""
+    return MagicMock()
+
+
+class TestErrorSignalingMiddleware:
+    """Tests for ErrorSignalingMiddleware.on_call_tool."""
+
+    @pytest.mark.asyncio
+    async def test_error_response_sets_is_error_true(self, middleware, mock_context):
+        """When a tool returns status='error', isError should be True."""
+        error_result = ToolResult(
+            structured_content={'status': 'error', 'message': 'Access denied'},
+        )
+        call_next = AsyncMock(return_value=error_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert isinstance(result, _ErrorToolResult)
+        mcp_result = result.to_mcp_result()
+        assert isinstance(mcp_result, CallToolResult)
+        assert mcp_result.isError is True
+        assert mcp_result.structuredContent == {'status': 'error', 'message': 'Access denied'}
+
+    @pytest.mark.asyncio
+    async def test_success_response_unchanged(self, middleware, mock_context):
+        """When a tool returns status='success', result should pass through unchanged."""
+        success_result = ToolResult(
+            structured_content={'status': 'success', 'data': {'cost': 100}},
+        )
+        call_next = AsyncMock(return_value=success_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result is success_result
+
+    @pytest.mark.asyncio
+    async def test_error_response_preserves_content(self, middleware, mock_context):
+        """Error response should preserve the original content blocks."""
+        error_result = ToolResult(
+            structured_content={
+                'status': 'error',
+                'error_type': 'ValidationError',
+                'message': 'Invalid date format',
+                'service': 'Cost Explorer',
+                'operation': 'getCostAndUsage',
+            },
+        )
+        call_next = AsyncMock(return_value=error_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        mcp_result = result.to_mcp_result()
+        assert mcp_result.isError is True
+        assert mcp_result.content == error_result.content
+        assert mcp_result.structuredContent['error_type'] == 'ValidationError'
+
+    @pytest.mark.asyncio
+    async def test_error_response_preserves_meta(self, middleware, mock_context):
+        """Error response should preserve meta if present."""
+        error_result = ToolResult(
+            structured_content={'status': 'error', 'message': 'fail'},
+            meta={'requestId': '123'},
+        )
+        call_next = AsyncMock(return_value=error_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        mcp_result = result.to_mcp_result()
+        assert mcp_result.isError is True
+        assert mcp_result.meta == {'requestId': '123'}
+
+    @pytest.mark.asyncio
+    async def test_no_structured_content_passes_through(self, middleware, mock_context):
+        """When structured_content is None, result should pass through."""
+        result_no_structured = ToolResult(content='plain text response')
+        call_next = AsyncMock(return_value=result_no_structured)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result is result_no_structured
+
+    @pytest.mark.asyncio
+    async def test_non_dict_structured_content_passes_through(self, middleware, mock_context):
+        """When structured_content is not a dict, result should pass through."""
+        # ToolResult requires structured_content to be a dict, so test with None
+        text_result = ToolResult(content=[TextContent(type='text', text='hello')])
+        call_next = AsyncMock(return_value=text_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result is text_result
+
+    @pytest.mark.asyncio
+    async def test_non_tool_result_passes_through(self, middleware, mock_context):
+        """When call_next returns something other than ToolResult, pass through."""
+        other_result = 'not a ToolResult'
+        call_next = AsyncMock(return_value=other_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result is other_result


### PR DESCRIPTION

<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Per the [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling), tools should signal errors via `isError` on CallToolResult.

Add ErrorSignalingMiddleware that intercepts tool results at the MCP protocol level. When a tool response contains `status='error'` in its JSON body, the middleware returns a CallToolResult with `isError=True`, preserving the original content and structuredContent for backward compatibility.


### User experience

  Before

  When an AWS API call fails or a validation error occurs, the MCP response looks like:
```
  {
    "isError": false,
    "content": [
      {
        "type": "text",
        "text": "{\"status\": \"error\", \"error_type\": \"AccessDeniedException\", \"message\": \"User is not authorized\", \"service\":
  \"Cost Explorer\", \"operation\": \"getCostAndUsage\"}"
      }
    ],
    "structuredContent": {
      "status": "error",
      "error_type": "AccessDeniedException",
      "message": "User is not authorized",
      "service": "Cost Explorer",
      "operation": "getCostAndUsage"
    }
  }
```

  MCP clients (Strands, Claude Desktop, etc.) see isError: false and treat this as a successful tool call. To detect the failure, they must parse the content text and look for "status": "error" — fragile and non-standard.

  After

```

  {
    "isError": true,
    "content": [
      {
        "type": "text",
        "text": "{\"status\": \"error\", \"error_type\": \"AccessDeniedException\", \"message\": \"User is not authorized\", \"service\":
  \"Cost Explorer\", \"operation\": \"getCostAndUsage\"}"
      }
    ],
    "structuredContent": {
      "status": "error",
      "error_type": "AccessDeniedException",
      "message": "User is not authorized",
      "service": "Cost Explorer",
      "operation": "getCostAndUsage"
    }
  }
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
