### PR TITLE
chore: release(amazon-bedrock-agentcore-mcp-server): 0.1.0 — refresh README, dynamic version, version bump

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/CHANGELOG.md
+++ b/src/amazon-bedrock-agentcore-mcp-server/CHANGELOG.md
@@ -7,13 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-- Server crash on Windows due to `asyncio.loop.add_signal_handler` being unsupported on the default `ProactorEventLoop` (#2752). Removed the redundant signal handler from `server_lifespan` — cleanup is already handled by the context manager's `finally` block on every graceful shutdown path (stdin EOF, SIGINT via default `KeyboardInterrupt`, HTTP shutdown via uvicorn's own signal handling).
+## 0.1.0 - 2026-05-14
 
 ### Added
 
+- **Runtime primitive** — 14 tools for deploying, managing, and invoking agent runtimes and endpoints (`create_agent_runtime`, `create_agent_runtime_endpoint`, `invoke_agent_runtime`, `stop_runtime_session`, `get_runtime_guide`, and others)
+- **Memory primitive** — 21 tools for memory resource management, event storage, semantic retrieval, batch operations, and extraction jobs (`memory_create`, `memory_create_event`, `memory_retrieve_records`, `memory_batch_create_records`, `get_memory_guide`, and others)
+- **Identity primitive** — 21 tools for workload identity, API key providers, OAuth2 providers, token vault configuration, and resource policies. Data plane operations (token retrieval) are intentionally excluded to keep credential material out of LLM context
+- **Gateway primitive** — 15 tools for managing API gateways, gateway targets (Lambda, OpenAPI, Smithy, MCP servers), and resource policies. `InvokeGateway` data plane operation is excluded for the same security reason
+- **Policy primitive** — 15 tools for policy engine management, authorization policies, and policy asset generation
+- **Code Interpreter primitive** — 9 tools for sandboxed code execution, package installation, and file transfer
+- **Browser automation tools** — 25 tools for cloud-based web interaction across 5 categories (session, navigation, observation, interaction, management)
+- **Service opt-in/opt-out** via `AGENTCORE_ENABLE_TOOLS` and `AGENTCORE_DISABLE_TOOLS` environment variables
+- **Server instructions** for MCP clients with browser usage tips
 - Initial project setup
-- Browser automation tools — 25 tools for cloud-based web interaction across 5 categories (session, navigation, observation, interaction, management)
-- Service opt-in/opt-out via `AGENTCORE_ENABLE_TOOLS` and `AGENTCORE_DISABLE_TOOLS` environment variables
-- Server instructions for MCP clients with browser usage tips
+
+### Changed
+
+- **README** rewritten to reflect 122-tool operational coverage across 7 primitives, including per-primitive tool callouts, configuration mechanisms, cost-awareness tiers, security posture (exclusion of credential-returning data plane operations), and architecture overview
+
+### Fixed
+
+- **User-agent version reporting** — `MCP_SERVER_VERSION` is now derived dynamically via `importlib.metadata.version()` instead of being hardcoded. Previously every release reported `0.1.0` regardless of installed version, blocking version-distribution analysis in service-side telemetry
+- Server crash on Windows due to `asyncio.loop.add_signal_handler` being unsupported on the default `ProactorEventLoop` (#2752). Removed the redundant signal handler from `server_lifespan` — cleanup is already handled by the context manager's `finally` block on every graceful shutdown path (stdin EOF, SIGINT via default `KeyboardInterrupt`, HTTP shutdown via uvicorn's own signal handling)

--- a/src/amazon-bedrock-agentcore-mcp-server/README.md
+++ b/src/amazon-bedrock-agentcore-mcp-server/README.md
@@ -1,38 +1,39 @@
 # AWS Bedrock AgentCore MCP Server
 
-Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services
+Model Context Protocol (MCP) server for Amazon Bedrock AgentCore — providing operational API tools that let AI coding agents manage AgentCore resources directly.
 
-This MCP server provides comprehensive access to Amazon Bedrock AgentCore documentation, enabling developers to search and retrieve detailed information about AgentCore platform services, APIs, tutorials, and best practices.
+## Overview
 
-## Features
+This MCP server gives AI agents (Claude Code, Kiro, Cursor, VS Code, Codex CLI) direct access to AgentCore platform APIs. Agents can create and manage runtimes, store and retrieve memories, configure identity providers, deploy gateways, and manage policies — all through standard MCP tool calls backed by real boto3 API calls.
 
-- **Search Documentation**: Search through curated AgentCore documentation with ranked results and contextual snippets
-- **Fetch Full Documents**: Retrieve complete documentation pages for in-depth understanding
-- **Browser Automation**: 25 cloud-based browser tools for web navigation, interaction, and data extraction — no local browser installation required
-- **Comprehensive Coverage**: Access documentation for all AgentCore services including Runtime, Memory, Code Interpreter, Browser, Gateway, Observability, and Identity
-- **Smart Caching**: Efficient document caching with on-demand content loading for optimal performance
-- **Curated Documentation List**: Uses llm.txt as a curated list of relevant AgentCore documentations, always fetching the latest version of the file
+**122 tools** across 7 operational primitives + documentation search.
+
+|Primitive           |Tools|What it does                                                                                   |
+|--------------------|----:|-----------------------------------------------------------------------------------------------|
+|**Runtime**         |14   |Deploy, manage, and invoke agent runtimes and endpoints                                        |
+|**Memory**          |21   |Create memory resources, store events, semantic search, batch operations, extraction jobs      |
+|**Identity**        |21   |Manage workload identities, API key providers, OAuth2 providers, token vault, resource policies|
+|**Gateway**         |15   |Create and manage API gateways, gateway targets, resource policies                             |
+|**Policy**          |15   |Create policy engines, manage policies, generate and review policy assets                      |
+|**Browser**         |25   |Cloud-based browser automation — navigate, click, type, screenshot, extract data               |
+|**Code Interpreter**|9    |Sandboxed code execution, file upload/download, package installation                           |
+|**Documentation**   |2    |Search and fetch AgentCore docs                                                                |
 
 ## Prerequisites
 
-### Installation Requirements
-
-1. Install `uv` from [Astral](https://docs.astral.sh/uv/getting-started/installation/) or the [GitHub README](https://github.com/astral-sh/uv#installation)
-2. Install Python 3.10 or newer using `uv python install 3.10` (or a more recent version)
+1. Install `uv` from [Astral](https://docs.astral.sh/uv/getting-started/installation/)
+1. Install Python 3.10+ using `uv python install 3.10`
+1. AWS credentials configured (AWS_PROFILE, AWS_ACCESS_KEY_ID, or IAM role)
 
 ## Installation
 
-| Kiro | Cursor | VS Code |
-|:----:|:------:|:-------:|
-| [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=bedrock-agentcore-mcp-server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.amazon-bedrock-agentcore-mcp-server%40latest%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%7D) | [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en/install-mcp?name=bedrock-agentcore-mcp-server&config=eyJjb21tYW5kIjoidXZ4IGF3c2xhYnMuYW1hem9uLWJlZHJvY2stYWdlbnRjb3JlLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwiZW52Ijp7IkZBU1RNQ1BfTE9HX0xFVkVMIjoiRVJST1IifSwiZGlzYWJsZWQiOmZhbHNlLCJhdXRvQXBwcm92ZSI6WyJzZWFyY2hfYWdlbnRjb3JlX2RvY3MiLCJmZXRjaF9hZ2VudGNvcmVfZG9jIl19) | [![Install on VS Code](https://img.shields.io/badge/Install_on-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Bedrock%20AgentCore%20MCP%20Server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.amazon-bedrock-agentcore-mcp-server%40latest%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%22search_agentcore_docs%22%2C%22fetch_agentcore_doc%22%5D%7D) |
+|Kiro                                                                                                                                                                                                                                                                                                         |Cursor                                                                                                                                                                                                                                                                                                                                                                                                     |VS Code                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=bedrock-agentcore-mcp-server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.amazon-bedrock-agentcore-mcp-server%40latest%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%7D)|[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en/install-mcp?name=bedrock-agentcore-mcp-server&config=eyJjb21tYW5kIjoidXZ4IGF3c2xhYnMuYW1hem9uLWJlZHJvY2stYWdlbnRjb3JlLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwiZW52Ijp7IkZBU1RNQ1BfTE9HX0xFVkVMIjoiRVJST1IifSwiZGlzYWJsZWQiOmZhbHNlLCJhdXRvQXBwcm92ZSI6WyJzZWFyY2hfYWdlbnRjb3JlX2RvY3MiLCJmZXRjaF9hZ2VudGNvcmVfZG9jIl19)|[![Install on VS Code](https://img.shields.io/badge/Install_on-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Bedrock%20AgentCore%20MCP%20Server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.amazon-bedrock-agentcore-mcp-server%40latest%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%22search_agentcore_docs%22%2C%22fetch_agentcore_doc%22%5D%7D)|
 
-Configure the MCP server in your MCP client configuration:
+### Configuration
 
-For [Kiro](https://kiro.dev/), see the [Kiro IDE documentation](https://kiro.dev/docs/mcp/configuration/) or the [Kiro CLI documentation](https://kiro.dev/docs/cli/mcp/configuration/) for details.
-
-For global configuration, edit `~/.kiro/settings/mcp.json`. For project-specific configuration, edit `.kiro/settings/mcp.json` in your project directory.
-
-Example configuration for Kiro (`~/.kiro/settings/mcp.json`):
+Add to your MCP client configuration (e.g., `~/.kiro/settings/mcp.json`):
 
 ```json
 {
@@ -42,222 +43,142 @@ Example configuration for Kiro (`~/.kiro/settings/mcp.json`):
       "args": ["awslabs.amazon-bedrock-agentcore-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false,
-      "autoApprove": []
-    }
-  }
-}
-```
-
-### Windows Installation
-
-For Windows users, the MCP server configuration format is slightly different:
-
-```json
-{
-  "mcpServers": {
-    "bedrock-agentcore-mcp-server": {
-      "disabled": false,
-      "timeout": 60,
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "tool",
-        "run",
-        "--from",
-        "awslabs.amazon-bedrock-agentcore-mcp-server@latest",
-        "awslabs.amazon-bedrock-agentcore-mcp-server.exe"
-      ],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
       }
     }
   }
 }
 ```
 
-Or using Docker after a successful `docker build -t mcp/amazon-bedrock-agentcore .`:
+### Windows
 
 ```json
 {
   "mcpServers": {
     "bedrock-agentcore-mcp-server": {
-      "command": "docker",
+      "command": "uv",
       "args": [
-        "run",
-        "--rm",
-        "--interactive",
-        "--env",
-        "FASTMCP_LOG_LEVEL=ERROR",
-        "mcp/amazon-bedrock-agentcore:latest"
+        "tool", "run", "--from",
+        "awslabs.amazon-bedrock-agentcore-mcp-server@latest",
+        "awslabs.amazon-bedrock-agentcore-mcp-server.exe"
       ],
-      "env": {},
-      "disabled": false,
-      "autoApprove": []
+      "env": { "FASTMCP_LOG_LEVEL": "ERROR" }
     }
   }
 }
 ```
 
-## Basic Usage
+## Tool Configuration
 
-The server provides access to comprehensive Amazon Bedrock AgentCore documentation covering:
+All primitive tools are enabled by default. Use environment variables to control which tools are registered:
 
-**Platform Services:**
-- AgentCore Runtime (serverless deployment and scaling)
-- AgentCore Memory (persistent knowledge with event and semantic memory)
-- AgentCore Code Interpreter (secure code execution in isolated sandboxes)
-- AgentCore Browser (fast, secure cloud-based browser for web interaction)
-- AgentCore Gateway (transform existing APIs into agent tools)
-- AgentCore Observability (real-time monitoring and tracing)
-- AgentCore Identity (secure authentication and access management)
+```bash
+# Disable specific primitives
+AGENTCORE_DISABLE_TOOLS=browser,code_interpreter
 
-**Development Resources:**
-- Getting started guides and prerequisites
-- Building your first agent or transforming existing code
-- Local development and testing workflows
-- Deployment to AgentCore using CLI
-- API reference documentation
-- Examples and tutorials for various use cases
-
-Example queries:
-- "How do I set up AgentCore Memory for my agent?"
-- "Show me examples of using the Code Interpreter service"
-- "What are the deployment options for AgentCore Runtime?"
-- "How do I integrate AgentCore Browser with my application?"
-- "Start a browser session and navigate to docs.aws.amazon.com"
-- "Take a screenshot of the current page and extract all links"
-
-## Browser Tools
-
-The server includes 25 browser automation tools powered by Amazon Bedrock AgentCore. Each session runs in an isolated Firecracker microVM — no local browser installation is needed.
-
-### Quick Start
-
-```python
-# 1. Start a session
-start_browser_session(timeout_seconds=300)
-
-# 2. Navigate and interact
-browser_navigate(session_id="...", url="https://example.com")
-browser_snapshot(session_id="...")       # accessibility tree with element refs
-browser_click(session_id="...", ref="e3")
-browser_type(session_id="...", ref="e5", text="search query")
-
-# 3. Clean up
-stop_browser_session(session_id="...")
+# Or enable only specific primitives
+AGENTCORE_ENABLE_TOOLS=memory,runtime,identity
 ```
 
-### Tool Categories
+When `AGENTCORE_ENABLE_TOOLS` is set, only the listed primitives are registered. Documentation tools (`search_agentcore_docs`, `fetch_agentcore_doc`) are always available.
 
-| Category | Tools | Description |
-|----------|-------|-------------|
-| **Session** (4) | `start_browser_session`, `get_browser_session`, `list_browser_sessions`, `stop_browser_session` | Create, inspect, list, and terminate sessions |
-| **Navigation** (3) | `browser_navigate`, `browser_navigate_back`, `browser_navigate_forward` | URL navigation and history |
-| **Observation** (6) | `browser_snapshot`, `browser_take_screenshot`, `browser_evaluate`, `browser_wait_for`, `browser_console_messages`, `browser_network_requests` | Page state, screenshots, JS execution, network |
-| **Interaction** (9) | `browser_click`, `browser_type`, `browser_fill_form`, `browser_select_option`, `browser_hover`, `browser_press_key`, `browser_upload_file`, `browser_handle_dialog`, `browser_mouse_wheel` | Click, type, forms, keyboard, dialogs |
-| **Management** (3) | `browser_tabs`, `browser_resize`, `browser_close` | Tab management, viewport, page lifecycle |
+## Primitives
 
-### Tips
+### Runtime (14 tools)
 
-- **Use DuckDuckGo or Bing** instead of Google — Google blocks cloud browser IPs with CAPTCHAs.
-- **Prefer `browser_evaluate` for data extraction** — snapshots show page structure; `browser_evaluate` with `querySelectorAll` extracts actual data efficiently.
-- **Use `browser_evaluate` for long text** — `browser_type` types character-by-character. For long inputs, use `document.querySelector("selector").value = "text"` instead.
-- **Idle timeout, not absolute** — `timeout_seconds` on `start_browser_session` resets on each tool call, not wall-clock duration.
+Manage agent runtimes and endpoints on AgentCore. Create runtimes, deploy endpoint versions, invoke agents, and manage sessions.
 
-## Tools
+Key tools: `create_agent_runtime`, `create_agent_runtime_endpoint`, `invoke_agent_runtime`, `stop_runtime_session`, `get_runtime_guide`
 
-### search_agentcore_docs
+### Memory (21 tools)
 
-Search curated AgentCore documentation and return ranked results with snippets.
+Create memory resources, store conversation events, retrieve semantically relevant memories, and manage extraction jobs. Supports both short-term (session events) and long-term (extracted insights) memory.
 
-```python
-search_agentcore_docs(query: str, k: int = 5) -> List[Dict[str, Any]]
+Key tools: `memory_create`, `memory_create_event`, `memory_retrieve_records`, `memory_batch_create_records`, `get_memory_guide`
+
+> **Note:** The MCP tools call AgentCore Memory APIs directly via boto3. The `agentcore` CLI is not required to use these tools.
+
+### Identity (21 tools)
+
+Manage workload identities, API key credential providers, OAuth2 credential providers, token vault configuration, and resource policies. Data plane operations (token retrieval) are intentionally excluded — they return live credentials that should not flow through LLM context.
+
+Key tools: `identity_create_workload_identity`, `identity_create_api_key_provider`, `identity_create_oauth2_provider`, `identity_get_token_vault`, `get_identity_guide`
+
+### Gateway (15 tools)
+
+Create and manage API gateways that transform existing APIs into agent-callable MCP tools. Manage gateway targets (Lambda, OpenAPI, Smithy, MCP servers) and resource policies. The `InvokeGateway` data plane operation is excluded — it requires agent-runtime JWTs and can return sensitive content.
+
+Key tools: `gateway_create`, `gateway_target_create`, `gateway_target_synchronize`, `gateway_resource_policy_put`, `get_gateway_guide`
+
+### Policy (15 tools)
+
+Create policy engines, manage authorization policies, and generate policy assets. Policy engines enforce fine-grained access control for agent actions.
+
+Key tools: `policy_engine_create`, `policy_create`, `policy_generation_start`, `policy_generation_get`, `get_policy_guide`
+
+### Browser (25 tools)
+
+Cloud-based browser automation powered by AgentCore. Each session runs in an isolated Firecracker microVM — no local browser installation needed.
+
+```
+start_browser_session → browser_navigate → browser_snapshot → browser_click → stop_browser_session
 ```
 
-**Parameters:**
-- `query`: Search query string (e.g., "bedrock agentcore", "memory integration", "deployment guide")
-- `k`: Maximum number of results to return (default: 5)
+Tips:
 
-**Returns:**
-List of dictionaries containing:
-- `url`: Document URL
-- `title`: Display title
-- `score`: Relevance score (0-1, higher is better)
-- `snippet`: Contextual content preview
+- Use DuckDuckGo or Bing instead of Google (CAPTCHAs block cloud IPs)
+- Use `browser_evaluate` with `querySelectorAll` for data extraction
+- `timeout_seconds` is an idle timeout, not absolute duration
 
-### fetch_agentcore_doc
+### Code Interpreter (9 tools)
 
-Fetch full document content by URL.
+Sandboxed code execution in isolated environments. Start a session, execute code or shell commands, install packages, and transfer files.
 
-```python
-fetch_agentcore_doc(uri: str) -> Dict[str, Any]
+Key tools: `start_code_interpreter_session`, `execute_code`, `execute_command`, `install_packages`, `upload_file`, `download_file`
+
+> **Cost note:** Sessions incur AWS charges. Stop sessions when done.
+
+### Documentation (2 tools)
+
+Search and fetch AgentCore documentation. These tools are always available regardless of `AGENTCORE_DISABLE_TOOLS` settings.
+
+- `search_agentcore_docs` — search with ranked results and snippets
+- `fetch_agentcore_doc` — retrieve full document content by URL
+
+## Cost Awareness
+
+Tools that create AWS resources or invoke compute incur charges. Each primitive’s guide tool (`get_memory_guide`, `get_runtime_guide`, etc.) documents cost tiers:
+
+- **Read-only** (no cost): get, list, guide operations
+- **Billable** (AWS charges): create, update, invoke, search operations
+- **Destructive** (irreversible): delete operations
+
+Billable and destructive tools include `COST WARNING:` or `WARNING:` in their descriptions so agents understand the implications before calling them.
+
+## Security
+
+- All API calls use boto3 with credentials resolved from your environment (AWS_PROFILE, env vars, or IAM role)
+- Operations that return credential material (tokens, API keys, secrets) are excluded from MCP tools — credentials should not flow through LLM context
+- Retrieved content (memory records, gateway responses) should be treated as untrusted input
+- User-agent tracking (`agentcore-mcp-server/{version} {primitive}`) is included in API calls for usage analytics — no telemetry is sent elsewhere
+
+## Architecture
+
+Each primitive is implemented as an independent sub-package under `tools/`:
+
+```
+tools/
+├── runtime/       # 14 tools — agent runtime management
+├── memory/        # 21 tools — memory resources and records
+├── identity/      # 21 tools — workload identity and credentials
+├── gateway/       # 15 tools — API gateway management
+├── policy/        # 15 tools — policy engine management
+├── browser/       # 25 tools — cloud browser automation
+├── code_interpreter/  # 9 tools — sandboxed code execution
+└── docs.py        # 2 tools — documentation search
 ```
 
-**Parameters:**
-- `uri`: Document URI (supports http/https URLs)
+Each sub-package contains: cached boto3 client wrapper, Pydantic response models, structured error handler, domain tool files, and a comprehensive guide tool.
 
-**Returns:**
-Dictionary containing:
-- `url`: Canonical document URL
-- `title`: Document title
-- `content`: Full document text content
-- `error`: Error message (if fetch failed)
+## License
 
-Use this tool to get complete documentation pages when search snippets aren't sufficient for understanding or implementing AgentCore features.
-
-### manage_agentcore_runtime
-
-Provides comprehensive information on deploying and managing agents in AgentCore Runtime.
-
-```python
-manage_agentcore_runtime() -> Dict[str, Any]
-```
-
-**Returns:**
-Detailed deployment guide covering:
-- Code requirements and validation checklist
-- Step-by-step CLI deployment workflow (configure, launch, invoke, status, destroy)
-- Required code patterns with BedrockAgentCoreApp
-- Common issues and troubleshooting
-- Session management and cleanup procedures
-
-Use this tool when you need to deploy agents to AgentCore Runtime or troubleshoot deployment issues.
-
-### manage_agentcore_memory
-
-Provides comprehensive information on managing AgentCore Memory resources.
-
-```python
-manage_agentcore_memory() -> Dict[str, Any]
-```
-
-**Returns:**
-Complete memory management guide covering:
-- Memory resource creation and configuration
-- Short-term memory (STM) and long-term memory (LTM) concepts
-- Semantic memory strategies for facts and knowledge
-- Full CLI command reference (create, get, list, delete, status)
-- Common workflows and examples
-
-Use this tool when working with AgentCore Memory for persistent knowledge storage.
-
-### manage_agentcore_gateway
-
-Provides comprehensive information on deploying and managing MCP Gateways in AgentCore.
-
-```python
-manage_agentcore_gateway() -> Dict[str, Any]
-```
-
-**Returns:**
-Complete gateway deployment guide covering:
-- Gateway creation and configuration requirements
-- Step-by-step CLI deployment workflow
-- Target management for Lambda, OpenAPI, and Smithy models
-- Authentication and authorization setup (Cognito, OAuth2, API keys)
-- Management commands (list, get, delete)
-- Common patterns and troubleshooting
-
-Use this tool when deploying MCP Gateways to provide managed endpoints for Model Context Protocol servers.
+Apache 2.0 — see <LICENSE> for details.

--- a/src/amazon-bedrock-agentcore-mcp-server/README.md
+++ b/src/amazon-bedrock-agentcore-mcp-server/README.md
@@ -178,7 +178,3 @@ tools/
 ```
 
 Each sub-package contains: cached boto3 client wrapper, Pydantic response models, structured error handler, domain tool files, and a comprehensive guide tool.
-
-## License
-
-Apache 2.0 — see <LICENSE> for details.

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.0.22'
+__version__ = '0.1.0'

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/user_agent.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/user_agent.py
@@ -32,7 +32,13 @@ Examples:
     agentcore-mcp-server/0.1.0 code-interpreter
 """
 
-MCP_SERVER_VERSION = '0.1.0'
+from importlib.metadata import PackageNotFoundError, version
+
+
+try:
+    MCP_SERVER_VERSION = version('awslabs.amazon-bedrock-agentcore-mcp-server')
+except PackageNotFoundError:
+    MCP_SERVER_VERSION = 'unknown'
 
 
 def build_user_agent(primitive: str, plane: str = '') -> str:

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.22"
+version = "0.1.0"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_user_agent.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_user_agent.py
@@ -14,10 +14,14 @@
 
 """Unit tests for shared user-agent utility."""
 
+import importlib
+from awslabs.amazon_bedrock_agentcore_mcp_server.utils import user_agent as ua
 from awslabs.amazon_bedrock_agentcore_mcp_server.utils.user_agent import (
     MCP_SERVER_VERSION,
     build_user_agent,
 )
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
 
 
 class TestBuildUserAgent:
@@ -66,3 +70,19 @@ class TestBuildUserAgent:
         v2 = build_user_agent('runtime').split('/')[1].split(' ')[0]
         v3 = build_user_agent('browser').split('/')[1].split(' ')[0]
         assert v1 == v2 == v3 == MCP_SERVER_VERSION
+
+
+class TestPackageVersionFallback:
+    """Tests for version detection fallback."""
+
+    def test_package_not_found_fallback(self):
+        """MCP_SERVER_VERSION falls back to 'unknown' when package metadata is missing."""
+        with patch('importlib.metadata.version', side_effect=PackageNotFoundError):
+            importlib.reload(ua)
+            try:
+                assert ua.MCP_SERVER_VERSION == 'unknown'
+                result = ua.build_user_agent('memory')
+                assert result == 'agentcore-mcp-server/unknown memory'
+            finally:
+                # Restore module to its normal state for other tests
+                importlib.reload(ua)

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.0.22"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },


### PR DESCRIPTION

<!-- markdownlint-disable MD041 MD043 -->
Fixes

### Summary

Retroactively tags the unified MCP server expansion as `0.1.0`, rewrites the README to reflect actual capabilities, 
and makes future version attribution dynamic.

### Background

Recent release of `awslabs.amazon-bedrock-agentcore-mcp-server` 
added 87 operational tools across Runtime, Memory, Identity, Gateway, 
and Policy primitives — bringing the total to 122 tools. This was a 
minor-version-grade change in semver terms but shipped as a `0.0.x` 
patch. Three secondary issues compounded the oversight:

1. **README out of date**: still described only the original documentation 
   search + browser tool surface, with no mention of the 87 new operational 
   tools or the configuration mechanisms for them.

2. **Version string hardcoded**: `utils/user_agent.py` carried 
   `MCP_SERVER_VERSION = '0.1.0'` as a hardcoded constant, disconnected 
   from `pyproject.toml`. The user-agent has reported `0.1.0` regardless 
   of installed version for every release to date.

3. **Service-side attribution blocked**: customers running 0.0.x patches 
   are indistinguishable in user-agent logs, preventing version-distribution 
   analysis.

### Changes

1. **`README.md`**: full rewrite covering 122 tools / 7 primitives, 
   per-primitive tool callouts, `AGENTCORE_ENABLE_TOOLS` / 
   `AGENTCORE_DISABLE_TOOLS` configuration, cost-awareness tiers, 
   security posture, and architecture overview.

2. **`utils/user_agent.py`**: read `MCP_SERVER_VERSION` dynamically via 
   `importlib.metadata.version()`, matching the pattern used by the 
   `bedrock-agentcore` SDK. Falls back to `'unknown'` if package 
   metadata is unavailable.

3. **Version bump**: `pyproject.toml`, `__init__.py`, and `uv.lock` 
   move from `0.0.22` to `0.1.0`. CHANGELOG entry added.

### Test plan

- [x] `pip install -e .` then check `MCP_SERVER_VERSION` resolves to `0.1.0`
- [x] Outbound boto3 user-agent contains `agentcore-mcp-server/0.1.0`
- [x] `uv lock` ran cleanly and updated lockfile to `0.1.0`
- [x ] Existing unit tests pass

### Risk

Low. README is content-only. Version bump is metadata. The user-agent 
change is invisible to customers — it only affects the value of an 
existing telemetry string.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x ] I have performed a self-review of this change
* [x ] Changes have been tested
* [x ] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
