### PR TITLE
feat(aws-network-mcp-server): add Load Balancer, Route 53/DNS, VPC Endpoint, and Route 53 Profiles troubleshooting tools

### DIFF
--- a/src/aws-network-mcp-server/README.md
+++ b/src/aws-network-mcp-server/README.md
@@ -1,11 +1,11 @@
 # AWS Core Network MCP Server
 
-A Model Context Protocol (MCP) server providing comprehensive tools for troubleshooting and analyzing AWS core networking services including Cloud WAN, Transit Gateway, VPC, Network Firewall, and VPN connections.
+A Model Context Protocol (MCP) server providing comprehensive tools for troubleshooting and analyzing AWS core networking services including Cloud WAN, Transit Gateway, VPC, Network Firewall, VPN connections, Load Balancers, Route 53 / DNS, and VPC Endpoints / PrivateLink.
 
 ### Key Features
 
 - **Systematic troubleshooting**: Built-in methodology for network path tracing and connectivity analysis
-- **Multi-service coverage**: Unified interface for Cloud WAN, Transit Gateway, VPC, Network Firewall, and VPN
+- **Multi-service coverage**: Unified interface for Cloud WAN, Transit Gateway, VPC, Network Firewall, VPN, Load Balancers, Route 53, and VPC Endpoints
 - **Flow log analysis**: Query and filter VPC, Transit Gateway, and Network Firewall flow logs from CloudWatch
 - **Inspection detection**: Automatically identify firewalls in traffic paths for security analysis
 - **Multi-region support**: Search for resources across all AWS regions
@@ -19,6 +19,9 @@ A Model Context Protocol (MCP) server providing comprehensive tools for troubles
 - **Routing analysis**: Trace traffic paths through VPC, Transit Gateway, and Cloud WAN
 - **Traffic verification**: Query flow logs to confirm actual traffic patterns
 - **Inspection detection**: Identify AWS Network Firewall and third-party firewalls in traffic paths
+- **Load balancer health**: List load balancers, inspect listeners and target groups, check per-target health status
+- **DNS troubleshooting**: List hosted zones, query DNS records, check health check statuses, inspect Resolver rules and endpoints
+- **VPC endpoint diagnostics**: Detailed endpoint inventory with type-specific fields, connectivity diagnostics with security group and ENI analysis
 
 ### Tools
 
@@ -60,6 +63,21 @@ A Model Context Protocol (MCP) server providing comprehensive tools for troubles
 
 #### VPN Tools
 27. `list_vpn_connections`: List all Site-to-Site VPN connections in a region
+
+#### Load Balancer Tools
+28. `list_load_balancers`: List all ALBs, NLBs, and GLBs in a region with optional type filtering
+29. `get_lb_details`: Get detailed load balancer configuration including listeners, target groups, and security groups
+30. `get_lb_target_health`: Get per-target health status with failure reasons for a target group
+
+#### Route 53 / DNS Tools
+31. `list_hosted_zones`: List Route 53 hosted zones with type (public/private) and VPC associations
+32. `query_dns_records`: Search DNS records within a hosted zone by type or name prefix
+33. `check_health_checks`: Check Route 53 health check statuses and identify failing endpoints
+34. `list_resolver_rules`: List Route 53 Resolver rules and endpoints for hybrid DNS troubleshooting
+
+#### VPC Endpoint Tools
+35. `list_vpc_endpoints_detailed`: List VPC endpoints with detailed type-specific information across VPCs
+36. `check_endpoint_connectivity`: Check connectivity diagnostics for a specific VPC endpoint
 
 ## Prerequisites
 - Have an AWS account with [credentials configured](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)
@@ -134,6 +152,7 @@ AWS Credentials in environment variables will also work but allows only single a
     {
       "Effect": "Allow",
       "Action": [
+        // --- EC2 / VPC (also used by VPC Endpoint tools) ---
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeNetworkAcls",
@@ -150,6 +169,8 @@ AWS Credentials in environment variables will also work but allows only single a
         "ec2:DescribeVpnConnections",
         "ec2:DescribeFlowLogs",
         "ec2:DescribeRegions",
+
+        // --- Cloud WAN / Network Manager ---
         "networkmanager:GetCoreNetwork",
         "networkmanager:GetCoreNetworkPolicy",
         "networkmanager:GetNetworkRoutes",
@@ -164,14 +185,41 @@ AWS Credentials in environment variables will also work but allows only single a
         "networkmanager:ListCoreNetworks",
         "networkmanager:ListAttachments",
         "networkmanager:ListPeerings",
+
+        // --- Network Firewall ---
         "network-firewall:DescribeFirewall",
         "network-firewall:DescribeFirewallPolicy",
         "network-firewall:DescribeRuleGroup",
         "network-firewall:DescribeLoggingConfiguration",
         "network-firewall:ListFirewalls",
+
+        // --- Load Balancer (Phase 1) ---
         "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+
+        // --- Route 53 / DNS (Phase 2) ---
+        "route53:ListHostedZones",
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets",
+        "route53:ListHealthChecks",
+        "route53:GetHealthCheckStatus",
+
+        // --- Route 53 Resolver (Phase 2) ---
+        "route53resolver:ListResolverRules",
+        "route53resolver:ListResolverEndpoints",
+        "route53resolver:ListResolverRuleAssociations",
+        "route53resolver:ListResolverEndpointIpAddresses",
+
+        // --- CloudWatch Metrics (Phase 2 — calculated health check status) ---
+        "cloudwatch:GetMetricStatistics",
+
+        // --- CloudWatch Logs ---
         "logs:StartQuery",
         "logs:GetQueryResults",
+
+        // --- STS ---
         "sts:GetCallerIdentity"
       ],
       "Resource": "*"

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/server.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/server.py
@@ -19,9 +19,13 @@ import sys
 from awslabs.aws_network_mcp_server.tools import (
     cloud_wan,
     general,
+    load_balancer,
     network_firewall,
+    route53,
+    route53_profiles,
     transit_gateway,
     vpc,
+    vpc_endpoints,
     vpn,
 )
 from fastmcp import FastMCP
@@ -49,6 +53,9 @@ mcp = FastMCP(
     - VPC: Network configuration, flow logs, ENI details
     - Network Firewall: Rules and flow logs
     - VPN: Connection details
+    - Load Balancer: ALB/NLB/GLB listing, details, target health
+    - Route 53 / DNS: Hosted zones, DNS records, health checks, Resolver rules and endpoints
+    - VPC Endpoints / PrivateLink: Detailed endpoint listing, connectivity diagnostics
     - General: IP lookup, ENI analysis
 
     ## Troubleshooting Workflow
@@ -64,6 +71,10 @@ mcp = FastMCP(
     - Transit Gateway routing: list_transit_gateways → get_tgw_details → get_all_tgw_routes
     - Firewall analysis: detect_tgw_inspection → get_firewall_rules → get_network_firewall_flow_logs
     - Traffic verification: get_vpc_flow_logs / get_tgw_flow_logs (filter by srcaddr, dstaddr, ports)
+    - Load balancer health: list_load_balancers → get_lb_details → get_lb_target_health
+    - VPC endpoint diagnostics: list_vpc_endpoints_detailed → check_endpoint_connectivity
+    - DNS troubleshooting: list_hosted_zones → query_dns_records → check_health_checks
+    - Hybrid DNS: list_resolver_rules → Verify forwarding rules and endpoint IPs
 
     ## Key Capabilities
     - Multi-region IP address search with find_ip_address(all_regions=True)
@@ -85,7 +96,18 @@ mcp = FastMCP(
 
 # Register tools at module level
 logger.info('Registering tools...')
-for module in (general, cloud_wan, network_firewall, transit_gateway, vpc, vpn):
+for module in (
+    general,
+    cloud_wan,
+    load_balancer,
+    network_firewall,
+    route53,
+    route53_profiles,
+    transit_gateway,
+    vpc,
+    vpc_endpoints,
+    vpn,
+):
     for tool_name in module.__all__:
         mcp.tool(getattr(module, tool_name))
 logger.info('Tools registered successfully')

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/__init__.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .get_lb_details import get_lb_details
+from .get_lb_target_health import get_lb_target_health
+from .list_load_balancers import list_load_balancers
+
+__all__ = ['get_lb_details', 'get_lb_target_health', 'list_load_balancers']

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/get_lb_details.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/get_lb_details.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+async def get_lb_details(
+    lb_arn: Annotated[
+        str,
+        Field(..., description='The ARN of the load balancer to retrieve details for.'),
+    ],
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the load balancer is deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """Get detailed configuration for a specific load balancer including listeners and target groups.
+
+    Use this tool when:
+    - Diagnosing connectivity issues with a specific ALB, NLB, or GLB
+    - Reviewing listener configuration (protocols, ports, default actions)
+    - Identifying associated target groups and their health check settings
+    - Checking security group associations for ALBs and NLBs
+    - Verifying AZ mapping and subnet placement
+
+    Common workflows:
+    1. get_lb_details() → Review listeners → Check target groups → get_lb_target_health()
+    2. get_lb_details() → Check security groups → get_eni_details() for deeper SG analysis
+    3. list_load_balancers() → get_lb_details() → Identify misconfigured listeners
+
+    Returns:
+        Dict containing:
+        - load_balancer: LB config with ARN, name, type, scheme, state, DNS, VPC, AZs, security groups
+        - listeners: List of listeners or None if sub-call failed
+        - listeners_error: Error message if listeners retrieval failed
+        - target_groups: List of target groups or None if sub-call failed
+        - target_groups_error: Error message if target groups retrieval failed
+        - region: AWS region queried
+    """
+    if not lb_arn.startswith('arn:aws:elasticloadbalancing:'):
+        raise ToolError(
+            'Error getting load balancer details. Error: Invalid lb_arn format. '
+            'Must start with "arn:aws:elasticloadbalancing:". '
+            'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        client = get_aws_client('elbv2', region, profile_name)
+        response = client.describe_load_balancers(LoadBalancerArns=[lb_arn])
+        lbs = response.get('LoadBalancers', [])
+        if not lbs:
+            raise ToolError(
+                f'Error getting load balancer details. Error: Load balancer not found: {lb_arn}. '
+                f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+            )
+        lb = lbs[0]
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error getting load balancer details. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    # Handle security groups: present for ALB, optional for NLB, absent for GLB
+    lb_type = lb.get('Type', '')
+    if lb_type == 'gateway':
+        lb['SecurityGroups'] = None
+    elif 'SecurityGroups' not in lb:
+        lb['SecurityGroups'] = []
+
+    # Retrieve listeners with independent error handling
+    listeners = None
+    listeners_error = None
+    try:
+        listener_paginator = client.get_paginator('describe_listeners')
+        listeners = []
+        for page in listener_paginator.paginate(LoadBalancerArn=lb_arn):
+            listeners.extend(page.get('Listeners', []))
+    except Exception as e:
+        listeners = None
+        listeners_error = str(e)
+
+    # Retrieve target groups with independent error handling
+    target_groups = None
+    target_groups_error = None
+    try:
+        tg_paginator = client.get_paginator('describe_target_groups')
+        target_groups = []
+        for page in tg_paginator.paginate(LoadBalancerArn=lb_arn):
+            target_groups.extend(page.get('TargetGroups', []))
+    except Exception as e:
+        target_groups = None
+        target_groups_error = str(e)
+
+    return {
+        'load_balancer': lb,
+        'listeners': listeners,
+        'listeners_error': listeners_error,
+        'target_groups': target_groups,
+        'target_groups_error': target_groups_error,
+        'region': region,
+    }

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/get_lb_target_health.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/get_lb_target_health.py
@@ -1,0 +1,95 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+async def get_lb_target_health(
+    target_group_arn: Annotated[
+        str,
+        Field(..., description='The ARN of the target group to check health for.'),
+    ],
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the target group is deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """Get per-target health status with failure reasons for a target group.
+
+    Use this tool when:
+    - Diagnosing why targets are unhealthy in a load balancer target group
+    - Checking health check status and failure reason codes for registered targets
+    - Verifying target registration and health after deployment changes
+    - Identifying draining, unused, or unavailable targets
+
+    Common workflows:
+    1. get_lb_details() → Identify target group → get_lb_target_health() for per-target status
+    2. get_lb_target_health() → Find unhealthy target → get_eni_details() for network analysis
+    3. list_load_balancers() → get_lb_details() → get_lb_target_health() for full diagnostics
+
+    Returns:
+        Dict containing:
+        - target_group: TG metadata with ARN, name, protocol, port, health check config, LB ARNs
+        - targets: List of targets with ID, port, health status, and reason code
+        - region: AWS region queried
+    """
+    if (
+        'arn:aws:elasticloadbalancing:' not in target_group_arn
+        or 'targetgroup/' not in target_group_arn
+    ):
+        raise ToolError(
+            'Error getting target health. Error: Invalid target_group_arn format. '
+            'Must be a valid ELBv2 target group ARN containing "targetgroup/". '
+            'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        client = get_aws_client('elbv2', region, profile_name)
+
+        # Get target group metadata
+        tg_response = client.describe_target_groups(TargetGroupArns=[target_group_arn])
+        tgs = tg_response.get('TargetGroups', [])
+        if not tgs:
+            raise ToolError(
+                f'Error getting target health. Error: Target group not found: {target_group_arn}. '
+                f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+            )
+        target_group = tgs[0]
+
+        # Get per-target health
+        health_response = client.describe_target_health(TargetGroupArn=target_group_arn)
+        targets = health_response.get('TargetHealthDescriptions', [])
+
+        return {
+            'target_group': target_group,
+            'targets': targets,
+            'region': region,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error getting target health. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/list_load_balancers.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/load_balancer/list_load_balancers.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+VALID_LB_TYPES = ('application', 'network', 'gateway')
+
+
+async def list_load_balancers(
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the load balancers are deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    lb_type: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter by load balancer type: "application", "network", or "gateway". Returns all types if not specified.',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """List all ELBv2 load balancers in the specified AWS region.
+
+    Use this tool when:
+    - Starting load balancer troubleshooting to identify available ALBs, NLBs, and GLBs
+    - Discovering load balancer infrastructure before detailed analysis
+    - Finding load balancer ARNs needed for get_lb_details()
+    - Auditing load balancer inventory across regions
+    - Filtering load balancers by type (application, network, gateway)
+
+    Common workflows:
+    1. List LBs → Identify target LB → get_lb_details() for listeners/target groups
+    2. List LBs → Find unhealthy LB → get_lb_target_health() for target diagnostics
+    3. List LBs → Identify VPC → get_vpc_network_details() for network context
+
+    Returns:
+        Dict containing:
+        - load_balancers: List of load balancer objects with ARN, name, type, scheme, state, DNS, VPC, AZs
+        - count: Number of load balancers found
+        - region: AWS region queried
+    """
+    if lb_type is not None and lb_type not in VALID_LB_TYPES:
+        raise ToolError(
+            f'Error listing load balancers. Error: Invalid lb_type "{lb_type}". '
+            f'Must be one of: {", ".join(VALID_LB_TYPES)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        client = get_aws_client('elbv2', region, profile_name)
+        paginator = client.get_paginator('describe_load_balancers')
+        load_balancers = []
+        for page in paginator.paginate():
+            load_balancers.extend(page.get('LoadBalancers', []))
+
+        if lb_type is not None:
+            load_balancers = [lb for lb in load_balancers if lb.get('Type') == lb_type]
+
+        return {
+            'load_balancers': load_balancers,
+            'count': len(load_balancers),
+            'region': region,
+        }
+    except Exception as e:
+        raise ToolError(
+            f'Error listing load balancers. Error: {str(e)}. REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/__init__.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .check_health_checks import check_health_checks
+from .list_dns_firewall_rules import list_dns_firewall_rules
+from .list_hosted_zones import list_hosted_zones
+from .list_resolver_rules import list_resolver_rules
+from .query_dns_records import query_dns_records
+
+__all__ = [
+    'check_health_checks',
+    'list_dns_firewall_rules',
+    'list_hosted_zones',
+    'list_resolver_rules',
+    'query_dns_records',
+]

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/check_health_checks.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/check_health_checks.py
@@ -1,0 +1,291 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from datetime import datetime, timedelta, timezone
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, List, Optional
+
+
+VALID_STATUS_FILTERS = ('healthy', 'unhealthy')
+RATE_LIMIT_THRESHOLD = 20
+
+
+def _extract_hc_config(hc: dict) -> dict:
+    """Extract health check configuration into a structured dict."""
+    config = hc.get('HealthCheckConfig', {})
+    return {
+        'ip_address': config.get('IPAddress'),
+        'fqdn': config.get('FullyQualifiedDomainName'),
+        'port': config.get('Port'),
+        'resource_path': config.get('ResourcePath'),
+        'request_interval': config.get('RequestInterval', 30),
+        'failure_threshold': config.get('FailureThreshold', 3),
+    }
+
+
+def _is_calculated(hc: dict) -> bool:
+    """Check if a health check is a calculated health check."""
+    hc_type = hc.get('HealthCheckConfig', {}).get('Type', '')
+    return hc_type == 'CALCULATED'
+
+
+def _get_hc_type(hc: dict) -> str:
+    """Get the health check type string."""
+    return hc.get('HealthCheckConfig', {}).get('Type', 'UNKNOWN')
+
+
+def _determine_status_from_checkers(status_response: dict) -> str:
+    """Determine overall status from GetHealthCheckStatus response."""
+    checkers = status_response.get('HealthCheckObservations', [])
+    if not checkers:
+        return 'unknown'
+    for checker in checkers:
+        sr = checker.get('StatusReport', {})
+        status = sr.get('Status', '')
+        if 'Failure' in status or 'Unhealthy' in status:
+            return 'unhealthy'
+    return 'healthy'
+
+
+def _parse_checker_results(status_response: dict) -> List[dict]:
+    """Parse per-region checker results from GetHealthCheckStatus."""
+    results = []
+    for obs in status_response.get('HealthCheckObservations', []):
+        sr = obs.get('StatusReport', {})
+        results.append(
+            {
+                'region': obs.get('Region', ''),
+                'status': sr.get('Status', ''),
+                'ip_address': obs.get('IPAddress', ''),
+            }
+        )
+    return results
+
+
+async def check_health_checks(
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    health_check_id: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Specific health check ID to inspect. When provided, returns detailed per-region checker status.',
+        ),
+    ] = None,
+    status_filter: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter by health check status: "healthy" or "unhealthy". Returns all if not specified.',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """Check Route 53 health check statuses and identify failing endpoints.
+
+    Use this tool when:
+    - Diagnosing DNS failover issues
+    - Identifying unhealthy endpoints monitored by Route 53
+    - Verifying health check configuration and status
+    - Troubleshooting calculated health checks
+    - Auditing health check inventory
+
+    Common workflows:
+    1. check_health_checks() → Identify failing HCs → Investigate endpoint issues
+    2. check_health_checks(status_filter="unhealthy") → Focus on problems
+    3. check_health_checks(health_check_id="...") → Detailed per-region checker status
+
+    Notes:
+    - GetHealthCheckStatus cannot be used for calculated health checks (uses CloudWatch instead)
+    - GetHealthCheckStatus is rate-limited; only called when health_check_id is specified or count ≤ 20
+    - CloudWatch Route 53 metrics are only available in us-east-1
+
+    Returns:
+        Dict containing:
+        - health_checks: List of health check objects with config and status
+        - count: Number of health checks found
+        - status_retrieval_note: Explanation if status retrieval was limited
+    """
+    if status_filter is not None and status_filter not in VALID_STATUS_FILTERS:
+        raise ToolError(
+            f'Error checking health checks. Error: Invalid status_filter "{status_filter}". '
+            f'Must be one of: {", ".join(VALID_STATUS_FILTERS)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        # Route 53 is global — no region needed
+        r53_client = get_aws_client('route53', None, profile_name)
+        # CloudWatch Route 53 metrics are ONLY in us-east-1
+        cw_client = get_aws_client('cloudwatch', 'us-east-1', profile_name)
+
+        status_note = None
+
+        if health_check_id:
+            return await _check_single_health_check(
+                r53_client, cw_client, health_check_id, status_filter
+            )
+
+        # List all health checks
+        paginator = r53_client.get_paginator('list_health_checks')
+        all_hcs = []
+        for page in paginator.paginate():
+            all_hcs.extend(page.get('HealthChecks', []))
+
+        calculated = [hc for hc in all_hcs if _is_calculated(hc)]
+        non_calculated = [hc for hc in all_hcs if not _is_calculated(hc)]
+
+        health_checks = []
+
+        # Process non-calculated health checks
+        fetch_status = len(non_calculated) <= RATE_LIMIT_THRESHOLD
+        if not fetch_status:
+            status_note = (
+                f'Status retrieval skipped for non-calculated health checks '
+                f'({len(non_calculated)} exceeds threshold of {RATE_LIMIT_THRESHOLD}). '
+                f'Provide a specific health_check_id to get detailed status.'
+            )
+
+        for hc in non_calculated:
+            hc_id = hc.get('Id', '')
+            hc_info = {
+                'id': hc_id,
+                'type': _get_hc_type(hc),
+                'config': _extract_hc_config(hc),
+                'status': 'unknown',
+                'checker_results': None,
+            }
+            if fetch_status:
+                try:
+                    status_resp = r53_client.get_health_check_status(HealthCheckId=hc_id)
+                    hc_info['status'] = _determine_status_from_checkers(status_resp)
+                    hc_info['checker_results'] = _parse_checker_results(status_resp)
+                except Exception:
+                    hc_info['status'] = 'unknown'
+            health_checks.append(hc_info)
+
+        # Process calculated health checks via CloudWatch
+        for hc in calculated:
+            hc_id = hc.get('Id', '')
+            hc_info = {
+                'id': hc_id,
+                'type': _get_hc_type(hc),
+                'config': _extract_hc_config(hc),
+                'status': 'unknown',
+                'checker_results': None,
+            }
+            hc_info['status'] = _get_cloudwatch_hc_status(cw_client, hc_id)
+            health_checks.append(hc_info)
+
+        # Apply status filter
+        if status_filter:
+            health_checks = [hc for hc in health_checks if hc['status'] == status_filter]
+
+        return {
+            'health_checks': health_checks,
+            'count': len(health_checks),
+            'status_retrieval_note': status_note,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error checking health checks. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+
+async def _check_single_health_check(
+    r53_client: Any,
+    cw_client: Any,
+    health_check_id: str,
+    status_filter: Optional[str],
+) -> Dict[str, Any]:
+    """Get detailed status for a single health check."""
+    # Find the health check config
+    paginator = r53_client.get_paginator('list_health_checks')
+    target_hc = None
+    for page in paginator.paginate():
+        for hc in page.get('HealthChecks', []):
+            if hc.get('Id') == health_check_id:
+                target_hc = hc
+                break
+        if target_hc:
+            break
+
+    if not target_hc:
+        raise ToolError(
+            f'Error checking health checks. Error: Health check {health_check_id} not found. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    hc_info = {
+        'id': health_check_id,
+        'type': _get_hc_type(target_hc),
+        'config': _extract_hc_config(target_hc),
+        'status': 'unknown',
+        'checker_results': None,
+    }
+
+    if _is_calculated(target_hc):
+        hc_info['status'] = _get_cloudwatch_hc_status(cw_client, health_check_id)
+    else:
+        try:
+            status_resp = r53_client.get_health_check_status(HealthCheckId=health_check_id)
+            hc_info['status'] = _determine_status_from_checkers(status_resp)
+            hc_info['checker_results'] = _parse_checker_results(status_resp)
+        except Exception:
+            hc_info['status'] = 'unknown'
+
+    result_list = [hc_info]
+    if status_filter and hc_info['status'] != status_filter:
+        result_list = []
+
+    return {
+        'health_checks': result_list,
+        'count': len(result_list),
+        'status_retrieval_note': None,
+    }
+
+
+def _get_cloudwatch_hc_status(cw_client: Any, health_check_id: str) -> str:
+    """Get health check status from CloudWatch for calculated health checks."""
+    try:
+        now = datetime.now(timezone.utc)
+        response = cw_client.get_metric_statistics(
+            Namespace='AWS/Route53',
+            MetricName='HealthCheckStatus',
+            Dimensions=[
+                {'Name': 'HealthCheckId', 'Value': health_check_id},
+            ],
+            Period=60,
+            Statistics=['Average'],
+            StartTime=now - timedelta(minutes=5),
+            EndTime=now,
+        )
+        datapoints = response.get('Datapoints', [])
+        if not datapoints:
+            return 'unknown'
+        # Use the most recent datapoint
+        latest = max(datapoints, key=lambda d: d.get('Timestamp', ''))
+        avg = latest.get('Average', 0.0)
+        return 'healthy' if avg >= 1.0 else 'unhealthy'
+    except Exception:
+        return 'unknown'

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_dns_firewall_rules.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_dns_firewall_rules.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+async def list_dns_firewall_rules(
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the DNS Firewall resources are deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    rule_group_id: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Optional DNS Firewall rule group ID to retrieve individual rules for a specific group.',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """List DNS Firewall rule groups with VPC associations. Use when diagnosing blocked DNS queries.
+
+    Use this tool when:
+    - Diagnosing DNS queries being blocked or altered by DNS Firewall policies
+    - Verifying which DNS Firewall rule groups are associated with specific VPCs
+    - Auditing DNS Firewall rule group configurations and priorities
+    - Troubleshooting DNS resolution failures caused by firewall rules
+    - Reviewing ALLOW, BLOCK, and ALERT actions on DNS domain lists
+
+    Common workflows:
+    1. list_dns_firewall_rules() → Identify rule groups → Check VPC associations
+    2. list_dns_firewall_rules(rule_group_id=...) → Review individual rules and actions
+    3. list_dns_firewall_rules() → Find rule groups → Verify priorities across VPCs
+
+    Returns:
+        Dict containing:
+        - firewall_rule_groups: List of DNS Firewall rule groups with VPC associations
+        - firewall_rules: List of individual rules (only when rule_group_id is provided)
+        - count: Total number of rule groups
+        - region: AWS region queried
+    """
+    try:
+        client = get_aws_client('route53resolver', region, profile_name)
+
+        # Get all firewall rule groups
+        groups_paginator = client.get_paginator('list_firewall_rule_groups')
+        all_groups = []
+        for page in groups_paginator.paginate():
+            all_groups.extend(page.get('FirewallRuleGroups', []))
+
+        # Get ALL VPC associations in one pass and build a lookup by rule group ID
+        all_associations = []
+        try:
+            assoc_paginator = client.get_paginator('list_firewall_rule_group_associations')
+            for assoc_page in assoc_paginator.paginate():
+                all_associations.extend(assoc_page.get('FirewallRuleGroupAssociations', []))
+        except Exception:
+            pass
+
+        group_vpc_map: Dict[str, list] = {}
+        for assoc in all_associations:
+            group_id = assoc.get('FirewallRuleGroupId', '')
+            vpc_id = assoc.get('VpcId')
+            priority = assoc.get('Priority')
+            if vpc_id:
+                group_vpc_map.setdefault(group_id, []).append(
+                    {
+                        'vpc_id': vpc_id,
+                        'priority': priority,
+                    }
+                )
+
+        # Build firewall rule groups with VPC associations
+        firewall_rule_groups = []
+        for group in all_groups:
+            group_id = group.get('Id', '')
+            firewall_rule_groups.append(
+                {
+                    'id': group_id,
+                    'name': group.get('Name', ''),
+                    'share_status': group.get('ShareStatus', ''),
+                    'owner_id': group.get('OwnerId', ''),
+                    'vpc_associations': group_vpc_map.get(group_id, []),
+                }
+            )
+
+        # If rule_group_id is provided, get individual rules for that group
+        firewall_rules = None
+        if rule_group_id:
+            rules_paginator = client.get_paginator('list_firewall_rules')
+            raw_rules = []
+            for page in rules_paginator.paginate(FirewallRuleGroupId=rule_group_id):
+                raw_rules.extend(page.get('FirewallRules', []))
+
+            firewall_rules = []
+            for rule in raw_rules:
+                firewall_rules.append(
+                    {
+                        'name': rule.get('Name', ''),
+                        'priority': rule.get('Priority'),
+                        'action': rule.get('Action', ''),
+                        'firewall_domain_list_id': rule.get('FirewallDomainListId', ''),
+                        'block_response': rule.get('BlockResponse'),
+                    }
+                )
+
+        return {
+            'firewall_rule_groups': firewall_rule_groups,
+            'firewall_rules': firewall_rules,
+            'count': len(firewall_rule_groups),
+            'region': region,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error listing DNS Firewall rules. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_dns_firewall_rules.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_dns_firewall_rules.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 from typing import Annotated, Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 async def list_dns_firewall_rules(
@@ -74,8 +78,9 @@ async def list_dns_firewall_rules(
             assoc_paginator = client.get_paginator('list_firewall_rule_group_associations')
             for assoc_page in assoc_paginator.paginate():
                 all_associations.extend(assoc_page.get('FirewallRuleGroupAssociations', []))
-        except Exception:
-            pass
+        except Exception as e:
+            # Non-fatal: continue without VPC association data
+            logger.debug('Failed to list firewall rule group associations: %s', e)
 
         group_vpc_map: Dict[str, list] = {}
         for assoc in all_associations:

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_hosted_zones.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_hosted_zones.py
@@ -1,0 +1,114 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+VALID_ZONE_TYPES = ('public', 'private')
+
+
+async def list_hosted_zones(
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    zone_type: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter by zone type: "public" or "private". Returns all zones if not specified.',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """List all Route 53 hosted zones with type and record counts.
+
+    Use this tool when:
+    - Discovering DNS zones in an AWS account
+    - Identifying public vs private hosted zones
+    - Finding private zones and their VPC associations
+    - Starting DNS troubleshooting to identify available hosted zones
+    - Auditing DNS zone inventory
+
+    Common workflows:
+    1. List zones → Identify target zone → query_dns_records() for record details
+    2. List zones → Find private zones → Verify VPC associations for DNS resolution
+    3. List zones → check_health_checks() for health check status
+
+    Returns:
+        Dict containing:
+        - hosted_zones: List of hosted zone objects with ID, name, record count, type, VPC associations
+        - count: Number of hosted zones found
+    """
+    if zone_type is not None and zone_type not in VALID_ZONE_TYPES:
+        raise ToolError(
+            f'Error listing hosted zones. Error: Invalid zone_type "{zone_type}". '
+            f'Must be one of: {", ".join(VALID_ZONE_TYPES)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        client = get_aws_client('route53', None, profile_name)
+        paginator = client.get_paginator('list_hosted_zones')
+        zones = []
+        for page in paginator.paginate():
+            zones.extend(page.get('HostedZones', []))
+
+        if zone_type is not None:
+            is_private = zone_type == 'private'
+            zones = [
+                z for z in zones if z.get('Config', {}).get('PrivateZone', False) == is_private
+            ]
+
+        hosted_zones = []
+        for zone in zones:
+            zone_id = zone.get('Id', '')
+            is_private = zone.get('Config', {}).get('PrivateZone', False)
+            zone_info = {
+                'id': zone_id,
+                'name': zone.get('Name', ''),
+                'record_count': zone.get('ResourceRecordSetCount', 0),
+                'is_private': is_private,
+                'comment': zone.get('Config', {}).get('Comment'),
+                'vpcs': None,
+            }
+
+            if is_private:
+                try:
+                    detail = client.get_hosted_zone(Id=zone_id)
+                    vpcs = detail.get('VPCs', [])
+                    zone_info['vpcs'] = [
+                        {'vpc_id': v.get('VPCId', ''), 'vpc_region': v.get('VPCRegion', '')}
+                        for v in vpcs
+                    ]
+                except Exception:
+                    zone_info['vpcs'] = []
+
+            hosted_zones.append(zone_info)
+
+        return {
+            'hosted_zones': hosted_zones,
+            'count': len(hosted_zones),
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error listing hosted zones. Error: {str(e)}. REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_resolver_rules.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_resolver_rules.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+async def list_resolver_rules(
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the Route 53 Resolver resources are deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """List Route 53 Resolver rules and endpoints for hybrid DNS troubleshooting.
+
+    Use this tool when:
+    - Diagnosing DNS resolution failures in hybrid cloud environments
+    - Verifying Resolver forwarding rules and their VPC associations
+    - Checking Resolver endpoint status and IP addresses
+    - Auditing DNS forwarding configuration across VPCs
+    - Troubleshooting on-premises to AWS DNS resolution
+
+    Common workflows:
+    1. list_resolver_rules() → Identify forwarding rules → Verify target IPs
+    2. list_resolver_rules() → Check endpoint status → Verify IP addresses and subnets
+    3. list_resolver_rules() → Find VPC associations → Verify DNS resolution scope
+
+    Returns:
+        Dict containing:
+        - resolver_rules: List of resolver rules with VPC associations
+        - resolver_endpoints: List of resolver endpoints with IP addresses
+        - region: AWS region queried
+    """
+    try:
+        client = get_aws_client('route53resolver', region, profile_name)
+
+        # Get all resolver rules
+        rules_paginator = client.get_paginator('list_resolver_rules')
+        all_rules = []
+        for page in rules_paginator.paginate():
+            all_rules.extend(page.get('ResolverRules', []))
+
+        # Get ALL VPC associations in one pass and build a lookup by rule ID
+        all_associations = []
+        try:
+            assoc_paginator = client.get_paginator('list_resolver_rule_associations')
+            for assoc_page in assoc_paginator.paginate():
+                all_associations.extend(assoc_page.get('ResolverRuleAssociations', []))
+        except Exception:
+            pass
+
+        rule_vpc_map: Dict[str, list] = {}
+        for assoc in all_associations:
+            rule_id = assoc.get('ResolverRuleId', '')
+            vpc_id = assoc.get('VPCId')
+            if vpc_id:
+                rule_vpc_map.setdefault(rule_id, []).append(vpc_id)
+
+        # Build resolver rules with VPC associations
+        resolver_rules = []
+        for rule in all_rules:
+            rule_id = rule.get('Id', '')
+
+            target_ips = []
+            for tip in rule.get('TargetIps', []):
+                target_ips.append(
+                    {
+                        'ip': tip.get('Ip', ''),
+                        'port': tip.get('Port', 53),
+                    }
+                )
+
+            resolver_rules.append(
+                {
+                    'id': rule_id,
+                    'name': rule.get('Name', ''),
+                    'domain_name': rule.get('DomainName', ''),
+                    'rule_type': rule.get('RuleType', ''),
+                    'status': rule.get('Status', ''),
+                    'target_ips': target_ips,
+                    'vpc_associations': rule_vpc_map.get(rule_id, []),
+                }
+            )
+
+        # Get all resolver endpoints
+        endpoints_paginator = client.get_paginator('list_resolver_endpoints')
+        all_endpoints = []
+        for page in endpoints_paginator.paginate():
+            all_endpoints.extend(page.get('ResolverEndpoints', []))
+
+        resolver_endpoints = []
+        for ep in all_endpoints:
+            ep_id = ep.get('Id', '')
+            ip_addresses = []
+            try:
+                ip_paginator = client.get_paginator('list_resolver_endpoint_ip_addresses')
+                for ip_page in ip_paginator.paginate(ResolverEndpointId=ep_id):
+                    for ip_addr in ip_page.get('IpAddresses', []):
+                        ip_addresses.append(
+                            {
+                                'ip': ip_addr.get('Ip', ''),
+                                'subnet_id': ip_addr.get('SubnetId', ''),
+                            }
+                        )
+            except Exception:
+                pass
+
+            resolver_endpoints.append(
+                {
+                    'id': ep_id,
+                    'name': ep.get('Name', ''),
+                    'direction': ep.get('Direction', ''),
+                    'vpc_id': ep.get('HostVPCId', ''),
+                    'status': ep.get('Status', ''),
+                    'ip_addresses': ip_addresses,
+                }
+            )
+
+        return {
+            'resolver_rules': resolver_rules,
+            'resolver_endpoints': resolver_endpoints,
+            'region': region,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error listing resolver rules. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_resolver_rules.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/list_resolver_rules.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 from typing import Annotated, Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 async def list_resolver_rules(
@@ -66,8 +70,9 @@ async def list_resolver_rules(
             assoc_paginator = client.get_paginator('list_resolver_rule_associations')
             for assoc_page in assoc_paginator.paginate():
                 all_associations.extend(assoc_page.get('ResolverRuleAssociations', []))
-        except Exception:
-            pass
+        except Exception as e:
+            # Non-fatal: continue without VPC association data
+            logger.debug('Failed to list resolver rule associations: %s', e)
 
         rule_vpc_map: Dict[str, list] = {}
         for assoc in all_associations:
@@ -122,8 +127,9 @@ async def list_resolver_rules(
                                 'subnet_id': ip_addr.get('SubnetId', ''),
                             }
                         )
-            except Exception:
-                pass
+            except Exception as e:
+                # Non-fatal: continue without IP address data for this endpoint
+                logger.debug('Failed to list IP addresses for resolver endpoint %s: %s', ep_id, e)
 
             resolver_endpoints.append(
                 {

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/query_dns_records.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53/query_dns_records.py
@@ -1,0 +1,200 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+VALID_RECORD_TYPES = (
+    'A',
+    'AAAA',
+    'CNAME',
+    'MX',
+    'TXT',
+    'SRV',
+    'NS',
+    'SOA',
+    'PTR',
+    'CAA',
+    'NAPTR',
+    'SPF',
+)
+
+
+def _determine_routing_policy(record: dict) -> str:
+    """Determine the routing policy from record fields."""
+    if 'Weight' in record:
+        return 'weighted'
+    if 'Region' in record:
+        return 'latency'
+    if 'Failover' in record:
+        return 'failover'
+    if 'GeoLocation' in record:
+        return 'geolocation'
+    if 'MultiValueAnswer' in record:
+        return 'multivalue'
+    return 'simple'
+
+
+async def query_dns_records(
+    hosted_zone_id: Annotated[
+        str,
+        Field(..., description='Route 53 hosted zone ID to query records from.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    record_type: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter by DNS record type: A, AAAA, CNAME, MX, TXT, SRV, NS, SOA, PTR, CAA, NAPTR, SPF. Returns all types if not specified.',
+        ),
+    ] = None,
+    name_prefix: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter records whose name starts with this prefix. Uses StartRecordName to optimize pagination start point, then filters client-side.',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """Query DNS records within a Route 53 hosted zone with optional filtering.
+
+    Use this tool when:
+    - Looking up specific DNS records in a hosted zone
+    - Verifying DNS configuration for a domain
+    - Finding alias records and their targets
+    - Checking routing policies (weighted, latency, failover, geolocation)
+    - Diagnosing DNS resolution issues
+
+    Common workflows:
+    1. list_hosted_zones() → Identify zone → query_dns_records() for record details
+    2. Query A/AAAA records → Verify IP addresses or alias targets
+    3. Query CNAME records → Trace DNS resolution chain
+
+    Note: StartRecordName/StartRecordType are pagination cursors, NOT filters.
+    Client-side filtering is mandatory for accurate results.
+
+    Returns:
+        Dict containing:
+        - records: List of DNS record objects with name, type, TTL, values, alias info, routing policy
+        - count: Number of records found
+        - hosted_zone_id: The queried hosted zone ID
+    """
+    if not hosted_zone_id:
+        raise ToolError(
+            'Error querying DNS records. Error: hosted_zone_id is required. '
+            'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    if record_type is not None and record_type not in VALID_RECORD_TYPES:
+        raise ToolError(
+            f'Error querying DNS records. Error: Invalid record_type "{record_type}". '
+            f'Must be one of: {", ".join(VALID_RECORD_TYPES)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        client = get_aws_client('route53', None, profile_name)
+
+        params: Dict[str, Any] = {'HostedZoneId': hosted_zone_id}
+        if name_prefix:
+            params['StartRecordName'] = name_prefix
+            if record_type:
+                params['StartRecordType'] = record_type
+
+        all_records = []
+        while True:
+            response = client.list_resource_record_sets(**params)
+            record_sets = response.get('ResourceRecordSets', [])
+
+            for rs in record_sets:
+                rs_name = rs.get('Name', '')
+                rs_type = rs.get('Type', '')
+
+                # Client-side name_prefix filter
+                if name_prefix and not rs_name.startswith(name_prefix):
+                    # Early-stop: records are lexicographically ordered
+                    # If we already collected records and this one doesn't match, stop
+                    if all_records or rs_name > name_prefix:
+                        return {
+                            'records': all_records,
+                            'count': len(all_records),
+                            'hosted_zone_id': hosted_zone_id,
+                        }
+                    continue
+
+                # Client-side record_type filter
+                if record_type and rs_type != record_type:
+                    continue
+
+                is_alias = 'AliasTarget' in rs
+                alias_target = None
+                if is_alias:
+                    at = rs['AliasTarget']
+                    alias_target = {
+                        'dns_name': at.get('DNSName', ''),
+                        'hosted_zone_id': at.get('HostedZoneId', ''),
+                        'evaluate_target_health': at.get('EvaluateTargetHealth', False),
+                    }
+
+                resource_records = None
+                if 'ResourceRecords' in rs:
+                    resource_records = [r.get('Value', '') for r in rs['ResourceRecords']]
+
+                record_info = {
+                    'name': rs_name,
+                    'type': rs_type,
+                    'ttl': rs.get('TTL'),
+                    'resource_records': resource_records,
+                    'alias_target': alias_target,
+                    'is_alias': is_alias,
+                    'routing_policy': _determine_routing_policy(rs),
+                    'health_check_id': rs.get('HealthCheckId'),
+                }
+                all_records.append(record_info)
+
+            if not response.get('IsTruncated', False):
+                break
+
+            params['StartRecordName'] = response['NextRecordName']
+            params['StartRecordType'] = response['NextRecordType']
+            if 'NextRecordIdentifier' in response:
+                params['StartRecordIdentifier'] = response['NextRecordIdentifier']
+
+        return {
+            'records': all_records,
+            'count': len(all_records),
+            'hosted_zone_id': hosted_zone_id,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        error_msg = str(e)
+        if 'NoSuchHostedZone' in error_msg:
+            raise ToolError(
+                f'Error querying DNS records. Error: Hosted zone {hosted_zone_id} not found. '
+                f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+            )
+        raise ToolError(
+            f'Error querying DNS records. Error: {error_msg}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53_profiles/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53_profiles/__init__.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .list_route53_profiles import list_route53_profiles
+
+__all__ = ['list_route53_profiles']

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53_profiles/list_route53_profiles.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53_profiles/list_route53_profiles.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+async def list_route53_profiles(
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the Route 53 Profiles are deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    profile_id: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Optional Route 53 Profile ID to retrieve attached resources for a specific profile.',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """List Route 53 Profiles with VPC associations and attached resources. Use when troubleshooting enterprise multi-VPC DNS management.
+
+    Use this tool when:
+    - Troubleshooting enterprise multi-VPC DNS management with Route 53 Profiles
+    - Verifying which profiles are associated with specific VPCs
+    - Reviewing resources attached to a profile (private hosted zones, resolver rules, DNS Firewall rule groups)
+    - Diagnosing DNS configuration inconsistencies across VPCs
+    - Auditing profile sharing status across accounts
+
+    Common workflows:
+    1. list_route53_profiles() → Identify profiles → Check VPC associations
+    2. list_route53_profiles(profile_id=...) → Review attached resources
+    3. list_route53_profiles() → Find profiles → Verify DNS config consistency
+
+    Returns:
+        Dict containing:
+        - profiles: List of Route 53 Profiles with VPC associations
+        - profile_resources: List of attached resources (only when profile_id is provided)
+        - count: Total number of profiles
+        - region: AWS region queried
+    """
+    try:
+        client = get_aws_client('route53profiles', region, profile_name)
+
+        # Get all profiles
+        profiles_paginator = client.get_paginator('list_profiles')
+        all_profiles = []
+        for page in profiles_paginator.paginate():
+            all_profiles.extend(page.get('ProfileSummaries', []))
+
+        # Get ALL profile associations in one pass and build a lookup by profile ID
+        all_associations = []
+        try:
+            assoc_paginator = client.get_paginator('list_profile_associations')
+            for assoc_page in assoc_paginator.paginate():
+                all_associations.extend(assoc_page.get('ProfileAssociations', []))
+        except Exception:
+            pass
+
+        profile_vpc_map: Dict[str, list] = {}
+        for assoc in all_associations:
+            pid = assoc.get('ProfileId', '')
+            vpc_id = assoc.get('ResourceId')
+            if vpc_id:
+                profile_vpc_map.setdefault(pid, []).append(vpc_id)
+
+        # Build profiles with VPC associations
+        profiles = []
+        for prof in all_profiles:
+            pid = prof.get('Id', '')
+            profiles.append(
+                {
+                    'id': pid,
+                    'name': prof.get('Name', ''),
+                    'status': prof.get('Status', ''),
+                    'share_status': prof.get('ShareStatus', ''),
+                    'vpc_associations': profile_vpc_map.get(pid, []),
+                }
+            )
+
+        # If profile_id is provided, get attached resources for that profile
+        profile_resources = None
+        if profile_id:
+            res_paginator = client.get_paginator('list_profile_resource_associations')
+            raw_resources = []
+            for page in res_paginator.paginate(ProfileId=profile_id):
+                raw_resources.extend(page.get('ProfileResourceAssociations', []))
+
+            profile_resources = []
+            for res in raw_resources:
+                profile_resources.append(
+                    {
+                        'resource_type': res.get('ResourceType', ''),
+                        'resource_id': res.get('ResourceArn', ''),
+                        'name': res.get('Name', ''),
+                        'status': res.get('Status', ''),
+                    }
+                )
+
+        return {
+            'profiles': profiles,
+            'profile_resources': profile_resources,
+            'count': len(profiles),
+            'region': region,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error listing Route 53 Profiles. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53_profiles/list_route53_profiles.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/route53_profiles/list_route53_profiles.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 from typing import Annotated, Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 async def list_route53_profiles(
@@ -74,8 +78,9 @@ async def list_route53_profiles(
             assoc_paginator = client.get_paginator('list_profile_associations')
             for assoc_page in assoc_paginator.paginate():
                 all_associations.extend(assoc_page.get('ProfileAssociations', []))
-        except Exception:
-            pass
+        except Exception as e:
+            # Non-fatal: continue without VPC association data
+            logger.debug('Failed to list Route 53 Profile associations: %s', e)
 
         profile_vpc_map: Dict[str, list] = {}
         for assoc in all_associations:

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/vpc_endpoints/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/vpc_endpoints/__init__.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .check_endpoint_connectivity import check_endpoint_connectivity
+from .list_vpc_endpoints_detailed import list_vpc_endpoints_detailed
+
+__all__ = ['check_endpoint_connectivity', 'list_vpc_endpoints_detailed']

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/vpc_endpoints/check_endpoint_connectivity.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/vpc_endpoints/check_endpoint_connectivity.py
@@ -1,0 +1,209 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, Optional
+
+
+async def check_endpoint_connectivity(
+    vpc_endpoint_id: Annotated[
+        str,
+        Field(
+            ...,
+            description='The VPC endpoint ID to check connectivity for (must start with vpce-).',
+        ),
+    ],
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region where the VPC endpoint is deployed.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """Check connectivity diagnostics for a specific VPC endpoint.
+
+    Aggregates endpoint state, private DNS config, security group rules, and ENI
+    details into a single connectivity diagnostic view. Handles partial failures
+    gracefully — if a sub-call (security groups or ENIs) fails, the successfully
+    retrieved data is still returned with an error indicator for the failed check.
+
+    Use this tool when:
+    - Diagnosing why a PrivateLink connection is failing
+    - Verifying security group rules allow traffic to the endpoint
+    - Checking private DNS configuration for interface endpoints
+    - Confirming ENI placement across Availability Zones
+
+    Common workflows:
+    1. list_vpc_endpoints_detailed() → check_endpoint_connectivity() for a specific endpoint
+    2. check_endpoint_connectivity() → Review SG rules → get_eni_details() for deeper analysis
+    3. check_endpoint_connectivity() → Verify private DNS → query_dns_records() for DNS validation
+
+    Returns:
+        Dict containing:
+        - endpoint: Basic endpoint info with state and availability
+        - private_dns: DNS configuration and entries
+        - security_groups: SG rules (interface endpoints only) or None
+        - security_groups_error: Error message if SG retrieval failed
+        - network_interfaces: ENI details or None
+        - network_interfaces_error: Error message if ENI retrieval failed
+        - connectivity_checks: Summary of key connectivity indicators
+        - region: AWS region queried
+    """
+    if not vpc_endpoint_id.startswith('vpce-'):
+        raise ToolError(
+            'Error checking endpoint connectivity. Error: Invalid vpc_endpoint_id format. '
+            'Must start with "vpce-". '
+            'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    try:
+        client = get_aws_client('ec2', region, profile_name)
+        response = client.describe_vpc_endpoints(VpcEndpointIds=[vpc_endpoint_id])
+        endpoints = response.get('VpcEndpoints', [])
+        if not endpoints:
+            raise ToolError(
+                f'Error checking endpoint connectivity. Error: VPC endpoint not found: '
+                f'{vpc_endpoint_id}. REQUIRED TO REMEDIATE BEFORE CONTINUING'
+            )
+        ep = endpoints[0]
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(
+            f'Error checking endpoint connectivity. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )
+
+    endpoint_type = ep.get('VpcEndpointType', '')
+    endpoint_state = ep.get('State', '')
+    is_available = endpoint_state == 'available'
+
+    endpoint_info = {
+        'id': ep.get('VpcEndpointId', ''),
+        'service_name': ep.get('ServiceName', ''),
+        'type': endpoint_type,
+        'vpc_id': ep.get('VpcId', ''),
+        'state': endpoint_state,
+        'is_available': is_available,
+    }
+
+    # Private DNS info
+    dns_entries = [
+        {
+            'dns_name': d.get('DnsName', ''),
+            'hosted_zone_id': d.get('HostedZoneId', ''),
+        }
+        for d in ep.get('DnsEntries', [])
+    ]
+    private_dns_enabled = ep.get('PrivateDnsEnabled', False)
+    private_dns = {
+        'enabled': private_dns_enabled,
+        'dns_entries': dns_entries,
+    }
+
+    # Security groups — only for interface endpoints
+    security_groups = None
+    security_groups_error = None
+    sg_ids = [g.get('GroupId', '') for g in ep.get('Groups', [])]
+    if endpoint_type == 'Interface' and sg_ids:
+        try:
+            sg_response = client.describe_security_groups(GroupIds=sg_ids)
+            security_groups = []
+            for sg in sg_response.get('SecurityGroups', []):
+                inbound_rules = []
+                for rule in sg.get('IpPermissions', []):
+                    protocol = rule.get('IpProtocol', '-1')
+                    from_port = rule.get('FromPort')
+                    to_port = rule.get('ToPort')
+                    if from_port is not None and to_port is not None:
+                        port_range = (
+                            str(from_port) if from_port == to_port else f'{from_port}-{to_port}'
+                        )
+                    else:
+                        port_range = 'all'
+
+                    sources = []
+                    for ip_range in rule.get('IpRanges', []):
+                        sources.append(ip_range.get('CidrIp', ''))
+                    for ip_range in rule.get('Ipv6Ranges', []):
+                        sources.append(ip_range.get('CidrIpv6', ''))
+                    for prefix in rule.get('PrefixListIds', []):
+                        sources.append(prefix.get('PrefixListId', ''))
+                    for group in rule.get('UserIdGroupPairs', []):
+                        sources.append(group.get('GroupId', ''))
+
+                    for source in sources:
+                        inbound_rules.append(
+                            {
+                                'protocol': protocol,
+                                'port_range': port_range,
+                                'source': source,
+                            }
+                        )
+
+                security_groups.append(
+                    {
+                        'id': sg.get('GroupId', ''),
+                        'name': sg.get('GroupName', ''),
+                        'inbound_rules': inbound_rules,
+                    }
+                )
+        except Exception as e:
+            security_groups = None
+            security_groups_error = str(e)
+
+    # Network interfaces
+    network_interfaces = None
+    network_interfaces_error = None
+    eni_ids = ep.get('NetworkInterfaceIds', [])
+    if eni_ids:
+        try:
+            eni_response = client.describe_network_interfaces(NetworkInterfaceIds=eni_ids)
+            network_interfaces = []
+            for eni in eni_response.get('NetworkInterfaces', []):
+                network_interfaces.append(
+                    {
+                        'id': eni.get('NetworkInterfaceId', ''),
+                        'subnet_id': eni.get('SubnetId', ''),
+                        'availability_zone': eni.get('AvailabilityZone', ''),
+                        'private_ip': eni.get('PrivateIpAddress', ''),
+                    }
+                )
+        except Exception as e:
+            network_interfaces = None
+            network_interfaces_error = str(e)
+
+    connectivity_checks = {
+        'state_ok': is_available,
+        'has_dns_entries': len(dns_entries) > 0,
+        'private_dns_enabled': private_dns_enabled,
+    }
+
+    return {
+        'endpoint': endpoint_info,
+        'private_dns': private_dns,
+        'security_groups': security_groups,
+        'security_groups_error': security_groups_error,
+        'network_interfaces': network_interfaces,
+        'network_interfaces_error': network_interfaces_error,
+        'connectivity_checks': connectivity_checks,
+        'region': region,
+    }

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/vpc_endpoints/list_vpc_endpoints_detailed.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/vpc_endpoints/list_vpc_endpoints_detailed.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from awslabs.aws_network_mcp_server.utils.aws_common import get_aws_client
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from typing import Annotated, Any, Dict, List, Optional
+
+
+async def list_vpc_endpoints_detailed(
+    region: Annotated[
+        Optional[str],
+        Field(..., description='AWS region to list VPC endpoints in.'),
+    ],
+    profile_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='AWS CLI Profile Name to access the AWS account where the resources are deployed. By default uses the profile configured in MCP configuration',
+        ),
+    ] = None,
+    vpc_id: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter endpoints by VPC ID. If not provided, returns endpoints across all VPCs.',
+        ),
+    ] = None,
+    service_name: Annotated[
+        Optional[str],
+        Field(
+            ...,
+            description='Filter endpoints by AWS service name (e.g., com.amazonaws.us-east-1.s3).',
+        ),
+    ] = None,
+) -> Dict[str, Any]:
+    """List VPC endpoints with detailed type-specific information across VPCs.
+
+    For basic VPC endpoint info within a single VPC, use get_vpc_network_details().
+    This tool provides detailed endpoint-specific information across VPCs, including
+    security group IDs, private DNS status, DNS entries, network interface IDs,
+    route table IDs, and creation timestamps for all endpoint types (Interface,
+    Gateway, GatewayLoadBalancer).
+
+    Use this tool when:
+    - Listing all VPC endpoints across multiple VPCs in a region
+    - Filtering endpoints by service name to find PrivateLink connections
+    - Checking private DNS configuration and DNS entries for interface endpoints
+    - Reviewing security group associations on interface endpoints
+    - Auditing gateway endpoint route table associations
+
+    Common workflows:
+    1. list_vpc_endpoints_detailed() → check_endpoint_connectivity() for specific endpoint
+    2. list_vpc_endpoints_detailed(service_name=...) → Identify all endpoints for a service
+    3. list_vpc_endpoints_detailed(vpc_id=...) → Deep dive into a VPC's endpoint config
+
+    Returns:
+        Dict containing:
+        - vpc_endpoints: List of endpoint dicts with type-specific fields
+        - count: Total number of endpoints returned
+        - region: AWS region queried
+    """
+    try:
+        client = get_aws_client('ec2', region, profile_name)
+
+        filters: List[Dict[str, Any]] = []
+        if vpc_id:
+            filters.append({'Name': 'vpc-id', 'Values': [vpc_id]})
+        if service_name:
+            filters.append({'Name': 'service-name', 'Values': [service_name]})
+
+        paginator = client.get_paginator('describe_vpc_endpoints')
+        paginate_params: Dict[str, Any] = {}
+        if filters:
+            paginate_params['Filters'] = filters
+
+        endpoints = []
+        for page in paginator.paginate(**paginate_params):
+            for ep in page.get('VpcEndpoints', []):
+                endpoint_type = ep.get('VpcEndpointType', '')
+                endpoint_dict: Dict[str, Any] = {
+                    'id': ep.get('VpcEndpointId', ''),
+                    'service_name': ep.get('ServiceName', ''),
+                    'type': endpoint_type,
+                    'vpc_id': ep.get('VpcId', ''),
+                    'state': ep.get('State', ''),
+                    'creation_timestamp': str(ep.get('CreationTimestamp', '')),
+                    'policy_document': ep.get('PolicyDocument'),
+                    'tags': ep.get('Tags', []),
+                }
+
+                if endpoint_type == 'Gateway':
+                    endpoint_dict['route_table_ids'] = ep.get('RouteTableIds', [])
+                    endpoint_dict['subnet_ids'] = None
+                    endpoint_dict['security_group_ids'] = None
+                    endpoint_dict['private_dns_enabled'] = None
+                    endpoint_dict['dns_entries'] = None
+                    endpoint_dict['network_interface_ids'] = None
+                elif endpoint_type == 'Interface':
+                    endpoint_dict['route_table_ids'] = None
+                    endpoint_dict['subnet_ids'] = ep.get('SubnetIds', [])
+                    endpoint_dict['security_group_ids'] = [
+                        g.get('GroupId', '') for g in ep.get('Groups', [])
+                    ]
+                    endpoint_dict['private_dns_enabled'] = ep.get('PrivateDnsEnabled', False)
+                    endpoint_dict['dns_entries'] = [
+                        {
+                            'dns_name': d.get('DnsName', ''),
+                            'hosted_zone_id': d.get('HostedZoneId', ''),
+                        }
+                        for d in ep.get('DnsEntries', [])
+                    ]
+                    endpoint_dict['network_interface_ids'] = ep.get('NetworkInterfaceIds', [])
+                elif endpoint_type == 'GatewayLoadBalancer':
+                    endpoint_dict['route_table_ids'] = None
+                    endpoint_dict['subnet_ids'] = ep.get('SubnetIds', [])
+                    endpoint_dict['security_group_ids'] = None
+                    endpoint_dict['private_dns_enabled'] = None
+                    endpoint_dict['dns_entries'] = None
+                    endpoint_dict['network_interface_ids'] = ep.get('NetworkInterfaceIds', [])
+
+                endpoints.append(endpoint_dict)
+
+        return {
+            'vpc_endpoints': endpoints,
+            'count': len(endpoints),
+            'region': region,
+        }
+    except Exception as e:
+        raise ToolError(
+            f'Error listing VPC endpoints. Error: {str(e)}. '
+            f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
+        )

--- a/src/aws-network-mcp-server/tests/test_integ_lb.py
+++ b/src/aws-network-mcp-server/tests/test_integ_lb.py
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for Phase 1 Load Balancer tools.
+
+These tests require real AWS credentials and LB resources.
+Run with: uv run --frozen pytest tests/test_integ_lb.py -v
+Skip in CI with: pytest -m "not integration"
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestListLoadBalancersIntegration:
+    """Integration tests for list_load_balancers."""
+
+    async def test_list_load_balancers_real(self):
+        """Test listing load balancers against real AWS API."""
+        pytest.skip('Integration test — requires real AWS credentials and LB resources')
+
+
+@pytest.mark.integration
+class TestGetLbDetailsIntegration:
+    """Integration tests for get_lb_details."""
+
+    async def test_get_lb_details_real(self):
+        """Test getting LB details against real AWS API."""
+        pytest.skip('Integration test — requires real AWS credentials and LB resources')
+
+
+@pytest.mark.integration
+class TestGetLbTargetHealthIntegration:
+    """Integration tests for get_lb_target_health."""
+
+    async def test_get_lb_target_health_real(self):
+        """Test getting target health against real AWS API."""
+        pytest.skip('Integration test — requires real AWS credentials and LB resources')

--- a/src/aws-network-mcp-server/tests/test_integ_route53.py
+++ b/src/aws-network-mcp-server/tests/test_integ_route53.py
@@ -1,0 +1,114 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for Phase 2 Route 53 / DNS tools.
+
+These tests require real AWS credentials and Route 53 resources.
+Run with: uv run --frozen pytest tests/test_integ_route53.py -v
+"""
+
+import pytest
+
+
+# Skip integration tests unless explicitly requested with: pytest -m integration
+pytestmark = pytest.mark.skip(
+    reason='Integration tests require real AWS credentials and resources'
+)
+
+
+@pytest.mark.integration
+class TestListHostedZonesIntegration:
+    """Integration tests for list_hosted_zones."""
+
+    async def test_list_hosted_zones_returns_results(self):
+        """Test that list_hosted_zones returns valid results against real AWS."""
+        from awslabs.aws_network_mcp_server.tools.route53.list_hosted_zones import (
+            list_hosted_zones,
+        )
+
+        result = await list_hosted_zones()
+        assert 'hosted_zones' in result
+        assert 'count' in result
+        assert isinstance(result['hosted_zones'], list)
+        assert isinstance(result['count'], int)
+
+    async def test_list_hosted_zones_filter_public(self):
+        """Test public zone filtering against real AWS."""
+        from awslabs.aws_network_mcp_server.tools.route53.list_hosted_zones import (
+            list_hosted_zones,
+        )
+
+        result = await list_hosted_zones(zone_type='public')
+        for zone in result['hosted_zones']:
+            assert zone['is_private'] is False
+
+
+@pytest.mark.integration
+class TestQueryDnsRecordsIntegration:
+    """Integration tests for query_dns_records."""
+
+    async def test_query_dns_records_returns_results(self):
+        """Test that query_dns_records returns valid results against real AWS.
+
+        Note: Requires at least one hosted zone to exist.
+        """
+        from awslabs.aws_network_mcp_server.tools.route53.list_hosted_zones import (
+            list_hosted_zones,
+        )
+        from awslabs.aws_network_mcp_server.tools.route53.query_dns_records import (
+            query_dns_records,
+        )
+
+        zones = await list_hosted_zones()
+        if zones['count'] == 0:
+            pytest.skip('No hosted zones available for integration test')
+
+        zone_id = zones['hosted_zones'][0]['id']
+        result = await query_dns_records(hosted_zone_id=zone_id)
+        assert 'records' in result
+        assert 'count' in result
+        assert 'hosted_zone_id' in result
+
+
+@pytest.mark.integration
+class TestCheckHealthChecksIntegration:
+    """Integration tests for check_health_checks."""
+
+    async def test_check_health_checks_returns_results(self):
+        """Test that check_health_checks returns valid results against real AWS."""
+        from awslabs.aws_network_mcp_server.tools.route53.check_health_checks import (
+            check_health_checks,
+        )
+
+        result = await check_health_checks()
+        assert 'health_checks' in result
+        assert 'count' in result
+        assert isinstance(result['health_checks'], list)
+
+
+@pytest.mark.integration
+class TestListResolverRulesIntegration:
+    """Integration tests for list_resolver_rules."""
+
+    async def test_list_resolver_rules_returns_results(self):
+        """Test that list_resolver_rules returns valid results against real AWS."""
+        from awslabs.aws_network_mcp_server.tools.route53.list_resolver_rules import (
+            list_resolver_rules,
+        )
+
+        result = await list_resolver_rules(region='us-east-1')
+        assert 'resolver_rules' in result
+        assert 'resolver_endpoints' in result
+        assert 'region' in result
+        assert result['region'] == 'us-east-1'

--- a/src/aws-network-mcp-server/tests/test_integ_route53_profiles.py
+++ b/src/aws-network-mcp-server/tests/test_integ_route53_profiles.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for Route 53 Profiles tools.
+
+These tests require real AWS credentials and Route 53 Profiles resources.
+They are skipped by default and should be run manually with:
+    pytest tests/test_integ_route53_profiles.py -v --no-header
+"""
+
+import pytest
+
+
+pytestmark = pytest.mark.skip(reason='Integration tests require real AWS resources')
+
+
+class TestRoute53ProfilesIntegration:
+    """Integration tests for Route 53 Profiles tools."""
+
+    async def test_list_route53_profiles(self):
+        """Test listing Route 53 Profiles against real AWS APIs."""
+        from awslabs.aws_network_mcp_server.tools.route53_profiles import list_route53_profiles
+
+        result = await list_route53_profiles(region='us-east-1')
+        assert 'profiles' in result
+        assert 'count' in result
+        assert 'region' in result
+        assert result['region'] == 'us-east-1'
+
+    async def test_list_route53_profiles_with_profile_id(self):
+        """Test listing Route 53 Profiles with a specific profile ID."""
+        from awslabs.aws_network_mcp_server.tools.route53_profiles import list_route53_profiles
+
+        # First list all profiles to get a profile ID
+        result = await list_route53_profiles(region='us-east-1')
+        if result['count'] > 0:
+            pid = result['profiles'][0]['id']
+            detail_result = await list_route53_profiles(region='us-east-1', profile_id=pid)
+            assert 'profile_resources' in detail_result

--- a/src/aws-network-mcp-server/tests/test_integ_vpc_endpoints.py
+++ b/src/aws-network-mcp-server/tests/test_integ_vpc_endpoints.py
@@ -1,0 +1,79 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for VPC Endpoint tools.
+
+These tests require real AWS credentials and VPC endpoint resources.
+Run with: uv run --frozen pytest tests/test_integ_vpc_endpoints.py -v
+
+Prerequisites:
+- AWS credentials configured (env vars, ~/.aws/credentials, or IAM role)
+- At least one VPC endpoint in the target region
+- IAM permissions: ec2:DescribeVpcEndpoints, ec2:DescribeSecurityGroups,
+  ec2:DescribeNetworkInterfaces
+"""
+
+import pytest
+
+
+# Mark all tests in this module as integration tests
+pytestmark = pytest.mark.integration
+
+
+class TestListVpcEndpointsDetailedInteg:
+    """Integration tests for list_vpc_endpoints_detailed."""
+
+    @pytest.mark.skip(reason='Integration test — requires AWS credentials and VPC endpoints')
+    async def test_list_all_endpoints(self):
+        """List all VPC endpoints in the default region."""
+        from awslabs.aws_network_mcp_server.tools.vpc_endpoints import (
+            list_vpc_endpoints_detailed,
+        )
+
+        result = await list_vpc_endpoints_detailed(region='us-east-1')
+        assert 'vpc_endpoints' in result
+        assert 'count' in result
+        assert isinstance(result['vpc_endpoints'], list)
+
+    @pytest.mark.skip(reason='Integration test — requires AWS credentials and VPC endpoints')
+    async def test_list_endpoints_with_vpc_filter(self):
+        """List VPC endpoints filtered by VPC ID."""
+        from awslabs.aws_network_mcp_server.tools.vpc_endpoints import (
+            list_vpc_endpoints_detailed,
+        )
+
+        # Replace with a real VPC ID in your test account
+        result = await list_vpc_endpoints_detailed(region='us-east-1', vpc_id='vpc-REPLACE_ME')
+        assert 'vpc_endpoints' in result
+        for ep in result['vpc_endpoints']:
+            assert ep['vpc_id'] == 'vpc-REPLACE_ME'
+
+
+class TestCheckEndpointConnectivityInteg:
+    """Integration tests for check_endpoint_connectivity."""
+
+    @pytest.mark.skip(reason='Integration test — requires AWS credentials and VPC endpoints')
+    async def test_check_interface_endpoint(self):
+        """Check connectivity for an interface VPC endpoint."""
+        from awslabs.aws_network_mcp_server.tools.vpc_endpoints import (
+            check_endpoint_connectivity,
+        )
+
+        # Replace with a real VPC endpoint ID in your test account
+        result = await check_endpoint_connectivity(
+            vpc_endpoint_id='vpce-REPLACE_ME', region='us-east-1'
+        )
+        assert 'endpoint' in result
+        assert 'connectivity_checks' in result
+        assert result['endpoint']['id'] == 'vpce-REPLACE_ME'

--- a/src/aws-network-mcp-server/tests/tools/load_balancer/__init__.py
+++ b/src/aws-network-mcp-server/tests/tools/load_balancer/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws-network-mcp-server/tests/tools/load_balancer/test_get_lb_details.py
+++ b/src/aws-network-mcp-server/tests/tools/load_balancer/test_get_lb_details.py
@@ -1,0 +1,214 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the get_lb_details tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+# Get the actual module - prevents function/module resolution issues
+lb_details_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.load_balancer.get_lb_details'
+)
+
+SAMPLE_ALB_ARN = (
+    'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/1234567890'
+)
+
+
+class TestGetLbDetails:
+    """Test cases for get_lb_details function."""
+
+    @pytest.fixture
+    def sample_alb(self):
+        """Sample ALB fixture."""
+        return {
+            'LoadBalancerArn': SAMPLE_ALB_ARN,
+            'LoadBalancerName': 'my-alb',
+            'Type': 'application',
+            'Scheme': 'internet-facing',
+            'State': {'Code': 'active'},
+            'DNSName': 'my-alb-123.us-east-1.elb.amazonaws.com',
+            'VpcId': 'vpc-12345678',
+            'SecurityGroups': ['sg-12345678'],
+            'AvailabilityZones': [
+                {'ZoneName': 'us-east-1a', 'SubnetId': 'subnet-111'},
+            ],
+        }
+
+    @pytest.fixture
+    def sample_listeners(self):
+        """Sample listeners fixture."""
+        return [
+            {
+                'ListenerArn': 'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-alb/1234567890/1111111111',
+                'Protocol': 'HTTPS',
+                'Port': 443,
+                'DefaultActions': [{'Type': 'forward'}],
+            },
+        ]
+
+    @pytest.fixture
+    def sample_target_groups(self):
+        """Sample target groups fixture."""
+        return [
+            {
+                'TargetGroupArn': 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/1234567890',
+                'TargetGroupName': 'my-tg',
+                'Protocol': 'HTTPS',
+                'Port': 443,
+            },
+        ]
+
+    @patch.object(lb_details_module, 'get_aws_client')
+    async def test_get_lb_details_success(
+        self, mock_get_client, sample_alb, sample_listeners, sample_target_groups
+    ):
+        """Test successful load balancer details retrieval."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_load_balancers.return_value = {'LoadBalancers': [sample_alb]}
+
+        mock_paginator_listeners = MagicMock()
+        mock_paginator_tgs = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'describe_listeners':
+                return mock_paginator_listeners
+            elif api_name == 'describe_target_groups':
+                return mock_paginator_tgs
+            return MagicMock()
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        mock_paginator_listeners.paginate.return_value = [{'Listeners': sample_listeners}]
+        mock_paginator_tgs.paginate.return_value = [{'TargetGroups': sample_target_groups}]
+
+        result = await lb_details_module.get_lb_details(lb_arn=SAMPLE_ALB_ARN, region='us-east-1')
+
+        assert result['load_balancer']['LoadBalancerName'] == 'my-alb'
+        assert result['listeners'] == sample_listeners
+        assert result['listeners_error'] is None
+        assert result['target_groups'] == sample_target_groups
+        assert result['target_groups_error'] is None
+        assert result['region'] == 'us-east-1'
+        mock_get_client.assert_called_once_with('elbv2', 'us-east-1', None)
+
+    @patch.object(lb_details_module, 'get_aws_client')
+    async def test_get_lb_details_with_profile(self, mock_get_client, sample_alb):
+        """Test load balancer details with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_load_balancers.return_value = {'LoadBalancers': [sample_alb]}
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'Listeners': [], 'TargetGroups': []}]
+
+        await lb_details_module.get_lb_details(
+            lb_arn=SAMPLE_ALB_ARN, region='us-east-1', profile_name='test-profile'
+        )
+
+        mock_get_client.assert_called_once_with('elbv2', 'us-east-1', 'test-profile')
+
+    async def test_get_lb_details_invalid_arn(self):
+        """Test invalid ARN validation."""
+        with pytest.raises(
+            ToolError,
+            match='Invalid lb_arn format',
+        ):
+            await lb_details_module.get_lb_details(lb_arn='invalid-arn', region='us-east-1')
+
+    @patch.object(lb_details_module, 'get_aws_client')
+    async def test_get_lb_details_not_found(self, mock_get_client):
+        """Test load balancer not found."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_load_balancers.return_value = {'LoadBalancers': []}
+
+        with pytest.raises(
+            ToolError,
+            match='Load balancer not found',
+        ):
+            await lb_details_module.get_lb_details(lb_arn=SAMPLE_ALB_ARN, region='us-east-1')
+
+    @patch.object(lb_details_module, 'get_aws_client')
+    async def test_get_lb_details_partial_failure_listeners(
+        self, mock_get_client, sample_alb, sample_target_groups
+    ):
+        """Test partial failure when listeners retrieval fails."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_load_balancers.return_value = {'LoadBalancers': [sample_alb]}
+
+        mock_paginator_listeners = MagicMock()
+        mock_paginator_tgs = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'describe_listeners':
+                return mock_paginator_listeners
+            elif api_name == 'describe_target_groups':
+                return mock_paginator_tgs
+            return MagicMock()
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        mock_paginator_listeners.paginate.side_effect = Exception('AccessDenied')
+        mock_paginator_tgs.paginate.return_value = [{'TargetGroups': sample_target_groups}]
+
+        result = await lb_details_module.get_lb_details(lb_arn=SAMPLE_ALB_ARN, region='us-east-1')
+
+        assert result['listeners'] is None
+        assert result['listeners_error'] == 'AccessDenied'
+        assert result['target_groups'] == sample_target_groups
+        assert result['target_groups_error'] is None
+
+    @patch.object(lb_details_module, 'get_aws_client')
+    async def test_get_lb_details_glb_no_security_groups(self, mock_get_client):
+        """Test GLB has security groups set to None."""
+        glb = {
+            'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/gwy/my-glb/1234567890',
+            'LoadBalancerName': 'my-glb',
+            'Type': 'gateway',
+            'Scheme': 'internal',
+            'State': {'Code': 'active'},
+            'DNSName': 'my-glb.us-east-1.elb.amazonaws.com',
+            'VpcId': 'vpc-12345678',
+        }
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_load_balancers.return_value = {'LoadBalancers': [glb]}
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'Listeners': [], 'TargetGroups': []}]
+
+        result = await lb_details_module.get_lb_details(
+            lb_arn='arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/gwy/my-glb/1234567890',
+            region='us-east-1',
+        )
+
+        assert result['load_balancer']['SecurityGroups'] is None
+
+    @patch.object(lb_details_module, 'get_aws_client')
+    async def test_get_lb_details_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_load_balancers.side_effect = Exception('ServiceUnavailableException')
+
+        with pytest.raises(
+            ToolError,
+            match='Error getting load balancer details. Error: ServiceUnavailableException. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await lb_details_module.get_lb_details(lb_arn=SAMPLE_ALB_ARN, region='us-east-1')

--- a/src/aws-network-mcp-server/tests/tools/load_balancer/test_get_lb_target_health.py
+++ b/src/aws-network-mcp-server/tests/tools/load_balancer/test_get_lb_target_health.py
@@ -1,0 +1,170 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the get_lb_target_health tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+# Get the actual module - prevents function/module resolution issues
+lb_health_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.load_balancer.get_lb_target_health'
+)
+
+SAMPLE_TG_ARN = 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/1234567890'
+
+
+class TestGetLbTargetHealth:
+    """Test cases for get_lb_target_health function."""
+
+    @pytest.fixture
+    def sample_target_group(self):
+        """Sample target group fixture."""
+        return {
+            'TargetGroupArn': SAMPLE_TG_ARN,
+            'TargetGroupName': 'my-tg',
+            'Protocol': 'HTTP',
+            'Port': 80,
+            'HealthCheckProtocol': 'HTTP',
+            'HealthCheckPort': '80',
+            'HealthCheckPath': '/health',
+            'LoadBalancerArns': [
+                'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/1234567890'
+            ],
+        }
+
+    @pytest.fixture
+    def sample_target_health(self):
+        """Sample target health descriptions fixture."""
+        return [
+            {
+                'Target': {'Id': 'i-1234567890abcdef0', 'Port': 80},
+                'TargetHealth': {'State': 'healthy'},
+            },
+            {
+                'Target': {'Id': 'i-0987654321fedcba0', 'Port': 80},
+                'TargetHealth': {
+                    'State': 'unhealthy',
+                    'Reason': 'Target.ResponseCodeMismatch',
+                    'Description': 'Health checks failed with these codes: [503]',
+                },
+            },
+        ]
+
+    @patch.object(lb_health_module, 'get_aws_client')
+    async def test_get_lb_target_health_success(
+        self, mock_get_client, sample_target_group, sample_target_health
+    ):
+        """Test successful target health retrieval."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_target_groups.return_value = {'TargetGroups': [sample_target_group]}
+        mock_client.describe_target_health.return_value = {
+            'TargetHealthDescriptions': sample_target_health
+        }
+
+        result = await lb_health_module.get_lb_target_health(
+            target_group_arn=SAMPLE_TG_ARN, region='us-east-1'
+        )
+
+        assert result['target_group'] == sample_target_group
+        assert result['targets'] == sample_target_health
+        assert result['region'] == 'us-east-1'
+        mock_get_client.assert_called_once_with('elbv2', 'us-east-1', None)
+
+    @patch.object(lb_health_module, 'get_aws_client')
+    async def test_get_lb_target_health_empty_targets(self, mock_get_client, sample_target_group):
+        """Test target group with no registered targets."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_target_groups.return_value = {'TargetGroups': [sample_target_group]}
+        mock_client.describe_target_health.return_value = {'TargetHealthDescriptions': []}
+
+        result = await lb_health_module.get_lb_target_health(
+            target_group_arn=SAMPLE_TG_ARN, region='us-east-1'
+        )
+
+        assert result['targets'] == []
+
+    @patch.object(lb_health_module, 'get_aws_client')
+    async def test_get_lb_target_health_with_profile(self, mock_get_client, sample_target_group):
+        """Test target health with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_target_groups.return_value = {'TargetGroups': [sample_target_group]}
+        mock_client.describe_target_health.return_value = {'TargetHealthDescriptions': []}
+
+        await lb_health_module.get_lb_target_health(
+            target_group_arn=SAMPLE_TG_ARN,
+            region='eu-central-1',
+            profile_name='test-profile',
+        )
+
+        mock_get_client.assert_called_once_with('elbv2', 'eu-central-1', 'test-profile')
+
+    async def test_get_lb_target_health_invalid_arn(self):
+        """Test invalid target group ARN validation."""
+        with pytest.raises(
+            ToolError,
+            match='Invalid target_group_arn format',
+        ):
+            await lb_health_module.get_lb_target_health(
+                target_group_arn='invalid-arn', region='us-east-1'
+            )
+
+    @patch.object(lb_health_module, 'get_aws_client')
+    async def test_get_lb_target_health_not_found(self, mock_get_client):
+        """Test target group not found."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_target_groups.return_value = {'TargetGroups': []}
+
+        with pytest.raises(
+            ToolError,
+            match='Target group not found',
+        ):
+            await lb_health_module.get_lb_target_health(
+                target_group_arn=SAMPLE_TG_ARN, region='us-east-1'
+            )
+
+    @patch.object(lb_health_module, 'get_aws_client')
+    async def test_get_lb_target_health_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_target_groups.side_effect = Exception('ServiceUnavailableException')
+
+        with pytest.raises(
+            ToolError,
+            match='Error getting target health. Error: ServiceUnavailableException. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await lb_health_module.get_lb_target_health(
+                target_group_arn=SAMPLE_TG_ARN, region='us-east-1'
+            )
+
+    @patch.object(lb_health_module, 'get_aws_client')
+    async def test_get_lb_target_health_client_error(self, mock_get_client):
+        """Test client creation error handling."""
+        mock_get_client.side_effect = Exception('Invalid credentials')
+
+        with pytest.raises(
+            ToolError,
+            match='Error getting target health. Error: Invalid credentials. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await lb_health_module.get_lb_target_health(
+                target_group_arn=SAMPLE_TG_ARN, region='us-east-1'
+            )

--- a/src/aws-network-mcp-server/tests/tools/load_balancer/test_list_load_balancers.py
+++ b/src/aws-network-mcp-server/tests/tools/load_balancer/test_list_load_balancers.py
@@ -1,0 +1,160 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the list_load_balancers tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+# Get the actual module - prevents function/module resolution issues
+lb_list_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.load_balancer.list_load_balancers'
+)
+
+
+class TestListLoadBalancers:
+    """Test cases for list_load_balancers function."""
+
+    @pytest.fixture
+    def sample_load_balancers(self):
+        """Sample load balancers fixture."""
+        return [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/1234567890',
+                'LoadBalancerName': 'my-alb',
+                'Type': 'application',
+                'Scheme': 'internet-facing',
+                'State': {'Code': 'active'},
+                'DNSName': 'my-alb-123.us-east-1.elb.amazonaws.com',
+                'VpcId': 'vpc-12345678',
+                'AvailabilityZones': [
+                    {'ZoneName': 'us-east-1a', 'SubnetId': 'subnet-111'},
+                    {'ZoneName': 'us-east-1b', 'SubnetId': 'subnet-222'},
+                ],
+                'SecurityGroups': ['sg-12345678'],
+            },
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/my-nlb/0987654321',
+                'LoadBalancerName': 'my-nlb',
+                'Type': 'network',
+                'Scheme': 'internal',
+                'State': {'Code': 'active'},
+                'DNSName': 'my-nlb-456.us-east-1.elb.amazonaws.com',
+                'VpcId': 'vpc-87654321',
+                'AvailabilityZones': [
+                    {'ZoneName': 'us-east-1a', 'SubnetId': 'subnet-333'},
+                ],
+            },
+        ]
+
+    @patch.object(lb_list_module, 'get_aws_client')
+    async def test_list_load_balancers_success(self, mock_get_client, sample_load_balancers):
+        """Test successful load balancers listing."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'LoadBalancers': sample_load_balancers}]
+
+        result = await lb_list_module.list_load_balancers(region='us-east-1')
+
+        assert result == {
+            'load_balancers': sample_load_balancers,
+            'count': 2,
+            'region': 'us-east-1',
+        }
+        mock_get_client.assert_called_once_with('elbv2', 'us-east-1', None)
+
+    @patch.object(lb_list_module, 'get_aws_client')
+    async def test_list_load_balancers_empty(self, mock_get_client):
+        """Test listing when no load balancers exist."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'LoadBalancers': []}]
+
+        result = await lb_list_module.list_load_balancers(region='us-west-2')
+
+        assert result == {'load_balancers': [], 'count': 0, 'region': 'us-west-2'}
+
+    @patch.object(lb_list_module, 'get_aws_client')
+    async def test_list_load_balancers_with_profile(self, mock_get_client, sample_load_balancers):
+        """Test load balancers listing with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'LoadBalancers': sample_load_balancers}]
+
+        await lb_list_module.list_load_balancers(
+            region='eu-central-1', profile_name='test-profile'
+        )
+
+        mock_get_client.assert_called_once_with('elbv2', 'eu-central-1', 'test-profile')
+
+    @patch.object(lb_list_module, 'get_aws_client')
+    async def test_list_load_balancers_filter_by_type(
+        self, mock_get_client, sample_load_balancers
+    ):
+        """Test filtering load balancers by type."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'LoadBalancers': sample_load_balancers}]
+
+        result = await lb_list_module.list_load_balancers(
+            region='us-east-1', lb_type='application'
+        )
+
+        assert result['count'] == 1
+        assert result['load_balancers'][0]['Type'] == 'application'
+
+    async def test_list_load_balancers_invalid_type(self):
+        """Test invalid lb_type validation."""
+        with pytest.raises(
+            ToolError,
+            match='Invalid lb_type "invalid"',
+        ):
+            await lb_list_module.list_load_balancers(region='us-east-1', lb_type='invalid')
+
+    @patch.object(lb_list_module, 'get_aws_client')
+    async def test_list_load_balancers_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.side_effect = Exception('ServiceUnavailableException')
+
+        with pytest.raises(
+            ToolError,
+            match='Error listing load balancers. Error: ServiceUnavailableException. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await lb_list_module.list_load_balancers(region='us-east-1')
+
+    @patch.object(lb_list_module, 'get_aws_client')
+    async def test_list_load_balancers_client_error(self, mock_get_client):
+        """Test client creation error handling."""
+        mock_get_client.side_effect = Exception('Invalid credentials')
+
+        with pytest.raises(
+            ToolError,
+            match='Error listing load balancers. Error: Invalid credentials. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await lb_list_module.list_load_balancers(region='us-east-1')

--- a/src/aws-network-mcp-server/tests/tools/route53/__init__.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws-network-mcp-server/tests/tools/route53/test_check_health_checks.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_check_health_checks.py
@@ -1,0 +1,278 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the check_health_checks tool."""
+
+import importlib
+import pytest
+from datetime import datetime, timezone
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, call, patch
+
+
+hc_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.route53.check_health_checks'
+)
+
+
+class TestCheckHealthChecks:
+    """Test cases for check_health_checks function."""
+
+    @pytest.fixture
+    def sample_health_checks(self):
+        """Sample health checks fixture."""
+        return [
+            {
+                'Id': 'hc-http-1',
+                'HealthCheckConfig': {
+                    'Type': 'HTTP',
+                    'IPAddress': '1.2.3.4',
+                    'Port': 80,
+                    'ResourcePath': '/health',
+                    'RequestInterval': 30,
+                    'FailureThreshold': 3,
+                },
+            },
+            {
+                'Id': 'hc-calc-1',
+                'HealthCheckConfig': {
+                    'Type': 'CALCULATED',
+                    'RequestInterval': 30,
+                    'FailureThreshold': 3,
+                },
+            },
+        ]
+
+    @pytest.fixture
+    def sample_status_response(self):
+        """Sample GetHealthCheckStatus response."""
+        return {
+            'HealthCheckObservations': [
+                {
+                    'Region': 'us-east-1',
+                    'IPAddress': '10.0.0.1',
+                    'StatusReport': {'Status': 'Success: HTTP Status Code 200'},
+                },
+                {
+                    'Region': 'eu-west-1',
+                    'IPAddress': '10.0.0.2',
+                    'StatusReport': {'Status': 'Success: HTTP Status Code 200'},
+                },
+            ]
+        }
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_check_single_health_check(
+        self, mock_get_client, sample_health_checks, sample_status_response
+    ):
+        """Test checking a single specific health check."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': sample_health_checks}]
+        mock_r53.get_health_check_status.return_value = sample_status_response
+
+        result = await hc_module.check_health_checks(health_check_id='hc-http-1')
+
+        assert result['count'] == 1
+        assert result['health_checks'][0]['id'] == 'hc-http-1'
+        assert result['health_checks'][0]['status'] == 'healthy'
+        assert len(result['health_checks'][0]['checker_results']) == 2
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_check_all_health_checks_under_threshold(
+        self, mock_get_client, sample_health_checks, sample_status_response
+    ):
+        """Test listing all HCs when count is under rate-limit threshold."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': sample_health_checks}]
+        mock_r53.get_health_check_status.return_value = sample_status_response
+
+        # CloudWatch for calculated HC
+        mock_cw.get_metric_statistics.return_value = {
+            'Datapoints': [
+                {'Timestamp': datetime(2025, 1, 1, tzinfo=timezone.utc), 'Average': 1.0}
+            ]
+        }
+
+        result = await hc_module.check_health_checks()
+
+        assert result['count'] == 2
+        assert result['status_retrieval_note'] is None
+        # Non-calculated HC should have status from GetHealthCheckStatus
+        http_hc = next(h for h in result['health_checks'] if h['id'] == 'hc-http-1')
+        assert http_hc['status'] == 'healthy'
+        # Calculated HC should have status from CloudWatch
+        calc_hc = next(h for h in result['health_checks'] if h['id'] == 'hc-calc-1')
+        assert calc_hc['status'] == 'healthy'
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_calculated_hc_cloudwatch_fallback(self, mock_get_client):
+        """Test calculated health check uses CloudWatch for status."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        calc_hc = {
+            'Id': 'hc-calc-1',
+            'HealthCheckConfig': {
+                'Type': 'CALCULATED',
+                'RequestInterval': 30,
+                'FailureThreshold': 3,
+            },
+        }
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': [calc_hc]}]
+
+        mock_cw.get_metric_statistics.return_value = {
+            'Datapoints': [
+                {'Timestamp': datetime(2025, 1, 1, tzinfo=timezone.utc), 'Average': 0.0}
+            ]
+        }
+
+        result = await hc_module.check_health_checks(health_check_id='hc-calc-1')
+
+        assert result['health_checks'][0]['status'] == 'unhealthy'
+        # Verify CloudWatch was called with correct params
+        mock_cw.get_metric_statistics.assert_called_once()
+        cw_call = mock_cw.get_metric_statistics.call_args
+        assert cw_call[1]['Namespace'] == 'AWS/Route53'
+        assert cw_call[1]['MetricName'] == 'HealthCheckStatus'
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_rate_limit_threshold_skips_status(self, mock_get_client):
+        """Test that status retrieval is skipped when count > 20."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        # Create 21 non-calculated health checks
+        many_hcs = [
+            {
+                'Id': f'hc-{i}',
+                'HealthCheckConfig': {
+                    'Type': 'HTTP',
+                    'IPAddress': f'1.2.3.{i}',
+                    'Port': 80,
+                    'RequestInterval': 30,
+                    'FailureThreshold': 3,
+                },
+            }
+            for i in range(21)
+        ]
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': many_hcs}]
+
+        result = await hc_module.check_health_checks()
+
+        assert result['count'] == 21
+        assert result['status_retrieval_note'] is not None
+        assert 'exceeds threshold' in result['status_retrieval_note']
+        # GetHealthCheckStatus should NOT have been called
+        mock_r53.get_health_check_status.assert_not_called()
+        # All should have 'unknown' status
+        for hc in result['health_checks']:
+            assert hc['status'] == 'unknown'
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_status_filter_healthy(self, mock_get_client, sample_health_checks):
+        """Test filtering by healthy status."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': sample_health_checks}]
+        mock_r53.get_health_check_status.return_value = {
+            'HealthCheckObservations': [
+                {
+                    'Region': 'us-east-1',
+                    'IPAddress': '10.0.0.1',
+                    'StatusReport': {'Status': 'Failure'},
+                },
+            ]
+        }
+        mock_cw.get_metric_statistics.return_value = {
+            'Datapoints': [
+                {'Timestamp': datetime(2025, 1, 1, tzinfo=timezone.utc), 'Average': 1.0}
+            ]
+        }
+
+        result = await hc_module.check_health_checks(status_filter='healthy')
+
+        # Only the calculated HC (healthy via CW) should be returned
+        assert result['count'] == 1
+        assert result['health_checks'][0]['id'] == 'hc-calc-1'
+
+    async def test_check_health_checks_invalid_status_filter(self):
+        """Test invalid status_filter validation."""
+        with pytest.raises(ToolError, match='Invalid status_filter "bad"'):
+            await hc_module.check_health_checks(status_filter='bad')
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_cloudwatch_client_uses_us_east_1(self, mock_get_client):
+        """CRITICAL: Verify CloudWatch client is created with us-east-1."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': []}]
+
+        await hc_module.check_health_checks()
+
+        # Verify the two get_aws_client calls
+        calls = mock_get_client.call_args_list
+        assert calls[0] == call('route53', None, None)
+        assert calls[1] == call('cloudwatch', 'us-east-1', None)
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_check_health_checks_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.side_effect = Exception('AccessDenied')
+
+        with pytest.raises(ToolError, match='Error checking health checks.*AccessDenied'):
+            await hc_module.check_health_checks()
+
+    @patch.object(hc_module, 'get_aws_client')
+    async def test_single_hc_not_found(self, mock_get_client):
+        """Test health check not found error."""
+        mock_r53 = MagicMock()
+        mock_cw = MagicMock()
+        mock_get_client.side_effect = [mock_r53, mock_cw]
+
+        mock_paginator = MagicMock()
+        mock_r53.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HealthChecks': []}]
+
+        with pytest.raises(ToolError, match='not found'):
+            await hc_module.check_health_checks(health_check_id='hc-nonexistent')

--- a/src/aws-network-mcp-server/tests/tools/route53/test_list_dns_firewall_rules.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_list_dns_firewall_rules.py
@@ -1,0 +1,242 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the list_dns_firewall_rules tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+firewall_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.route53.list_dns_firewall_rules'
+)
+
+
+class TestListDnsFirewallRules:
+    """Test cases for list_dns_firewall_rules function."""
+
+    @pytest.fixture
+    def sample_rule_groups(self):
+        """Sample firewall rule groups fixture."""
+        return [
+            {
+                'Id': 'rslvr-frg-111',
+                'Name': 'block-malware-domains',
+                'ShareStatus': 'NOT_SHARED',
+                'OwnerId': '123456789012',
+            },
+            {
+                'Id': 'rslvr-frg-222',
+                'Name': 'allow-internal-domains',
+                'ShareStatus': 'SHARED_WITH_ME',
+                'OwnerId': '987654321098',
+            },
+        ]
+
+    @pytest.fixture
+    def sample_associations(self):
+        """Sample firewall rule group associations fixture."""
+        return [
+            {
+                'FirewallRuleGroupId': 'rslvr-frg-111',
+                'VpcId': 'vpc-aaa',
+                'Priority': 100,
+            },
+            {
+                'FirewallRuleGroupId': 'rslvr-frg-111',
+                'VpcId': 'vpc-bbb',
+                'Priority': 200,
+            },
+            {
+                'FirewallRuleGroupId': 'rslvr-frg-222',
+                'VpcId': 'vpc-aaa',
+                'Priority': 300,
+            },
+        ]
+
+    @pytest.fixture
+    def sample_firewall_rules(self):
+        """Sample individual firewall rules fixture."""
+        return [
+            {
+                'Name': 'block-bad-domains',
+                'Priority': 1,
+                'Action': 'BLOCK',
+                'FirewallDomainListId': 'rslvr-fdl-111',
+                'BlockResponse': 'NXDOMAIN',
+            },
+            {
+                'Name': 'alert-suspicious',
+                'Priority': 2,
+                'Action': 'ALERT',
+                'FirewallDomainListId': 'rslvr-fdl-222',
+                'BlockResponse': None,
+            },
+        ]
+
+    @patch.object(firewall_module, 'get_aws_client')
+    async def test_list_dns_firewall_rules_success(
+        self, mock_get_client, sample_rule_groups, sample_associations
+    ):
+        """Test successful DNS Firewall rule groups listing with VPC associations."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        groups_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_firewall_rule_groups':
+                return groups_paginator
+            elif api_name == 'list_firewall_rule_group_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+
+        groups_paginator.paginate.return_value = [{'FirewallRuleGroups': sample_rule_groups}]
+        assoc_paginator.paginate.return_value = [
+            {'FirewallRuleGroupAssociations': sample_associations}
+        ]
+
+        result = await firewall_module.list_dns_firewall_rules(region='us-east-1')
+
+        assert result['region'] == 'us-east-1'
+        assert result['count'] == 2
+        assert len(result['firewall_rule_groups']) == 2
+        assert result['firewall_rules'] is None
+
+        # Verify first group has two VPC associations
+        group1 = result['firewall_rule_groups'][0]
+        assert group1['id'] == 'rslvr-frg-111'
+        assert group1['name'] == 'block-malware-domains'
+        assert len(group1['vpc_associations']) == 2
+        assert group1['vpc_associations'][0] == {'vpc_id': 'vpc-aaa', 'priority': 100}
+        assert group1['vpc_associations'][1] == {'vpc_id': 'vpc-bbb', 'priority': 200}
+
+        # Verify second group has one VPC association
+        group2 = result['firewall_rule_groups'][1]
+        assert group2['id'] == 'rslvr-frg-222'
+        assert len(group2['vpc_associations']) == 1
+
+        mock_get_client.assert_called_once_with('route53resolver', 'us-east-1', None)
+
+    @patch.object(firewall_module, 'get_aws_client')
+    async def test_list_dns_firewall_rules_empty(self, mock_get_client):
+        """Test listing when no DNS Firewall rule groups exist."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        groups_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_firewall_rule_groups':
+                return groups_paginator
+            elif api_name == 'list_firewall_rule_group_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        groups_paginator.paginate.return_value = [{'FirewallRuleGroups': []}]
+        assoc_paginator.paginate.return_value = [{'FirewallRuleGroupAssociations': []}]
+
+        result = await firewall_module.list_dns_firewall_rules(region='us-west-2')
+
+        assert result == {
+            'firewall_rule_groups': [],
+            'firewall_rules': None,
+            'count': 0,
+            'region': 'us-west-2',
+        }
+
+    @patch.object(firewall_module, 'get_aws_client')
+    async def test_list_dns_firewall_rules_with_profile(self, mock_get_client, sample_rule_groups):
+        """Test DNS Firewall rules listing with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        groups_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_firewall_rule_groups':
+                return groups_paginator
+            elif api_name == 'list_firewall_rule_group_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        groups_paginator.paginate.return_value = [{'FirewallRuleGroups': sample_rule_groups}]
+        assoc_paginator.paginate.return_value = [{'FirewallRuleGroupAssociations': []}]
+
+        await firewall_module.list_dns_firewall_rules(
+            region='eu-central-1', profile_name='test-profile'
+        )
+
+        mock_get_client.assert_called_once_with('route53resolver', 'eu-central-1', 'test-profile')
+
+    @patch.object(firewall_module, 'get_aws_client')
+    async def test_list_dns_firewall_rules_with_rule_group_id(
+        self, mock_get_client, sample_rule_groups, sample_associations, sample_firewall_rules
+    ):
+        """Test listing with rule_group_id returns individual firewall rules."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        groups_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+        rules_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_firewall_rule_groups':
+                return groups_paginator
+            elif api_name == 'list_firewall_rule_group_associations':
+                return assoc_paginator
+            elif api_name == 'list_firewall_rules':
+                return rules_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+
+        groups_paginator.paginate.return_value = [{'FirewallRuleGroups': sample_rule_groups}]
+        assoc_paginator.paginate.return_value = [
+            {'FirewallRuleGroupAssociations': sample_associations}
+        ]
+        rules_paginator.paginate.return_value = [{'FirewallRules': sample_firewall_rules}]
+
+        result = await firewall_module.list_dns_firewall_rules(
+            region='us-east-1', rule_group_id='rslvr-frg-111'
+        )
+
+        assert result['firewall_rules'] is not None
+        assert len(result['firewall_rules']) == 2
+        assert result['firewall_rules'][0]['name'] == 'block-bad-domains'
+        assert result['firewall_rules'][0]['action'] == 'BLOCK'
+        assert result['firewall_rules'][0]['block_response'] == 'NXDOMAIN'
+        assert result['firewall_rules'][1]['name'] == 'alert-suspicious'
+        assert result['firewall_rules'][1]['action'] == 'ALERT'
+        assert result['firewall_rules'][1]['block_response'] is None
+
+        rules_paginator.paginate.assert_called_once_with(FirewallRuleGroupId='rslvr-frg-111')
+
+    @patch.object(firewall_module, 'get_aws_client')
+    async def test_list_dns_firewall_rules_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        groups_paginator = MagicMock()
+        mock_client.get_paginator.return_value = groups_paginator
+        groups_paginator.paginate.side_effect = Exception('AccessDenied')
+
+        with pytest.raises(ToolError, match='Error listing DNS Firewall rules.*AccessDenied'):
+            await firewall_module.list_dns_firewall_rules(region='us-east-1')

--- a/src/aws-network-mcp-server/tests/tools/route53/test_list_dns_firewall_rules.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_list_dns_firewall_rules.py
@@ -240,3 +240,43 @@ class TestListDnsFirewallRules:
 
         with pytest.raises(ToolError, match='Error listing DNS Firewall rules.*AccessDenied'):
             await firewall_module.list_dns_firewall_rules(region='us-east-1')
+
+    @patch.object(firewall_module, 'get_aws_client')
+    async def test_list_dns_firewall_rules_associations_failure_logs_and_continues(
+        self, mock_get_client, sample_rule_groups, caplog
+    ):
+        """When list_firewall_rule_group_associations fails, function logs and continues with empty associations."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        groups_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_firewall_rule_groups':
+                return groups_paginator
+            elif api_name == 'list_firewall_rule_group_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        groups_paginator.paginate.return_value = [{'FirewallRuleGroups': sample_rule_groups}]
+        assoc_paginator.paginate.side_effect = Exception('AssociationsAccessDenied')
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger='awslabs.aws_network_mcp_server.tools.route53.list_dns_firewall_rules',
+        ):
+            result = await firewall_module.list_dns_firewall_rules(region='us-east-1')
+
+        # Function returns groups with empty vpc_associations
+        assert result['count'] == 2
+        for group in result['firewall_rule_groups']:
+            assert group['vpc_associations'] == []
+
+        # Verify the failure was logged at debug level
+        assert any(
+            'Failed to list firewall rule group associations' in record.message
+            for record in caplog.records
+        )

--- a/src/aws-network-mcp-server/tests/tools/route53/test_list_hosted_zones.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_list_hosted_zones.py
@@ -1,0 +1,151 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the list_hosted_zones tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+hz_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.route53.list_hosted_zones'
+)
+
+
+class TestListHostedZones:
+    """Test cases for list_hosted_zones function."""
+
+    @pytest.fixture
+    def sample_zones(self):
+        """Sample hosted zones fixture."""
+        return [
+            {
+                'Id': '/hostedzone/Z1234PUBLIC',
+                'Name': 'example.com.',
+                'ResourceRecordSetCount': 10,
+                'Config': {'PrivateZone': False, 'Comment': 'Public zone'},
+            },
+            {
+                'Id': '/hostedzone/Z5678PRIVATE',
+                'Name': 'internal.example.com.',
+                'ResourceRecordSetCount': 5,
+                'Config': {'PrivateZone': True, 'Comment': 'Private zone'},
+            },
+        ]
+
+    @patch.object(hz_module, 'get_aws_client')
+    async def test_list_hosted_zones_success(self, mock_get_client, sample_zones):
+        """Test successful hosted zones listing."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HostedZones': sample_zones}]
+        mock_client.get_hosted_zone.return_value = {
+            'VPCs': [{'VPCId': 'vpc-123', 'VPCRegion': 'us-east-1'}]
+        }
+
+        result = await hz_module.list_hosted_zones()
+
+        assert result['count'] == 2
+        assert len(result['hosted_zones']) == 2
+        assert result['hosted_zones'][0]['is_private'] is False
+        assert result['hosted_zones'][0]['vpcs'] is None
+        assert result['hosted_zones'][1]['is_private'] is True
+        assert result['hosted_zones'][1]['vpcs'] == [
+            {'vpc_id': 'vpc-123', 'vpc_region': 'us-east-1'}
+        ]
+        mock_get_client.assert_called_once_with('route53', None, None)
+
+    @patch.object(hz_module, 'get_aws_client')
+    async def test_list_hosted_zones_empty(self, mock_get_client):
+        """Test listing when no hosted zones exist."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HostedZones': []}]
+
+        result = await hz_module.list_hosted_zones()
+
+        assert result == {'hosted_zones': [], 'count': 0}
+
+    @patch.object(hz_module, 'get_aws_client')
+    async def test_list_hosted_zones_with_profile(self, mock_get_client, sample_zones):
+        """Test hosted zones listing with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HostedZones': sample_zones}]
+        mock_client.get_hosted_zone.return_value = {'VPCs': []}
+
+        await hz_module.list_hosted_zones(profile_name='test-profile')
+
+        mock_get_client.assert_called_once_with('route53', None, 'test-profile')
+
+    @patch.object(hz_module, 'get_aws_client')
+    async def test_list_hosted_zones_filter_public(self, mock_get_client, sample_zones):
+        """Test filtering by public zone type."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HostedZones': sample_zones}]
+
+        result = await hz_module.list_hosted_zones(zone_type='public')
+
+        assert result['count'] == 1
+        assert result['hosted_zones'][0]['name'] == 'example.com.'
+        assert result['hosted_zones'][0]['is_private'] is False
+
+    @patch.object(hz_module, 'get_aws_client')
+    async def test_list_hosted_zones_filter_private(self, mock_get_client, sample_zones):
+        """Test filtering by private zone type with VPC associations."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'HostedZones': sample_zones}]
+        mock_client.get_hosted_zone.return_value = {
+            'VPCs': [
+                {'VPCId': 'vpc-aaa', 'VPCRegion': 'us-east-1'},
+                {'VPCId': 'vpc-bbb', 'VPCRegion': 'us-west-2'},
+            ]
+        }
+
+        result = await hz_module.list_hosted_zones(zone_type='private')
+
+        assert result['count'] == 1
+        assert result['hosted_zones'][0]['is_private'] is True
+        assert len(result['hosted_zones'][0]['vpcs']) == 2
+
+    async def test_list_hosted_zones_invalid_zone_type(self):
+        """Test invalid zone_type validation."""
+        with pytest.raises(ToolError, match='Invalid zone_type "invalid"'):
+            await hz_module.list_hosted_zones(zone_type='invalid')
+
+    @patch.object(hz_module, 'get_aws_client')
+    async def test_list_hosted_zones_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.side_effect = Exception('AccessDenied')
+
+        with pytest.raises(ToolError, match='Error listing hosted zones.*AccessDenied'):
+            await hz_module.list_hosted_zones()

--- a/src/aws-network-mcp-server/tests/tools/route53/test_list_resolver_rules.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_list_resolver_rules.py
@@ -1,0 +1,205 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the list_resolver_rules tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+resolver_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.route53.list_resolver_rules'
+)
+
+
+class TestListResolverRules:
+    """Test cases for list_resolver_rules function."""
+
+    @pytest.fixture
+    def sample_rules(self):
+        """Sample resolver rules fixture."""
+        return [
+            {
+                'Id': 'rslvr-rr-111',
+                'Name': 'forward-onprem',
+                'DomainName': 'corp.example.com.',
+                'RuleType': 'FORWARD',
+                'Status': 'COMPLETE',
+                'TargetIps': [
+                    {'Ip': '10.0.0.53', 'Port': 53},
+                    {'Ip': '10.0.1.53', 'Port': 53},
+                ],
+            },
+            {
+                'Id': 'rslvr-rr-222',
+                'Name': 'system-rule',
+                'DomainName': 'amazonaws.com.',
+                'RuleType': 'SYSTEM',
+                'Status': 'COMPLETE',
+                'TargetIps': [],
+            },
+        ]
+
+    @pytest.fixture
+    def sample_endpoints(self):
+        """Sample resolver endpoints fixture."""
+        return [
+            {
+                'Id': 'rslvr-out-111',
+                'Name': 'outbound-ep',
+                'Direction': 'OUTBOUND',
+                'HostVPCId': 'vpc-123',
+                'Status': 'OPERATIONAL',
+                'IpAddressCount': 2,
+            },
+        ]
+
+    @patch.object(resolver_module, 'get_aws_client')
+    async def test_list_resolver_rules_success(
+        self, mock_get_client, sample_rules, sample_endpoints
+    ):
+        """Test successful resolver rules listing."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Set up paginators
+        rules_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+        endpoints_paginator = MagicMock()
+        ip_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_resolver_rules':
+                return rules_paginator
+            elif api_name == 'list_resolver_rule_associations':
+                return assoc_paginator
+            elif api_name == 'list_resolver_endpoints':
+                return endpoints_paginator
+            elif api_name == 'list_resolver_endpoint_ip_addresses':
+                return ip_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+
+        rules_paginator.paginate.return_value = [{'ResolverRules': sample_rules}]
+        assoc_paginator.paginate.return_value = [
+            {
+                'ResolverRuleAssociations': [
+                    {'ResolverRuleId': 'rslvr-rr-111', 'VPCId': 'vpc-aaa'},
+                    {'ResolverRuleId': 'rslvr-rr-111', 'VPCId': 'vpc-bbb'},
+                    {'ResolverRuleId': 'rslvr-rr-222', 'VPCId': 'vpc-aaa'},
+                ]
+            }
+        ]
+        endpoints_paginator.paginate.return_value = [{'ResolverEndpoints': sample_endpoints}]
+        ip_paginator.paginate.return_value = [
+            {
+                'IpAddresses': [
+                    {'Ip': '10.0.0.10', 'SubnetId': 'subnet-111'},
+                    {'Ip': '10.0.1.10', 'SubnetId': 'subnet-222'},
+                ]
+            }
+        ]
+
+        result = await resolver_module.list_resolver_rules(region='us-east-1')
+
+        assert result['region'] == 'us-east-1'
+        assert len(result['resolver_rules']) == 2
+        assert result['resolver_rules'][0]['vpc_associations'] == ['vpc-aaa', 'vpc-bbb']
+        assert result['resolver_rules'][0]['target_ips'] == [
+            {'ip': '10.0.0.53', 'port': 53},
+            {'ip': '10.0.1.53', 'port': 53},
+        ]
+        assert len(result['resolver_endpoints']) == 1
+        assert result['resolver_endpoints'][0]['ip_addresses'] == [
+            {'ip': '10.0.0.10', 'subnet_id': 'subnet-111'},
+            {'ip': '10.0.1.10', 'subnet_id': 'subnet-222'},
+        ]
+        mock_get_client.assert_called_once_with('route53resolver', 'us-east-1', None)
+
+    @patch.object(resolver_module, 'get_aws_client')
+    async def test_list_resolver_rules_empty(self, mock_get_client):
+        """Test listing when no resolver rules or endpoints exist."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        rules_paginator = MagicMock()
+        endpoints_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_resolver_rules':
+                return rules_paginator
+            elif api_name == 'list_resolver_endpoints':
+                return endpoints_paginator
+            return MagicMock()
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        rules_paginator.paginate.return_value = [{'ResolverRules': []}]
+        endpoints_paginator.paginate.return_value = [{'ResolverEndpoints': []}]
+
+        result = await resolver_module.list_resolver_rules(region='us-west-2')
+
+        assert result == {
+            'resolver_rules': [],
+            'resolver_endpoints': [],
+            'region': 'us-west-2',
+        }
+
+    @patch.object(resolver_module, 'get_aws_client')
+    async def test_list_resolver_rules_with_profile(
+        self, mock_get_client, sample_rules, sample_endpoints
+    ):
+        """Test resolver rules listing with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        rules_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+        endpoints_paginator = MagicMock()
+        ip_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_resolver_rules':
+                return rules_paginator
+            elif api_name == 'list_resolver_rule_associations':
+                return assoc_paginator
+            elif api_name == 'list_resolver_endpoints':
+                return endpoints_paginator
+            elif api_name == 'list_resolver_endpoint_ip_addresses':
+                return ip_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        rules_paginator.paginate.return_value = [{'ResolverRules': sample_rules}]
+        assoc_paginator.paginate.return_value = [{'ResolverRuleAssociations': []}]
+        endpoints_paginator.paginate.return_value = [{'ResolverEndpoints': sample_endpoints}]
+        ip_paginator.paginate.return_value = [{'IpAddresses': []}]
+
+        await resolver_module.list_resolver_rules(
+            region='eu-central-1', profile_name='test-profile'
+        )
+
+        mock_get_client.assert_called_once_with('route53resolver', 'eu-central-1', 'test-profile')
+
+    @patch.object(resolver_module, 'get_aws_client')
+    async def test_list_resolver_rules_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        rules_paginator = MagicMock()
+        mock_client.get_paginator.return_value = rules_paginator
+        rules_paginator.paginate.side_effect = Exception('AccessDenied')
+
+        with pytest.raises(ToolError, match='Error listing resolver rules.*AccessDenied'):
+            await resolver_module.list_resolver_rules(region='us-east-1')

--- a/src/aws-network-mcp-server/tests/tools/route53/test_list_resolver_rules.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_list_resolver_rules.py
@@ -203,3 +203,95 @@ class TestListResolverRules:
 
         with pytest.raises(ToolError, match='Error listing resolver rules.*AccessDenied'):
             await resolver_module.list_resolver_rules(region='us-east-1')
+
+    @patch.object(resolver_module, 'get_aws_client')
+    async def test_list_resolver_rules_associations_failure_logs_and_continues(
+        self, mock_get_client, sample_rules, caplog
+    ):
+        """When list_resolver_rule_associations fails, function logs and continues with empty associations."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        rules_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+        endpoints_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_resolver_rules':
+                return rules_paginator
+            elif api_name == 'list_resolver_rule_associations':
+                return assoc_paginator
+            elif api_name == 'list_resolver_endpoints':
+                return endpoints_paginator
+            return MagicMock()
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        rules_paginator.paginate.return_value = [{'ResolverRules': sample_rules}]
+        assoc_paginator.paginate.side_effect = Exception('AssociationsAccessDenied')
+        endpoints_paginator.paginate.return_value = [{'ResolverEndpoints': []}]
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger='awslabs.aws_network_mcp_server.tools.route53.list_resolver_rules',
+        ):
+            result = await resolver_module.list_resolver_rules(region='us-east-1')
+
+        # Function returns rules with empty vpc_associations
+        for rule in result['resolver_rules']:
+            assert rule['vpc_associations'] == []
+
+        # Verify the failure was logged at debug level
+        assert any(
+            'Failed to list resolver rule associations' in record.message
+            for record in caplog.records
+        )
+
+    @patch.object(resolver_module, 'get_aws_client')
+    async def test_list_resolver_rules_endpoint_ip_failure_logs_and_continues(
+        self, mock_get_client, sample_endpoints, caplog
+    ):
+        """When list_resolver_endpoint_ip_addresses fails for an endpoint, function logs and continues with empty IPs for that endpoint."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        rules_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+        endpoints_paginator = MagicMock()
+        ip_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_resolver_rules':
+                return rules_paginator
+            elif api_name == 'list_resolver_rule_associations':
+                return assoc_paginator
+            elif api_name == 'list_resolver_endpoints':
+                return endpoints_paginator
+            elif api_name == 'list_resolver_endpoint_ip_addresses':
+                return ip_paginator
+            return MagicMock()
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        rules_paginator.paginate.return_value = [{'ResolverRules': []}]
+        assoc_paginator.paginate.return_value = [{'ResolverRuleAssociations': []}]
+        endpoints_paginator.paginate.return_value = [{'ResolverEndpoints': sample_endpoints}]
+        ip_paginator.paginate.side_effect = Exception('EndpointIpsAccessDenied')
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger='awslabs.aws_network_mcp_server.tools.route53.list_resolver_rules',
+        ):
+            result = await resolver_module.list_resolver_rules(region='us-east-1')
+
+        # Endpoint is still returned but with empty ip_addresses
+        assert len(result['resolver_endpoints']) == 1
+        assert result['resolver_endpoints'][0]['ip_addresses'] == []
+
+        # Verify the failure was logged at debug level with endpoint id context
+        assert any(
+            'Failed to list IP addresses for resolver endpoint rslvr-out-111' in record.message
+            for record in caplog.records
+        )

--- a/src/aws-network-mcp-server/tests/tools/route53/test_query_dns_records.py
+++ b/src/aws-network-mcp-server/tests/tools/route53/test_query_dns_records.py
@@ -1,0 +1,332 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the query_dns_records tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+dns_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.route53.query_dns_records'
+)
+
+
+class TestQueryDnsRecords:
+    """Test cases for query_dns_records function."""
+
+    @pytest.fixture
+    def sample_records(self):
+        """Sample DNS record sets fixture."""
+        return {
+            'ResourceRecordSets': [
+                {
+                    'Name': 'example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '1.2.3.4'}],
+                },
+                {
+                    'Name': 'www.example.com.',
+                    'Type': 'CNAME',
+                    'TTL': 600,
+                    'ResourceRecords': [{'Value': 'example.com'}],
+                },
+                {
+                    'Name': 'alias.example.com.',
+                    'Type': 'A',
+                    'AliasTarget': {
+                        'DNSName': 'my-alb-123.us-east-1.elb.amazonaws.com.',
+                        'HostedZoneId': 'Z35SXDOTRQ7X7K',
+                        'EvaluateTargetHealth': True,
+                    },
+                },
+            ],
+            'IsTruncated': False,
+        }
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_success(self, mock_get_client, sample_records):
+        """Test successful DNS records query."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.return_value = sample_records
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234')
+
+        assert result['count'] == 3
+        assert result['hosted_zone_id'] == 'Z1234'
+        assert result['records'][0]['name'] == 'example.com.'
+        assert result['records'][0]['type'] == 'A'
+        assert result['records'][0]['is_alias'] is False
+        assert result['records'][0]['routing_policy'] == 'simple'
+        mock_get_client.assert_called_once_with('route53', None, None)
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_record_type_filter(self, mock_get_client, sample_records):
+        """Test filtering by record type."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.return_value = sample_records
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234', record_type='A')
+
+        assert result['count'] == 2
+        for r in result['records']:
+            assert r['type'] == 'A'
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_name_prefix_filter(self, mock_get_client):
+        """Test filtering by name prefix."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.return_value = {
+            'ResourceRecordSets': [
+                {
+                    'Name': 'www.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '1.2.3.4'}],
+                },
+                {
+                    'Name': 'www.example.com.',
+                    'Type': 'AAAA',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '::1'}],
+                },
+                {
+                    'Name': 'xyz.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '5.6.7.8'}],
+                },
+            ],
+            'IsTruncated': False,
+        }
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234', name_prefix='www.')
+
+        assert result['count'] == 2
+        for r in result['records']:
+            assert r['name'].startswith('www.')
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_alias_detection(self, mock_get_client, sample_records):
+        """Test alias record detection."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.return_value = sample_records
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234')
+
+        alias_record = result['records'][2]
+        assert alias_record['is_alias'] is True
+        assert (
+            alias_record['alias_target']['dns_name'] == 'my-alb-123.us-east-1.elb.amazonaws.com.'
+        )
+        assert alias_record['ttl'] is None
+        assert alias_record['resource_records'] is None
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_routing_policy_detection(self, mock_get_client):
+        """Test routing policy detection from record fields."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.return_value = {
+            'ResourceRecordSets': [
+                {
+                    'Name': 'w.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'SetIdentifier': 'w1',
+                    'Weight': 70,
+                    'ResourceRecords': [{'Value': '1.1.1.1'}],
+                },
+                {
+                    'Name': 'l.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'SetIdentifier': 'l1',
+                    'Region': 'us-east-1',
+                    'ResourceRecords': [{'Value': '2.2.2.2'}],
+                },
+                {
+                    'Name': 'f.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'SetIdentifier': 'f1',
+                    'Failover': 'PRIMARY',
+                    'ResourceRecords': [{'Value': '3.3.3.3'}],
+                },
+                {
+                    'Name': 'g.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'SetIdentifier': 'g1',
+                    'GeoLocation': {'CountryCode': 'US'},
+                    'ResourceRecords': [{'Value': '4.4.4.4'}],
+                },
+            ],
+            'IsTruncated': False,
+        }
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234')
+
+        assert result['records'][0]['routing_policy'] == 'weighted'
+        assert result['records'][1]['routing_policy'] == 'latency'
+        assert result['records'][2]['routing_policy'] == 'failover'
+        assert result['records'][3]['routing_policy'] == 'geolocation'
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_manual_pagination(self, mock_get_client):
+        """Test manual pagination with IsTruncated."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.side_effect = [
+            {
+                'ResourceRecordSets': [
+                    {
+                        'Name': 'a.example.com.',
+                        'Type': 'A',
+                        'TTL': 300,
+                        'ResourceRecords': [{'Value': '1.1.1.1'}],
+                    },
+                ],
+                'IsTruncated': True,
+                'NextRecordName': 'b.example.com.',
+                'NextRecordType': 'A',
+            },
+            {
+                'ResourceRecordSets': [
+                    {
+                        'Name': 'b.example.com.',
+                        'Type': 'A',
+                        'TTL': 300,
+                        'ResourceRecords': [{'Value': '2.2.2.2'}],
+                    },
+                ],
+                'IsTruncated': False,
+            },
+        ]
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234')
+
+        assert result['count'] == 2
+        assert mock_client.list_resource_record_sets.call_count == 2
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_early_stop_name_prefix(self, mock_get_client):
+        """Test early-stop when name_prefix no longer matches."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.return_value = {
+            'ResourceRecordSets': [
+                {
+                    'Name': 'api.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '1.1.1.1'}],
+                },
+                {
+                    'Name': 'api.example.com.',
+                    'Type': 'AAAA',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '::1'}],
+                },
+                {
+                    'Name': 'www.example.com.',
+                    'Type': 'A',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': '2.2.2.2'}],
+                },
+            ],
+            'IsTruncated': True,
+            'NextRecordName': 'zzz.example.com.',
+            'NextRecordType': 'A',
+        }
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234', name_prefix='api.')
+
+        # Should stop early when 'www.example.com.' doesn't match 'api.' prefix
+        assert result['count'] == 2
+        # Should NOT make a second API call due to early-stop
+        assert mock_client.list_resource_record_sets.call_count == 1
+
+    async def test_query_dns_records_empty_zone_id(self):
+        """Test empty hosted_zone_id validation."""
+        with pytest.raises(ToolError, match='hosted_zone_id is required'):
+            await dns_module.query_dns_records(hosted_zone_id='')
+
+    async def test_query_dns_records_invalid_record_type(self):
+        """Test invalid record_type validation."""
+        with pytest.raises(ToolError, match='Invalid record_type "INVALID"'):
+            await dns_module.query_dns_records(hosted_zone_id='Z1234', record_type='INVALID')
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_no_such_hosted_zone(self, mock_get_client):
+        """Test NoSuchHostedZone error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.side_effect = Exception(
+            'An error occurred (NoSuchHostedZone)'
+        )
+
+        with pytest.raises(ToolError, match='not found'):
+            await dns_module.query_dns_records(hosted_zone_id='Z_INVALID')
+
+    @patch.object(dns_module, 'get_aws_client')
+    async def test_query_dns_records_pagination_with_identifier(self, mock_get_client):
+        """Test pagination handles NextRecordIdentifier for weighted/latency records."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_record_sets.side_effect = [
+            {
+                'ResourceRecordSets': [
+                    {
+                        'Name': 'w.example.com.',
+                        'Type': 'A',
+                        'TTL': 300,
+                        'SetIdentifier': 'w1',
+                        'Weight': 70,
+                        'ResourceRecords': [{'Value': '1.1.1.1'}],
+                    },
+                ],
+                'IsTruncated': True,
+                'NextRecordName': 'w.example.com.',
+                'NextRecordType': 'A',
+                'NextRecordIdentifier': 'w2',
+            },
+            {
+                'ResourceRecordSets': [
+                    {
+                        'Name': 'w.example.com.',
+                        'Type': 'A',
+                        'TTL': 300,
+                        'SetIdentifier': 'w2',
+                        'Weight': 30,
+                        'ResourceRecords': [{'Value': '2.2.2.2'}],
+                    },
+                ],
+                'IsTruncated': False,
+            },
+        ]
+
+        result = await dns_module.query_dns_records(hosted_zone_id='Z1234')
+
+        assert result['count'] == 2
+        # Verify the second call includes StartRecordIdentifier
+        second_call = mock_client.list_resource_record_sets.call_args_list[1]
+        assert second_call[1].get('StartRecordIdentifier') == 'w2'

--- a/src/aws-network-mcp-server/tests/tools/route53_profiles/__init__.py
+++ b/src/aws-network-mcp-server/tests/tools/route53_profiles/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws-network-mcp-server/tests/tools/route53_profiles/test_list_route53_profiles.py
+++ b/src/aws-network-mcp-server/tests/tools/route53_profiles/test_list_route53_profiles.py
@@ -1,0 +1,231 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the list_route53_profiles tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+profiles_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.route53_profiles.list_route53_profiles'
+)
+
+
+class TestListRoute53Profiles:
+    """Test cases for list_route53_profiles function."""
+
+    @pytest.fixture
+    def sample_profiles(self):
+        """Sample Route 53 Profiles fixture."""
+        return [
+            {
+                'Id': 'rp-111aaa',
+                'Name': 'enterprise-dns-profile',
+                'Status': 'COMPLETE',
+                'ShareStatus': 'NOT_SHARED',
+            },
+            {
+                'Id': 'rp-222bbb',
+                'Name': 'shared-dns-profile',
+                'Status': 'COMPLETE',
+                'ShareStatus': 'SHARED_BY_ME',
+            },
+        ]
+
+    @pytest.fixture
+    def sample_associations(self):
+        """Sample profile associations fixture."""
+        return [
+            {
+                'ProfileId': 'rp-111aaa',
+                'ResourceId': 'vpc-aaa',
+            },
+            {
+                'ProfileId': 'rp-111aaa',
+                'ResourceId': 'vpc-bbb',
+            },
+            {
+                'ProfileId': 'rp-222bbb',
+                'ResourceId': 'vpc-ccc',
+            },
+        ]
+
+    @pytest.fixture
+    def sample_resources(self):
+        """Sample profile resource associations fixture."""
+        return [
+            {
+                'ResourceType': 'PRIVATE_HOSTED_ZONE',
+                'ResourceArn': 'arn:aws:route53:::hostedzone/Z111',
+                'Name': 'corp.example.com',
+                'Status': 'COMPLETE',
+            },
+            {
+                'ResourceType': 'FIREWALL_RULE_GROUP',
+                'ResourceArn': 'arn:aws:route53resolver:us-east-1:123456789012:firewall-rule-group/rslvr-frg-111',
+                'Name': 'block-malware',
+                'Status': 'COMPLETE',
+            },
+        ]
+
+    @patch.object(profiles_module, 'get_aws_client')
+    async def test_list_route53_profiles_success(
+        self, mock_get_client, sample_profiles, sample_associations
+    ):
+        """Test successful Route 53 Profiles listing with VPC associations."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        profiles_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_profiles':
+                return profiles_paginator
+            elif api_name == 'list_profile_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+
+        profiles_paginator.paginate.return_value = [{'ProfileSummaries': sample_profiles}]
+        assoc_paginator.paginate.return_value = [{'ProfileAssociations': sample_associations}]
+
+        result = await profiles_module.list_route53_profiles(region='us-east-1')
+
+        assert result['region'] == 'us-east-1'
+        assert result['count'] == 2
+        assert len(result['profiles']) == 2
+        assert result['profile_resources'] is None
+
+        # Verify first profile has two VPC associations
+        prof1 = result['profiles'][0]
+        assert prof1['id'] == 'rp-111aaa'
+        assert prof1['name'] == 'enterprise-dns-profile'
+        assert prof1['status'] == 'COMPLETE'
+        assert prof1['share_status'] == 'NOT_SHARED'
+        assert prof1['vpc_associations'] == ['vpc-aaa', 'vpc-bbb']
+
+        # Verify second profile has one VPC association
+        prof2 = result['profiles'][1]
+        assert prof2['id'] == 'rp-222bbb'
+        assert prof2['vpc_associations'] == ['vpc-ccc']
+
+        mock_get_client.assert_called_once_with('route53profiles', 'us-east-1', None)
+
+    @patch.object(profiles_module, 'get_aws_client')
+    async def test_list_route53_profiles_empty(self, mock_get_client):
+        """Test listing when no Route 53 Profiles exist."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        profiles_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_profiles':
+                return profiles_paginator
+            elif api_name == 'list_profile_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        profiles_paginator.paginate.return_value = [{'ProfileSummaries': []}]
+        assoc_paginator.paginate.return_value = [{'ProfileAssociations': []}]
+
+        result = await profiles_module.list_route53_profiles(region='us-west-2')
+
+        assert result == {
+            'profiles': [],
+            'profile_resources': None,
+            'count': 0,
+            'region': 'us-west-2',
+        }
+
+    @patch.object(profiles_module, 'get_aws_client')
+    async def test_list_route53_profiles_with_profile(self, mock_get_client, sample_profiles):
+        """Test Route 53 Profiles listing with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        profiles_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_profiles':
+                return profiles_paginator
+            elif api_name == 'list_profile_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        profiles_paginator.paginate.return_value = [{'ProfileSummaries': sample_profiles}]
+        assoc_paginator.paginate.return_value = [{'ProfileAssociations': []}]
+
+        await profiles_module.list_route53_profiles(
+            region='eu-central-1', profile_name='test-profile'
+        )
+
+        mock_get_client.assert_called_once_with('route53profiles', 'eu-central-1', 'test-profile')
+
+    @patch.object(profiles_module, 'get_aws_client')
+    async def test_list_route53_profiles_with_profile_id(
+        self, mock_get_client, sample_profiles, sample_associations, sample_resources
+    ):
+        """Test listing with profile_id returns attached resources."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        profiles_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+        res_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_profiles':
+                return profiles_paginator
+            elif api_name == 'list_profile_associations':
+                return assoc_paginator
+            elif api_name == 'list_profile_resource_associations':
+                return res_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+
+        profiles_paginator.paginate.return_value = [{'ProfileSummaries': sample_profiles}]
+        assoc_paginator.paginate.return_value = [{'ProfileAssociations': sample_associations}]
+        res_paginator.paginate.return_value = [{'ProfileResourceAssociations': sample_resources}]
+
+        result = await profiles_module.list_route53_profiles(
+            region='us-east-1', profile_id='rp-111aaa'
+        )
+
+        assert result['profile_resources'] is not None
+        assert len(result['profile_resources']) == 2
+        assert result['profile_resources'][0]['resource_type'] == 'PRIVATE_HOSTED_ZONE'
+        assert result['profile_resources'][0]['name'] == 'corp.example.com'
+        assert result['profile_resources'][1]['resource_type'] == 'FIREWALL_RULE_GROUP'
+        assert result['profile_resources'][1]['name'] == 'block-malware'
+
+        res_paginator.paginate.assert_called_once_with(ProfileId='rp-111aaa')
+
+    @patch.object(profiles_module, 'get_aws_client')
+    async def test_list_route53_profiles_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        profiles_paginator = MagicMock()
+        mock_client.get_paginator.return_value = profiles_paginator
+        profiles_paginator.paginate.side_effect = Exception('AccessDenied')
+
+        with pytest.raises(ToolError, match='Error listing Route 53 Profiles.*AccessDenied'):
+            await profiles_module.list_route53_profiles(region='us-east-1')

--- a/src/aws-network-mcp-server/tests/tools/route53_profiles/test_list_route53_profiles.py
+++ b/src/aws-network-mcp-server/tests/tools/route53_profiles/test_list_route53_profiles.py
@@ -229,3 +229,43 @@ class TestListRoute53Profiles:
 
         with pytest.raises(ToolError, match='Error listing Route 53 Profiles.*AccessDenied'):
             await profiles_module.list_route53_profiles(region='us-east-1')
+
+    @patch.object(profiles_module, 'get_aws_client')
+    async def test_list_route53_profiles_associations_failure_logs_and_continues(
+        self, mock_get_client, sample_profiles, caplog
+    ):
+        """When list_profile_associations fails, function logs and continues with empty associations."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        profiles_paginator = MagicMock()
+        assoc_paginator = MagicMock()
+
+        def get_paginator_side_effect(api_name):
+            if api_name == 'list_profiles':
+                return profiles_paginator
+            elif api_name == 'list_profile_associations':
+                return assoc_paginator
+
+        mock_client.get_paginator.side_effect = get_paginator_side_effect
+        profiles_paginator.paginate.return_value = [{'ProfileSummaries': sample_profiles}]
+        assoc_paginator.paginate.side_effect = Exception('AssociationsAccessDenied')
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger='awslabs.aws_network_mcp_server.tools.route53_profiles.list_route53_profiles',
+        ):
+            result = await profiles_module.list_route53_profiles(region='us-east-1')
+
+        # Function returns profiles with empty vpc_associations
+        assert result['count'] == 2
+        for profile in result['profiles']:
+            assert profile['vpc_associations'] == []
+
+        # Verify the failure was logged at debug level
+        assert any(
+            'Failed to list Route 53 Profile associations' in record.message
+            for record in caplog.records
+        )

--- a/src/aws-network-mcp-server/tests/tools/vpc_endpoints/__init__.py
+++ b/src/aws-network-mcp-server/tests/tools/vpc_endpoints/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws-network-mcp-server/tests/tools/vpc_endpoints/test_check_endpoint_connectivity.py
+++ b/src/aws-network-mcp-server/tests/tools/vpc_endpoints/test_check_endpoint_connectivity.py
@@ -1,0 +1,336 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the check_endpoint_connectivity tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+check_conn_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.vpc_endpoints.check_endpoint_connectivity'
+)
+
+SAMPLE_ENDPOINT_ID = 'vpce-0123456789abcdef0'
+
+
+class TestCheckEndpointConnectivity:
+    """Test cases for check_endpoint_connectivity function."""
+
+    @pytest.fixture
+    def sample_interface_endpoint(self):
+        """Sample interface endpoint from DescribeVpcEndpoints."""
+        return {
+            'VpcEndpointId': SAMPLE_ENDPOINT_ID,
+            'ServiceName': 'com.amazonaws.us-east-1.execute-api',
+            'VpcEndpointType': 'Interface',
+            'VpcId': 'vpc-12345678',
+            'State': 'available',
+            'PrivateDnsEnabled': True,
+            'DnsEntries': [
+                {
+                    'DnsName': 'vpce-0123456789abcdef0.execute-api.us-east-1.vpce.amazonaws.com',
+                    'HostedZoneId': 'Z1234567890',
+                },
+            ],
+            'Groups': [
+                {'GroupId': 'sg-aaa', 'GroupName': 'endpoint-sg'},
+            ],
+            'NetworkInterfaceIds': ['eni-111', 'eni-222'],
+        }
+
+    @pytest.fixture
+    def sample_gateway_endpoint(self):
+        """Sample gateway endpoint from DescribeVpcEndpoints."""
+        return {
+            'VpcEndpointId': 'vpce-gw-0123456789abcdef0',
+            'ServiceName': 'com.amazonaws.us-east-1.s3',
+            'VpcEndpointType': 'Gateway',
+            'VpcId': 'vpc-12345678',
+            'State': 'available',
+            'PrivateDnsEnabled': False,
+            'DnsEntries': [],
+            'Groups': [],
+            'NetworkInterfaceIds': [],
+            'RouteTableIds': ['rtb-111'],
+        }
+
+    @pytest.fixture
+    def sample_security_groups(self):
+        """Sample security groups response."""
+        return {
+            'SecurityGroups': [
+                {
+                    'GroupId': 'sg-aaa',
+                    'GroupName': 'endpoint-sg',
+                    'IpPermissions': [
+                        {
+                            'IpProtocol': 'tcp',
+                            'FromPort': 443,
+                            'ToPort': 443,
+                            'IpRanges': [{'CidrIp': '10.0.0.0/8'}],
+                            'Ipv6Ranges': [],
+                            'PrefixListIds': [],
+                            'UserIdGroupPairs': [],
+                        },
+                    ],
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def sample_enis(self):
+        """Sample network interfaces response."""
+        return {
+            'NetworkInterfaces': [
+                {
+                    'NetworkInterfaceId': 'eni-111',
+                    'SubnetId': 'subnet-aaa',
+                    'AvailabilityZone': 'us-east-1a',
+                    'PrivateIpAddress': '10.0.1.100',
+                },
+                {
+                    'NetworkInterfaceId': 'eni-222',
+                    'SubnetId': 'subnet-bbb',
+                    'AvailabilityZone': 'us-east-1b',
+                    'PrivateIpAddress': '10.0.2.100',
+                },
+            ]
+        }
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_success(
+        self,
+        mock_get_client,
+        sample_interface_endpoint,
+        sample_security_groups,
+        sample_enis,
+    ):
+        """Test successful connectivity check for interface endpoint."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {
+            'VpcEndpoints': [sample_interface_endpoint]
+        }
+        mock_client.describe_security_groups.return_value = sample_security_groups
+        mock_client.describe_network_interfaces.return_value = sample_enis
+
+        result = await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+        )
+
+        assert result['endpoint']['id'] == SAMPLE_ENDPOINT_ID
+        assert result['endpoint']['is_available'] is True
+        assert result['private_dns']['enabled'] is True
+        assert len(result['private_dns']['dns_entries']) == 1
+        assert result['security_groups'] is not None
+        assert len(result['security_groups']) == 1
+        assert result['security_groups'][0]['id'] == 'sg-aaa'
+        assert result['security_groups'][0]['inbound_rules'][0]['port_range'] == '443'
+        assert result['security_groups'][0]['inbound_rules'][0]['source'] == '10.0.0.0/8'
+        assert result['security_groups_error'] is None
+        assert result['network_interfaces'] is not None
+        assert len(result['network_interfaces']) == 2
+        assert result['network_interfaces_error'] is None
+        assert result['connectivity_checks']['state_ok'] is True
+        assert result['connectivity_checks']['has_dns_entries'] is True
+        assert result['connectivity_checks']['private_dns_enabled'] is True
+        assert result['region'] == 'us-east-1'
+        mock_get_client.assert_called_once_with('ec2', 'us-east-1', None)
+
+    async def test_check_connectivity_invalid_id(self):
+        """Test invalid endpoint ID validation."""
+        with pytest.raises(
+            ToolError,
+            match='Invalid vpc_endpoint_id format',
+        ):
+            await check_conn_module.check_endpoint_connectivity(
+                vpc_endpoint_id='invalid-id', region='us-east-1'
+            )
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_not_found(self, mock_get_client):
+        """Test endpoint not found."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {'VpcEndpoints': []}
+
+        with pytest.raises(
+            ToolError,
+            match='VPC endpoint not found',
+        ):
+            await check_conn_module.check_endpoint_connectivity(
+                vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+            )
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_unavailable_state(self, mock_get_client):
+        """Test endpoint in non-available state."""
+        ep = {
+            'VpcEndpointId': SAMPLE_ENDPOINT_ID,
+            'ServiceName': 'com.amazonaws.us-east-1.s3',
+            'VpcEndpointType': 'Interface',
+            'VpcId': 'vpc-12345678',
+            'State': 'pending',
+            'PrivateDnsEnabled': False,
+            'DnsEntries': [],
+            'Groups': [],
+            'NetworkInterfaceIds': [],
+        }
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {'VpcEndpoints': [ep]}
+
+        result = await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+        )
+
+        assert result['endpoint']['state'] == 'pending'
+        assert result['endpoint']['is_available'] is False
+        assert result['connectivity_checks']['state_ok'] is False
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_sg_retrieval_failure(
+        self, mock_get_client, sample_interface_endpoint, sample_enis
+    ):
+        """Test partial failure when security group retrieval fails."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {
+            'VpcEndpoints': [sample_interface_endpoint]
+        }
+        mock_client.describe_security_groups.side_effect = Exception('AccessDenied')
+        mock_client.describe_network_interfaces.return_value = sample_enis
+
+        result = await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+        )
+
+        assert result['security_groups'] is None
+        assert result['security_groups_error'] == 'AccessDenied'
+        assert result['network_interfaces'] is not None
+        assert len(result['network_interfaces']) == 2
+        assert result['network_interfaces_error'] is None
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_eni_retrieval_failure(
+        self, mock_get_client, sample_interface_endpoint, sample_security_groups
+    ):
+        """Test partial failure when ENI retrieval fails."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {
+            'VpcEndpoints': [sample_interface_endpoint]
+        }
+        mock_client.describe_security_groups.return_value = sample_security_groups
+        mock_client.describe_network_interfaces.side_effect = Exception('Throttling')
+
+        result = await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+        )
+
+        assert result['security_groups'] is not None
+        assert result['security_groups_error'] is None
+        assert result['network_interfaces'] is None
+        assert result['network_interfaces_error'] == 'Throttling'
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_gateway_no_sgs_no_enis(
+        self, mock_get_client, sample_gateway_endpoint
+    ):
+        """Test gateway endpoint has no SGs or ENIs to check."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {
+            'VpcEndpoints': [sample_gateway_endpoint]
+        }
+
+        result = await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id='vpce-gw-0123456789abcdef0', region='us-east-1'
+        )
+
+        assert result['endpoint']['type'] == 'Gateway'
+        assert result['security_groups'] is None
+        assert result['security_groups_error'] is None
+        assert result['network_interfaces'] is None
+        assert result['network_interfaces_error'] is None
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_private_dns_disabled(self, mock_get_client):
+        """Test endpoint with private DNS disabled."""
+        ep = {
+            'VpcEndpointId': SAMPLE_ENDPOINT_ID,
+            'ServiceName': 'com.amazonaws.us-east-1.s3',
+            'VpcEndpointType': 'Interface',
+            'VpcId': 'vpc-12345678',
+            'State': 'available',
+            'PrivateDnsEnabled': False,
+            'DnsEntries': [
+                {
+                    'DnsName': 'vpce-0123456789abcdef0.s3.us-east-1.vpce.amazonaws.com',
+                    'HostedZoneId': 'Z1234567890',
+                },
+            ],
+            'Groups': [],
+            'NetworkInterfaceIds': [],
+        }
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {'VpcEndpoints': [ep]}
+
+        result = await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+        )
+
+        assert result['private_dns']['enabled'] is False
+        assert result['connectivity_checks']['private_dns_enabled'] is False
+        assert result['connectivity_checks']['has_dns_entries'] is True
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_with_profile(
+        self, mock_get_client, sample_interface_endpoint
+    ):
+        """Test connectivity check with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.return_value = {
+            'VpcEndpoints': [sample_interface_endpoint]
+        }
+        mock_client.describe_security_groups.return_value = {'SecurityGroups': []}
+        mock_client.describe_network_interfaces.return_value = {'NetworkInterfaces': []}
+
+        await check_conn_module.check_endpoint_connectivity(
+            vpc_endpoint_id=SAMPLE_ENDPOINT_ID,
+            region='us-east-1',
+            profile_name='test-profile',
+        )
+
+        mock_get_client.assert_called_once_with('ec2', 'us-east-1', 'test-profile')
+
+    @patch.object(check_conn_module, 'get_aws_client')
+    async def test_check_connectivity_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.describe_vpc_endpoints.side_effect = Exception('ServiceUnavailableException')
+
+        with pytest.raises(
+            ToolError,
+            match='Error checking endpoint connectivity. Error: ServiceUnavailableException. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await check_conn_module.check_endpoint_connectivity(
+                vpc_endpoint_id=SAMPLE_ENDPOINT_ID, region='us-east-1'
+            )

--- a/src/aws-network-mcp-server/tests/tools/vpc_endpoints/test_list_vpc_endpoints_detailed.py
+++ b/src/aws-network-mcp-server/tests/tools/vpc_endpoints/test_list_vpc_endpoints_detailed.py
@@ -1,0 +1,293 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the list_vpc_endpoints_detailed tool."""
+
+import importlib
+import pytest
+from fastmcp.exceptions import ToolError
+from unittest.mock import MagicMock, patch
+
+
+list_endpoints_module = importlib.import_module(
+    'awslabs.aws_network_mcp_server.tools.vpc_endpoints.list_vpc_endpoints_detailed'
+)
+
+
+class TestListVpcEndpointsDetailed:
+    """Test cases for list_vpc_endpoints_detailed function."""
+
+    @pytest.fixture
+    def sample_interface_endpoint(self):
+        """Sample interface VPC endpoint."""
+        return {
+            'VpcEndpointId': 'vpce-0123456789abcdef0',
+            'ServiceName': 'com.amazonaws.us-east-1.s3',
+            'VpcEndpointType': 'Interface',
+            'VpcId': 'vpc-12345678',
+            'State': 'available',
+            'CreationTimestamp': '2024-01-15T10:30:00+00:00',
+            'PolicyDocument': '{"Version":"2012-10-17"}',
+            'Tags': [{'Key': 'Name', 'Value': 'my-endpoint'}],
+            'SubnetIds': ['subnet-111', 'subnet-222'],
+            'Groups': [
+                {'GroupId': 'sg-aaa', 'GroupName': 'endpoint-sg'},
+            ],
+            'PrivateDnsEnabled': True,
+            'DnsEntries': [
+                {
+                    'DnsName': 'vpce-0123456789abcdef0-abc.s3.us-east-1.vpce.amazonaws.com',
+                    'HostedZoneId': 'Z1234567890',
+                },
+            ],
+            'NetworkInterfaceIds': ['eni-111', 'eni-222'],
+        }
+
+    @pytest.fixture
+    def sample_gateway_endpoint(self):
+        """Sample gateway VPC endpoint."""
+        return {
+            'VpcEndpointId': 'vpce-gw-0123456789abcdef0',
+            'ServiceName': 'com.amazonaws.us-east-1.s3',
+            'VpcEndpointType': 'Gateway',
+            'VpcId': 'vpc-12345678',
+            'State': 'available',
+            'CreationTimestamp': '2024-01-10T08:00:00+00:00',
+            'PolicyDocument': '{"Version":"2012-10-17"}',
+            'Tags': [],
+            'RouteTableIds': ['rtb-111', 'rtb-222'],
+        }
+
+    @pytest.fixture
+    def sample_gwlb_endpoint(self):
+        """Sample GatewayLoadBalancer VPC endpoint."""
+        return {
+            'VpcEndpointId': 'vpce-gwlb-0123456789abcdef0',
+            'ServiceName': 'com.amazonaws.vpce.us-east-1.vpce-svc-123',
+            'VpcEndpointType': 'GatewayLoadBalancer',
+            'VpcId': 'vpc-12345678',
+            'State': 'available',
+            'CreationTimestamp': '2024-02-01T12:00:00+00:00',
+            'PolicyDocument': None,
+            'Tags': [],
+            'SubnetIds': ['subnet-333'],
+            'NetworkInterfaceIds': ['eni-333'],
+        }
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_success_interface(
+        self, mock_get_client, sample_interface_endpoint
+    ):
+        """Test successful listing with an interface endpoint."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_interface_endpoint]}]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(region='us-east-1')
+
+        assert result['count'] == 1
+        assert result['region'] == 'us-east-1'
+        ep = result['vpc_endpoints'][0]
+        assert ep['id'] == 'vpce-0123456789abcdef0'
+        assert ep['type'] == 'Interface'
+        assert ep['security_group_ids'] == ['sg-aaa']
+        assert ep['private_dns_enabled'] is True
+        assert len(ep['dns_entries']) == 1
+        assert ep['network_interface_ids'] == ['eni-111', 'eni-222']
+        assert ep['subnet_ids'] == ['subnet-111', 'subnet-222']
+        assert ep['route_table_ids'] is None
+        mock_get_client.assert_called_once_with('ec2', 'us-east-1', None)
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_success_gateway(self, mock_get_client, sample_gateway_endpoint):
+        """Test successful listing with a gateway endpoint."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_gateway_endpoint]}]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(region='us-east-1')
+
+        assert result['count'] == 1
+        ep = result['vpc_endpoints'][0]
+        assert ep['type'] == 'Gateway'
+        assert ep['route_table_ids'] == ['rtb-111', 'rtb-222']
+        assert ep['security_group_ids'] is None
+        assert ep['private_dns_enabled'] is None
+        assert ep['dns_entries'] is None
+        assert ep['network_interface_ids'] is None
+        assert ep['subnet_ids'] is None
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_success_gwlb(self, mock_get_client, sample_gwlb_endpoint):
+        """Test successful listing with a GatewayLoadBalancer endpoint."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_gwlb_endpoint]}]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(region='us-east-1')
+
+        assert result['count'] == 1
+        ep = result['vpc_endpoints'][0]
+        assert ep['type'] == 'GatewayLoadBalancer'
+        assert ep['subnet_ids'] == ['subnet-333']
+        assert ep['network_interface_ids'] == ['eni-333']
+        assert ep['security_group_ids'] is None
+        assert ep['private_dns_enabled'] is None
+        assert ep['dns_entries'] is None
+        assert ep['route_table_ids'] is None
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_empty(self, mock_get_client):
+        """Test listing with no endpoints found."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': []}]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(region='us-east-1')
+
+        assert result['vpc_endpoints'] == []
+        assert result['count'] == 0
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_with_vpc_filter(
+        self, mock_get_client, sample_interface_endpoint
+    ):
+        """Test listing with vpc_id filter."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_interface_endpoint]}]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(
+            region='us-east-1', vpc_id='vpc-12345678'
+        )
+
+        assert result['count'] == 1
+        mock_paginator.paginate.assert_called_once_with(
+            Filters=[{'Name': 'vpc-id', 'Values': ['vpc-12345678']}]
+        )
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_with_service_name_filter(
+        self, mock_get_client, sample_interface_endpoint
+    ):
+        """Test listing with service_name filter."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_interface_endpoint]}]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(
+            region='us-east-1', service_name='com.amazonaws.us-east-1.s3'
+        )
+
+        assert result['count'] == 1
+        mock_paginator.paginate.assert_called_once_with(
+            Filters=[{'Name': 'service-name', 'Values': ['com.amazonaws.us-east-1.s3']}]
+        )
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_with_both_filters(
+        self, mock_get_client, sample_interface_endpoint
+    ):
+        """Test listing with both vpc_id and service_name filters."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_interface_endpoint]}]
+
+        await list_endpoints_module.list_vpc_endpoints_detailed(
+            region='us-east-1',
+            vpc_id='vpc-12345678',
+            service_name='com.amazonaws.us-east-1.s3',
+        )
+
+        mock_paginator.paginate.assert_called_once_with(
+            Filters=[
+                {'Name': 'vpc-id', 'Values': ['vpc-12345678']},
+                {'Name': 'service-name', 'Values': ['com.amazonaws.us-east-1.s3']},
+            ]
+        )
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_with_profile(self, mock_get_client, sample_interface_endpoint):
+        """Test listing with specific AWS profile."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{'VpcEndpoints': [sample_interface_endpoint]}]
+
+        await list_endpoints_module.list_vpc_endpoints_detailed(
+            region='us-east-1', profile_name='test-profile'
+        )
+
+        mock_get_client.assert_called_once_with('ec2', 'us-east-1', 'test-profile')
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_mixed_types(
+        self,
+        mock_get_client,
+        sample_interface_endpoint,
+        sample_gateway_endpoint,
+        sample_gwlb_endpoint,
+    ):
+        """Test listing with mixed endpoint types."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                'VpcEndpoints': [
+                    sample_interface_endpoint,
+                    sample_gateway_endpoint,
+                    sample_gwlb_endpoint,
+                ]
+            }
+        ]
+
+        result = await list_endpoints_module.list_vpc_endpoints_detailed(region='us-east-1')
+
+        assert result['count'] == 3
+        types = [ep['type'] for ep in result['vpc_endpoints']]
+        assert 'Interface' in types
+        assert 'Gateway' in types
+        assert 'GatewayLoadBalancer' in types
+
+    @patch.object(list_endpoints_module, 'get_aws_client')
+    async def test_list_endpoints_aws_error(self, mock_get_client):
+        """Test AWS API error handling."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.side_effect = Exception('UnauthorizedAccess')
+
+        with pytest.raises(
+            ToolError,
+            match='Error listing VPC endpoints. Error: UnauthorizedAccess. REQUIRED TO REMEDIATE BEFORE CONTINUING',
+        ):
+            await list_endpoints_module.list_vpc_endpoints_detailed(region='us-east-1')


### PR DESCRIPTION
## Summary

Adds **11 read-only AWS network troubleshooting tools** to the `aws-network-mcp-server` package, organized into four phases with full unit and integration test coverage. Tools cover Load Balancers (ELBv2), Route 53 / DNS Firewall / Resolver, VPC Endpoints, and Route 53 Profiles — closing visible gaps for common network-debugging workflows.

> **Status:** Draft for early maintainer feedback. Tracking RFC: [awslabs/mcp#2868](https://github.com/awslabs/mcp/issues/2868).

## Contributor Statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

## Motivation

The `aws-network-mcp-server` already exposes building blocks for VPC, Transit Gateway, and VPN troubleshooting, but several routinely-needed surfaces were missing — most notably anything ELBv2-related, hosted-zone / health-check inspection, and a structured view of VPC interface endpoints. This PR adds those surfaces in line with the package's existing tool patterns (Pydantic-validated args, Field-described parameters, error-mapped responses, no mutating actions).

## What's included

### Phase 1 — Load Balancer (3 tools)
- `list_load_balancers` — list ALB / NLB / GWLB with filtering by name or scheme
- `get_load_balancer_details` — full LB config including listeners, attributes, target groups
- `get_target_health` — per-target health state, reason codes, descriptions

### Phase 2 — Route 53 / DNS (5 tools)
- `query_dns_records` — query a name with parsed answer / authority / additional sections
- `list_hosted_zones` — public + private zones with filters
- `check_health_checks` — health check status, recent failure reasons, configuration
- `list_resolver_rules` — Route 53 Resolver rules and their VPC associations
- `list_dns_firewall_rules` — DNS Firewall rule groups and rules

### Phase 3 — VPC Endpoints (2 tools)
- `list_vpc_endpoints_detailed` — interface / gateway / GWLB endpoints with policy + DNS info
- `check_endpoint_connectivity` — endpoint state, ENI placement, security-group reachability hints

### Phase 4 — Route 53 Profiles + glue (1 tool)
- `list_route53_profiles` — Route 53 Profiles with associated VPCs and resources

Plus tool registration in `server.py` and a documentation update in `README.md`.

## IAM / permissions note

All new tools are **strictly read-only**. They use the following AWS API actions; please ensure the IAM policy guidance in `README.md` reflects the union of these for users who only need network-troubleshooting capabilities:

- `elasticloadbalancing:Describe*`
- `route53:Get*`, `route53:List*`
- `route53resolver:List*`, `route53resolver:Get*`
- `route53profiles:List*`, `route53profiles:Get*`
- `ec2:DescribeVpcEndpoints`, `ec2:DescribeNetworkInterfaces`, `ec2:DescribeSecurityGroups`

No `Create*`, `Modify*`, or `Delete*` actions are used.

## Testing

- **Unit tests:** `330 passed, 13 skipped` (skips are integration tests gated on AWS credentials)
- **Coverage:** `94%` (line + branch) measured via `uv run --frozen pytest --cov --cov-branch`
- **Pre-commit:** all hooks pass (ruff check + ruff format idempotent, license header, etc.); `gitleaks` skipped locally per project convention
- **Integration tests:** included for each phase under `tests/test_integ_*.py` — opt-in, require AWS credentials

## Recent updates

- Replaced 4 `try/except/pass` blocks flagged by `github-advanced-security` Bandit (B110) with explicit `logger.debug()` calls so failures in optional association lookups are observable instead of silently swallowed.
- Added 4 unit tests covering the now-logged exception paths.

## Checklist

- [x] Tools follow existing `aws-network-mcp-server` conventions (Pydantic args, `Field(...)` descriptions, async functions, structured error responses)
- [x] Read-only operations only — no mutations
- [x] Unit tests for each new tool (success + error paths)
- [x] Integration tests scaffolded for live-AWS validation
- [x] `README.md` updated with new tool list
- [x] `server.py` updated to register all new tools
- [x] `pre-commit run --all-files` passes (excluding `gitleaks`)
- [x] Coverage ≥ 90%
- [x] Bandit security warnings addressed
- [ ] Awaiting maintainer feedback on RFC #2868 before un-drafting

## Reviewer notes

- **Commits are organized by phase** (4 phase commits + 1 follow-up fix commit) for ease of section-by-section review. Happy to squash on request.
- **No upstream-conflicting paths.** A pre-flight scan against `upstream/main` (110 commits since fork) found zero file overlap with our changes; rebase will be conflict-free.
- **No new top-level dependencies.** All new tools rely on `boto3` clients already used elsewhere in this server.
- The `check_endpoint_connectivity` tool intentionally only *describes* reachability based on endpoint state, ENI presence, and SG rules — it does not perform any network probing.

## Related

- RFC: [awslabs/mcp#2868](https://github.com/awslabs/mcp/issues/2868)

---

**This PR is filed as a draft.** I'd appreciate maintainer guidance on the RFC before promoting to ready-for-review. Happy to adjust scope, IAM doc wording, or commit organization based on feedback.
