### PR TITLE
fix(aws-transform-mcp-server): prevent path traversal in download_s3_…

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
@@ -16,6 +16,7 @@
 
 import os
 from loguru import logger
+from typing import Optional
 
 
 # File basenames that must never be read.
@@ -87,3 +88,26 @@ def validate_read_path(file_path: str) -> str:
         raise ValueError(f'Blocked filename: {os.path.basename(resolved)} cannot be uploaded.')
 
     return resolved
+
+
+def validate_write_path(save_path: str, file_name: Optional[str] = None) -> str:
+    """Validate and resolve a file path before writing a download.
+
+    Prevents path traversal by stripping directory components from *file_name*
+    via os.path.basename(), ensuring the write stays within *save_path*.
+
+    Returns the resolved absolute write path.
+    Raises ValueError if file_name resolves to an empty basename.
+    """
+    resolved_dir = os.path.realpath(os.path.expanduser(save_path))
+
+    if file_name:
+        safe_name = os.path.basename(file_name)
+        if not safe_name:
+            raise ValueError(f'Invalid file name after sanitization: {file_name!r}')
+    else:
+        safe_name = None
+
+    if safe_name:
+        return os.path.join(resolved_dir, safe_name)
+    return resolved_dir

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
@@ -95,15 +95,20 @@ def validate_write_path(save_path: str, file_name: Optional[str] = None) -> str:
 
     Prevents path traversal by stripping directory components from *file_name*
     via os.path.basename(), ensuring the write stays within *save_path*.
+    Also blocks writes into sensitive directories.
 
     Returns the resolved absolute write path.
-    Raises ValueError if file_name resolves to an empty basename.
+    Raises ValueError on any policy violation.
     """
     resolved_dir = os.path.realpath(os.path.expanduser(save_path))
 
+    if _in_blocked_dir(resolved_dir):
+        logger.warning('[security] Blocked write to sensitive directory: {}', save_path)
+        raise ValueError(f'Writing to sensitive directory is not allowed: {save_path}')
+
     if file_name:
         safe_name = os.path.basename(file_name)
-        if not safe_name:
+        if not safe_name or safe_name == '..':
             raise ValueError(f'Invalid file name after sanitization: {file_name!r}')
     else:
         safe_name = None

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
@@ -255,6 +255,8 @@ async def download_s3_content(
     function returns ``{"savedTo": ..., "sizeBytes": ...}``.  Otherwise the
     content is returned as ``{"content": ...}``.
     """
+    from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
     async with httpx.AsyncClient() as client:
         response = await client.get(s3_url, follow_redirects=True)
         response.raise_for_status()
@@ -262,9 +264,11 @@ async def download_s3_content(
         if save_path is not None:
             resolved_name = file_name or default_name or 'download'
             if save_path.endswith('/') or '.' not in os.path.basename(save_path):
-                full_path = os.path.join(save_path, resolved_name)
+                full_path = validate_write_path(save_path, resolved_name)
             else:
-                full_path = save_path
+                full_path = validate_write_path(
+                    os.path.dirname(save_path), os.path.basename(save_path)
+                )
             with open(full_path, 'wb') as fh:
                 fh.write(response.content)
             return {'savedTo': full_path, 'sizeBytes': len(response.content)}

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/get_resource.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/get_resource.py
@@ -20,7 +20,7 @@ from awslabs.aws_transform_mcp_server.audit import audited_tool
 from awslabs.aws_transform_mcp_server.config_store import is_fes_available
 from awslabs.aws_transform_mcp_server.guidance_nudge import job_needs_check
 from awslabs.aws_transform_mcp_server.tool_utils import (
-    READ_ONLY,
+    CREATE,
     download_s3_content,
     error_result,
     failure_result,
@@ -132,7 +132,7 @@ class GetResourceHandler:
             mcp,
             'get_resource',
             title='Get Resource',
-            annotations=READ_ONLY,
+            annotations=CREATE,
             description=TOOL_DESCRIPTION,
         )(self.get_resource)
 

--- a/src/aws-transform-mcp-server/tests/test_file_validation.py
+++ b/src/aws-transform-mcp-server/tests/test_file_validation.py
@@ -102,3 +102,77 @@ class TestValidateReadPath:
             ):
                 validate_read_path(blocked_file)
             mock_logger.warning.assert_called_once()
+
+
+class TestValidateWritePath:
+    """Tests for validate_write_path — path traversal, blocked dirs, edge cases."""
+
+    def test_traversal_in_filename_stripped(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        result = validate_write_path('/tmp/downloads', '../../etc/passwd')
+        assert result == '/tmp/downloads/passwd'
+
+    def test_deep_traversal_stripped(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        result = validate_write_path('/tmp/downloads', '../../../../root/.ssh/authorized_keys')
+        assert result == '/tmp/downloads/authorized_keys'
+
+    def test_legitimate_filename_unchanged(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        result = validate_write_path('/tmp/downloads', 'artifact.json')
+        assert result == '/tmp/downloads/artifact.json'
+
+    def test_no_filename_returns_resolved_dir(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = validate_write_path(tmpdir)
+            assert result == os.path.realpath(tmpdir)
+
+    def test_blocked_dir_raises_valueerror(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_write_path(os.path.join(home, '.ssh'), 'authorized_keys')
+
+    def test_blocked_dir_aws_raises_valueerror(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_write_path(os.path.join(home, '.aws'), 'credentials')
+
+    def test_dotdot_filename_raises_valueerror(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with pytest.raises(ValueError, match='Invalid file name'):
+            validate_write_path('/tmp', '..')
+
+    def test_slash_filename_raises_valueerror(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with pytest.raises(ValueError, match='Invalid file name'):
+            validate_write_path('/tmp', '/')
+
+    def test_tilde_expansion_in_save_path(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_write_path('~/.ssh', 'key')
+        result = validate_write_path('/tmp', 'file.txt')
+        assert result == '/tmp/file.txt'
+
+    def test_blocked_dir_logs_warning(self):
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        home = os.path.expanduser('~')
+        with (
+            patch('awslabs.aws_transform_mcp_server.file_validation.logger') as mock_logger,
+            pytest.raises(ValueError),
+        ):
+            validate_write_path(os.path.join(home, '.ssh'), 'authorized_keys')
+        mock_logger.warning.assert_called_once()

--- a/src/aws-transform-mcp-server/tests/test_tool_utils.py
+++ b/src/aws-transform-mcp-server/tests/test_tool_utils.py
@@ -455,3 +455,119 @@ class TestDownloadS3ContentWithFilePath:
             assert result['sizeBytes'] == len(b'file data')
             with open(full_path, 'rb') as fh:
                 assert fh.read() == b'file data'
+
+
+class TestDownloadS3ContentPathTraversal:
+    """Security tests: path traversal in file_name must not escape save_path."""
+
+    @pytest.mark.asyncio
+    async def test_traversal_in_filename_neutralized(self, tmp_path):
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'malicious content'
+        mock_response.raise_for_status = lambda: None
+
+        with patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient') as MockClient:
+            instance = AsyncMock()
+            instance.get.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = instance
+
+            save_dir = str(tmp_path) + '/'
+            result = await download_s3_content(
+                'https://s3.example.com/artifact',
+                save_path=save_dir,
+                file_name='../../etc/passwd',
+            )
+            # Traversal stripped: file lands in tmp_path, not /etc/
+            assert result['savedTo'] == os.path.join(str(tmp_path), 'passwd')
+            assert os.path.dirname(result['savedTo']) == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_deep_traversal_in_filename_neutralized(self, tmp_path):
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'payload'
+        mock_response.raise_for_status = lambda: None
+
+        with patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient') as MockClient:
+            instance = AsyncMock()
+            instance.get.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = instance
+
+            save_dir = str(tmp_path) + '/'
+            result = await download_s3_content(
+                'https://s3.example.com/artifact',
+                save_path=save_dir,
+                file_name='../../../../root/.ssh/authorized_keys',
+            )
+            assert result['savedTo'] == os.path.join(str(tmp_path), 'authorized_keys')
+
+    @pytest.mark.asyncio
+    async def test_blocked_save_path_raises(self):
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'evil'
+        mock_response.raise_for_status = lambda: None
+
+        with patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient') as MockClient:
+            instance = AsyncMock()
+            instance.get.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = instance
+
+            home = os.path.expanduser('~')
+            with pytest.raises(ValueError, match='sensitive directory'):
+                await download_s3_content(
+                    'https://s3.example.com/artifact',
+                    save_path=os.path.join(home, '.ssh') + '/',
+                    file_name='authorized_keys',
+                )
+
+    @pytest.mark.asyncio
+    async def test_dotdot_filename_raises(self, tmp_path):
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'data'
+        mock_response.raise_for_status = lambda: None
+
+        with patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient') as MockClient:
+            instance = AsyncMock()
+            instance.get.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = instance
+
+            save_dir = str(tmp_path) + '/'
+            with pytest.raises(ValueError, match='Invalid file name'):
+                await download_s3_content(
+                    'https://s3.example.com/artifact',
+                    save_path=save_dir,
+                    file_name='..',
+                )
+
+    @pytest.mark.asyncio
+    async def test_traversal_in_save_path_with_extension(self, tmp_path):
+        """When save_path looks like a file (has extension), traversal in it is resolved."""
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'content'
+        mock_response.raise_for_status = lambda: None
+
+        with patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient') as MockClient:
+            instance = AsyncMock()
+            instance.get.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = instance
+
+            safe_file = os.path.join(str(tmp_path), 'output.txt')
+            result = await download_s3_content(
+                'https://s3.example.com/data',
+                save_path=safe_file,
+            )
+            assert result['savedTo'] == os.path.join(str(tmp_path), 'output.txt')


### PR DESCRIPTION
  ## Summary

  ### Changes

Sanitize `file_name` via `os.path.basename()` before joining with `save_path` in `download_s3_content()`, preventing directory traversal attacks where malicious `file_name` values (e.g. `../../etc/passwd`) could write outside the intended directory.

  - Added `validate_write_path()` to `file_validation.py` — strips directory components from the filename and resolves the target directory to an absolute path
  - Updated `download_s3_content()` in `tool_utils.py` to call `validate_write_path()` instead of raw `os.path.join()`
  - Changed `get_resource` tool annotation from `READ_ONLY` to `CREATE` since it performs filesystem writes when `savePath` is provided

  ### User experience

Before: An LLM manipulated via prompt injection could invoke `get_resource` with a traversal payload like `fileName="../../.bashrc"`, writing artifact content to arbitrary locations on the host filesystem. The `READ_ONLY` annotation also meant MCP clients could auto-approve the tool without user confirmation.

After: Traversal components are stripped from filenames (e.g. `../../etc/passwd` → `passwd`), so downloads always land in the user-specified directory. The `CREATE` annotation ensures MCP clients prompt for user confirmation before executing.
  ## Checklist

  If your change doesn't seem to apply, please leave them unchecked.

  * [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
  * [x] I have performed a self-review of this change
  * [x] Changes have been tested
  * [x] Changes are documented

  Is this a breaking change? N

  Checklist:

  * [ ] Migration process documented
  * [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
