### PR TITLE
fix(billing-cost-management): enable WAL mode and busy timeout for SQ…

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -128,6 +128,8 @@ def get_db_connection() -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
 
     # Create connection and cursor
     conn = sqlite3.connect(db_path)
+    conn.execute('PRAGMA journal_mode=WAL')
+    conn.execute('PRAGMA busy_timeout=5000')
     cursor = conn.cursor()
 
     # Create schema_info table to track created tables if it doesn't exist


### PR DESCRIPTION
## Summary

Parallel subagent requests caused "database is locked" errors because the default journal mode uses exclusive locks.
WAL allows concurrent readers alongside one writer, and busy_timeout prevents immediate failure during brief write contention.


### Changes

- Enable WAL mode
- Set busy_timeout

### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
