### PR TITLE
feat(amazon-bedrock-agentcore-mcp-server): add invoke_agent_runtime_command

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/__init__.py
@@ -23,6 +23,8 @@ Tool cost classification
 **Per-use billable (create/use microVM sessions — compute charges):**
 - invoke_agent_runtime
   Invokes an agent, spinning up or reusing a microVM session.
+- invoke_agent_runtime_command
+  Runs a shell command in a runtime session via HTTP EventStream.
 
 **One-time setup (creates infrastructure):**
 - create_agent_runtime

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/guide.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/guide.py
@@ -122,6 +122,8 @@ All require a `/ping` GET endpoint returning `{"status": "Healthy"}`.
 ### Per-use billable (creates/uses microVM sessions)
 - `invoke_agent_runtime` — sends request to agent, charges for
   compute time while session is active
+- `invoke_agent_runtime_command` — runs a shell command, streams
+  stdout/stderr via HTTP EventStream
 
 ### One-time setup (creates infrastructure)
 - `create_agent_runtime` — provisions runtime definition
@@ -156,6 +158,7 @@ bedrock-agentcore:UpdateAgentRuntimeEndpoint
 bedrock-agentcore:DeleteAgentRuntimeEndpoint
 bedrock-agentcore:ListAgentRuntimeEndpoints
 bedrock-agentcore:InvokeAgentRuntime
+bedrock-agentcore:InvokeAgentRuntimeCommand
 bedrock-agentcore:StopRuntimeSession
 ```
 

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/invocation.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/invocation.py
@@ -16,7 +16,12 @@
 
 import asyncio
 from .error_handler import handle_runtime_error
-from .models import ErrorResponse, InvokeRuntimeResponse, StopSessionResponse
+from .models import (
+    ErrorResponse,
+    InvokeCommandResponse,
+    InvokeRuntimeResponse,
+    StopSessionResponse,
+)
 from mcp.server.fastmcp import Context
 from pydantic import Field
 from typing import Annotated, Callable, Optional, Union
@@ -60,6 +65,85 @@ def _read_response_body(resp: dict) -> str:
     return ''
 
 
+_STREAM_EXCEPTION_KEYS = (
+    'accessDeniedException',
+    'internalServerException',
+    'resourceNotFoundException',
+    'serviceQuotaExceededException',
+    'throttlingException',
+    'validationException',
+    'runtimeClientError',
+)
+
+
+def _parse_command_event_stream(stream) -> dict:
+    """Walk an InvokeAgentRuntimeCommand EventStream and aggregate output.
+
+    The stream yields events shaped like::
+
+        {"chunk": {"contentStart": {}}}
+        {"chunk": {"contentDelta": {"stdout": "..."}}}
+        {"chunk": {"contentDelta": {"stderr": "..."}}}
+        {"chunk": {"contentStop": {"exitCode": 0, "status": "COMPLETED"}}}
+
+    Or a typed-exception member (validationException, throttlingException, ...)
+    in lieu of further chunks.
+    """
+    out = {
+        'stdout': '',
+        'stderr': '',
+        'exit_code': None,
+        'command_status': '',
+        'error': None,
+    }
+    if stream is None:
+        return out
+
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    for event in stream:
+        if not isinstance(event, dict):
+            continue
+
+        for ex_key in _STREAM_EXCEPTION_KEYS:
+            if ex_key in event:
+                ex = event[ex_key] or {}
+                out['error'] = {
+                    'type': ex_key,
+                    'message': ex.get('message', ''),
+                    'http_status': ex.get('httpStatusCode', ''),
+                }
+                out['stdout'] = ''.join(stdout_parts)
+                out['stderr'] = ''.join(stderr_parts)
+                return out
+
+        chunk = event.get('chunk')
+        if not isinstance(chunk, dict):
+            continue
+        delta = chunk.get('contentDelta')
+        if isinstance(delta, dict):
+            if 'stdout' in delta:
+                stdout_parts.append(_decode_chunk(delta['stdout']))
+            if 'stderr' in delta:
+                stderr_parts.append(_decode_chunk(delta['stderr']))
+        stop = chunk.get('contentStop')
+        if isinstance(stop, dict):
+            out['exit_code'] = stop.get('exitCode')
+            out['command_status'] = stop.get('status', '')
+
+    out['stdout'] = ''.join(stdout_parts)
+    out['stderr'] = ''.join(stderr_parts)
+    return out
+
+
+def _decode_chunk(value) -> str:
+    if isinstance(value, bytes):
+        return value.decode('utf-8', errors='replace')
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 class InvocationTools:
     """Tools for invoking agents and managing runtime sessions."""
 
@@ -74,6 +158,7 @@ class InvocationTools:
     def register(self, mcp) -> None:
         """Register invocation tools with the MCP server."""
         mcp.tool(name='invoke_agent_runtime')(self.invoke_agent_runtime)
+        mcp.tool(name='invoke_agent_runtime_command')(self.invoke_agent_runtime_command)
         mcp.tool(name='stop_runtime_session')(self.stop_runtime_session)
 
     async def invoke_agent_runtime(
@@ -150,6 +235,85 @@ class InvocationTools:
             )
         except Exception as e:
             return handle_runtime_error('InvokeAgentRuntime', e)
+
+    async def invoke_agent_runtime_command(
+        self,
+        ctx: Context,
+        agent_runtime_arn: Annotated[
+            str,
+            Field(
+                description=(
+                    'ARN of the agent runtime, e.g. '
+                    '"arn:aws:bedrock-agentcore:us-west-2:123:runtime/my-agent".'
+                )
+            ),
+        ],
+        command: Annotated[
+            str,
+            Field(description='Shell command to run inside the runtime, e.g. "ls -la /tmp".'),
+        ],
+        timeout: Annotated[
+            int,
+            Field(description='Per-command timeout in seconds. Server-side bounds apply.', ge=1),
+        ] = 30,
+        runtime_session_id: Annotated[
+            Optional[str],
+            Field(
+                description=(
+                    'Session ID (33-256 chars). Reuse to share state across commands. '
+                    'Auto-generated if omitted.'
+                )
+            ),
+        ] = None,
+        qualifier: Annotated[
+            str, Field(description='Endpoint qualifier. Defaults to DEFAULT.')
+        ] = 'DEFAULT',
+    ) -> Union[InvokeCommandResponse, ErrorResponse]:
+        """Run a shell command in an AgentCore Runtime via InvokeAgentRuntimeCommand.
+
+        This is the HTTP EventStream variant — runs a single command, streams
+        stdout/stderr chunks, and returns the aggregated output once the
+        command finishes (or the timeout fires).
+
+        **BILLABLE OPERATION:** Reuses or creates a microVM session that
+        incurs compute charges. Reuse ``runtime_session_id`` across calls
+        to avoid cold-start cost; call ``stop_runtime_session`` when done.
+
+        """
+        try:
+            client = self._get_client()
+            kwargs: dict = {
+                'agentRuntimeArn': agent_runtime_arn,
+                'qualifier': qualifier,
+                'body': {'command': command, 'timeout': timeout},
+            }
+            if runtime_session_id is not None:
+                kwargs['runtimeSessionId'] = runtime_session_id
+
+            resp = await asyncio.to_thread(client.invoke_agent_runtime_command, **kwargs)
+            parsed = await asyncio.to_thread(_parse_command_event_stream, resp.get('stream'))
+
+            if parsed.get('error') is not None:
+                err = parsed['error']
+                return ErrorResponse(
+                    message=f'InvokeAgentRuntimeCommand failed: {err.get("message", "")}',
+                    error_type=err.get('type', 'UnknownStreamError'),
+                    error_code=str(err.get('http_status', '')),
+                )
+
+            return InvokeCommandResponse(
+                status='success',
+                runtime_session_id=resp.get('runtimeSessionId', ''),
+                content_type=resp.get('contentType', ''),
+                http_status_code=resp.get('statusCode'),
+                stdout=parsed['stdout'],
+                stderr=parsed['stderr'],
+                exit_code=parsed.get('exit_code'),
+                command_status=parsed.get('command_status', ''),
+                message='Command completed.',
+            )
+        except Exception as e:
+            return handle_runtime_error('InvokeAgentRuntimeCommand', e)
 
     async def stop_runtime_session(
         self,

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/models.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/runtime/models.py
@@ -224,6 +224,20 @@ class StopSessionResponse(BaseModel):
     message: str = ''
 
 
+class InvokeCommandResponse(BaseModel):
+    """Response from invoke_agent_runtime_command (HTTP streaming)."""
+
+    status: str
+    runtime_session_id: str = ''
+    content_type: str = ''
+    http_status_code: Optional[int] = None
+    stdout: str = ''
+    stderr: str = ''
+    exit_code: Optional[int] = None
+    command_status: str = ''
+    message: str = ''
+
+
 # ------------------------------------------------------------------
 # Guide
 # ------------------------------------------------------------------

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/browser/test_integ_mcp_protocol.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/browser/test_integ_mcp_protocol.py
@@ -67,6 +67,7 @@ RUNTIME_TOOLS = {
     'delete_agent_runtime_endpoint',
     'list_agent_runtime_endpoints',
     'invoke_agent_runtime',
+    'invoke_agent_runtime_command',
     'stop_runtime_session',
     'get_runtime_guide',
 }

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/runtime/test_unit_command.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/runtime/test_unit_command.py
@@ -34,6 +34,7 @@ class TestParseCommandEventStream:
     """EventStream parsing for InvokeAgentRuntimeCommand."""
 
     def test_none_stream(self):
+        """None stream returns empty defaults without error."""
         out = _parse_command_event_stream(None)
         assert out['stdout'] == ''
         assert out['stderr'] == ''
@@ -41,6 +42,7 @@ class TestParseCommandEventStream:
         assert out['error'] is None
 
     def test_normal_flow(self):
+        """stdout/stderr deltas concatenate; contentStop yields exitCode and status."""
         events = [
             {'chunk': {'contentStart': {}}},
             {'chunk': {'contentDelta': {'stdout': 'hello\n'}}},
@@ -56,6 +58,7 @@ class TestParseCommandEventStream:
         assert out['error'] is None
 
     def test_stream_typed_exception(self):
+        """Typed exception member in stream is captured and stops parsing."""
         events = [
             {'chunk': {'contentDelta': {'stdout': 'partial\n'}}},
             {'validationException': {'message': 'bad timeout', 'httpStatusCode': 400}},
@@ -67,11 +70,13 @@ class TestParseCommandEventStream:
         assert out['stdout'] == 'partial\n'
 
     def test_byte_payload(self):
+        """Byte stdout chunks are decoded to str."""
         events = [{'chunk': {'contentDelta': {'stdout': b'bin\n'}}}]
         out = _parse_command_event_stream(iter(events))
         assert out['stdout'] == 'bin\n'
 
     def test_non_utf8_payload(self):
+        """Non-UTF8 bytes are replaced rather than crashing."""
         events = [{'chunk': {'contentDelta': {'stdout': b'\x80\x81'}}}]
         out = _parse_command_event_stream(iter(events))
         assert '�' in out['stdout']
@@ -82,6 +87,7 @@ class TestInvokeAgentRuntimeCommand:
 
     @pytest.mark.asyncio
     async def test_success(self, mock_ctx, data_factory, mock_data_client):
+        """Happy path: response fields populate InvokeCommandResponse and request kwargs match."""
         mock_data_client.invoke_agent_runtime_command.return_value = {
             'runtimeSessionId': 'sess-1',
             'contentType': 'application/vnd.amazon.eventstream',
@@ -115,6 +121,7 @@ class TestInvokeAgentRuntimeCommand:
 
     @pytest.mark.asyncio
     async def test_timeout_forwarded_in_body(self, mock_ctx, data_factory, mock_data_client):
+        """Timeout parameter is forwarded into the request body."""
         mock_data_client.invoke_agent_runtime_command.return_value = {
             'runtimeSessionId': 'sess',
             'stream': iter([]),
@@ -133,6 +140,7 @@ class TestInvokeAgentRuntimeCommand:
     async def test_propagates_non_200_status_code(
         self, mock_ctx, data_factory, mock_data_client
     ):
+        """Non-200 statusCode from response envelope surfaces on http_status_code."""
         mock_data_client.invoke_agent_runtime_command.return_value = {
             'runtimeSessionId': 'sess',
             'statusCode': 207,
@@ -153,6 +161,7 @@ class TestInvokeAgentRuntimeCommand:
 
     @pytest.mark.asyncio
     async def test_omits_session_when_none(self, mock_ctx, data_factory, mock_data_client):
+        """runtime_session_id=None is omitted from kwargs to let the server auto-generate."""
         mock_data_client.invoke_agent_runtime_command.return_value = {
             'runtimeSessionId': 'auto',
             'stream': iter([]),
@@ -168,6 +177,7 @@ class TestInvokeAgentRuntimeCommand:
 
     @pytest.mark.asyncio
     async def test_typed_exception_in_stream(self, mock_ctx, data_factory, mock_data_client):
+        """Typed exception in stream becomes an ErrorResponse."""
         mock_data_client.invoke_agent_runtime_command.return_value = {
             'runtimeSessionId': 'sess',
             'stream': iter(
@@ -187,6 +197,7 @@ class TestInvokeAgentRuntimeCommand:
 
     @pytest.mark.asyncio
     async def test_client_error(self, mock_ctx, data_factory, mock_data_client):
+        """boto3 ClientError is caught and returned as ErrorResponse."""
         mock_data_client.invoke_agent_runtime_command.side_effect = _client_error(
             'AccessDeniedException', 'Forbidden', 403
         )

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/runtime/test_unit_command.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/runtime/test_unit_command.py
@@ -1,0 +1,200 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for invoke_agent_runtime_command and the EventStream parser."""
+
+import pytest
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.runtime.invocation import (
+    InvocationTools,
+    _parse_command_event_stream,
+)
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.runtime.models import (
+    ErrorResponse,
+    InvokeCommandResponse,
+)
+from botocore.exceptions import ClientError
+
+
+def _client_error(code='ValidationException', message='bad', status=400):
+    return ClientError(
+        {
+            'Error': {'Code': code, 'Message': message},
+            'ResponseMetadata': {'HTTPStatusCode': status},
+        },
+        'TestOp',
+    )
+
+
+class TestParseCommandEventStream:
+    """EventStream parsing for InvokeAgentRuntimeCommand."""
+
+    def test_none_stream(self):
+        out = _parse_command_event_stream(None)
+        assert out['stdout'] == ''
+        assert out['stderr'] == ''
+        assert out['exit_code'] is None
+        assert out['error'] is None
+
+    def test_normal_flow(self):
+        events = [
+            {'chunk': {'contentStart': {}}},
+            {'chunk': {'contentDelta': {'stdout': 'hello\n'}}},
+            {'chunk': {'contentDelta': {'stdout': 'world\n'}}},
+            {'chunk': {'contentDelta': {'stderr': 'oops\n'}}},
+            {'chunk': {'contentStop': {'exitCode': 0, 'status': 'COMPLETED'}}},
+        ]
+        out = _parse_command_event_stream(iter(events))
+        assert out['stdout'] == 'hello\nworld\n'
+        assert out['stderr'] == 'oops\n'
+        assert out['exit_code'] == 0
+        assert out['command_status'] == 'COMPLETED'
+        assert out['error'] is None
+
+    def test_stream_typed_exception(self):
+        events = [
+            {'chunk': {'contentDelta': {'stdout': 'partial\n'}}},
+            {'validationException': {'message': 'bad timeout', 'httpStatusCode': 400}},
+            {'chunk': {'contentDelta': {'stdout': 'after-error'}}},
+        ]
+        out = _parse_command_event_stream(iter(events))
+        assert out['error'] is not None
+        assert out['error']['type'] == 'validationException'
+        assert out['stdout'] == 'partial\n'
+
+    def test_byte_payload(self):
+        events = [{'chunk': {'contentDelta': {'stdout': b'bin\n'}}}]
+        out = _parse_command_event_stream(iter(events))
+        assert out['stdout'] == 'bin\n'
+
+    def test_non_utf8_payload(self):
+        events = [{'chunk': {'contentDelta': {'stdout': b'\x80\x81'}}}]
+        out = _parse_command_event_stream(iter(events))
+        assert '�' in out['stdout']
+
+
+class TestInvokeAgentRuntimeCommand:
+    """Tests for the HTTP command tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_ctx, data_factory, mock_data_client):
+        mock_data_client.invoke_agent_runtime_command.return_value = {
+            'runtimeSessionId': 'sess-1',
+            'contentType': 'application/vnd.amazon.eventstream',
+            'statusCode': 200,
+            'stream': iter(
+                [
+                    {'chunk': {'contentDelta': {'stdout': 'hi\n'}}},
+                    {'chunk': {'contentStop': {'exitCode': 0, 'status': 'COMPLETED'}}},
+                ]
+            ),
+        }
+        tools = InvocationTools(data_factory)
+        result = await tools.invoke_agent_runtime_command(
+            ctx=mock_ctx,
+            agent_runtime_arn='arn:test',
+            command='echo hi',
+            timeout=5,
+            runtime_session_id='sess-1',
+        )
+        assert isinstance(result, InvokeCommandResponse)
+        assert result.runtime_session_id == 'sess-1'
+        assert result.stdout == 'hi\n'
+        assert result.exit_code == 0
+        assert result.command_status == 'COMPLETED'
+
+        kwargs = mock_data_client.invoke_agent_runtime_command.call_args.kwargs
+        assert kwargs['agentRuntimeArn'] == 'arn:test'
+        assert kwargs['qualifier'] == 'DEFAULT'
+        assert kwargs['body'] == {'command': 'echo hi', 'timeout': 5}
+        assert kwargs['runtimeSessionId'] == 'sess-1'
+
+    @pytest.mark.asyncio
+    async def test_timeout_forwarded_in_body(self, mock_ctx, data_factory, mock_data_client):
+        mock_data_client.invoke_agent_runtime_command.return_value = {
+            'runtimeSessionId': 'sess',
+            'stream': iter([]),
+        }
+        tools = InvocationTools(data_factory)
+        await tools.invoke_agent_runtime_command(
+            ctx=mock_ctx,
+            agent_runtime_arn='arn:test',
+            command='sleep 1',
+            timeout=120,
+        )
+        kwargs = mock_data_client.invoke_agent_runtime_command.call_args.kwargs
+        assert kwargs['body'] == {'command': 'sleep 1', 'timeout': 120}
+
+    @pytest.mark.asyncio
+    async def test_propagates_non_200_status_code(
+        self, mock_ctx, data_factory, mock_data_client
+    ):
+        mock_data_client.invoke_agent_runtime_command.return_value = {
+            'runtimeSessionId': 'sess',
+            'statusCode': 207,
+            'stream': iter(
+                [{'chunk': {'contentStop': {'exitCode': 1, 'status': 'FAILED'}}}]
+            ),
+        }
+        tools = InvocationTools(data_factory)
+        result = await tools.invoke_agent_runtime_command(
+            ctx=mock_ctx,
+            agent_runtime_arn='arn:test',
+            command='false',
+        )
+        assert isinstance(result, InvokeCommandResponse)
+        assert result.http_status_code == 207
+        assert result.exit_code == 1
+        assert result.command_status == 'FAILED'
+
+    @pytest.mark.asyncio
+    async def test_omits_session_when_none(self, mock_ctx, data_factory, mock_data_client):
+        mock_data_client.invoke_agent_runtime_command.return_value = {
+            'runtimeSessionId': 'auto',
+            'stream': iter([]),
+        }
+        tools = InvocationTools(data_factory)
+        await tools.invoke_agent_runtime_command(
+            ctx=mock_ctx,
+            agent_runtime_arn='arn:test',
+            command='echo hi',
+        )
+        kwargs = mock_data_client.invoke_agent_runtime_command.call_args.kwargs
+        assert 'runtimeSessionId' not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_typed_exception_in_stream(self, mock_ctx, data_factory, mock_data_client):
+        mock_data_client.invoke_agent_runtime_command.return_value = {
+            'runtimeSessionId': 'sess',
+            'stream': iter(
+                [
+                    {'validationException': {'message': 'bad', 'httpStatusCode': 400}},
+                ]
+            ),
+        }
+        tools = InvocationTools(data_factory)
+        result = await tools.invoke_agent_runtime_command(
+            ctx=mock_ctx,
+            agent_runtime_arn='arn:test',
+            command='',
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.error_type == 'validationException'
+
+    @pytest.mark.asyncio
+    async def test_client_error(self, mock_ctx, data_factory, mock_data_client):
+        mock_data_client.invoke_agent_runtime_command.side_effect = _client_error(
+            'AccessDeniedException', 'Forbidden', 403
+        )
+        tools = InvocationTools(data_factory)
+        result = await tools.invoke_agent_runtime_command(
+            ctx=mock_ctx,
+            agent_runtime_arn='arn:test',
+            command='ls',
+        )
+        assert isinstance(result, ErrorResponse)
+        assert result.error_type == 'AccessDeniedException'


### PR DESCRIPTION
## Summary
- Adds new MCP tool `invoke_agent_runtime_command` wrapping the `InvokeAgentRuntimeCommand` data-plane API. Runs a single shell command in an AgentCore Runtime microVM and streams stdout/stderr via HTTP EventStream.
- Parser handles stdout/stderr chunks, `exitCode`/`status`, typed exceptions (e.g. `validationException`), and non-UTF8 byte payloads.
- Updates runtime guide cost tiers + IAM permissions; adds `InvokeCommandResponse` model.

## Test plan
- [x] 11 unit tests in `tests/runtime/test_unit_command.py` (parser edge cases, timeout forwarding into request body, non-200 statusCode propagation, session-id omission, ClientError path) — all passing
- [x] Full suite: 821 passed, 50 deselected
- [x] Manual live verification on a beta endpoint with an allowlisted READY runtime — confirmed stdout, exit code, command status, and content type round-trip
- [ ] No live integ test added for the runtime command path; runtime test dir has no integ suite today (only `tests/browser/test_integ_*.py` exists, gated by `@pytest.mark.live`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).