### PR TITLE
fix(aws-api-mcp-server): expand environment variables before workdir …

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/file_system_controls.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/file_system_controls.py
@@ -141,6 +141,9 @@ def validate_file_path(file_path: str) -> str:
 
     if FILE_ACCESS_MODE == FileAccessMode.UNRESTRICTED:
         return file_path
+    # Expand environment variables and user home directory before validation
+    # to prevent bypass via $HOME, ${HOME}, $TMPDIR, etc.
+    file_path = os.path.expandvars(os.path.expanduser(file_path))
 
     # Reject unexpanded tilde paths (e.g., ~invalid_user/path)
     if file_path.startswith('~') and not os.path.isabs(os.path.expanduser(file_path)):

--- a/src/aws-api-mcp-server/tests/common/test_file_system_controls.py
+++ b/src/aws-api-mcp-server/tests/common/test_file_system_controls.py
@@ -193,3 +193,47 @@ def test_ecs_deploy_get_file_contents_is_patched(_mock_open):
     with pytest.raises(SanitizedException) as exc_info:
         awscli.customizations.ecs.deploy.ECSDeploy._get_file_contents(instance, '$MY_SECRET')
     assert SECRET_VALUE not in str(exc_info.value)
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_home_path_blocked():
+    """Test that $HOME/path is blocked when it resolves outside working directory."""
+    with patch.dict(os.environ, {'HOME': '/Users/testuser'}):
+        with pytest.raises(FilePathValidationError):
+            validate_file_path('$HOME/secret.json')
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_home_braces_path_blocked():
+    """Test that ${HOME}/path is blocked when it resolves outside working directory."""
+    with patch.dict(os.environ, {'HOME': '/Users/testuser'}):
+        with pytest.raises(FilePathValidationError):
+            validate_file_path('${HOME}/secret.json')
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_tmpdir_path_blocked():
+    """Test that $TMPDIR/path is blocked when it resolves outside working directory."""
+    with patch.dict(os.environ, {'TMPDIR': '/var/folders/tmp'}):
+        with pytest.raises(FilePathValidationError):
+            validate_file_path('$TMPDIR/secret.json')
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_path_inside_workdir_allowed():
+    """Test that $MY_DIR/path is allowed when it resolves inside working directory."""
+    with patch.dict(os.environ, {'MY_DIR': '/test/workdir'}):
+        result = validate_file_path('$MY_DIR/safe_file.txt')
+        assert result == '/test/workdir/safe_file.txt'

--- a/src/aws-api-mcp-server/tests/parser/test_parser_customizations.py
+++ b/src/aws-api-mcp-server/tests/parser/test_parser_customizations.py
@@ -496,3 +496,63 @@ def test_local_file_uri_validation_failure():
 def test_codeartifact_login_allowed_in_unrestricted_mode():
     """Test that codeartifact login is allowed when FILE_ACCESS_MODE is UNRESTRICTED."""
     assert not is_denied_custom_operation('codeartifact', 'login')
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_home_blocked_in_ecs_deploy():
+    """Test that $HOME/path is blocked in ecs deploy when it resolves outside workdir."""
+    import os
+    from unittest.mock import patch as mock_patch
+
+    with mock_patch.dict(os.environ, {'HOME': '/Users/testuser'}):
+        with pytest.raises(FileParameterError):
+            parse(
+                'aws ecs deploy --service test --task-definition $HOME/secret.json --codedeploy-appspec $HOME/secret.json'
+            )
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_home_braces_blocked_in_ecs_deploy():
+    """Test that ${HOME}/path is blocked in ecs deploy when it resolves outside workdir."""
+    import os
+    from unittest.mock import patch as mock_patch
+
+    with mock_patch.dict(os.environ, {'HOME': '/Users/testuser'}):
+        with pytest.raises(FileParameterError):
+            parse(
+                'aws ecs deploy --service test --task-definition ${HOME}/secret.json --codedeploy-appspec ${HOME}/secret.json'
+            )
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_env_var_tmpdir_blocked_in_cloudformation_deploy():
+    """Test that $TMPDIR/path is blocked in cloudformation deploy."""
+    import os
+    from unittest.mock import patch as mock_patch
+
+    with mock_patch.dict(os.environ, {'TMPDIR': '/var/folders/tmp'}):
+        with pytest.raises(FileParameterError):
+            parse(
+                'aws cloudformation deploy --template-file $TMPDIR/secret.json --stack-name test'
+            )
+
+
+@patch(
+    'awslabs.aws_api_mcp_server.core.common.file_system_controls.WORKING_DIRECTORY',
+    '/test/workdir',
+)
+def test_tilde_still_blocked_in_ecs_deploy():
+    """Test that ~/path remains blocked (regression check for PR #1390 fix)."""
+    with pytest.raises(FileParameterError):
+        parse(
+            'aws ecs deploy --service test --task-definition ~/secret.json --codedeploy-appspec ~/secret.json'
+        )


### PR DESCRIPTION
## Summary

Fix workdir file restriction bypass via `$HOME`/`${HOME}` environment variable expansion in custom CLI operations.

### Changes

Add `os.path.expandvars()` :
- `validate_file_path()` in `file_system_controls.py` — defense-in-depth, expands before the workdir boundary check

### Problem

When `FILE_ACCESS_MODE=workdir`, paths like `$HOME/secret.json` bypassed validation because:
1. `validate_file_path()` called `abspath("$HOME/secret.json")` → `/workdir/$HOME/secret.json` (inside workdir, passes check)
2. Downstream AWS CLI consumer ([`ECSDeploy._get_file_contents`](https://github.com/aws/aws-cli/blob/7e17abfc144f5e04c8e48fc1783a1735b16c0d6a/awscli/customizations/ecs/deploy.py#L160)) called `expandvars()` → `/Users/<user>/secret.json` (reads file outside workdir)

### Testing

- 8 new unit tests covering `$HOME`, `${HOME}`, `$TMPDIR` variants
- End-to-end parser tests for `ecs deploy`, `cloudformation deploy`
- Regression test for `~/path` (PR #1390 fix intact)
- Full suite: 726 passed, 0 failures

### Checklist

- [x] I have reviewed the contributing guidelines
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Is this a breaking change? No

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
