### PR TITLE
fix(elasticache-mcp-server): enforce readonly mode on delete and modify serverless cache tools

### DIFF
--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/common/decorators.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/common/decorators.py
@@ -14,13 +14,24 @@
 
 """Decorators for ElastiCache MCP Server."""
 
+from ..context import Context
 from functools import wraps
 from typing import Any, Callable
 
 
-def handle_exceptions(func: Callable) -> Callable:
-    """Decorator to handle exceptions in ElastiCache operations.
+def readonly_safe(func: Callable) -> Callable:
+    """Mark a tool as safe to run in readonly mode.
 
+    Tools without this decorator will be blocked when readonly mode is enabled.
+    """
+    setattr(func, '_readonly_safe', True)
+    return func
+
+
+def handle_exceptions(func: Callable) -> Callable:
+    """Decorator to handle exceptions and enforce readonly mode for ElastiCache operations.
+
+    Blocks tool execution in readonly mode unless the tool is marked with @readonly_safe.
     Wraps the function in a try-catch block and returns any exceptions
     in a standardized error format.
 
@@ -28,12 +39,16 @@ def handle_exceptions(func: Callable) -> Callable:
         func: The function to wrap
 
     Returns:
-        The wrapped function that handles exceptions
+        The wrapped function that enforces readonly mode and handles exceptions
     """
 
     @wraps(func)
     async def wrapper(*args: Any, **kwargs: Any):
         try:
+            if Context.readonly_mode() and not getattr(func, '_readonly_safe', False):
+                raise ValueError(
+                    'You have configured this tool in readonly mode. To make this change you will have to update your configuration.'
+                )
             return await func(*args, **kwargs)
         except Exception as e:
             return {'error': str(e)}

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/connect.py
@@ -15,7 +15,7 @@
 """Connect module for creating and configuring jump host EC2 instances to access ElastiCache clusters."""
 
 from ...common.connection import EC2ConnectionManager, ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from ...context import Context
 from botocore.exceptions import ClientError
@@ -172,6 +172,7 @@ async def connect_jump_host_cc(cache_cluster_id: str, instance_id: str) -> Dict[
 
 @mcp.tool(name='get-ssh-tunnel-command-cache-cluster')
 @handle_exceptions
+@readonly_safe
 async def get_ssh_tunnel_command_cc(
     cache_cluster_id: str, instance_id: str
 ) -> Dict[str, Union[str, int]]:

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/describe.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/describe.py
@@ -15,13 +15,14 @@
 """Describe cache clusters tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Dict, Optional
 
 
 @mcp.tool(name='describe-cache-clusters')
 @handle_exceptions
+@readonly_safe
 async def describe_cache_clusters(
     cache_cluster_id: Optional[str] = None,
     max_records: Optional[int] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/ce/get_cost_and_usage.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/ce/get_cost_and_usage.py
@@ -15,7 +15,7 @@
 """Get cost and usage data for ElastiCache resources."""
 
 from ...common.connection import CostExplorerConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, Dict
@@ -36,6 +36,7 @@ class GetCostAndUsageRequest(BaseModel):
 
 @mcp.tool(name='get-cost-and-usage')
 @handle_exceptions
+@readonly_safe
 async def get_cost_and_usage(request: GetCostAndUsageRequest) -> Dict[str, Any]:
     """Get cost and usage data for ElastiCache resources.
 

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cw/get_metric_statistics.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cw/get_metric_statistics.py
@@ -15,7 +15,7 @@
 """Tool for getting CloudWatch metric statistics."""
 
 from ...common.connection import CloudWatchConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional
 
 @mcp.tool(name='get-metric-statistics')
 @handle_exceptions
+@readonly_safe
 async def get_metric_statistics(
     metric_name: str,
     start_time: str,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_groups.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_groups.py
@@ -15,13 +15,14 @@
 """Tool for describing CloudWatch Logs log groups."""
 
 from ...common.connection import CloudWatchLogsConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Any, Dict, List, Optional
 
 
 @mcp.tool(name='describe-log-groups')
 @handle_exceptions
+@readonly_safe
 async def describe_log_groups(
     account_identifiers: Optional[List[str]] = None,
     log_group_name_prefix: Optional[str] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_streams.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/describe_log_streams.py
@@ -15,13 +15,14 @@
 """Tool for describing CloudWatch Logs log streams."""
 
 from ...common.connection import CloudWatchLogsConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Any, Dict, Optional
 
 
 @mcp.tool(name='describe-log-streams')
 @handle_exceptions
+@readonly_safe
 async def describe_log_streams(
     log_group_name: Optional[str] = None,
     log_group_identifier: Optional[str] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/filter_log_events.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/filter_log_events.py
@@ -15,7 +15,7 @@
 """Tool for filtering log events from CloudWatch Logs."""
 
 from ...common.connection import CloudWatchLogsConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional
 
 @mcp.tool(name='filter-log-events')
 @handle_exceptions
+@readonly_safe
 async def filter_log_events(
     log_group_name: Optional[str] = None,
     log_group_identifier: Optional[str] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/get_log_events.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cwlogs/get_log_events.py
@@ -15,7 +15,7 @@
 """Tool for retrieving log events from CloudWatch Logs."""
 
 from ...common.connection import CloudWatchLogsConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -23,6 +23,7 @@ from typing import Any, Dict, Optional
 
 @mcp.tool(name='get-log-events')
 @handle_exceptions
+@readonly_safe
 async def get_log_events(
     log_stream_name: str,
     log_group_name: Optional[str] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/firehose/list_delivery_streams.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/firehose/list_delivery_streams.py
@@ -15,13 +15,14 @@
 """Tool for listing Kinesis Firehose delivery streams."""
 
 from ...common.connection import FirehoseConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Any, Dict
 
 
 @mcp.tool(name='list-delivery-streams')
 @handle_exceptions
+@readonly_safe
 async def list_delivery_streams(
     limit: Any = None,
     delivery_stream_type: Any = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_cache_engine_versions.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_cache_engine_versions.py
@@ -15,13 +15,14 @@
 """Describe cache engine versions tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Dict, Optional
 
 
 @mcp.tool(name='describe-cache-engine-versions')
 @handle_exceptions
+@readonly_safe
 async def describe_cache_engine_versions(
     engine: Optional[str] = None,
     engine_version: Optional[str] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_engine_default_parameters.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_engine_default_parameters.py
@@ -15,13 +15,14 @@
 """Describe engine default parameters tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Dict, Optional
 
 
 @mcp.tool(name='describe-engine-default-parameters')
 @handle_exceptions
+@readonly_safe
 async def describe_engine_default_parameters(
     cache_parameter_group_family: str,
     max_records: Optional[int] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_events.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_events.py
@@ -15,7 +15,7 @@
 """Describe events tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from datetime import datetime
 from typing import Dict, Optional
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 
 @mcp.tool(name='describe-events')
 @handle_exceptions
+@readonly_safe
 async def describe_events(
     source_type: Optional[str] = None,
     source_identifier: Optional[str] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_service_updates.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/misc/describe_service_updates.py
@@ -15,13 +15,14 @@
 """Describe service updates tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Dict, List, Optional
 
 
 @mcp.tool(name='describe-service-updates')
 @handle_exceptions
+@readonly_safe
 async def describe_service_updates(
     service_update_name: Optional[str] = None,
     service_update_status: Optional[List[str]] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/connect.py
@@ -15,7 +15,7 @@
 """Connect module for creating and configuring jump host EC2 instances to access ElastiCache replication groups."""
 
 from ...common.connection import EC2ConnectionManager, ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from ...context import Context
 from botocore.exceptions import ClientError
@@ -200,6 +200,7 @@ async def connect_jump_host_rg(replication_group_id: str, instance_id: str) -> D
 
 @mcp.tool(name='get-ssh-tunnel-command-replication-group')
 @handle_exceptions
+@readonly_safe
 async def get_ssh_tunnel_command_rg(
     replication_group_id: str, instance_id: str
 ) -> Dict[str, Union[str, int]]:

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/describe.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/describe.py
@@ -15,13 +15,14 @@
 """Describe replication groups tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Dict, Optional
 
 
 @mcp.tool(name='describe-replication-groups')
 @handle_exceptions
+@readonly_safe
 async def describe_replication_groups(
     replication_group_id: Optional[str] = None,
     max_records: Optional[int] = None,

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/test_migration.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/test_migration.py
@@ -15,7 +15,7 @@
 """Test migration tool for ElastiCache MCP server."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, Dict, List, Union
@@ -112,6 +112,7 @@ def prepare_request_dict(request: MigrationTestRequest) -> Dict[str, Any]:
 
 @mcp.tool(name='test-migration')
 @handle_exceptions
+@readonly_safe
 async def test_migration(request: MigrationTestRequest) -> Dict:
     """Test migration to an Amazon ElastiCache replication group.
 

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/connect.py
@@ -15,7 +15,7 @@
 """Connect module for creating and configuring jump host EC2 instances to access ElastiCache serverless caches."""
 
 from ...common.connection import EC2ConnectionManager, ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from ...context import Context
 from botocore.exceptions import ClientError
@@ -186,6 +186,7 @@ async def connect_jump_host_serverless(
 
 @mcp.tool(name='get-ssh-tunnel-command-serverless-cache')
 @handle_exceptions
+@readonly_safe
 async def get_ssh_tunnel_command_serverless(
     serverless_cache_name: str, instance_id: str
 ) -> Dict[str, Union[str, int]]:

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/describe.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/serverless/describe.py
@@ -15,13 +15,14 @@
 """Describe serverless cache operations."""
 
 from ...common.connection import ElastiCacheConnectionManager
-from ...common.decorators import handle_exceptions
+from ...common.decorators import handle_exceptions, readonly_safe
 from ...common.server import mcp
 from typing import Dict, Optional
 
 
 @mcp.tool(name='describe-serverless-caches')
 @handle_exceptions
+@readonly_safe
 async def describe_serverless_caches(
     serverless_cache_name: Optional[str] = None,
     max_items: Optional[int] = None,

--- a/src/elasticache-mcp-server/tests/tools/cc/test_connect_coverage_additional.py
+++ b/src/elasticache-mcp-server/tests/tools/cc/test_connect_coverage_additional.py
@@ -823,3 +823,53 @@ async def test_create_jump_host_cc_general_exception():
 
         assert 'error' in result
         assert 'General error' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_get_ssh_tunnel_command_cc_works_in_readonly_mode():
+    """Test that get_ssh_tunnel_command works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from awslabs.elasticache_mcp_server.tools.cc.connect import get_ssh_tunnel_command_cc
+    from unittest.mock import MagicMock, patch
+
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [
+            {
+                'Instances': [
+                    {
+                        'KeyName': 'mykey',
+                        'PublicDnsName': 'ec2.example.com',
+                        'Platform': '',
+                        'ImageId': 'ami-123',
+                    }
+                ]
+            }
+        ]
+    }
+    mock_elasticache = MagicMock()
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheNodes': [{'Endpoint': {'Address': 'cache.example.com', 'Port': 6379}}],
+                'Engine': 'redis',
+            }
+        ]
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        result = await get_ssh_tunnel_command_cc(
+            cache_cluster_id='test-cluster', instance_id='i-123'
+        )
+        assert 'error' not in result
+        assert 'command' in result

--- a/src/elasticache-mcp-server/tests/tools/cc/test_describe.py
+++ b/src/elasticache-mcp-server/tests/tools/cc/test_describe.py
@@ -107,3 +107,25 @@ async def test_describe_cache_clusters_not_found():
 
         assert 'error' in result
         assert error_message in result['error']
+
+
+@pytest.mark.asyncio
+async def test_describe_cache_clusters_works_in_readonly_mode():
+    """Test that describe works even when readonly mode is enabled."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.describe_cache_clusters.return_value = {
+        'CacheClusters': [{'CacheClusterId': 'test-cluster'}]
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_cache_clusters()
+        assert 'error' not in result
+        assert 'CacheClusters' in result

--- a/src/elasticache-mcp-server/tests/tools/ce/test_get_cost_and_usage.py
+++ b/src/elasticache-mcp-server/tests/tools/ce/test_get_cost_and_usage.py
@@ -210,3 +210,25 @@ class TestGetCostAndUsage:
         response = await get_cost_and_usage(request)
         assert 'error' in response
         assert error_message in response['error']
+
+
+@pytest.mark.asyncio
+async def test_get_cost_and_usage_works_in_readonly_mode():
+    """Test that get_cost_and_usage works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.get_cost_and_usage.return_value = {'ResultsByTime': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.CostExplorerConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        request = GetCostAndUsageRequest(
+            time_period='2026-01-01/2026-01-31',
+            granularity='MONTHLY',
+        )
+        result = await get_cost_and_usage(request)
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/cw/test_get_metric_statistics.py
+++ b/src/elasticache-mcp-server/tests/tools/cw/test_get_metric_statistics.py
@@ -218,3 +218,27 @@ async def test_get_metric_statistics_engine_cpu_utilization():
             'Label': 'EngineCPUUtilization',
             'Datapoints': mock_response['Datapoints'],
         }
+
+
+@pytest.mark.asyncio
+async def test_get_metric_statistics_works_in_readonly_mode():
+    """Test that get_metric_statistics works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.return_value = {'Datapoints': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.CloudWatchConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await get_metric_statistics(
+            metric_name='CPUUtilization',
+            start_time='2026-01-01T00:00:00Z',
+            end_time='2026-01-02T00:00:00Z',
+            period=300,
+            statistics=['Average'],
+        )
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/cwlogs/test_create_log_group.py
+++ b/src/elasticache-mcp-server/tests/tools/cwlogs/test_create_log_group.py
@@ -95,3 +95,15 @@ async def test_create_log_group_error():
 
         assert 'error' in result
         assert 'Log group already exists' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_create_log_group_readonly_mode():
+    """Test create_log_group in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import patch
+
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        result = await create_log_group(log_group_name='test-log-group')
+        assert 'error' in result
+        assert 'readonly mode' in result['error']

--- a/src/elasticache-mcp-server/tests/tools/cwlogs/test_describe_log_groups.py
+++ b/src/elasticache-mcp-server/tests/tools/cwlogs/test_describe_log_groups.py
@@ -270,3 +270,22 @@ async def test_describe_log_groups_max_items_with_remainder():
         assert result['nextToken'] == 'token1'
         assert result['logGroups'][0]['logGroupName'] == 'group-1'
         assert result['logGroups'][2]['logGroupName'] == 'group-3'
+
+
+@pytest.mark.asyncio
+async def test_describe_log_groups_works_in_readonly_mode():
+    """Test that describe_log_groups works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import MagicMock, patch
+
+    mock_client = MagicMock()
+    mock_client.describe_log_groups.return_value = {'logGroups': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.CloudWatchLogsConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_log_groups()
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/cwlogs/test_describe_log_streams.py
+++ b/src/elasticache-mcp-server/tests/tools/cwlogs/test_describe_log_streams.py
@@ -313,3 +313,22 @@ async def test_describe_log_streams_error():
 
         # Verify error response
         assert result == {'error': 'Test error'}
+
+
+@pytest.mark.asyncio
+async def test_describe_log_streams_works_in_readonly_mode():
+    """Test that describe_log_streams works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import MagicMock, patch
+
+    mock_client = MagicMock()
+    mock_client.describe_log_streams.return_value = {'logStreams': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.CloudWatchLogsConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_log_streams(log_group_name='test-group')
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/cwlogs/test_filter_log_events.py
+++ b/src/elasticache-mcp-server/tests/tools/cwlogs/test_filter_log_events.py
@@ -172,3 +172,22 @@ async def test_filter_log_events_pagination(mock_logs_client):
 
     # Verify response includes pagination token
     assert result['nextToken'] == 'next-page-token'
+
+
+@pytest.mark.asyncio
+async def test_filter_log_events_works_in_readonly_mode():
+    """Test that filter_log_events works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import MagicMock, patch
+
+    mock_client = MagicMock()
+    mock_client.filter_log_events.return_value = {'events': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.CloudWatchLogsConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await filter_log_events(log_group_name='test-group')
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/cwlogs/test_get_log_events.py
+++ b/src/elasticache-mcp-server/tests/tools/cwlogs/test_get_log_events.py
@@ -124,3 +124,22 @@ async def test_get_log_events_error(mock_logs_client):
 
     assert 'error' in result
     assert 'Log stream not found' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_get_log_events_works_in_readonly_mode():
+    """Test that get_log_events works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import MagicMock, patch
+
+    mock_client = MagicMock()
+    mock_client.get_log_events.return_value = {'events': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.CloudWatchLogsConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await get_log_events(log_group_name='test-group', log_stream_name='test-stream')
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/firehose/test_list_delivery_streams.py
+++ b/src/elasticache-mcp-server/tests/tools/firehose/test_list_delivery_streams.py
@@ -166,3 +166,22 @@ async def test_list_delivery_streams_missing_fields():
         # Verify response with default values
         assert result['DeliveryStreamNames'] == []
         assert result['HasMoreDeliveryStreams'] is False
+
+
+@pytest.mark.asyncio
+async def test_list_delivery_streams_works_in_readonly_mode():
+    """Test that list_delivery_streams works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import MagicMock, patch
+
+    mock_client = MagicMock()
+    mock_client.list_delivery_streams.return_value = {'DeliveryStreamNames': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.FirehoseConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await list_delivery_streams()
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/misc/test_batch_apply_update_action.py
+++ b/src/elasticache-mcp-server/tests/tools/misc/test_batch_apply_update_action.py
@@ -101,3 +101,17 @@ async def test_batch_apply_update_action_missing_targets():
 
         assert 'error' in result
         assert error_message in result['error']
+
+
+@pytest.mark.asyncio
+async def test_batch_apply_update_action_readonly_mode():
+    """Test batch_apply_update_action in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        result = await batch_apply_update_action(
+            service_update_name='test-update',
+            replication_group_ids=['test-rg'],
+        )
+        assert 'error' in result
+        assert 'readonly mode' in result['error']

--- a/src/elasticache-mcp-server/tests/tools/misc/test_batch_stop_update_action.py
+++ b/src/elasticache-mcp-server/tests/tools/misc/test_batch_stop_update_action.py
@@ -101,3 +101,17 @@ async def test_batch_stop_update_action_missing_targets():
 
         assert 'error' in result
         assert error_message in result['error']
+
+
+@pytest.mark.asyncio
+async def test_batch_stop_update_action_readonly_mode():
+    """Test batch_stop_update_action in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        result = await batch_stop_update_action(
+            service_update_name='test-update',
+            replication_group_ids=['test-rg'],
+        )
+        assert 'error' in result
+        assert 'readonly mode' in result['error']

--- a/src/elasticache-mcp-server/tests/tools/misc/test_describe_engine_default_parameters.py
+++ b/src/elasticache-mcp-server/tests/tools/misc/test_describe_engine_default_parameters.py
@@ -129,3 +129,23 @@ async def test_describe_engine_default_parameters_invalid_parameter_combination(
 
         assert 'error' in result
         assert error_message in result['error']
+
+
+@pytest.mark.asyncio
+async def test_describe_engine_default_parameters_works_in_readonly_mode():
+    """Test that describe_engine_default_parameters works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.describe_engine_default_parameters.return_value = {
+        'EngineDefaults': {'Parameters': []}
+    }
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_engine_default_parameters(cache_parameter_group_family='redis7')
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/misc/test_describe_events.py
+++ b/src/elasticache-mcp-server/tests/tools/misc/test_describe_events.py
@@ -201,3 +201,21 @@ async def test_describe_events_invalid_parameter_combination():
         result = await describe_events(duration=60, start_time=datetime(2025, 1, 1, 12, 0, 0))
         assert 'error' in result
         assert error_message in result['error']
+
+
+@pytest.mark.asyncio
+async def test_describe_events_works_in_readonly_mode():
+    """Test that describe_events works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.describe_events.return_value = {'Events': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_events()
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/misc/test_describe_service_updates.py
+++ b/src/elasticache-mcp-server/tests/tools/misc/test_describe_service_updates.py
@@ -233,3 +233,21 @@ async def test_describe_service_updates_pagination_edge_cases():
         # Test with negative max items
         await describe_service_updates(max_items=-1)
         mock_client.describe_service_updates.assert_called_with(MaxItems=-1)
+
+
+@pytest.mark.asyncio
+async def test_describe_service_updates_works_in_readonly_mode():
+    """Test that describe_service_updates works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.describe_service_updates.return_value = {'ServiceUpdates': []}
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_service_updates()
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/rg/test_connect_coverage_additional.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_connect_coverage_additional.py
@@ -368,3 +368,50 @@ async def test_create_jump_host_rg_readonly_mode():
         result = await create_jump_host_rg('rg-test', 'test-key')
         assert 'error' in result
         assert 'You have configured this tool in readonly mode' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_get_ssh_tunnel_command_rg_works_in_readonly_mode():
+    """Test that get_ssh_tunnel_command works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from awslabs.elasticache_mcp_server.tools.rg.connect import get_ssh_tunnel_command_rg
+    from unittest.mock import MagicMock, patch
+
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [
+            {
+                'Instances': [
+                    {
+                        'KeyName': 'mykey',
+                        'PublicDnsName': 'ec2.example.com',
+                        'Platform': '',
+                        'ImageId': 'ami-123',
+                    }
+                ]
+            }
+        ]
+    }
+    mock_elasticache = MagicMock()
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [
+            {'ConfigurationEndpoint': {'Address': 'cache.example.com', 'Port': 6379}}
+        ]
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        result = await get_ssh_tunnel_command_rg(
+            replication_group_id='test-rg', instance_id='i-123'
+        )
+        assert 'error' not in result
+        assert 'command' in result

--- a/src/elasticache-mcp-server/tests/tools/rg/test_create.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_create.py
@@ -492,3 +492,46 @@ class TestCreateReplicationGroup:
         response = await create_replication_group(request)
         assert 'error' in response
         assert error_message in response['error']
+
+
+@pytest.mark.asyncio
+async def test_create_replication_group_readonly_mode():
+    """Test creating a replication group in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import patch
+
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        request = CreateReplicationGroupRequest(
+            replication_group_id='test-rg',
+            replication_group_description='test',
+            cache_node_type=None,
+            engine=None,
+            engine_version=None,
+            num_cache_clusters=None,
+            preferred_cache_cluster_azs=None,
+            num_node_groups=None,
+            replicas_per_node_group=None,
+            node_group_configuration=None,
+            cache_parameter_group_name=None,
+            cache_subnet_group_name=None,
+            cache_security_group_names=None,
+            security_group_ids=None,
+            tags=None,
+            snapshot_arns=None,
+            snapshot_name=None,
+            preferred_maintenance_window=None,
+            port=None,
+            notification_topic_arn=None,
+            auto_minor_version_upgrade=None,
+            snapshot_retention_limit=None,
+            snapshot_window=None,
+            auth_token=None,
+            transit_encryption_enabled=None,
+            at_rest_encryption_enabled=None,
+            kms_key_id=None,
+            user_group_ids=None,
+            log_delivery_configurations=None,
+        )
+        result = await create_replication_group(request)
+        assert 'error' in result
+        assert 'readonly mode' in result['error']

--- a/src/elasticache-mcp-server/tests/tools/rg/test_describe.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_describe.py
@@ -120,3 +120,25 @@ async def test_describe_replication_groups_invalid_parameter():
 
         assert 'error' in result
         assert error_message in result['error']
+
+
+@pytest.mark.asyncio
+async def test_describe_replication_groups_works_in_readonly_mode():
+    """Test that describe works even when readonly mode is enabled."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'ReplicationGroupId': 'test-rg'}]
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_replication_groups()
+        assert 'error' not in result
+        assert 'ReplicationGroups' in result

--- a/src/elasticache-mcp-server/tests/tools/rg/test_start_migration.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_start_migration.py
@@ -233,3 +233,19 @@ class TestStartMigration:
         response = await start_migration(request)
         assert 'error' in response
         assert error_message in response['error']
+
+
+@pytest.mark.asyncio
+async def test_start_migration_readonly_mode():
+    """Test starting migration in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import patch
+
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        request = StartMigrationRequest(
+            replication_group_id='test-rg',
+            customer_node_endpoint_list='Address=1.2.3.4,Port=6379',
+        )
+        result = await start_migration(request)
+        assert 'error' in result
+        assert 'readonly mode' in result['error']

--- a/src/elasticache-mcp-server/tests/tools/rg/test_test_migration.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_test_migration.py
@@ -209,3 +209,29 @@ class TestTestMigration:
         response = await test_migration(request)
         assert 'error' in response
         assert error_message in response['error']
+
+
+@pytest.mark.asyncio
+async def test_test_migration_works_in_readonly_mode():
+    """Test that test_migration works even when readonly mode is enabled (it's a connectivity probe, not mutating)."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from unittest.mock import MagicMock, patch
+
+    mock_client = MagicMock()
+    mock_client.test_migration.return_value = {
+        'ReplicationGroup': {'ReplicationGroupId': 'test-rg'}
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        request = MigrationTestRequest(
+            replication_group_id='test-rg',
+            customer_node_endpoint_list='Address=1.2.3.4,Port=6379',
+        )
+        result = await test_migration(request)
+        assert 'error' not in result

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_connect_additional.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_connect_additional.py
@@ -709,3 +709,52 @@ async def test_connect_jump_host_serverless_no_subnet_ids():
         # Should fail with appropriate error message
         assert 'error' in result
         assert 'No subnet IDs found for serverless cache cache-1' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_get_ssh_tunnel_command_serverless_works_in_readonly_mode():
+    """Test that get_ssh_tunnel_command works in readonly mode."""
+    from awslabs.elasticache_mcp_server.context import Context
+    from awslabs.elasticache_mcp_server.tools.serverless.connect import (
+        get_ssh_tunnel_command_serverless,
+    )
+    from unittest.mock import MagicMock, patch
+
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [
+            {
+                'Instances': [
+                    {
+                        'KeyName': 'mykey',
+                        'PublicDnsName': 'ec2.example.com',
+                        'Platform': '',
+                        'ImageId': 'ami-123',
+                    }
+                ]
+            }
+        ]
+    }
+    mock_elasticache = MagicMock()
+    mock_elasticache.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [
+            {'Endpoint': {'Address': 'cache.example.com', 'Port': 6379}, 'Engine': 'redis'}
+        ]
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.EC2ConnectionManager.get_connection',
+            return_value=mock_ec2,
+        ),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_elasticache,
+        ),
+    ):
+        result = await get_ssh_tunnel_command_serverless(
+            serverless_cache_name='test-cache', instance_id='i-123'
+        )
+        assert 'error' not in result
+        assert 'command' in result

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_create.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_create.py
@@ -1,6 +1,7 @@
 """Tests for the create serverless tool."""
 
 import pytest  # type: ignore
+from awslabs.elasticache_mcp_server.context import Context
 from awslabs.elasticache_mcp_server.tools.serverless.create import create_serverless_cache
 from awslabs.elasticache_mcp_server.tools.serverless.models import (
     CacheUsageLimits,
@@ -10,6 +11,30 @@ from awslabs.elasticache_mcp_server.tools.serverless.models import (
     Tag,
 )
 from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_create_serverless_cache_readonly_mode():
+    """Test creating a serverless cache in readonly mode."""
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        request = CreateServerlessCacheRequest(
+            serverless_cache_name='test-cache',
+            engine='redis',
+            description=None,
+            kms_key_id=None,
+            major_engine_version=None,
+            snapshot_arns_to_restore=None,
+            subnet_ids=None,
+            tags=None,
+            security_group_ids=None,
+            cache_usage_limits=None,
+            user_group_id=None,
+            snapshot_retention_limit=None,
+            daily_snapshot_time=None,
+        )
+        result = await create_serverless_cache(request)
+        assert 'error' in result
+        assert 'readonly mode' in result['error']
 
 
 @pytest.mark.asyncio

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_delete.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_delete.py
@@ -1,8 +1,18 @@
 """Tests for the delete serverless tool."""
 
 import pytest
+from awslabs.elasticache_mcp_server.context import Context
 from awslabs.elasticache_mcp_server.tools.serverless.delete import delete_serverless_cache
 from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_delete_serverless_cache_readonly_mode():
+    """Test deleting a serverless cache in readonly mode."""
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        result = await delete_serverless_cache(serverless_cache_name='test-cache')
+        assert 'error' in result
+        assert 'readonly mode' in result['error']
 
 
 @pytest.mark.asyncio

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_describe.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_describe.py
@@ -189,3 +189,25 @@ async def test_describe_serverless_caches_invalid_parameter():
             str(getattr(mock_client.exceptions, 'InvalidParameterValueException')())
             in result['error']
         )
+
+
+@pytest.mark.asyncio
+async def test_describe_serverless_caches_works_in_readonly_mode():
+    """Test that describe works even when readonly mode is enabled."""
+    from awslabs.elasticache_mcp_server.context import Context
+
+    mock_client = MagicMock()
+    mock_client.describe_serverless_caches.return_value = {
+        'ServerlessCaches': [{'ServerlessCacheName': 'test-cache'}]
+    }
+
+    with (
+        patch.object(Context, 'readonly_mode', return_value=True),
+        patch(
+            'awslabs.elasticache_mcp_server.common.connection.ElastiCacheConnectionManager.get_connection',
+            return_value=mock_client,
+        ),
+    ):
+        result = await describe_serverless_caches()
+        assert 'error' not in result
+        assert 'ServerlessCaches' in result

--- a/src/elasticache-mcp-server/tests/tools/serverless/test_modify.py
+++ b/src/elasticache-mcp-server/tests/tools/serverless/test_modify.py
@@ -1,6 +1,7 @@
 """Tests for the modify serverless tool."""
 
 import pytest
+from awslabs.elasticache_mcp_server.context import Context
 from awslabs.elasticache_mcp_server.tools.serverless.models import (
     CacheUsageLimits,
     DataStorageLimits,
@@ -9,6 +10,26 @@ from awslabs.elasticache_mcp_server.tools.serverless.models import (
 )
 from awslabs.elasticache_mcp_server.tools.serverless.modify import modify_serverless_cache
 from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_modify_serverless_cache_readonly_mode():
+    """Test modifying a serverless cache in readonly mode."""
+    with patch.object(Context, 'readonly_mode', return_value=True):
+        request = ModifyServerlessCacheRequest(
+            serverless_cache_name='test-cache',
+            description='Updated Cache',
+            major_engine_version=None,
+            snapshot_retention_limit=None,
+            daily_snapshot_time=None,
+            cache_usage_limits=None,
+            remove_user_group=None,
+            user_group_id=None,
+            security_group_ids=None,
+        )
+        result = await modify_serverless_cache(request)
+        assert 'error' in result
+        assert 'readonly mode' in result['error']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

The `--readonly` flag was enforced on `create-serverless-cache` but missing on `delete-serverless-cache` and `modify-serverless-cache`, allowing those operations to reach AWS APIs when readonly mode was enabled.

**Fix approach:** Rather than adding inline checks to the two affected tools (which doesn't prevent future regressions), this PR moves readonly enforcement into the `handle_exceptions` decorator — which is already applied to every tool. Tools are now blocked by default in readonly mode unless explicitly marked with `@readonly_safe`.

**Why this approach:**
- **Default-deny** — new tools are blocked in readonly mode unless the author explicitly marks them safe. Forgetting the marker results in an overly-restricted tool (safe failure), not a bypass (security hole).
- **Minimal per-tool diff** — read-only tools get a one-line `@readonly_safe` decorator. Mutating tools need no changes.
- **No framework exists** — the awslabs/mcp mono-repo has no shared readonly mechanism. Each server implements its own. Peer servers (aurora-dsql, postgres, dataprocessing) all use inline checks with no decorator precedent.

**Alternatives considered:**
- Inline fix only (2 files): Fixes the bug but doesn't prevent future regressions.
- Opt-in `@require_write_access` decorator: Same refactor cost but still opt-in — forgetting it leaves a gap.
- Custom tool registrar wrapping `@mcp.tool`: Largest refactor, deviates from mono-repo conventions.

### User experience

**Before:** A server configured with `--readonly` could still delete or modify serverless caches.

**After:** All mutating operations are blocked in readonly mode. Read-only operations (describe, list, get-ssh-tunnel-command, test-migration) continue to work normally.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? Y — Tools that extend this server and use `@handle_exceptions` will now be blocked in readonly mode unless marked with `@readonly_safe`. This is intentional to prevent future readonly bypasses.

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
