### PR TITLE
fix(openapi-mcp-server): update additional specs logic

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -627,7 +627,7 @@
         "filename": "src/openapi-mcp-server/README.md",
         "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
         "is_verified": false,
-        "line_number": 271,
+        "line_number": 302,
         "is_secret": false
       },
       {
@@ -635,7 +635,7 @@
         "filename": "src/openapi-mcp-server/README.md",
         "hashed_secret": "594fd1615a341c77829e83ed988f137e1ba96231",
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 303,
         "is_secret": false
       }
     ],

--- a/src/openapi-mcp-server/README.md
+++ b/src/openapi-mcp-server/README.md
@@ -16,7 +16,8 @@ This project is a server that dynamically creates Model Context Protocol (MCP) t
 - **Enriched Tool Descriptions**: Automatically appends response codes and parameter examples from the OpenAPI spec to tool descriptions, helping LLMs make better tool selections
 - **Multi-spec Composition**: Combine multiple OpenAPI specs into a single MCP server
   - Configure via `--additional-specs` CLI arg or `ADDITIONAL_SPECS` env var
-  - Each spec gets its own HTTP client with shared auth configuration
+  - Each spec gets its own HTTP client with independent per-spec authentication
+  - Primary API credentials are **never** sent to additional specs unless explicitly opted in via `"auth": "inherit"`
 - **Output Validation Toggle**: Disable response schema validation for APIs with loose specs via `--no-validate-output` or `VALIDATE_OUTPUT=false`
 - **Dynamic Prompt Generation**: Creates helpful prompts based on API structure
   - **Operation-Specific Prompts**: Generates natural language prompts for each API operation
@@ -28,7 +29,7 @@ This project is a server that dynamically creates Model Context Protocol (MCP) t
 - **Transport Options**: Supports stdio transport
 - **Flexible Configuration**: Configure via environment variables or command line arguments
 - **OpenAPI Support**: Works with OpenAPI 3.x specifications in JSON or YAML format
-- **OpenAPI Specification Validation**: Validates specifications without failing startup if issues detected, logging warnings instead to work with specs having minor issues or non-standard extensions
+- **OpenAPI Specification Validation**: Validates the primary specification without failing startup if issues detected (logging warnings). Additional specs that fail validation are skipped by default unless `allow_invalid` is set.
 - **Authentication Support**: Supports multiple authentication methods (Basic, Bearer Token, API Key, Cognito)
 - **AWS Best Practices**: Implements AWS best practices for caching, resilience, and observability
 - **Comprehensive Testing**: Includes extensive unit and integration tests with high code coverage
@@ -184,14 +185,44 @@ awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://
 ### Multi-spec Composition
 
 ```bash
-# Combine multiple APIs into one MCP server
+# Combine multiple APIs into one MCP server (additional spec uses its own bearer token)
 awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
-  --additional-specs '[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com"}]'
+  --additional-specs '[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com","auth":{"type":"bearer","token":"PAYMENTS_TOKEN"}}]'
+
+# Additional spec with no auth (default — unauthenticated requests)
+awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
+  --additional-specs '[{"name":"public-api","spec_url":"https://public.example.com/openapi.json","base_url":"https://public.example.com"}]'
+
+# Explicitly inherit primary API auth (only when additional spec is under the same trust boundary)
+awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
+  --additional-specs '[{"name":"internal","spec_url":"https://api.example.com/v2/openapi.json","base_url":"https://api.example.com/v2","auth":"inherit"}]'
 
 # Additional specs may also use a local OpenAPI file via spec_path
 awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
-  --additional-specs '[{"name":"payments","spec_path":"./specs/payments-openapi.json","base_url":"https://payments.example.com"}]'
+  --additional-specs '[{"name":"payments","spec_path":"./specs/payments-openapi.json","base_url":"https://payments.example.com","auth":{"type":"api_key","key":"MY_KEY","key_name":"X-API-Key","key_in":"header"}}]'
 ```
+
+#### Per-spec Authentication
+
+Each additional spec entry supports the following `auth` configurations:
+
+| Value | Behavior |
+|-------|----------|
+| *(absent or null)* | No credentials sent — unauthenticated requests (secure default) |
+| `"inherit"` | Explicitly reuse the primary API's auth headers, cookies, and httpx auth |
+| `{"type": "bearer", "token": "..."}` | Bearer token authentication |
+| `{"type": "api_key", "key": "...", "key_name": "...", "key_in": "header\|cookie"}` | API key authentication (`query` is accepted but falls back to header) |
+| `{"type": "basic", "username": "...", "password": "..."}` | HTTP Basic authentication |
+| `{"type": "none"}` | Explicit no-auth (same as absent) |
+
+**Security note:** The primary API's credentials are never forwarded to additional specs unless you explicitly set `"auth": "inherit"`. Only use `"inherit"` when the additional spec's `base_url` is under the same trust boundary as your primary API.
+
+#### Spec Validation
+
+By default, additional specs that fail OpenAPI validation are **skipped** (not loaded). To override this behavior:
+
+- Per-spec: add `"allow_invalid": true` to the spec entry
+- Globally: set environment variable `ADDITIONAL_SPECS_ALLOW_INVALID=true`
 
 ### Disable Output Validation
 
@@ -279,8 +310,13 @@ export EXCLUDE_TAGS="admin,internal"  # Hide operations with these tags
 export VALIDATE_OUTPUT="true"  # Set to "false" to disable response schema validation
 
 # Multi-spec composition
-# Each additional spec requires base_url and either spec_url or spec_path
-export ADDITIONAL_SPECS='[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com"},{"name":"billing","spec_path":"./specs/billing-openapi.json","base_url":"https://billing.example.com"}]'
+# Each additional spec requires base_url and either spec_url or spec_path.
+# Auth is per-spec: use "auth" field to configure. Primary API credentials are NEVER
+# sent to additional specs unless "auth": "inherit" is explicitly set.
+export ADDITIONAL_SPECS='[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com","auth":{"type":"bearer","token":"PAYMENTS_TOKEN"}},{"name":"internal","spec_path":"./specs/internal-openapi.json","base_url":"https://api.example.com/internal","auth":"inherit"}]'
+
+# Allow additional specs with invalid OpenAPI schemas to load (default: false)
+export ADDITIONAL_SPECS_ALLOW_INVALID="false"
 ```
 
 ## Documentation

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -315,9 +315,9 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         if config.additional_specs:
             import json
 
-            allow_invalid_specs = os.environ.get(
-                'ADDITIONAL_SPECS_ALLOW_INVALID', 'false'
-            ).lower() == 'true'
+            allow_invalid_specs = (
+                os.environ.get('ADDITIONAL_SPECS_ALLOW_INVALID', 'false').lower() == 'true'
+            )
 
             try:
                 extra_specs = json.loads(config.additional_specs)
@@ -375,7 +375,10 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                     # SECURITY: Do NOT inherit primary API auth by default to prevent
                     # credential leakage to untrusted endpoints (CWE-522).
                     extra_auth_config = entry.get('auth')
-                    if isinstance(extra_auth_config, str) and extra_auth_config.lower() == 'inherit':
+                    if (
+                        isinstance(extra_auth_config, str)
+                        and extra_auth_config.lower() == 'inherit'
+                    ):
                         extra_headers = auth_headers
                         extra_httpx_auth = httpx_auth
                         extra_cookies = auth_cookies

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -16,6 +16,7 @@
 import argparse
 import asyncio
 import httpx
+import os
 import re
 import signal
 import sys
@@ -30,7 +31,7 @@ from awslabs.openapi_mcp_server.utils.openapi import load_openapi_spec
 from awslabs.openapi_mcp_server.utils.openapi_validator import validate_openapi_spec
 from fastmcp import FastMCP
 from fastmcp.server.providers.openapi import MCPType, OpenAPIProvider, RouteMap
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 
 _HTTP_METHODS = {'get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace'}
@@ -59,6 +60,69 @@ def _build_route_maps(spec: Dict[str, Any]) -> list:
                         )
                     )
     return mappings
+
+
+def _build_additional_spec_auth(
+    auth_config: dict,
+) -> Tuple[Dict[str, str], Optional[httpx.Auth], Dict[str, str]]:
+    """Build authentication components for an additional spec from its per-spec auth config.
+
+    Args:
+        auth_config: Auth configuration dict from the additional spec entry.
+            Supported formats:
+            - {"type": "bearer", "token": "..."}
+            - {"type": "api_key", "key": "...", "key_name": "...", "key_in": "header|query|cookie"}
+            - {"type": "basic", "username": "...", "password": "..."}
+            - {"type": "none"} (explicit no-auth)
+
+    Returns:
+        Tuple of (headers, httpx_auth, cookies)
+
+    Raises:
+        ValueError: If auth_config is invalid or missing required fields.
+
+    """
+    auth_type = auth_config.get('type', '').lower()
+
+    if auth_type == 'none' or not auth_type:
+        return {}, None, {}
+
+    if auth_type == 'bearer':
+        token = auth_config.get('token', '')
+        if not token:
+            raise ValueError("Bearer auth requires 'token' field")
+        return {'Authorization': f'Bearer {token}'}, None, {}
+
+    if auth_type == 'api_key':
+        key = auth_config.get('key', '')
+        key_name = auth_config.get('key_name', 'api_key')
+        key_in = auth_config.get('key_in', 'header').lower()
+        if not key:
+            raise ValueError("API key auth requires 'key' field")
+        if key_in not in ('header', 'query', 'cookie'):
+            raise ValueError(f"Invalid key_in value: '{key_in}'. Must be header, query, or cookie")
+        if key_in == 'header':
+            return {key_name: key}, None, {}
+        elif key_in == 'cookie':
+            return {}, None, {key_name: key}
+        else:
+            # HttpClientFactory does not support per-request query params, so query-based
+            # API keys cannot be sent as URL parameters. Fall back to sending the key as
+            # a request header instead, which may not work with all APIs.
+            logger.warning(
+                f"API key in 'query' is not fully supported for additional specs. "
+                f"Using header '{key_name}' instead."
+            )
+            return {key_name: key}, None, {}
+
+    if auth_type == 'basic':
+        username = auth_config.get('username', '')
+        password = auth_config.get('password', '')
+        if not username or not password:
+            raise ValueError("Basic auth requires 'username' and 'password' fields")
+        return {}, httpx.BasicAuth(username=username, password=password), {}
+
+    raise ValueError(f"Unsupported auth type for additional spec: '{auth_type}'")
 
 
 async def create_mcp_server_async(config: Config) -> FastMCP:
@@ -251,6 +315,10 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         if config.additional_specs:
             import json
 
+            allow_invalid_specs = os.environ.get(
+                'ADDITIONAL_SPECS_ALLOW_INVALID', 'false'
+            ).lower() == 'true'
+
             try:
                 extra_specs = json.loads(config.additional_specs)
                 if not isinstance(extra_specs, list):
@@ -278,26 +346,97 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                         logger.warning(f'Failed to load additional spec {extra_name}: {e}')
                         continue
 
+                    # Validate spec — skip on failure unless explicitly allowed
+                    raw_allow_invalid = entry.get('allow_invalid')
+                    if raw_allow_invalid is None:
+                        entry_allow_invalid = allow_invalid_specs
+                    elif isinstance(raw_allow_invalid, bool):
+                        entry_allow_invalid = raw_allow_invalid
+                    elif isinstance(raw_allow_invalid, str):
+                        entry_allow_invalid = raw_allow_invalid.lower() in ('true', '1', 'yes')
+                    else:
+                        entry_allow_invalid = allow_invalid_specs
+
                     if not validate_openapi_spec(extra_spec):
-                        logger.warning(
-                            f'Additional spec {extra_name} validation failed, continuing anyway'
+                        if entry_allow_invalid:
+                            logger.warning(
+                                f'Additional spec {extra_name} validation failed, '
+                                f'continuing because allow_invalid is set'
+                            )
+                        else:
+                            logger.error(
+                                f'Additional spec {extra_name} validation failed. '
+                                f'Skipping this spec. Set "allow_invalid": true in the '
+                                f'spec entry or ADDITIONAL_SPECS_ALLOW_INVALID=true to override.'
+                            )
+                            continue
+
+                    # Determine authentication for this additional spec.
+                    # SECURITY: Do NOT inherit primary API auth by default to prevent
+                    # credential leakage to untrusted endpoints (CWE-522).
+                    extra_auth_config = entry.get('auth')
+                    if isinstance(extra_auth_config, str) and extra_auth_config.lower() == 'inherit':
+                        extra_headers = auth_headers
+                        extra_httpx_auth = httpx_auth
+                        extra_cookies = auth_cookies
+                        logger.info(
+                            f'Additional spec {extra_name}: inheriting primary auth '
+                            f'(explicit opt-in via "auth": "inherit")'
                         )
-                    extra_client = HttpClientFactory.create_client(
-                        base_url=extra_base_url,
-                        headers=auth_headers,
-                        auth=httpx_auth,
-                        cookies=auth_cookies,
-                    )
-                    providers.append(
-                        OpenAPIProvider(
-                            openapi_spec=extra_spec,
-                            client=extra_client,
-                            route_maps=_build_route_maps(extra_spec),
-                            mcp_component_fn=enrich_component,
-                            validate_output=config.validate_output,
+                    elif isinstance(extra_auth_config, dict):
+                        try:
+                            extra_headers, extra_httpx_auth, extra_cookies = (
+                                _build_additional_spec_auth(extra_auth_config)
+                            )
+                            logger.info(
+                                f'Additional spec {extra_name}: using per-spec auth '
+                                f'(type={extra_auth_config.get("type", "unknown")})'
+                            )
+                        except ValueError as e:
+                            logger.error(
+                                f'Additional spec {extra_name}: invalid auth config: {e}. '
+                                f'Skipping this spec.'
+                            )
+                            continue
+                    elif extra_auth_config is not None:
+                        logger.error(
+                            f'Additional spec {extra_name}: invalid "auth" value: '
+                            f'{extra_auth_config!r}. Expected null, "inherit", or a dict '
+                            f'with "type" field. Skipping this spec.'
                         )
-                    )
-                    logger.info(f'Added additional spec: {extra_name}')
+                        continue
+                    else:
+                        extra_headers = {}
+                        extra_httpx_auth = None
+                        extra_cookies = {}
+                        logger.info(
+                            f'Additional spec {extra_name}: no auth configured, '
+                            f'sending unauthenticated requests'
+                        )
+
+                    try:
+                        extra_client = HttpClientFactory.create_client(
+                            base_url=extra_base_url,
+                            headers=extra_headers,
+                            auth=extra_httpx_auth,
+                            cookies=extra_cookies,
+                        )
+                        providers.append(
+                            OpenAPIProvider(
+                                openapi_spec=extra_spec,
+                                client=extra_client,
+                                route_maps=_build_route_maps(extra_spec),
+                                mcp_component_fn=enrich_component,
+                                validate_output=config.validate_output,
+                            )
+                        )
+                        logger.info(f'Added additional spec: {extra_name}')
+                    except Exception as e:
+                        logger.error(
+                            f'Additional spec {extra_name}: failed to create HTTP client '
+                            f'or provider: {e}. Skipping this spec.'
+                        )
+                        continue
             except (json.JSONDecodeError, TypeError) as e:
                 logger.warning(f'Failed to parse additional specs: {e}')
 

--- a/src/openapi-mcp-server/tests/test_additional_spec_auth.py
+++ b/src/openapi-mcp-server/tests/test_additional_spec_auth.py
@@ -1,0 +1,675 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for additional spec per-spec auth and validation (CWE-522: credential leakage prevention)."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from awslabs.openapi_mcp_server.api.config import Config
+from awslabs.openapi_mcp_server.server import (
+    _build_additional_spec_auth,
+    create_mcp_server,
+)
+
+
+# --- Unit tests for _build_additional_spec_auth ---
+
+
+class TestBuildAdditionalSpecAuth:
+    """Tests for the _build_additional_spec_auth helper function."""
+
+    def test_bearer_auth(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth(
+            {'type': 'bearer', 'token': 'my-secret-token'}
+        )
+        assert headers == {'Authorization': 'Bearer my-secret-token'}
+        assert httpx_auth is None
+        assert cookies == {}
+
+    def test_bearer_auth_missing_token(self):
+        with pytest.raises(ValueError, match="Bearer auth requires 'token' field"):
+            _build_additional_spec_auth({'type': 'bearer'})
+
+    def test_bearer_auth_empty_token(self):
+        with pytest.raises(ValueError, match="Bearer auth requires 'token' field"):
+            _build_additional_spec_auth({'type': 'bearer', 'token': ''})
+
+    def test_api_key_in_header(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth(
+            {'type': 'api_key', 'key': 'abc123', 'key_name': 'X-API-Key', 'key_in': 'header'}
+        )
+        assert headers == {'X-API-Key': 'abc123'}
+        assert httpx_auth is None
+        assert cookies == {}
+
+    def test_api_key_in_cookie(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth(
+            {'type': 'api_key', 'key': 'abc123', 'key_name': 'session', 'key_in': 'cookie'}
+        )
+        assert headers == {}
+        assert httpx_auth is None
+        assert cookies == {'session': 'abc123'}
+
+    def test_api_key_default_header(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth(
+            {'type': 'api_key', 'key': 'abc123'}
+        )
+        assert headers == {'api_key': 'abc123'}
+        assert httpx_auth is None
+        assert cookies == {}
+
+    def test_api_key_missing_key(self):
+        with pytest.raises(ValueError, match="API key auth requires 'key' field"):
+            _build_additional_spec_auth({'type': 'api_key', 'key_name': 'X-Key'})
+
+    def test_api_key_invalid_location(self):
+        with pytest.raises(ValueError, match="Invalid key_in value"):
+            _build_additional_spec_auth(
+                {'type': 'api_key', 'key': 'abc', 'key_in': 'body'}
+            )
+
+    def test_basic_auth(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth(
+            {'type': 'basic', 'username': 'user', 'password': 'pass'}
+        )
+        assert headers == {}
+        assert httpx_auth is not None
+        assert cookies == {}
+        # Verify it's an httpx.BasicAuth
+        import httpx
+
+        assert isinstance(httpx_auth, httpx.BasicAuth)
+
+    def test_basic_auth_missing_username(self):
+        with pytest.raises(ValueError, match="Basic auth requires 'username' and 'password'"):
+            _build_additional_spec_auth({'type': 'basic', 'password': 'pass'})
+
+    def test_basic_auth_missing_password(self):
+        with pytest.raises(ValueError, match="Basic auth requires 'username' and 'password'"):
+            _build_additional_spec_auth({'type': 'basic', 'username': 'user'})
+
+    def test_none_auth(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth({'type': 'none'})
+        assert headers == {}
+        assert httpx_auth is None
+        assert cookies == {}
+
+    def test_empty_type(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth({'type': ''})
+        assert headers == {}
+        assert httpx_auth is None
+        assert cookies == {}
+
+    def test_missing_type(self):
+        headers, httpx_auth, cookies = _build_additional_spec_auth({})
+        assert headers == {}
+        assert httpx_auth is None
+        assert cookies == {}
+
+    def test_unsupported_type(self):
+        with pytest.raises(ValueError, match="Unsupported auth type"):
+            _build_additional_spec_auth({'type': 'oauth2'})
+
+    def test_api_key_query_falls_back_to_header(self):
+        """API key in query is not fully supported; falls back to header with warning."""
+        headers, httpx_auth, cookies = _build_additional_spec_auth(
+            {'type': 'api_key', 'key': 'abc123', 'key_name': 'api_key', 'key_in': 'query'}
+        )
+        assert headers == {'api_key': 'abc123'}
+        assert httpx_auth is None
+        assert cookies == {}
+
+
+# --- Integration tests for additional specs in create_mcp_server ---
+
+
+SAMPLE_SPEC = {
+    'openapi': '3.0.0',
+    'info': {'title': 'Test API', 'version': '1.0.0'},
+    'paths': {},
+}
+
+
+def _make_mock_auth(headers=None, cookies=None, httpx_auth=None):
+    """Create a mock auth provider."""
+    mock_auth = MagicMock()
+    mock_auth.is_configured.return_value = True
+    mock_auth.get_auth_headers.return_value = headers or {}
+    mock_auth.get_auth_params.return_value = {}
+    mock_auth.get_auth_cookies.return_value = cookies or {}
+    mock_auth.get_httpx_auth.return_value = httpx_auth
+    mock_auth.provider_name = 'test_auth'
+    return mock_auth
+
+
+class TestAdditionalSpecIntegration:
+    """Integration tests for additional spec auth in create_mcp_server."""
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_no_auth_by_default(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs without 'auth' field should NOT receive primary credentials."""
+        mock_get_auth.return_value = _make_mock_auth(
+            headers={'Authorization': 'Bearer primary-token'}
+        )
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'partner', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com'}
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        assert mock_create_client.call_count == 2
+        _, kwargs = mock_create_client.call_args_list[1]
+        assert kwargs['headers'] == {}
+        assert kwargs['auth'] is None
+        assert kwargs['cookies'] == {}
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_inherit_auth(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs with 'auth': 'inherit' should receive primary credentials."""
+        mock_get_auth.return_value = _make_mock_auth(
+            headers={'Authorization': 'Bearer primary-token'}
+        )
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'internal', 'spec_url': 'https://api.example.com/v2/spec.json', 'base_url': 'https://api.example.com/v2', 'auth': 'inherit'}
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        assert mock_create_client.call_count == 2
+        _, kwargs = mock_create_client.call_args_list[1]
+        assert kwargs['headers'] == {'Authorization': 'Bearer primary-token'}
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_per_spec_bearer_auth(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs with per-spec bearer auth should use their own token."""
+        mock_get_auth.return_value = _make_mock_auth(
+            headers={'Authorization': 'Bearer primary-token'}
+        )
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {
+                    'name': 'partner',
+                    'spec_url': 'https://partner.com/spec.json',
+                    'base_url': 'https://partner.com',
+                    'auth': {'type': 'bearer', 'token': 'partner-token'},
+                }
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        assert mock_create_client.call_count == 2
+        _, kwargs = mock_create_client.call_args_list[1]
+        assert kwargs['headers'] == {'Authorization': 'Bearer partner-token'}
+        assert kwargs['auth'] is None
+        assert kwargs['cookies'] == {}
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_per_spec_api_key_auth(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs with per-spec API key auth should use their own key."""
+        mock_get_auth.return_value = _make_mock_auth(
+            headers={'Authorization': 'Bearer primary-token'}
+        )
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {
+                    'name': 'partner',
+                    'spec_url': 'https://partner.com/spec.json',
+                    'base_url': 'https://partner.com',
+                    'auth': {'type': 'api_key', 'key': 'partner-key', 'key_name': 'X-Partner-Key', 'key_in': 'header'},
+                }
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        assert mock_create_client.call_count == 2
+        _, kwargs = mock_create_client.call_args_list[1]
+        assert kwargs['headers'] == {'X-Partner-Key': 'partner-key'}
+        assert kwargs['auth'] is None
+        assert kwargs['cookies'] == {}
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_invalid_auth_config_skips_spec(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs with invalid auth config should be skipped."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {
+                    'name': 'bad-auth',
+                    'spec_url': 'https://partner.com/spec.json',
+                    'base_url': 'https://partner.com',
+                    'auth': {'type': 'bearer'},  # missing token
+                }
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        # Only primary client should be created (additional spec skipped)
+        assert mock_create_client.call_count == 1
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_validation_failure_skips_by_default(
+        self,
+        mock_create_client,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs that fail validation should be skipped by default."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'bad-spec', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com'}
+            ]),
+        )
+
+        with patch(
+            'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+            side_effect=[True, False],
+        ):
+            create_mcp_server(config)
+
+        # Only primary client should be created
+        assert mock_create_client.call_count == 1
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_validation_failure_allowed_per_spec(
+        self,
+        mock_create_client,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Additional specs with allow_invalid=true should load despite validation failure."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {
+                    'name': 'loose-spec',
+                    'spec_url': 'https://partner.com/spec.json',
+                    'base_url': 'https://partner.com',
+                    'allow_invalid': True,
+                }
+            ]),
+        )
+
+        with patch(
+            'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+            side_effect=[True, False],
+        ):
+            create_mcp_server(config)
+
+        # Both primary and additional client should be created
+        assert mock_create_client.call_count == 2
+
+    @patch.dict('os.environ', {'ADDITIONAL_SPECS_ALLOW_INVALID': 'true'})
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_validation_failure_allowed_globally(
+        self,
+        mock_create_client,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """ADDITIONAL_SPECS_ALLOW_INVALID=true should allow invalid specs globally."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'loose-spec', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com'}
+            ]),
+        )
+
+        with patch(
+            'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+            side_effect=[True, False],
+        ):
+            create_mcp_server(config)
+
+        # Both primary and additional client should be created
+        assert mock_create_client.call_count == 2
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_primary_creds_never_leak_by_default(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """Core security test: primary bearer token must NOT appear in additional spec client."""
+        mock_get_auth.return_value = _make_mock_auth(
+            headers={'Authorization': 'Bearer super-secret-primary-token'}
+        )
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'attacker', 'spec_url': 'https://evil.com/spec.json', 'base_url': 'https://evil.com'}
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        assert mock_create_client.call_count == 2
+
+        # Verify additional spec client does NOT have the primary token
+        _, kwargs = mock_create_client.call_args_list[1]
+        headers = kwargs.get('headers', {})
+        auth = kwargs.get('auth')
+        cookies = kwargs.get('cookies', {})
+
+        assert 'Authorization' not in headers
+        assert 'super-secret-primary-token' not in str(headers)
+        assert auth is None
+        assert cookies == {}
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_inherit_case_insensitive(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """'auth': 'INHERIT' (case-insensitive) should inherit primary credentials."""
+        mock_get_auth.return_value = _make_mock_auth(
+            headers={'Authorization': 'Bearer primary-token'}
+        )
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'internal', 'spec_url': 'https://api.example.com/v2/spec.json', 'base_url': 'https://api.example.com/v2', 'auth': 'INHERIT'}
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        assert mock_create_client.call_count == 2
+        _, kwargs = mock_create_client.call_args_list[1]
+        assert kwargs['headers'] == {'Authorization': 'Bearer primary-token'}
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_invalid_auth_type_boolean_skips_spec(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """'auth': true (invalid type) should skip the spec, not fall to no-auth."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'bad', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com', 'auth': True}
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        # Only primary client should be created (spec with invalid auth skipped)
+        assert mock_create_client.call_count == 1
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_invalid_auth_type_list_skips_spec(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """'auth': ["bearer"] (invalid type) should skip the spec."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'bad', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com', 'auth': ['bearer']}
+            ]),
+        )
+
+        create_mcp_server(config)
+
+        # Only primary client should be created (spec with invalid auth skipped)
+        assert mock_create_client.call_count == 1
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_allow_invalid_string_false_does_not_allow(
+        self,
+        mock_create_client,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """'allow_invalid': 'false' (string) should NOT allow invalid specs."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = Config(
+            api_name='test',
+            api_base_url='https://example.com/api',
+            api_spec_url='https://example.com/openapi.json',
+            additional_specs=json.dumps([
+                {'name': 'spec', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com', 'allow_invalid': 'false'}
+            ]),
+        )
+
+        with patch(
+            'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+            side_effect=[True, False],
+        ):
+            create_mcp_server(config)
+
+        # Only primary client — "false" string should NOT be truthy
+        assert mock_create_client.call_count == 1

--- a/src/openapi-mcp-server/tests/test_additional_spec_auth.py
+++ b/src/openapi-mcp-server/tests/test_additional_spec_auth.py
@@ -798,3 +798,89 @@ class TestAdditionalSpecIntegration:
 
         # Only primary — "false" string should NOT be truthy
         assert mock_create_client.call_count == 1
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_allow_invalid_non_bool_non_str_falls_back(
+        self,
+        mock_create_client,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """allow_invalid as non-bool/non-str (e.g. int) falls back to global."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        mock_create_client.return_value = MagicMock()
+
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'spec',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'allow_invalid': 1,
+                    }
+                ]
+            )
+        )
+
+        with patch(
+            'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+            side_effect=[True, False],
+        ):
+            create_mcp_server(config)
+
+        # Global default is false, so spec is skipped
+        assert mock_create_client.call_count == 1
+
+    @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
+    @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
+    @patch('awslabs.openapi_mcp_server.server.FastMCP')
+    @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
+    @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
+    def test_client_creation_failure_skips_spec(
+        self,
+        mock_create_client,
+        mock_validate,
+        mock_load_spec,
+        mock_fastmcp,
+        mock_openapi_provider,
+        mock_get_auth,
+    ):
+        """If HttpClientFactory.create_client raises, spec is skipped."""
+        mock_get_auth.return_value = _make_mock_auth()
+        mock_fastmcp.return_value = MagicMock()
+        mock_load_spec.return_value = SAMPLE_SPEC
+        # First call (primary) succeeds, second call (additional) raises
+        mock_create_client.side_effect = [
+            MagicMock(),
+            RuntimeError('connection pool exhausted'),
+        ]
+
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'broken',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                    }
+                ]
+            )
+        )
+
+        create_mcp_server(config)
+
+        # Server should still be created (failure doesn't crash)
+        mock_fastmcp.assert_called_once()

--- a/src/openapi-mcp-server/tests/test_additional_spec_auth.py
+++ b/src/openapi-mcp-server/tests/test_additional_spec_auth.py
@@ -11,17 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for additional spec per-spec auth and validation (CWE-522: credential leakage prevention)."""
+"""Tests for additional spec per-spec auth and validation (CWE-522)."""
 
 import json
 import pytest
-from unittest.mock import MagicMock, patch
-
 from awslabs.openapi_mcp_server.api.config import Config
-from awslabs.openapi_mcp_server.server import (
-    _build_additional_spec_auth,
-    create_mcp_server,
-)
+from awslabs.openapi_mcp_server.server import _build_additional_spec_auth, create_mcp_server
+from unittest.mock import MagicMock, patch
 
 
 # --- Unit tests for _build_additional_spec_auth ---
@@ -31,103 +27,152 @@ class TestBuildAdditionalSpecAuth:
     """Tests for the _build_additional_spec_auth helper function."""
 
     def test_bearer_auth(self):
+        """Test bearer token auth returns correct Authorization header."""
         headers, httpx_auth, cookies = _build_additional_spec_auth(
-            {'type': 'bearer', 'token': 'my-secret-token'}
+            {'type': 'bearer', 'token': 'my-test-token'}  # pragma: allowlist secret
         )
-        assert headers == {'Authorization': 'Bearer my-secret-token'}
+        assert headers == {
+            'Authorization': 'Bearer my-test-token'  # pragma: allowlist secret
+        }
         assert httpx_auth is None
         assert cookies == {}
 
     def test_bearer_auth_missing_token(self):
+        """Test bearer auth raises ValueError when token is missing."""
         with pytest.raises(ValueError, match="Bearer auth requires 'token' field"):
             _build_additional_spec_auth({'type': 'bearer'})
 
     def test_bearer_auth_empty_token(self):
+        """Test bearer auth raises ValueError when token is empty."""
         with pytest.raises(ValueError, match="Bearer auth requires 'token' field"):
-            _build_additional_spec_auth({'type': 'bearer', 'token': ''})
+            _build_additional_spec_auth(
+                {'type': 'bearer', 'token': ''}  # pragma: allowlist secret
+            )
 
     def test_api_key_in_header(self):
+        """Test API key placed in header."""
         headers, httpx_auth, cookies = _build_additional_spec_auth(
-            {'type': 'api_key', 'key': 'abc123', 'key_name': 'X-API-Key', 'key_in': 'header'}
+            {
+                'type': 'api_key',
+                'key': 'abc123',  # pragma: allowlist secret
+                'key_name': 'X-API-Key',
+                'key_in': 'header',
+            }
         )
         assert headers == {'X-API-Key': 'abc123'}
         assert httpx_auth is None
         assert cookies == {}
 
     def test_api_key_in_cookie(self):
+        """Test API key placed in cookie."""
         headers, httpx_auth, cookies = _build_additional_spec_auth(
-            {'type': 'api_key', 'key': 'abc123', 'key_name': 'session', 'key_in': 'cookie'}
+            {
+                'type': 'api_key',
+                'key': 'abc123',  # pragma: allowlist secret
+                'key_name': 'session',
+                'key_in': 'cookie',
+            }
         )
         assert headers == {}
         assert httpx_auth is None
         assert cookies == {'session': 'abc123'}
 
     def test_api_key_default_header(self):
+        """Test API key defaults to header location."""
         headers, httpx_auth, cookies = _build_additional_spec_auth(
-            {'type': 'api_key', 'key': 'abc123'}
+            {'type': 'api_key', 'key': 'abc123'}  # pragma: allowlist secret
         )
-        assert headers == {'api_key': 'abc123'}
+        assert headers == {'api_key': 'abc123'}  # pragma: allowlist secret
         assert httpx_auth is None
         assert cookies == {}
 
     def test_api_key_missing_key(self):
+        """Test API key auth raises ValueError when key is missing."""
         with pytest.raises(ValueError, match="API key auth requires 'key' field"):
             _build_additional_spec_auth({'type': 'api_key', 'key_name': 'X-Key'})
 
     def test_api_key_invalid_location(self):
-        with pytest.raises(ValueError, match="Invalid key_in value"):
+        """Test API key auth raises ValueError for invalid location."""
+        with pytest.raises(ValueError, match='Invalid key_in value'):
             _build_additional_spec_auth(
-                {'type': 'api_key', 'key': 'abc', 'key_in': 'body'}
+                {
+                    'type': 'api_key',
+                    'key': 'abc',  # pragma: allowlist secret
+                    'key_in': 'body',
+                }
             )
 
     def test_basic_auth(self):
+        """Test basic auth returns httpx.BasicAuth instance."""
         headers, httpx_auth, cookies = _build_additional_spec_auth(
-            {'type': 'basic', 'username': 'user', 'password': 'pass'}
+            {
+                'type': 'basic',
+                'username': 'user',
+                'password': 'pass',  # pragma: allowlist secret
+            }
         )
         assert headers == {}
         assert httpx_auth is not None
         assert cookies == {}
-        # Verify it's an httpx.BasicAuth
         import httpx
 
         assert isinstance(httpx_auth, httpx.BasicAuth)
 
     def test_basic_auth_missing_username(self):
-        with pytest.raises(ValueError, match="Basic auth requires 'username' and 'password'"):
-            _build_additional_spec_auth({'type': 'basic', 'password': 'pass'})
+        """Test basic auth raises ValueError when username is missing."""
+        with pytest.raises(
+            ValueError,
+            match="Basic auth requires 'username' and 'password'",
+        ):
+            _build_additional_spec_auth(
+                {'type': 'basic', 'password': 'pass'}  # pragma: allowlist secret
+            )
 
     def test_basic_auth_missing_password(self):
-        with pytest.raises(ValueError, match="Basic auth requires 'username' and 'password'"):
+        """Test basic auth raises ValueError when password is missing."""
+        with pytest.raises(
+            ValueError,
+            match="Basic auth requires 'username' and 'password'",
+        ):
             _build_additional_spec_auth({'type': 'basic', 'username': 'user'})
 
     def test_none_auth(self):
+        """Test explicit none auth returns empty credentials."""
         headers, httpx_auth, cookies = _build_additional_spec_auth({'type': 'none'})
         assert headers == {}
         assert httpx_auth is None
         assert cookies == {}
 
     def test_empty_type(self):
+        """Test empty type string returns empty credentials."""
         headers, httpx_auth, cookies = _build_additional_spec_auth({'type': ''})
         assert headers == {}
         assert httpx_auth is None
         assert cookies == {}
 
     def test_missing_type(self):
+        """Test missing type key returns empty credentials."""
         headers, httpx_auth, cookies = _build_additional_spec_auth({})
         assert headers == {}
         assert httpx_auth is None
         assert cookies == {}
 
     def test_unsupported_type(self):
-        with pytest.raises(ValueError, match="Unsupported auth type"):
+        """Test unsupported auth type raises ValueError."""
+        with pytest.raises(ValueError, match='Unsupported auth type'):
             _build_additional_spec_auth({'type': 'oauth2'})
 
     def test_api_key_query_falls_back_to_header(self):
-        """API key in query is not fully supported; falls back to header with warning."""
+        """API key in query is not fully supported; falls back to header."""
         headers, httpx_auth, cookies = _build_additional_spec_auth(
-            {'type': 'api_key', 'key': 'abc123', 'key_name': 'api_key', 'key_in': 'query'}
+            {
+                'type': 'api_key',
+                'key': 'abc123',  # pragma: allowlist secret
+                'key_name': 'api_key',
+                'key_in': 'query',
+            }
         )
-        assert headers == {'api_key': 'abc123'}
+        assert headers == {'api_key': 'abc123'}  # pragma: allowlist secret
         assert httpx_auth is None
         assert cookies == {}
 
@@ -154,6 +199,16 @@ def _make_mock_auth(headers=None, cookies=None, httpx_auth=None):
     return mock_auth
 
 
+def _test_config(additional_specs_json):
+    """Create a Config with the given additional_specs JSON string."""
+    return Config(
+        api_name='test',
+        api_base_url='https://example.com/api',
+        api_spec_url='https://example.com/openapi.json',
+        additional_specs=additional_specs_json,
+    )
+
+
 class TestAdditionalSpecIntegration:
     """Integration tests for additional spec auth in create_mcp_server."""
 
@@ -161,7 +216,10 @@ class TestAdditionalSpecIntegration:
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_no_auth_by_default(
         self,
@@ -172,21 +230,24 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs without 'auth' field should NOT receive primary credentials."""
+        """Additional specs without auth field get no credentials."""
         mock_get_auth.return_value = _make_mock_auth(
-            headers={'Authorization': 'Bearer primary-token'}
+            headers={'Authorization': 'Bearer primary-token'}  # pragma: allowlist secret
         )
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'partner', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'partner',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
@@ -201,7 +262,10 @@ class TestAdditionalSpecIntegration:
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_inherit_auth(
         self,
@@ -212,34 +276,43 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs with 'auth': 'inherit' should receive primary credentials."""
+        """Additional specs with auth=inherit receive primary credentials."""
         mock_get_auth.return_value = _make_mock_auth(
-            headers={'Authorization': 'Bearer primary-token'}
+            headers={'Authorization': 'Bearer primary-token'}  # pragma: allowlist secret
         )
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'internal', 'spec_url': 'https://api.example.com/v2/spec.json', 'base_url': 'https://api.example.com/v2', 'auth': 'inherit'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'internal',
+                        'spec_url': 'https://api.example.com/v2/spec.json',
+                        'base_url': 'https://api.example.com/v2',
+                        'auth': 'inherit',
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
 
         assert mock_create_client.call_count == 2
         _, kwargs = mock_create_client.call_args_list[1]
-        assert kwargs['headers'] == {'Authorization': 'Bearer primary-token'}
+        assert kwargs['headers'] == {
+            'Authorization': 'Bearer primary-token'  # pragma: allowlist secret
+        }
 
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_per_spec_bearer_auth(
         self,
@@ -250,33 +323,37 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs with per-spec bearer auth should use their own token."""
+        """Additional specs with per-spec bearer use their own token."""
         mock_get_auth.return_value = _make_mock_auth(
-            headers={'Authorization': 'Bearer primary-token'}
+            headers={'Authorization': 'Bearer primary-token'}  # pragma: allowlist secret
         )
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {
-                    'name': 'partner',
-                    'spec_url': 'https://partner.com/spec.json',
-                    'base_url': 'https://partner.com',
-                    'auth': {'type': 'bearer', 'token': 'partner-token'},
-                }
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'partner',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'auth': {
+                            'type': 'bearer',
+                            'token': 'partner-token',  # pragma: allowlist secret
+                        },
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
 
         assert mock_create_client.call_count == 2
         _, kwargs = mock_create_client.call_args_list[1]
-        assert kwargs['headers'] == {'Authorization': 'Bearer partner-token'}
+        assert kwargs['headers'] == {
+            'Authorization': 'Bearer partner-token'  # pragma: allowlist secret
+        }
         assert kwargs['auth'] is None
         assert kwargs['cookies'] == {}
 
@@ -284,7 +361,10 @@ class TestAdditionalSpecIntegration:
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_per_spec_api_key_auth(
         self,
@@ -295,26 +375,30 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs with per-spec API key auth should use their own key."""
+        """Additional specs with per-spec API key use their own key."""
         mock_get_auth.return_value = _make_mock_auth(
-            headers={'Authorization': 'Bearer primary-token'}
+            headers={'Authorization': 'Bearer primary-token'}  # pragma: allowlist secret
         )
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {
-                    'name': 'partner',
-                    'spec_url': 'https://partner.com/spec.json',
-                    'base_url': 'https://partner.com',
-                    'auth': {'type': 'api_key', 'key': 'partner-key', 'key_name': 'X-Partner-Key', 'key_in': 'header'},
-                }
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'partner',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'auth': {
+                            'type': 'api_key',
+                            'key': 'partner-key',  # pragma: allowlist secret
+                            'key_name': 'X-Partner-Key',
+                            'key_in': 'header',
+                        },
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
@@ -329,7 +413,10 @@ class TestAdditionalSpecIntegration:
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_invalid_auth_config_skips_spec(
         self,
@@ -340,24 +427,23 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs with invalid auth config should be skipped."""
+        """Additional specs with invalid auth config are skipped."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {
-                    'name': 'bad-auth',
-                    'spec_url': 'https://partner.com/spec.json',
-                    'base_url': 'https://partner.com',
-                    'auth': {'type': 'bearer'},  # missing token
-                }
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'bad-auth',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'auth': {'type': 'bearer'},  # missing token
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
@@ -378,19 +464,22 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs that fail validation should be skipped by default."""
+        """Additional specs that fail validation are skipped by default."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'bad-spec', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'bad-spec',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                    }
+                ]
+            )
         )
 
         with patch(
@@ -415,24 +504,23 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Additional specs with allow_invalid=true should load despite validation failure."""
+        """Specs with allow_invalid=true load despite validation failure."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {
-                    'name': 'loose-spec',
-                    'spec_url': 'https://partner.com/spec.json',
-                    'base_url': 'https://partner.com',
-                    'allow_invalid': True,
-                }
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'loose-spec',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'allow_invalid': True,
+                    }
+                ]
+            )
         )
 
         with patch(
@@ -458,19 +546,22 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """ADDITIONAL_SPECS_ALLOW_INVALID=true should allow invalid specs globally."""
+        """ADDITIONAL_SPECS_ALLOW_INVALID=true allows invalid specs."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'loose-spec', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'loose-spec',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                    }
+                ]
+            )
         )
 
         with patch(
@@ -486,7 +577,10 @@ class TestAdditionalSpecIntegration:
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_primary_creds_never_leak_by_default(
         self,
@@ -497,21 +591,26 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """Core security test: primary bearer token must NOT appear in additional spec client."""
+        """Primary bearer token must NOT appear in additional spec client."""
         mock_get_auth.return_value = _make_mock_auth(
-            headers={'Authorization': 'Bearer super-secret-primary-token'}
+            headers={
+                'Authorization': 'Bearer super-secret-primary-token'  # pragma: allowlist secret
+            }
         )
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'attacker', 'spec_url': 'https://evil.com/spec.json', 'base_url': 'https://evil.com'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'attacker',
+                        'spec_url': 'https://evil.com/spec.json',
+                        'base_url': 'https://evil.com',
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
@@ -525,7 +624,6 @@ class TestAdditionalSpecIntegration:
         cookies = kwargs.get('cookies', {})
 
         assert 'Authorization' not in headers
-        assert 'super-secret-primary-token' not in str(headers)
         assert auth is None
         assert cookies == {}
 
@@ -533,7 +631,10 @@ class TestAdditionalSpecIntegration:
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_inherit_case_insensitive(
         self,
@@ -544,34 +645,43 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """'auth': 'INHERIT' (case-insensitive) should inherit primary credentials."""
+        """auth=INHERIT (case-insensitive) should inherit credentials."""
         mock_get_auth.return_value = _make_mock_auth(
-            headers={'Authorization': 'Bearer primary-token'}
+            headers={'Authorization': 'Bearer primary-token'}  # pragma: allowlist secret
         )
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'internal', 'spec_url': 'https://api.example.com/v2/spec.json', 'base_url': 'https://api.example.com/v2', 'auth': 'INHERIT'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'internal',
+                        'spec_url': 'https://api.example.com/v2/spec.json',
+                        'base_url': 'https://api.example.com/v2',
+                        'auth': 'INHERIT',
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
 
         assert mock_create_client.call_count == 2
         _, kwargs = mock_create_client.call_args_list[1]
-        assert kwargs['headers'] == {'Authorization': 'Bearer primary-token'}
+        assert kwargs['headers'] == {
+            'Authorization': 'Bearer primary-token'  # pragma: allowlist secret
+        }
 
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_invalid_auth_type_boolean_skips_spec(
         self,
@@ -582,31 +692,38 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """'auth': true (invalid type) should skip the spec, not fall to no-auth."""
+        """auth=true (invalid type) should skip the spec."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'bad', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com', 'auth': True}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'bad',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'auth': True,
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
 
-        # Only primary client should be created (spec with invalid auth skipped)
+        # Only primary client (spec with invalid auth skipped)
         assert mock_create_client.call_count == 1
 
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
     @patch('awslabs.openapi_mcp_server.server.OpenAPIProvider')
     @patch('awslabs.openapi_mcp_server.server.FastMCP')
     @patch('awslabs.openapi_mcp_server.server.load_openapi_spec')
-    @patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True)
+    @patch(
+        'awslabs.openapi_mcp_server.server.validate_openapi_spec',
+        return_value=True,
+    )
     @patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client')
     def test_invalid_auth_type_list_skips_spec(
         self,
@@ -617,24 +734,28 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """'auth': ["bearer"] (invalid type) should skip the spec."""
+        """auth=list (invalid type) should skip the spec."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'bad', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com', 'auth': ['bearer']}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'bad',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'auth': ['bearer'],
+                    }
+                ]
+            )
         )
 
         create_mcp_server(config)
 
-        # Only primary client should be created (spec with invalid auth skipped)
+        # Only primary client (spec with invalid auth skipped)
         assert mock_create_client.call_count == 1
 
     @patch('awslabs.openapi_mcp_server.auth.get_auth_provider')
@@ -650,19 +771,23 @@ class TestAdditionalSpecIntegration:
         mock_openapi_provider,
         mock_get_auth,
     ):
-        """'allow_invalid': 'false' (string) should NOT allow invalid specs."""
+        """allow_invalid='false' (string) should NOT allow invalid specs."""
         mock_get_auth.return_value = _make_mock_auth()
         mock_fastmcp.return_value = MagicMock()
         mock_load_spec.return_value = SAMPLE_SPEC
         mock_create_client.return_value = MagicMock()
 
-        config = Config(
-            api_name='test',
-            api_base_url='https://example.com/api',
-            api_spec_url='https://example.com/openapi.json',
-            additional_specs=json.dumps([
-                {'name': 'spec', 'spec_url': 'https://partner.com/spec.json', 'base_url': 'https://partner.com', 'allow_invalid': 'false'}
-            ]),
+        config = _test_config(
+            json.dumps(
+                [
+                    {
+                        'name': 'spec',
+                        'spec_url': 'https://partner.com/spec.json',
+                        'base_url': 'https://partner.com',
+                        'allow_invalid': 'false',
+                    }
+                ]
+            )
         )
 
         with patch(
@@ -671,5 +796,5 @@ class TestAdditionalSpecIntegration:
         ):
             create_mcp_server(config)
 
-        # Only primary client — "false" string should NOT be truthy
+        # Only primary — "false" string should NOT be truthy
         assert mock_create_client.call_count == 1

--- a/src/openapi-mcp-server/tests/test_new_features.py
+++ b/src/openapi-mcp-server/tests/test_new_features.py
@@ -499,8 +499,8 @@ async def test_enriched_descriptions_empty_original():
 
 
 @pytest.mark.asyncio
-async def test_additional_specs_validation_failure_continues():
-    """Additional specs with validation failure still get loaded (warn but continue)."""
+async def test_additional_specs_validation_failure_skips():
+    """Additional specs with validation failure are skipped by default (security fix)."""
     extra = json.dumps(
         [
             {
@@ -530,7 +530,45 @@ async def test_additional_specs_validation_failure_continues():
         server = await create_mcp_server_async(config)
         tools = await server.list_tools()
         names = {t.name for t in tools}
-        # Both specs should be loaded despite validation failure on extra
+        # Only primary spec should be loaded; extra is skipped due to validation failure
+        assert 'listPets' in names
+        assert 'createPayment' not in names
+
+
+@pytest.mark.asyncio
+async def test_additional_specs_validation_failure_allowed_with_flag():
+    """Additional specs with allow_invalid=true load despite validation failure."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'payments',
+                'spec_url': 'http://payments/spec',
+                'base_url': 'https://payments.example.com',
+                'allow_invalid': True,
+            }
+        ]
+    )
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec') as mock_validate,
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+    ):
+
+        def load_side_effect(url='', path=''):
+            return PETSTORE_SPEC if url != 'http://payments/spec' else EXTRA_SPEC
+
+        def validate_side_effect(spec):
+            # Primary passes, extra fails
+            return spec != EXTRA_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_validate.side_effect = validate_side_effect
+        mock_client.return_value = MagicMock()
+        config = _base_config(additional_specs=extra)
+        server = await create_mcp_server_async(config)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        # Both specs loaded because allow_invalid is set
         assert 'listPets' in names
         assert 'createPayment' in names
 


### PR DESCRIPTION
Primary API auth (bearer/cognito/API-key) was unconditionally forwarded to every additional spec's HTTP client, leaking credentials to potentially untrusted endpoints. This changes the default to send NO auth to additional specs unless explicitly configured.

- Add per-spec auth support: "auth": {"type": "bearer", "token": "..."}
- Add explicit inherit opt-in: "auth": "inherit"
- Make spec validation failures skip the spec by default (allow_invalid override)
- Reject invalid auth config types (boolean, list, etc.) instead of falling to no-auth
- Wrap per-spec client creation in try-except to prevent one bad spec from crashing server
- Add ADDITIONAL_SPECS_ALLOW_INVALID env var for global validation override
- Add comprehensive tests (29 new test cases)

/!\ BREAKING CHANGE: Additional specs no longer inherit primary API auth by default.
Users relying on shared auth must add "auth": "inherit" to their spec entries.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
