### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/src/valkey-mcp-server/awslabs/valkey_mcp_server/common/connection.py
+++ b/src/valkey-mcp-server/awslabs/valkey_mcp_server/common/connection.py
@@ -64,6 +64,7 @@ class ValkeyConnectionManager:
                     'ssl_ca_certs': VALKEY_CFG.get('ssl_ca_certs'),
                     'decode_responses': decode_responses,
                     'lib_name': f'valkey-py(mcp-server_v{__version__})',
+                    'client_name': 'valkey_mcp_server_client',
                 }
 
                 # Add max_connections parameter based on mode


### PR DESCRIPTION
Fixes #3629

## Summary

### Changes

Adds `client_name='valkey_mcp_server_client'` to the Valkey connection kwargs in `connection.py`. This sends a `CLIENT SETNAME` command on connection, making the connection identifiable in `CLIENT LIST` output and monitoring tools.

### User experience

**Before:** Connections from the Valkey MCP Server appear anonymous in `CLIENT LIST` — operators cannot distinguish them from other clients sharing the same Valkey cluster.

**After:** Connections are identified as `valkey_mcp_server_client` in `CLIENT LIST`, CloudWatch metrics (ElastiCache), and monitoring dashboards like Valkey Admin.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:
* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
