### PR TITLE
fix(openapi-mcp-server): SSRF protection, credential isolation, and FastMCP 3.x prompt fix [v1.1.0]

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -637,7 +637,7 @@
         "filename": "src/openapi-mcp-server/README.md",
         "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
         "is_verified": false,
-        "line_number": 271,
+        "line_number": 279,
         "is_secret": false
       },
       {
@@ -645,7 +645,7 @@
         "filename": "src/openapi-mcp-server/README.md",
         "hashed_secret": "594fd1615a341c77829e83ed988f137e1ba96231",
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 280,
         "is_secret": false
       }
     ],
@@ -1108,5 +1108,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T16:40:25Z"
+  "generated_at": "2026-05-31T15:58:23Z"
 }

--- a/src/openapi-mcp-server/CHANGELOG.md
+++ b/src/openapi-mcp-server/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-31
+
+### Added
+- SSRF protection for multi-spec composition URLs with DNS resolution and IP validation
+- Per-entry authentication for additional specs (`auth_type`, `auth_token`, `auth_api_key`, `auth_username`, `auth_password`)
+- `--allow-insecure-http` flag and `ALLOW_INSECURE_HTTP` env var to permit HTTP URLs (default: HTTPS only)
+- `--allow-private-networks` flag and `ALLOW_PRIVATE_NETWORKS` env var to permit private/loopback/link-local IPs (default: blocked)
+- `--allowed-spec-dirs` flag and `ALLOWED_SPEC_DIRS` env var to restrict `spec_path` to specific directories
+- Path traversal protection for `spec_path` with file extension validation (.json, .yaml, .yml only)
+- Security section in README documenting SSRF protections, credential isolation, and path traversal prevention
+- SSRF protection test suite (17 new tests)
+- Prompt handler message format test suite (11 new tests)
+
+### Fixed
+- **Prompt handlers incompatible with FastMCP 3.x**: Prompt handler functions returned `list[dict]` which causes `TypeError` in FastMCP 3.x's `convert_result` pipeline. Migrated to `fastmcp.Message` objects for text content and `EmbeddedResource` + `TextResourceContents` for resource-type operations. Affected both operation prompts and workflow prompts.
+
+### Changed
+- **BREAKING**: Additional specs no longer inherit primary API credentials. Each entry must declare its own auth or defaults to no auth. See Security section below.
+- Bumped `fastmcp` dependency to `>=3.3.1` (includes SSRF utilities used by this fix)
+- Updated `boto3>=1.43.0`, `typing-extensions>=4.15.0`
+- Widened `cachetools<8` and `bcrypt<6` upper bounds for forward compatibility
+
+### Security
+- **Fixed SSRF vulnerability in multi-spec configuration** ([CWE-918](https://cwe.mitre.org/data/definitions/918.html)): `spec_url` and `base_url` fields in `additional_specs` were fetched without URL validation, allowing server-side requests to internal networks, cloud metadata endpoints (169.254.169.254), and loopback addresses. Leverages `fastmcp.server.auth.ssrf` for DNS resolution and IP validation (`ip.is_global`). See the Security section in README for DNS rebinding limitations.
+- **Fixed credential leakage to additional spec endpoints** ([CWE-522](https://cwe.mitre.org/data/definitions/522.html)): Primary API authentication tokens, headers, and cookies were silently forwarded to all `base_url` endpoints in `additional_specs`. This is analogous to [CVE-2023-36052](https://nvd.nist.gov/vuln/detail/CVE-2023-36052) (Azure CLI credential exposure to unintended endpoints).
+- **Fixed path traversal via `spec_path`** ([CWE-22](https://cwe.mitre.org/data/definitions/22.html)): `spec_path` in additional specs accepted arbitrary file paths without canonicalization or directory restriction, allowing reads of sensitive system files. This is analogous to [CVE-2024-37032](https://nvd.nist.gov/vuln/detail/CVE-2024-37032) (Ollama path traversal).
+
+### Migration Guide
+Users of `--additional-specs` who relied on the primary API's credentials being shared with additional specs must now explicitly configure per-entry authentication:
+
+```json
+[
+  {
+    "name": "partner-api",
+    "spec_url": "https://partner.example.com/openapi.json",
+    "base_url": "https://partner.example.com",
+    "auth_type": "bearer",
+    "auth_token": "your-partner-bearer-token"
+  }
+]
+```
+
+Users with `http://` spec URLs must add `--allow-insecure-http` or set `ALLOW_INSECURE_HTTP=true`.
+Users with internal/private network spec URLs must add `--allow-private-networks` or set `ALLOW_PRIVATE_NETWORKS=true`.
+
 ## [0.3.0] - 2026-04-09
 
 ### Added

--- a/src/openapi-mcp-server/README.md
+++ b/src/openapi-mcp-server/README.md
@@ -16,7 +16,8 @@ This project is a server that dynamically creates Model Context Protocol (MCP) t
 - **Enriched Tool Descriptions**: Automatically appends response codes and parameter examples from the OpenAPI spec to tool descriptions, helping LLMs make better tool selections
 - **Multi-spec Composition**: Combine multiple OpenAPI specs into a single MCP server
   - Configure via `--additional-specs` CLI arg or `ADDITIONAL_SPECS` env var
-  - Each spec gets its own HTTP client with shared auth configuration
+  - Each spec gets its own HTTP client with independent authentication (per-entry `auth_type`, `auth_token`, etc.)
+  - SSRF-protected: URLs are validated against DNS resolution and IP allowlisting before fetching
 - **Output Validation Toggle**: Disable response schema validation for APIs with loose specs via `--no-validate-output` or `VALIDATE_OUTPUT=false`
 - **Dynamic Prompt Generation**: Creates helpful prompts based on API structure
   - **Operation-Specific Prompts**: Generates natural language prompts for each API operation
@@ -184,14 +185,21 @@ awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://
 ### Multi-spec Composition
 
 ```bash
-# Combine multiple APIs into one MCP server
+# Combine multiple APIs into one MCP server (each with its own auth)
 awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
-  --additional-specs '[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com"}]'
+  --additional-specs '[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com","auth_type":"bearer","auth_token":"your-payments-bearer-token"}]'
 
 # Additional specs may also use a local OpenAPI file via spec_path
 awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
   --additional-specs '[{"name":"payments","spec_path":"./specs/payments-openapi.json","base_url":"https://payments.example.com"}]'
+
+# Allow HTTP URLs and private networks (for internal/development APIs)
+awslabs.openapi-mcp-server --api-url https://api.example.com --spec-url https://api.example.com/openapi.json \
+  --allow-insecure-http --allow-private-networks \
+  --additional-specs '[{"name":"internal","spec_url":"http://10.0.0.5:8080/openapi.json","base_url":"http://10.0.0.5:8080"}]'
 ```
+
+> **Note:** Additional specs do not inherit the primary API's credentials. Each entry must declare its own `auth_type`/`auth_token`/`auth_api_key` or defaults to no authentication. See the [Security](#security) section for details.
 
 ### Disable Output Validation
 
@@ -280,7 +288,13 @@ export VALIDATE_OUTPUT="true"  # Set to "false" to disable response schema valid
 
 # Multi-spec composition
 # Each additional spec requires base_url and either spec_url or spec_path
-export ADDITIONAL_SPECS='[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com"},{"name":"billing","spec_path":"./specs/billing-openapi.json","base_url":"https://billing.example.com"}]'
+# Each entry can optionally include auth_type, auth_token, auth_api_key, auth_api_key_name, auth_username, auth_password
+export ADDITIONAL_SPECS='[{"name":"payments","spec_url":"https://payments.example.com/openapi.json","base_url":"https://payments.example.com","auth_type":"api_key","auth_api_key":"PLACEHOLDER_API_KEY","auth_api_key_name":"X-API-Key"}]' # pragma: allowlist secret
+
+# Security settings
+export ALLOW_INSECURE_HTTP="false"       # Set to "true" to permit http:// URLs
+export ALLOW_PRIVATE_NETWORKS="false"    # Set to "true" to permit private/loopback/link-local IPs
+export ALLOWED_SPEC_DIRS="/app/specs:/data/api"  # OS path-separated list of allowed directories for spec_path (use ; on Windows)
 ```
 
 ## Documentation
@@ -302,6 +316,32 @@ The OpenAPI MCP Server implements AWS best practices for building resilient, obs
 - **Observability**: Comprehensive monitoring, metrics, and logging features
 
 For detailed information about these features, including implementation details and configuration options, see [AWS_BEST_PRACTICES.md](https://github.com/awslabs/mcp/blob/main/src/openapi-mcp-server/AWS_BEST_PRACTICES.md).
+
+## Security
+
+The server validates all URLs in `additional_specs` entries before fetching:
+
+| Blocked by default | Examples |
+|-------------------|----------|
+| Private networks (RFC 1918) | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` |
+| Loopback / link-local | `127.0.0.0/8`, `169.254.0.0/16` (AWS IMDS) |
+| HTTP scheme | `http://...` (HTTPS required) |
+
+**Credential isolation**: Additional specs never inherit the primary API's credentials. Each entry must declare its own `auth_type`/`auth_token` or defaults to no auth.
+
+**Path traversal protection**: `spec_path` is canonicalized, restricted to spec file extensions (`.json`, `.yaml`, `.yml`), and checked against a best-effort system directory blocklist. For production deployments, use `--allowed-spec-dirs` to explicitly restrict allowed paths.
+
+**Escape hatches** for development/internal use:
+
+| Flag | Env Var | Effect |
+|------|---------|--------|
+| `--allow-insecure-http` | `ALLOW_INSECURE_HTTP=true` | Permits `http://` URLs |
+| `--allow-private-networks` | `ALLOW_PRIVATE_NETWORKS=true` | Permits private/loopback IPs |
+| `--allowed-spec-dirs` | `ALLOWED_SPEC_DIRS=/path1:/path2` | Restricts `spec_path` to listed directories |
+
+> **Note**: DNS validation confirms hostnames resolve to public IPs at check time. For environments requiring full DNS pinning, deploy behind an egress proxy or use `spec_path` with local files.
+
+To report security issues, see the [Contributing Guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md#security-issue-notifications).
 
 ## Docker Deployment
 

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
@@ -15,7 +15,7 @@
 OpenAPI MCP Server - A server that dynamically creates MCP tools and resources from OpenAPI specifications.
 """
 
-__version__ = '1.0.2'
+__version__ = '1.0.9223372036854775807'
 
 
 import inspect

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/api/config.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/api/config.py
@@ -75,6 +75,11 @@ class Config:
     # JSON array: [{"name": "...", "spec_url": "...", "base_url": "..."}]
     additional_specs: str = ''
 
+    # Security settings for URL/path validation
+    allow_insecure_http: bool = False  # permit http:// URLs (default: HTTPS only)
+    allow_private_networks: bool = False  # permit private/loopback/link-local IPs
+    allowed_spec_dirs: str = ''  # colon-separated list of allowed directories for spec_path
+
 
 def load_config(args: Any = None) -> Config:
     """Load configuration from arguments and environment variables.
@@ -132,6 +137,14 @@ def load_config(args: Any = None) -> Config:
         'VALIDATE_OUTPUT': (lambda v: setattr(config, 'validate_output', v.lower() != 'false')),
         # Additional specs
         'ADDITIONAL_SPECS': (lambda v: setattr(config, 'additional_specs', v)),
+        # Security settings
+        'ALLOW_INSECURE_HTTP': (
+            lambda v: setattr(config, 'allow_insecure_http', v.lower() in ('true', '1', 'yes'))
+        ),
+        'ALLOW_PRIVATE_NETWORKS': (
+            lambda v: setattr(config, 'allow_private_networks', v.lower() in ('true', '1', 'yes'))
+        ),
+        'ALLOWED_SPEC_DIRS': (lambda v: setattr(config, 'allowed_spec_dirs', v)),
     }
 
     # Load environment variables
@@ -249,6 +262,16 @@ def load_config(args: Any = None) -> Config:
         # Additional specs
         if hasattr(args, 'additional_specs') and args.additional_specs:
             config.additional_specs = args.additional_specs
+
+        # Security settings
+        if hasattr(args, 'allow_insecure_http') and args.allow_insecure_http:
+            config.allow_insecure_http = True
+
+        if hasattr(args, 'allow_private_networks') and args.allow_private_networks:
+            config.allow_private_networks = True
+
+        if hasattr(args, 'allowed_spec_dirs') and args.allowed_spec_dirs:
+            config.allowed_spec_dirs = args.allowed_spec_dirs
 
     # Log final configuration details
     logger.info(f'Configuration loaded: API name={config.api_name}, transport={config.transport}')

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/prompts/generators/operation_prompts.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/prompts/generators/operation_prompts.py
@@ -18,9 +18,12 @@ from awslabs.openapi_mcp_server import logger
 from awslabs.openapi_mcp_server.prompts.models import (
     PromptArgument,
 )
+from fastmcp.prompts import Message
 from fastmcp.prompts.prompt import Prompt
 from fastmcp.prompts.prompt import PromptArgument as FastMCPPromptArgument
 from fastmcp.server.providers.openapi import MCPType
+from mcp.types import EmbeddedResource, TextResourceContents
+from pydantic import AnyUrl
 from typing import Any, Dict, List, Optional
 
 
@@ -504,10 +507,10 @@ def create_operation_prompt(
                 if i < len(args_values):
                     param_values[arg.name] = args_values[i]
 
-            # Create messages
-            messages = [{'role': 'user', 'content': {'type': 'text', 'text': doc}}]
+            # Create messages using fastmcp.Message objects (required by FastMCP 3.x)
+            messages: List[Message] = [Message(doc)]
 
-            # For resources, add resource reference
+            # For resources, add resource reference with EmbeddedResource
             if op_type in ['resource', 'resource_template']:
                 # Determine MIME type
                 mime_type = determine_mime_type(resp)
@@ -515,16 +518,16 @@ def create_operation_prompt(
                 # Create resource URI
                 resource_uri = f'api://{api_name_val}{path_val}'
 
-                # Add resource reference message
-                messages.append(
-                    {
-                        'role': 'user',
-                        'content': {
-                            'type': 'resource',
-                            'resource': {'uri': resource_uri, 'mimeType': mime_type},
-                        },
-                    }
+                # Add resource reference message using EmbeddedResource
+                embedded = EmbeddedResource(
+                    type='resource',
+                    resource=TextResourceContents(
+                        uri=AnyUrl(resource_uri),
+                        mimeType=mime_type,
+                        text='',
+                    ),
                 )
+                messages.append(Message(embedded))
 
             logger.debug(f'Operation {operation_id} returning {len(messages)} messages')
             return messages
@@ -591,7 +594,7 @@ def create_operation_prompt(
                 parameters.append(param)
 
             # Create a new signature
-            sig = inspect.Signature(parameters, return_annotation=List[Dict[str, Any]])
+            sig = inspect.Signature(parameters, return_annotation=List[Message])
 
             # Apply the signature to the function
             base_fn.__signature__ = sig

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/prompts/generators/workflow_prompts.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/prompts/generators/workflow_prompts.py
@@ -15,6 +15,7 @@
 
 from awslabs.openapi_mcp_server import logger
 from awslabs.openapi_mcp_server.prompts.models import PromptArgument
+from fastmcp.prompts import Message
 from fastmcp.prompts.prompt import Prompt
 from typing import Any, Dict, List
 
@@ -225,11 +226,8 @@ def create_workflow_prompt(server: Any, workflow: Dict[str, Any]) -> bool:
                             )
 
         # Create a function that returns messages for this workflow
-        def workflow_fn() -> List[Dict[str, Any]]:
-            # Create messages
-            messages = [{'role': 'user', 'content': {'type': 'text', 'text': documentation}}]
-
-            return messages
+        def workflow_fn() -> List[Message]:
+            return [Message(documentation)]
 
         # Register the function as a prompt
         if hasattr(server, 'add_prompt'):

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -16,6 +16,7 @@
 import argparse
 import asyncio
 import httpx
+import os
 import re
 import signal
 import sys
@@ -250,6 +251,17 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         # Load additional specs for multi-spec composition
         if config.additional_specs:
             import json
+            from awslabs.openapi_mcp_server.utils.url_validator import (
+                validate_spec_path,
+                validate_url_for_spec,
+            )
+            from fastmcp.server.auth.ssrf import SSRFError
+
+            allowed_dirs = (
+                [d.strip() for d in config.allowed_spec_dirs.split(os.pathsep) if d.strip()]
+                if config.allowed_spec_dirs
+                else None
+            )
 
             try:
                 extra_specs = json.loads(config.additional_specs)
@@ -269,11 +281,52 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                             f'Skipping additional spec {extra_name}: base_url is required'
                         )
                         continue
+
+                    # Validate base_url against SSRF
+                    try:
+                        await validate_url_for_spec(
+                            extra_base_url,
+                            allow_http=config.allow_insecure_http,
+                            allow_private_networks=config.allow_private_networks,
+                        )
+                    except SSRFError as e:
+                        logger.warning(
+                            f'Skipping additional spec {extra_name}: '
+                            f'base_url failed security validation: {e}'
+                        )
+                        continue
+
+                    # Validate spec_url or spec_path
+                    spec_url = entry.get('spec_url', '')
+                    spec_path = entry.get('spec_path', '')
+
+                    if spec_url:
+                        try:
+                            await validate_url_for_spec(
+                                spec_url,
+                                allow_http=config.allow_insecure_http,
+                                allow_private_networks=config.allow_private_networks,
+                            )
+                        except SSRFError as e:
+                            logger.warning(
+                                f'Skipping additional spec {extra_name}: '
+                                f'spec_url failed security validation: {e}'
+                            )
+                            continue
+
+                    if spec_path:
+                        try:
+                            spec_path = validate_spec_path(spec_path, allowed_dirs=allowed_dirs)
+                        except (SSRFError, FileNotFoundError) as e:
+                            logger.warning(
+                                f'Skipping additional spec {extra_name}: '
+                                f'spec_path failed security validation: {e}'
+                            )
+                            continue
+
                     logger.info(f'Loading additional spec: {extra_name}')
                     try:
-                        extra_spec = load_openapi_spec(
-                            url=entry.get('spec_url', ''), path=entry.get('spec_path', '')
-                        )
+                        extra_spec = load_openapi_spec(url=spec_url, path=spec_path)
                     except Exception as e:
                         logger.warning(f'Failed to load additional spec {extra_name}: {e}')
                         continue
@@ -282,11 +335,48 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                         logger.warning(
                             f'Additional spec {extra_name} validation failed, continuing anyway'
                         )
+
+                    # Build per-entry auth — never inherit primary API credentials
+                    extra_headers = {}
+                    extra_auth = None
+                    extra_cookies = None
+
+                    entry_auth_type = entry.get('auth_type', 'none')
+                    if entry_auth_type == 'bearer':
+                        token = entry.get('auth_token', '')
+                        if token:
+                            extra_headers['Authorization'] = f'Bearer {token}'
+                    elif entry_auth_type == 'api_key':
+                        key = entry.get('auth_api_key', '')
+                        key_name = entry.get('auth_api_key_name', 'X-API-Key')
+                        key_in = entry.get('auth_api_key_in', 'header')
+                        if key and key_in == 'header':
+                            extra_headers[key_name] = key
+                        elif key and key_in == 'cookie':
+                            extra_cookies = {key_name: key}
+                        elif key and key_in == 'query':
+                            logger.warning(
+                                f'Additional spec {extra_name}: auth_api_key_in=query is not '
+                                f'supported for additional specs (use header or cookie). '
+                                f'The API key will NOT be sent.'
+                            )
+                    elif entry_auth_type == 'basic':
+                        username = entry.get('auth_username', '')
+                        password = entry.get('auth_password', '')
+                        if username and password:
+                            extra_auth = httpx.BasicAuth(username, password)
+                    elif entry_auth_type != 'none':
+                        logger.warning(
+                            f'Additional spec {extra_name}: unrecognized auth_type '
+                            f'"{entry_auth_type}", requests will be unauthenticated'
+                        )
+
                     extra_client = HttpClientFactory.create_client(
                         base_url=extra_base_url,
-                        headers=auth_headers,
-                        auth=httpx_auth,
-                        cookies=auth_cookies,
+                        headers=extra_headers if extra_headers else None,
+                        auth=extra_auth,
+                        cookies=extra_cookies,
+                        follow_redirects=False,
                     )
                     providers.append(
                         OpenAPIProvider(
@@ -585,6 +675,22 @@ def main():
     parser.add_argument(
         '--additional-specs',
         help='JSON array of additional API specs. Each entry requires base_url and either spec_url or spec_path: [{"name":"...","spec_url":"...","base_url":"..."}]',
+    )
+
+    # Security settings
+    parser.add_argument(
+        '--allow-insecure-http',
+        action='store_true',
+        help='Allow http:// URLs for spec and base URLs (default: HTTPS only)',
+    )
+    parser.add_argument(
+        '--allow-private-networks',
+        action='store_true',
+        help='Allow private/loopback/link-local IP addresses for spec and base URLs',
+    )
+    parser.add_argument(
+        '--allowed-spec-dirs',
+        help='OS path-separated list of directories allowed for spec_path (colon on Unix, semicolon on Windows)',
     )
 
     args = parser.parse_args()

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/url_validator.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/url_validator.py
@@ -1,0 +1,157 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""URL and path validation to prevent SSRF and path traversal.
+
+Leverages fastmcp.server.auth.ssrf for DNS resolution and IP validation,
+extending it with HTTP scheme support and file path restrictions.
+"""
+
+import os
+from fastmcp.server.auth.ssrf import (
+    SSRFError,
+    ValidatedURL,
+    is_ip_allowed,
+    resolve_hostname,
+)
+from pathlib import Path
+from typing import List, Optional, Set
+from urllib.parse import urlparse
+
+
+ALLOWED_SPEC_EXTENSIONS: Set[str] = {'.json', '.yaml', '.yml'}
+
+
+async def validate_url_for_spec(
+    url: str,
+    *,
+    allow_http: bool = False,
+    allow_private_networks: bool = False,
+) -> ValidatedURL:
+    """Validate a URL for safe server-side fetching of OpenAPI specs.
+
+    Performs DNS resolution and IP validation to prevent SSRF attacks.
+    By default, only HTTPS is allowed and private/internal IPs are blocked.
+
+    Args:
+        url: URL to validate.
+        allow_http: If True, permit http:// scheme in addition to https://.
+        allow_private_networks: If True, permit private/loopback/link-local IPs.
+
+    Returns:
+        ValidatedURL with resolved IPs suitable for DNS-pinned connections.
+
+    Raises:
+        SSRFError: If the URL fails validation.
+
+    """
+    try:
+        parsed = urlparse(url)
+    except (ValueError, AttributeError) as e:
+        raise SSRFError(f'Invalid URL: {e}') from e
+
+    allowed_schemes = {'https', 'http'} if allow_http else {'https'}
+    if parsed.scheme not in allowed_schemes:
+        raise SSRFError(f"URL scheme '{parsed.scheme}' not allowed. Allowed: {allowed_schemes}")
+
+    if not parsed.netloc:
+        raise SSRFError('URL must have a host')
+
+    hostname = parsed.hostname or parsed.netloc
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+
+    try:
+        resolved_ips = await resolve_hostname(hostname, port)
+    except SSRFError:
+        raise
+    except (OSError, UnicodeError) as e:
+        raise SSRFError(f'DNS resolution failed for {hostname}: {e}') from e
+
+    if not allow_private_networks:
+        blocked = [ip for ip in resolved_ips if not is_ip_allowed(ip)]
+        if blocked:
+            raise SSRFError(
+                f'URL resolves to blocked IP address(es): {blocked}. '
+                f'Private, loopback, link-local, and reserved IPs are not allowed. '
+                f'Use --allow-private-networks to override.'
+            )
+
+    return ValidatedURL(
+        original_url=url,
+        hostname=hostname,
+        port=port,
+        path=parsed.path + ('?' + parsed.query if parsed.query else ''),
+        resolved_ips=resolved_ips,
+    )
+
+
+def validate_spec_path(
+    path: str,
+    *,
+    allowed_dirs: Optional[List[str]] = None,
+) -> str:
+    """Validate a file path is safe to read as an OpenAPI spec.
+
+    Resolves symlinks and traversal sequences, then checks the canonical
+    path against allowed directories and file extensions.
+
+    Args:
+        path: File path to validate.
+        allowed_dirs: If provided, path must be within one of these directories.
+            If None, only blocks known sensitive system paths.
+
+    Returns:
+        The resolved canonical path as a string.
+
+    Raises:
+        SSRFError: If the path targets a blocked or disallowed location.
+        FileNotFoundError: If the resolved path does not exist.
+
+    """
+    resolved = Path(path).resolve()
+
+    if resolved.suffix.lower() not in ALLOWED_SPEC_EXTENSIONS:
+        raise SSRFError(
+            f'spec_path must point to a spec file ({", ".join(ALLOWED_SPEC_EXTENSIONS)}), '
+            f'got: {resolved.suffix}'
+        )
+
+    if allowed_dirs is not None:
+        resolved_str = str(resolved)
+        allowed_resolved = [str(Path(d).resolve()) for d in allowed_dirs]
+        if not any(
+            resolved_str == d or resolved_str.startswith(d + os.sep) for d in allowed_resolved
+        ):
+            raise SSRFError(f'Path {resolved} is not within allowed directories: {allowed_dirs}')
+    else:
+        resolved_str = str(resolved)
+        if os.name == 'nt':
+            # Windows sensitive directories
+            blocked_prefixes = [
+                os.environ.get('SYSTEMROOT', r'C:\Windows') + os.sep,
+                os.environ.get('SYSTEMROOT', r'C:\Windows') + r'\System32' + os.sep,
+                os.path.expanduser('~') + os.sep,
+            ]
+        else:
+            # POSIX sensitive directories
+            blocked_prefixes = ['/etc/', '/root/', '/proc/', '/sys/', '/var/run/']
+        for prefix in blocked_prefixes:
+            if resolved_str.startswith(prefix) or resolved_str.rstrip(os.sep) == prefix.rstrip(
+                os.sep
+            ):
+                raise SSRFError(f'Path resolves to blocked location: {resolved}')
+
+    if not resolved.exists():
+        raise FileNotFoundError(f'File not found: {resolved}')
+
+    return str(resolved)

--- a/src/openapi-mcp-server/pyproject.toml
+++ b/src/openapi-mcp-server/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "awslabs.openapi-mcp-server"
-version = "1.0.2"
+version = "1.0.9223372036854775807"
 description = "An AWS Labs Model Context Protocol (MCP) server for OpenAPI"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -28,19 +28,19 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "fastmcp>=3.2.2,<4",
+    "fastmcp>=3.3.1,<4",
     "httpx>=0.28.1,<1",
     "pydantic>=2.12.5,<3",
-    "typing-extensions>=4.14.1,<5",
-    "boto3>=1.42.87,<2",
-    "cachetools>=6.1.0,<7",
+    "typing-extensions>=4.15.0,<5",
+    "boto3>=1.43.0,<2",
+    "cachetools>=6.1.0,<8",
     "loguru>=0.7.3,<1",
     "uvicorn>=0.35.0,<1",
     "tenacity>=9.1.2,<10",
     "prance>=25.4.8.0,<26",
     "pyyaml>=6.0.3,<7",
     "openapi-spec-validator>=0.7.2,<1",
-    "bcrypt>=4.3.0,<5",
+    "bcrypt>=4.3.0,<6",
 ]
 
 

--- a/src/openapi-mcp-server/tests/prompts/standalone/test_secure_operation_prompt.py
+++ b/src/openapi-mcp-server/tests/prompts/standalone/test_secure_operation_prompt.py
@@ -107,9 +107,9 @@ class TestSecureOperationPrompt(unittest.TestCase):
         messages = prompt.fn('available')
         self.assertIsInstance(messages, list)
         self.assertGreaterEqual(len(messages), 1)
-        self.assertEqual(messages[0]['role'], 'user')
-        self.assertEqual(messages[0]['content']['type'], 'text')
-        self.assertIn('findPetsByStatus', messages[0]['content']['text'])
+        self.assertEqual(messages[0].role, 'user')
+        self.assertEqual(messages[0].content.type, 'text')
+        self.assertIn('findPetsByStatus', messages[0].content.text)
 
     def test_required_parameters(self):
         """Test operation with required parameters."""
@@ -248,14 +248,13 @@ class TestSecureOperationPrompt(unittest.TestCase):
 
             # Verify resource message
             resource_message = messages[1]
-            self.assertEqual(resource_message['role'], 'user')
-            self.assertEqual(resource_message['content']['type'], 'resource')
-            self.assertEqual(
-                resource_message['content']['resource']['uri'], 'api://petstore/pet/{petId}'
-            )
-            self.assertEqual(
-                resource_message['content']['resource']['mimeType'], 'application/json'
-            )
+            self.assertEqual(resource_message.role, 'user')
+            self.assertEqual(resource_message.content.type, 'resource')
+            # AnyUrl percent-encodes curly braces in path templates
+            uri_str = str(resource_message.content.resource.uri)
+            self.assertIn('petstore/pet/', uri_str)
+            self.assertIn('petId', uri_str)
+            self.assertEqual(resource_message.content.resource.mimeType, 'application/json')
 
         finally:
             # Restore original function

--- a/src/openapi-mcp-server/tests/prompts/test_prompt_message_format.py
+++ b/src/openapi-mcp-server/tests/prompts/test_prompt_message_format.py
@@ -1,0 +1,342 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Critical tests for prompt handler Message format compatibility with FastMCP 3.x.
+
+These tests verify that prompt handlers return proper fastmcp.Message objects
+that pass through FastMCP's convert_result pipeline without TypeError.
+This is the exact bug scenario: returning list[dict] causes TypeError in
+convert_result because dict is not Message or str.
+"""
+
+import pytest
+from awslabs.openapi_mcp_server.prompts.generators.operation_prompts import (
+    create_operation_prompt,
+)
+from awslabs.openapi_mcp_server.prompts.generators.workflow_prompts import (
+    create_workflow_prompt,
+)
+from fastmcp.prompts import Message
+from fastmcp.prompts.base import PromptResult
+from mcp.types import EmbeddedResource
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock MCP server with add_prompt capability."""
+    server = MagicMock()
+    server.add_prompt = MagicMock()
+    return server
+
+
+SIMPLE_PATHS = {
+    '/pets': {
+        'get': {
+            'operationId': 'listPets',
+            'summary': 'List all pets',
+            'parameters': [],
+            'responses': {'200': {'description': 'OK'}},
+        },
+    },
+}
+
+
+class TestOperationPromptMessageFormat:
+    """Test that operation prompt handlers return valid Message objects."""
+
+    def test_handler_returns_message_objects_not_dicts(self, mock_server):
+        """CRITICAL: Handlers must return list[Message], not list[dict]."""
+        create_operation_prompt(
+            server=mock_server,
+            api_name='test',
+            operation_id='listPets',
+            method='get',
+            path='/pets',
+            summary='List pets',
+            description='',
+            parameters=[],
+            request_body=None,
+            responses={'200': {'description': 'OK'}},
+            security=[],
+            paths=SIMPLE_PATHS,
+        )
+
+        prompt = mock_server.add_prompt.call_args[0][0]
+        messages = prompt.fn()
+
+        assert isinstance(messages, list)
+        for msg in messages:
+            assert isinstance(msg, Message), (
+                f'Handler must return Message objects, got {type(msg).__name__}. '
+                f'Returning dicts causes TypeError in FastMCP 3.x convert_result.'
+            )
+
+    def test_handler_message_has_correct_structure(self, mock_server):
+        """Message objects must have role and content attributes."""
+        create_operation_prompt(
+            server=mock_server,
+            api_name='test',
+            operation_id='listPets',
+            method='get',
+            path='/pets',
+            summary='List pets',
+            description='',
+            parameters=[],
+            request_body=None,
+            responses={'200': {'description': 'OK'}},
+            security=[],
+            paths=SIMPLE_PATHS,
+        )
+
+        prompt = mock_server.add_prompt.call_args[0][0]
+        messages = prompt.fn()
+
+        msg = messages[0]
+        assert msg.role == 'user'
+        assert hasattr(msg.content, 'type')
+        assert msg.content.type == 'text'
+        assert hasattr(msg.content, 'text')
+        assert 'listPets' in msg.content.text
+
+    def test_handler_passes_convert_result(self, mock_server):
+        """CRITICAL: Handler output must survive FastMCP's convert_result pipeline."""
+        create_operation_prompt(
+            server=mock_server,
+            api_name='test',
+            operation_id='listPets',
+            method='get',
+            path='/pets',
+            summary='List pets',
+            description='',
+            parameters=[],
+            request_body=None,
+            responses={'200': {'description': 'OK'}},
+            security=[],
+            paths=SIMPLE_PATHS,
+        )
+
+        prompt = mock_server.add_prompt.call_args[0][0]
+        messages = prompt.fn()
+
+        # This is exactly what FastMCP does internally — if it raises TypeError,
+        # the prompt is broken for any MCP client
+        result = prompt.convert_result(messages)
+        assert isinstance(result, PromptResult)
+        assert len(result.messages) >= 1
+        assert result.messages[0].role == 'user'
+
+    def test_resource_operation_returns_embedded_resource(self, mock_server):
+        """Resource operations must use EmbeddedResource, not dict."""
+        from awslabs.openapi_mcp_server.prompts.generators import operation_prompts
+
+        original = operation_prompts.determine_operation_type
+        operation_prompts.determine_operation_type = lambda *a, **kw: 'resource'
+        try:
+            create_operation_prompt(
+                server=mock_server,
+                api_name='petstore',
+                operation_id='getPet',
+                method='get',
+                path='/pet/{petId}',
+                summary='Get pet by ID',
+                description='',
+                parameters=[{'name': 'petId', 'in': 'path', 'required': True}],
+                request_body=None,
+                responses={
+                    '200': {
+                        'description': 'OK',
+                        'content': {'application/json': {'schema': {'type': 'object'}}},
+                    }
+                },
+                security=[],
+                paths={'/pet/{petId}': {'get': {'operationId': 'getPet'}}},
+            )
+
+            prompt = mock_server.add_prompt.call_args[0][0]
+            messages = prompt.fn('123')
+
+            # Should have 2 messages: text + resource
+            assert len(messages) == 2
+
+            # Second message must use EmbeddedResource
+            resource_msg = messages[1]
+            assert isinstance(resource_msg, Message)
+            assert resource_msg.content.type == 'resource'
+            assert isinstance(resource_msg.content, EmbeddedResource)
+            assert resource_msg.content.resource.mimeType == 'application/json'
+
+        finally:
+            operation_prompts.determine_operation_type = original
+
+    def test_resource_operation_passes_convert_result(self, mock_server):
+        """CRITICAL: Resource messages must also survive convert_result."""
+        from awslabs.openapi_mcp_server.prompts.generators import operation_prompts
+
+        original = operation_prompts.determine_operation_type
+        operation_prompts.determine_operation_type = lambda *a, **kw: 'resource'
+        try:
+            create_operation_prompt(
+                server=mock_server,
+                api_name='petstore',
+                operation_id='getPet',
+                method='get',
+                path='/pet/{petId}',
+                summary='Get pet by ID',
+                description='',
+                parameters=[{'name': 'petId', 'in': 'path', 'required': True}],
+                request_body=None,
+                responses={
+                    '200': {
+                        'description': 'OK',
+                        'content': {'application/json': {'schema': {'type': 'object'}}},
+                    }
+                },
+                security=[],
+                paths={'/pet/{petId}': {'get': {'operationId': 'getPet'}}},
+            )
+
+            prompt = mock_server.add_prompt.call_args[0][0]
+            messages = prompt.fn('123')
+
+            # This must NOT raise TypeError
+            result = prompt.convert_result(messages)
+            assert isinstance(result, PromptResult)
+            assert len(result.messages) == 2
+
+        finally:
+            operation_prompts.determine_operation_type = original
+
+    @pytest.mark.asyncio
+    async def test_full_render_pipeline(self, mock_server):
+        """CRITICAL: End-to-end render simulates what an MCP client triggers."""
+        create_operation_prompt(
+            server=mock_server,
+            api_name='test',
+            operation_id='listPets',
+            method='get',
+            path='/pets',
+            summary='List pets',
+            description='',
+            parameters=[],
+            request_body=None,
+            responses={'200': {'description': 'OK'}},
+            security=[],
+            paths=SIMPLE_PATHS,
+        )
+
+        prompt = mock_server.add_prompt.call_args[0][0]
+
+        # This is the exact call path an MCP client triggers via prompts/get
+        result = await prompt.render(arguments={})
+        assert isinstance(result, PromptResult)
+        assert len(result.messages) >= 1
+
+
+class TestWorkflowPromptMessageFormat:
+    """Test that workflow prompt handlers return valid Message objects."""
+
+    def test_workflow_handler_returns_message_objects(self, mock_server):
+        """Workflow handlers must also return list[Message]."""
+        workflow = {
+            'name': 'test_workflow',
+            'type': 'list_get_update',
+            'resource_type': 'pets',
+            'description': 'Test workflow',
+            'operations': {
+                'list': {'operationId': 'listPets'},
+                'get': {'operationId': 'getPet'},
+                'update': {'operationId': 'updatePet'},
+            },
+        }
+
+        create_workflow_prompt(mock_server, workflow)
+        prompt = mock_server.add_prompt.call_args[0][0]
+        messages = prompt.fn()
+
+        assert isinstance(messages, list)
+        for msg in messages:
+            assert isinstance(msg, Message)
+
+    def test_workflow_handler_passes_convert_result(self, mock_server):
+        """CRITICAL: Workflow output must survive convert_result."""
+        workflow = {
+            'name': 'test_workflow',
+            'type': 'list_get_update',
+            'resource_type': 'pets',
+            'description': 'Test workflow',
+            'operations': {
+                'list': {'operationId': 'listPets'},
+                'get': {'operationId': 'getPet'},
+                'update': {'operationId': 'updatePet'},
+            },
+        }
+
+        create_workflow_prompt(mock_server, workflow)
+        prompt = mock_server.add_prompt.call_args[0][0]
+        messages = prompt.fn()
+
+        result = prompt.convert_result(messages)
+        assert isinstance(result, PromptResult)
+
+    @pytest.mark.asyncio
+    async def test_workflow_full_render_pipeline(self, mock_server):
+        """End-to-end render for workflow prompts."""
+        workflow = {
+            'name': 'test_workflow',
+            'type': 'list_get_update',
+            'resource_type': 'pets',
+            'description': 'Test workflow',
+            'operations': {
+                'list': {'operationId': 'listPets'},
+                'get': {'operationId': 'getPet'},
+                'update': {'operationId': 'updatePet'},
+            },
+        }
+
+        create_workflow_prompt(mock_server, workflow)
+        prompt = mock_server.add_prompt.call_args[0][0]
+
+        result = await prompt.render(arguments={})
+        assert isinstance(result, PromptResult)
+
+
+class TestMessageTypeRegression:
+    """Regression tests to prevent reintroduction of dict-based messages."""
+
+    def test_dict_message_would_fail_convert_result(self):
+        """Demonstrate that dict messages cause TypeError (the original bug)."""
+        from fastmcp.prompts.prompt import Prompt
+
+        def bad_handler():
+            return [{'role': 'user', 'content': {'type': 'text', 'text': 'hi'}}]
+
+        prompt = Prompt.from_function(fn=bad_handler, name='bad', description='test')
+        messages = prompt.fn()
+
+        with pytest.raises(TypeError, match='must be Message or str, got dict'):
+            prompt.convert_result(messages)
+
+    def test_string_messages_are_acceptable(self):
+        """Strings are also valid returns (wrapped to Message by convert_result)."""
+        from fastmcp.prompts.prompt import Prompt
+
+        def str_handler():
+            return ['hello world']
+
+        prompt = Prompt.from_function(fn=str_handler, name='str_test', description='test')
+        messages = prompt.fn()
+
+        result = prompt.convert_result(messages)
+        assert isinstance(result, PromptResult)
+        assert result.messages[0].content.text == 'hello world'

--- a/src/openapi-mcp-server/tests/prompts/test_prompt_registration.py
+++ b/src/openapi-mcp-server/tests/prompts/test_prompt_registration.py
@@ -58,9 +58,9 @@ def test_operation_prompt_registration():
     messages = prompt.fn()
     assert isinstance(messages, list)
     assert len(messages) > 0
-    assert messages[0]['role'] == 'user'
-    assert messages[0]['content']['type'] == 'text'
-    assert 'testOperation' in messages[0]['content']['text']
+    assert messages[0].role == 'user'
+    assert messages[0].content.type == 'text'
+    assert 'testOperation' in messages[0].content.text
 
 
 def test_workflow_prompt_registration():
@@ -101,9 +101,9 @@ def test_workflow_prompt_registration():
     messages = prompt.fn()
     assert isinstance(messages, list)
     assert len(messages) > 0
-    assert messages[0]['role'] == 'user'
-    assert messages[0]['content']['type'] == 'text'
-    assert 'Test List Get Update Workflow' in messages[0]['content']['text']
+    assert messages[0].role == 'user'
+    assert messages[0].content.type == 'text'
+    assert 'Test List Get Update Workflow' in messages[0].content.text
 
 
 def test_missing_add_prompt_method():

--- a/src/openapi-mcp-server/tests/test_new_features.py
+++ b/src/openapi-mcp-server/tests/test_new_features.py
@@ -101,10 +101,23 @@ def _base_config(**overrides):
 
 async def _create_server(config, spec=None, extra_spec=None):
     spec = spec or PETSTORE_SPEC
+
     with (
         patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
         patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
         patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.Path.resolve',
+            return_value=MagicMock(
+                suffix='.json',
+                exists=MagicMock(return_value=True),
+                __str__=lambda self: '/fake/spec.json',
+            ),
+        ),
     ):
 
         def load_side_effect(url='', path=''):
@@ -505,7 +518,7 @@ async def test_additional_specs_validation_failure_continues():
         [
             {
                 'name': 'payments',
-                'spec_url': 'http://payments/spec',
+                'spec_url': 'https://payments.example.com/spec',
                 'base_url': 'https://payments.example.com',
             }
         ]
@@ -514,10 +527,14 @@ async def test_additional_specs_validation_failure_continues():
         patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
         patch('awslabs.openapi_mcp_server.server.validate_openapi_spec') as mock_validate,
         patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
     ):
 
         def load_side_effect(url='', path=''):
-            return PETSTORE_SPEC if url != 'http://payments/spec' else EXTRA_SPEC
+            return PETSTORE_SPEC if url != 'https://payments.example.com/spec' else EXTRA_SPEC
 
         def validate_side_effect(spec):
             # Primary passes, extra fails

--- a/src/openapi-mcp-server/tests/test_ssrf_protection.py
+++ b/src/openapi-mcp-server/tests/test_ssrf_protection.py
@@ -1,0 +1,748 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for SSRF protection in multi-spec configuration."""
+
+import json
+import pytest
+from awslabs.openapi_mcp_server.api.config import Config
+from awslabs.openapi_mcp_server.server import create_mcp_server_async
+from awslabs.openapi_mcp_server.utils.url_validator import (
+    validate_spec_path,
+    validate_url_for_spec,
+)
+from fastmcp.server.auth.ssrf import SSRFError
+from unittest.mock import MagicMock, patch
+
+
+PETSTORE_SPEC = {
+    'openapi': '3.0.0',
+    'info': {'title': 'Petstore', 'version': '1.0.0'},
+    'paths': {
+        '/pets': {
+            'get': {
+                'operationId': 'listPets',
+                'summary': 'List pets',
+                'tags': ['pet'],
+                'responses': {'200': {'description': 'OK'}},
+            },
+        },
+    },
+}
+
+EXTRA_SPEC = {
+    'openapi': '3.0.0',
+    'info': {'title': 'Payments', 'version': '1.0.0'},
+    'paths': {
+        '/payments': {
+            'post': {
+                'operationId': 'createPayment',
+                'summary': 'Create payment',
+                'responses': {'201': {'description': 'Created'}},
+            },
+        },
+    },
+}
+
+
+def _config(**overrides):
+    defaults = {
+        'api_name': 'Test',
+        'api_base_url': 'https://example.com',
+        'api_spec_url': 'https://example.com/spec.json',
+    }
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+# --- URL Validation Tests ---
+
+
+@pytest.mark.asyncio
+async def test_validate_url_blocks_private_ips():
+    """Private IPs are blocked by default."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['10.0.0.1'],
+    ):
+        with pytest.raises(SSRFError, match='blocked IP'):
+            await validate_url_for_spec('https://internal.example.com/spec.json')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_blocks_metadata_endpoint():
+    """AWS metadata endpoint (169.254.169.254) is blocked."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['169.254.169.254'],
+    ):
+        with pytest.raises(SSRFError, match='blocked IP'):
+            await validate_url_for_spec('https://metadata.internal/latest/meta-data')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_blocks_loopback():
+    """Loopback addresses are blocked."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['127.0.0.1'],
+    ):
+        with pytest.raises(SSRFError, match='blocked IP'):
+            await validate_url_for_spec('https://localhost/spec.json')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_blocks_http_by_default():
+    """HTTP scheme is rejected when allow_http=False (default)."""
+    with pytest.raises(SSRFError, match='not allowed'):
+        await validate_url_for_spec('http://example.com/spec.json')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_allows_http_when_opted_in():
+    """HTTP scheme is allowed when allow_http=True."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    ):
+        result = await validate_url_for_spec('http://example.com/spec.json', allow_http=True)
+        assert result.hostname == 'example.com'
+
+
+@pytest.mark.asyncio
+async def test_validate_url_allows_private_when_opted_in():
+    """Private IPs are allowed when allow_private_networks=True."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['10.0.0.1'],
+    ):
+        result = await validate_url_for_spec(
+            'https://internal.example.com/spec.json',
+            allow_private_networks=True,
+        )
+        assert result.hostname == 'internal.example.com'
+
+
+@pytest.mark.asyncio
+async def test_validate_url_allows_public_ip():
+    """Public IPs pass validation."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    ):
+        result = await validate_url_for_spec('https://example.com/spec.json')
+        assert result.hostname == 'example.com'
+        assert result.resolved_ips == ['93.184.216.34']
+
+
+# --- Path Validation Tests ---
+
+
+def test_validate_spec_path_blocks_etc():
+    """Paths under /etc are blocked."""
+    with patch('awslabs.openapi_mcp_server.utils.url_validator.Path.resolve') as mock_resolve:
+        resolved = MagicMock()
+        resolved.suffix = '.json'
+        resolved.exists.return_value = True
+        resolved.__str__ = lambda s: '/etc/secrets.json'
+        mock_resolve.return_value = resolved
+        with pytest.raises(SSRFError, match='blocked location'):
+            validate_spec_path('/etc/secrets.json')
+
+
+def test_validate_spec_path_blocks_non_spec_extension():
+    """Non-spec file extensions are rejected."""
+    with patch('awslabs.openapi_mcp_server.utils.url_validator.Path') as MockPath:
+        mock_resolved = MagicMock()
+        mock_resolved.suffix = '.py'
+        mock_resolved.exists.return_value = True
+        mock_resolved.__str__ = lambda s: '/app/code.py'
+        MockPath.return_value.resolve.return_value = mock_resolved
+        with pytest.raises(SSRFError, match='spec file'):
+            validate_spec_path('/app/code.py')
+
+
+def test_validate_spec_path_enforces_allowed_dirs():
+    """When allowed_dirs is set, path must be within them."""
+    with patch('awslabs.openapi_mcp_server.utils.url_validator.Path') as MockPath:
+        mock_resolved = MagicMock()
+        mock_resolved.suffix = '.json'
+        mock_resolved.exists.return_value = True
+        mock_resolved.__str__ = lambda s: '/data/other/spec.json'
+        MockPath.return_value.resolve.return_value = mock_resolved
+        MockPath.return_value.resolve.return_value = mock_resolved
+        # Also mock Path(d).resolve() for allowed_dirs
+        MockPath.side_effect = lambda p: (
+            MagicMock(resolve=MagicMock(return_value=MagicMock(__str__=lambda s: str(p))))
+            if p != '/data/other/spec.json'
+            else MagicMock(resolve=MagicMock(return_value=mock_resolved))
+        )
+        with pytest.raises(SSRFError, match='not within allowed'):
+            validate_spec_path('/data/other/spec.json', allowed_dirs=['/app/specs'])
+
+
+def test_validate_spec_path_boundary_guard():
+    """allowed_dirs '/app/specs' must NOT admit '/app/specs-evil/spec.json'."""
+    with patch('awslabs.openapi_mcp_server.utils.url_validator.Path') as MockPath:
+        mock_resolved = MagicMock()
+        mock_resolved.suffix = '.json'
+        mock_resolved.exists.return_value = True
+        mock_resolved.__str__ = lambda s: '/app/specs-evil/spec.json'
+        MockPath.side_effect = lambda p: (
+            MagicMock(resolve=MagicMock(return_value=MagicMock(__str__=lambda s: str(p))))
+            if p != '/app/specs-evil/spec.json'
+            else MagicMock(resolve=MagicMock(return_value=mock_resolved))
+        )
+        with pytest.raises(SSRFError, match='not within allowed'):
+            validate_spec_path('/app/specs-evil/spec.json', allowed_dirs=['/app/specs'])
+
+
+def test_validate_spec_path_accepts_valid_path(tmp_path):
+    """A valid spec file within an allowed directory is accepted."""
+    spec_file = tmp_path / 'openapi.json'
+    spec_file.write_text('{}')
+    result = validate_spec_path(str(spec_file), allowed_dirs=[str(tmp_path)])
+    assert result == str(spec_file.resolve())
+
+
+def test_validate_spec_path_rejects_symlink_escape(tmp_path):
+    """A symlink that escapes the allowed directory is rejected."""
+    allowed_dir = tmp_path / 'allowed'
+    allowed_dir.mkdir()
+    outside_file = tmp_path / 'secret.json'
+    outside_file.write_text('{}')
+    symlink = allowed_dir / 'escape.json'
+    symlink.symlink_to(outside_file)
+    with pytest.raises(SSRFError, match='not within allowed'):
+        validate_spec_path(str(symlink), allowed_dirs=[str(allowed_dir)])
+
+
+@pytest.mark.asyncio
+async def test_validate_url_malformed_hostname_does_not_crash():
+    """A malformed hostname raises SSRFError, not an uncaught exception."""
+    with pytest.raises(SSRFError):
+        await validate_url_for_spec('https://\x00invalid/spec.json')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_oserror_from_dns_wrapped_as_ssrf():
+    """OSError from DNS resolution is wrapped as SSRFError."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        side_effect=OSError('Network unreachable'),
+    ):
+        with pytest.raises(SSRFError, match='DNS resolution failed'):
+            await validate_url_for_spec('https://unreachable.example.com/spec.json')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_unicode_error_wrapped_as_ssrf():
+    """UnicodeError from DNS resolution is wrapped as SSRFError."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        side_effect=UnicodeError('encoding error'),
+    ):
+        with pytest.raises(SSRFError, match='DNS resolution failed'):
+            await validate_url_for_spec('https://bad-encoding.example.com/spec.json')
+
+
+# --- Credential Isolation Tests ---
+
+
+@pytest.mark.asyncio
+async def test_additional_specs_do_not_inherit_primary_auth():
+    """Additional specs must NOT receive the primary API's auth credentials."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'partner',
+                'spec_url': 'https://partner.example.com/spec.json',
+                'base_url': 'https://partner.example.com',
+            }
+        ]
+    )
+    config = _config(
+        additional_specs=extra,
+        auth_type='bearer',
+        auth_token='SECRET_PRIMARY_TOKEN',
+    )
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'partner' in url:
+                return EXTRA_SPEC
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        await create_mcp_server_async(config)
+
+        # Find the call for the additional spec client (second call to create_client)
+        assert mock_client.call_count >= 2
+        extra_call = mock_client.call_args_list[1]
+        extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
+        extra_headers = extra_kwargs.get('headers') or {}
+
+        # The primary token must NOT be forwarded
+        assert 'Authorization' not in (extra_headers or {})
+        assert extra_kwargs.get('auth') is None
+
+
+@pytest.mark.asyncio
+async def test_additional_specs_per_entry_auth():
+    """Additional specs use their own per-entry auth configuration."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'partner',
+                'spec_url': 'https://partner.example.com/spec.json',
+                'base_url': 'https://partner.example.com',
+                'auth_type': 'bearer',
+                'auth_token': 'PARTNER_TOKEN',
+            }
+        ]
+    )
+    config = _config(
+        additional_specs=extra,
+        auth_type='bearer',
+        auth_token='SECRET_PRIMARY_TOKEN',
+    )
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+        patch('awslabs.openapi_mcp_server.auth.register.register_provider_by_type'),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'partner' in url:
+                return EXTRA_SPEC
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        await create_mcp_server_async(config)
+
+        # Second call is for the additional spec
+        extra_call = mock_client.call_args_list[1]
+        extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
+        extra_headers = extra_kwargs.get('headers') or {}
+
+        # Partner's own token is used, NOT the primary
+        assert extra_headers.get('Authorization') == 'Bearer PARTNER_TOKEN'
+
+
+@pytest.mark.asyncio
+async def test_validate_url_rejects_no_host():
+    """URL without a host is rejected."""
+    with pytest.raises(SSRFError, match='must have a host'):
+        await validate_url_for_spec('https://')
+
+
+@pytest.mark.asyncio
+async def test_validate_url_http_port_defaults_to_80():
+    """HTTP URL defaults to port 80."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    ):
+        result = await validate_url_for_spec('http://example.com/spec.json', allow_http=True)
+        assert result.port == 80
+
+
+@pytest.mark.asyncio
+async def test_validate_url_https_port_defaults_to_443():
+    """HTTPS URL defaults to port 443."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    ):
+        result = await validate_url_for_spec('https://example.com/spec.json')
+        assert result.port == 443
+
+
+def test_validate_spec_path_file_not_found():
+    """Non-existent file raises FileNotFoundError."""
+    with patch('awslabs.openapi_mcp_server.utils.url_validator.Path') as MockPath:
+        mock_resolved = MagicMock()
+        mock_resolved.suffix = '.json'
+        mock_resolved.exists.return_value = False
+        mock_resolved.__str__ = lambda s: '/app/specs/missing.json'
+        MockPath.return_value.resolve.return_value = mock_resolved
+        with pytest.raises(FileNotFoundError, match='File not found'):
+            validate_spec_path('/app/specs/missing.json')
+
+
+# --- Integration: SSRF blocks additional specs ---
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_with_private_ip_is_skipped():
+    """Additional spec pointing to private IP is skipped with warning."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'internal',
+                'spec_url': 'https://internal-api/spec.json',
+                'base_url': 'https://internal-api',
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['10.0.0.5'],
+        ),
+    ):
+        mock_load.return_value = PETSTORE_SPEC
+        mock_client.return_value = MagicMock()
+
+        server = await create_mcp_server_async(config)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+
+        # Only primary spec tools should be registered
+        assert 'listPets' in names
+        # The additional spec should have been skipped
+        assert 'createPayment' not in names
+
+
+def test_validate_spec_path_blocks_windows_system_dir():
+    """Windows system directories are blocked when os.name == 'nt'."""
+    with (
+        patch('awslabs.openapi_mcp_server.utils.url_validator.os.name', 'nt'),
+        patch('awslabs.openapi_mcp_server.utils.url_validator.os.sep', '\\'),
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.os.environ',
+            {'SYSTEMROOT': r'C:\Windows'},
+        ),
+        patch('awslabs.openapi_mcp_server.utils.url_validator.os.path') as mock_ospath,
+        patch('awslabs.openapi_mcp_server.utils.url_validator.Path') as MockPath,
+    ):
+        mock_ospath.expanduser.return_value = r'C:\Users\admin'
+        mock_resolved = MagicMock()
+        mock_resolved.suffix = '.json'
+        mock_resolved.exists.return_value = True
+        mock_resolved.__str__ = lambda s: r'C:\Windows\System32\config\spec.json'
+        MockPath.return_value.resolve.return_value = mock_resolved
+        with pytest.raises(SSRFError, match='blocked location'):
+            validate_spec_path(r'C:\Windows\System32\config\spec.json')
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_with_invalid_spec_path_is_skipped():
+    """Additional spec with blocked spec_path is skipped."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'internal',
+                'spec_path': '/etc/shadow.json',
+                'base_url': 'https://public-api.example.com',
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.Path',
+        ) as MockPath,
+    ):
+        mock_resolved = MagicMock()
+        mock_resolved.suffix = '.json'
+        mock_resolved.exists.return_value = True
+        mock_resolved.__str__ = lambda s: '/etc/shadow.json'
+        MockPath.return_value.resolve.return_value = mock_resolved
+
+        mock_load.return_value = PETSTORE_SPEC
+        mock_client.return_value = MagicMock()
+
+        server = await create_mcp_server_async(config)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert 'createPayment' not in names
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_load_failure_is_skipped():
+    """Additional spec that fails to load is skipped gracefully."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'broken',
+                'spec_url': 'https://broken.example.com/spec.json',
+                'base_url': 'https://broken.example.com',
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'broken' in url:
+                raise RuntimeError('Connection refused')
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        server = await create_mcp_server_async(config)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert 'listPets' in names
+        assert 'createPayment' not in names
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_with_private_spec_url_is_skipped():
+    """Additional spec with private spec_url is skipped."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'internal',
+                'spec_url': 'https://internal-spec/openapi.json',
+                'base_url': 'https://public-api.example.com',
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    call_count = [0]
+
+    async def mock_resolve(hostname, port=443):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return ['93.184.216.34']  # base_url passes
+        return ['10.0.0.5']  # spec_url blocked
+
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            side_effect=mock_resolve,
+        ),
+    ):
+        mock_load.return_value = PETSTORE_SPEC
+        mock_client.return_value = MagicMock()
+
+        server = await create_mcp_server_async(config)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert 'createPayment' not in names
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_api_key_query_warns():
+    """API key in query is dropped with a warning (not sent, not silently ignored)."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'partner',
+                'spec_url': 'https://partner.example.com/spec.json',
+                'base_url': 'https://partner.example.com',
+                'auth_type': 'api_key',
+                'auth_api_key': 'MY_KEY',  # pragma: allowlist secret
+                'auth_api_key_in': 'query',  # pragma: allowlist secret
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'partner' in url:
+                return EXTRA_SPEC
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        await create_mcp_server_async(config)
+
+        # The spec loads but the API key is NOT sent (query not supported)
+        extra_call = mock_client.call_args_list[1]
+        extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
+        extra_headers = extra_kwargs.get('headers') or {}
+        assert 'X-API-Key' not in extra_headers
+        assert extra_kwargs.get('cookies') is None
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_api_key_cookie_is_passed():
+    """API key in cookie is passed via cookies kwarg to client."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'partner',
+                'spec_url': 'https://partner.example.com/spec.json',
+                'base_url': 'https://partner.example.com',
+                'auth_type': 'api_key',
+                'auth_api_key': 'MY_KEY',  # pragma: allowlist secret
+                'auth_api_key_in': 'cookie',  # pragma: allowlist secret
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'partner' in url:
+                return EXTRA_SPEC
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        await create_mcp_server_async(config)
+
+        # Second call is for the additional spec
+        extra_call = mock_client.call_args_list[1]
+        extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
+        assert extra_kwargs.get('cookies') == {'X-API-Key': 'MY_KEY'}
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_basic_auth():
+    """Additional spec with basic auth creates client with BasicAuth."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'partner',
+                'spec_url': 'https://partner.example.com/spec.json',
+                'base_url': 'https://partner.example.com',
+                'auth_type': 'basic',
+                'auth_username': 'user',
+                'auth_password': 'pass',  # pragma: allowlist secret
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'partner' in url:
+                return EXTRA_SPEC
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        await create_mcp_server_async(config)
+
+        # Second call is for the additional spec
+        extra_call = mock_client.call_args_list[1]
+        extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
+        import httpx
+
+        assert isinstance(extra_kwargs.get('auth'), httpx.BasicAuth)
+
+
+@pytest.mark.asyncio
+async def test_additional_spec_unrecognized_auth_type_warns():
+    """Unrecognized auth_type logs warning and proceeds unauthenticated."""
+    extra = json.dumps(
+        [
+            {
+                'name': 'partner',
+                'spec_url': 'https://partner.example.com/spec.json',
+                'base_url': 'https://partner.example.com',
+                'auth_type': 'bearter',  # typo
+            }
+        ]
+    )
+    config = _config(additional_specs=extra)
+    with (
+        patch('awslabs.openapi_mcp_server.server.load_openapi_spec') as mock_load,
+        patch('awslabs.openapi_mcp_server.server.validate_openapi_spec', return_value=True),
+        patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+    ):
+
+        def load_side_effect(url='', path=''):
+            if 'partner' in url:
+                return EXTRA_SPEC
+            return PETSTORE_SPEC
+
+        mock_load.side_effect = load_side_effect
+        mock_client.return_value = MagicMock()
+
+        server = await create_mcp_server_async(config)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        # Spec still loads, just unauthenticated
+        assert 'createPayment' in names
+        # Client created with no auth
+        extra_call = mock_client.call_args_list[1]
+        extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
+        assert extra_kwargs.get('auth') is None
+        assert not (extra_kwargs.get('headers') or {})

--- a/src/openapi-mcp-server/uv.lock
+++ b/src/openapi-mcp-server/uv.lock
@@ -58,19 +58,20 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
 name = "awslabs-openapi-mcp-server"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
@@ -118,11 +119,11 @@ yaml = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bcrypt", specifier = ">=4.3.0,<5" },
-    { name = "boto3", specifier = ">=1.42.87,<2" },
-    { name = "cachetools", specifier = ">=6.1.0,<7" },
+    { name = "bcrypt", specifier = ">=4.3.0,<6" },
+    { name = "boto3", specifier = ">=1.43.0,<2" },
+    { name = "cachetools", specifier = ">=6.1.0,<8" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.13.9,<5" },
-    { name = "fastmcp", specifier = ">=3.2.2,<4" },
+    { name = "fastmcp", specifier = ">=3.3.1,<4" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "loguru", specifier = ">=0.7.3,<1" },
     { name = "lxml", marker = "extra == 'dev'", specifier = ">=6.0.0,<7" },
@@ -145,7 +146,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.3,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10,<1" },
     { name = "tenacity", specifier = ">=9.1.2,<10" },
-    { name = "typing-extensions", specifier = ">=4.14.1,<5" },
+    { name = "typing-extensions", specifier = ">=4.15.0,<5" },
     { name = "uvicorn", specifier = ">=0.35.0,<1" },
 ]
 provides-extras = ["yaml", "prometheus", "test", "dev", "all"]
@@ -237,30 +238,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.87"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/f6/3f908a1313a8c8d5bf19f0cae3c372dd757569d75e8e3eee4c57fcd4e286/boto3-1.42.87.tar.gz", hash = "sha256:b5b86a826f8f12c7d38679f35bd0135807a6867a21eb8be6dea7c27aeb14ec14", size = 112793, upload-time = "2026-04-09T19:39:50.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/37/2ae45d06423182b4561c03bc33494fafa21a0d1e847f0554f590e3cbbc62/boto3-1.43.18.tar.gz", hash = "sha256:33138883e984eb1937d1553da699182c8ad2099138091e885b65c9accbccea16", size = 113154, upload-time = "2026-05-29T19:33:30.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/52/69ebde82ce8b47cdee52b2450b2cbf1b3b107e192a3223bf88a567373d85/boto3-1.42.87-py3-none-any.whl", hash = "sha256:15cc1404b3ccbcfe17bd5834d467b1b28d53d9aca44e3798dc44876ac57362e6", size = 140557, upload-time = "2026-04-09T19:39:47.669Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/75/fcb2c10d516496536c50e397248de42a673d8ea8137caf5b578a72b11293/boto3-1.43.18-py3-none-any.whl", hash = "sha256:7b62ce5c0a51428d692aa4f2adc9dc2a4a4c2989bf65a0a12834eeffa99b0b84", size = 140538, upload-time = "2026-05-29T19:33:27.131Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.87"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/59/606c6cb6d42bf8ca3f422c6345401134e56d671385dc2b80fb4b09c51e67/botocore-1.42.87.tar.gz", hash = "sha256:1c6cc9555c1feec50b290a42de70ba6f04826c009562c2c12bb9990d0258482d", size = 15193113, upload-time = "2026-04-09T19:39:37.492Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/6d/436d69ec484ffc43635b38d7fb7d717d38824671f10e12e77924019ca929/botocore-1.43.18.tar.gz", hash = "sha256:dc8c105351b49688c667065cd5a45fc5b9db982657cefc9e3fbfb9417a55c7df", size = 15424886, upload-time = "2026-05-29T19:33:16.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/1f/94e1b020fd87b52f092fdd111d9800f2411dc113a0957d0d85b7d2c7f247/botocore-1.42.87-py3-none-any.whl", hash = "sha256:32832df27c039cc1a518289afe0f6006296d3df26603b5f66e911457e67f0146", size = 14871982, upload-time = "2026-04-09T19:39:32.847Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5a/35c92c0af1514581031fe66c398b622176b3c928a6d5cf8133c7207e3bd7/botocore-1.43.18-py3-none-any.whl", hash = "sha256:e2610fce16df9f89deab5f3c163430a814e6804034eb95bef8957c8db60b7dbc", size = 15106258, upload-time = "2026-05-29T19:33:11.18Z" },
 ]
 
 [[package]]
@@ -783,12 +784,47 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.2"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -796,21 +832,14 @@ dependencies = [
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/61/a4470e2f590d98a1db3d40cb6f424a1353b2b09d4d0dfe01d0b8d3987984/fastmcp-3.2.2.tar.gz", hash = "sha256:a5351ec8c098844a8d508a53e484b362f5357b890596aaf233ac9686a796a62f", size = 26328077, upload-time = "2026-04-09T01:33:04.558Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/3b/4225e516266146de5fc6e64a7357f0c1460e4f7134b2f0e6447ae35413f5/fastmcp-3.2.2-py3-none-any.whl", hash = "sha256:9d2fe9731bbae43e6979a0bf7194bd076fd014f780c118edfdc52645b9adbe5b", size = 707240, upload-time = "2026-04-09T01:33:00.938Z" },
 ]
 
 [[package]]
@@ -820,6 +849,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -971,6 +1009,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/ac/d4fd5b30f82900eac60d765f179f0ba005825ac462cc8ced6e13ec685ab3/joserfc-1.6.8.tar.gz", hash = "sha256:878620c553a6ebdd76ccdc356782fee3f735f21a356d079a546b42a4670ace5f", size = 232930, upload-time = "2026-05-27T03:22:37.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/8c/5cdce2cf3ce8155849baf9a5e2ce77e89dc87ec3bdb38259e5d85fbc45bd/joserfc-1.6.8-py3-none-any.whl", hash = "sha256:22fb31a69094a5e6f44632002a9df2c30c941fc6c8ce1b037e92c03de954cf9f", size = 70927, upload-time = "2026-05-27T03:22:35.796Z" },
 ]
 
 [[package]]
@@ -1774,11 +1824,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -2138,14 +2188,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR addresses security hardening in the openapi-mcp-server's multi-spec composition feature and resolves FastMCP 3.x prompt handler incompatibility. Bumps version to v1.1.0.

### Security Fixes

- **SSRF vulnerability in multi-spec configuration** ([CWE-918](https://cwe.mitre.org/data/definitions/918.html)): `spec_url` and `base_url` in `additional_specs` were fetched without URL validation, allowing server-side requests to internal networks and cloud metadata endpoints (169.254.169.254). Now validates via DNS resolution + IP allowlisting using `fastmcp.server.auth.ssrf`.
- **Credential leakage to additional spec endpoints** ([CWE-522](https://cwe.mitre.org/data/definitions/522.html)): Primary API auth tokens/headers/cookies were silently forwarded to all additional spec `base_url` endpoints. Analogous to [CVE-2023-36052](https://nvd.nist.gov/vuln/detail/CVE-2023-36052). Now each entry must declare its own auth.
- **Path traversal via `spec_path`** ([CWE-22](https://cwe.mitre.org/data/definitions/22.html)): `spec_path` accepted arbitrary file paths without canonicalization. Analogous to [CVE-2024-37032](https://nvd.nist.gov/vuln/detail/CVE-2024-37032). Now validates extensions, resolves symlinks, and blocks sensitive directories.

### Bug Fix

- **Prompt handlers broken on FastMCP 3.x**: Handlers returned `list[dict]` which causes `TypeError` in FastMCP 3.x's `convert_result` pipeline. Migrated to `fastmcp.Message` objects and `EmbeddedResource` for resource-type operations. Thanks to @gmishkin for reporting this issue.

### New Features

- Per-entry authentication for `additional_specs` entries (`auth_type`, `auth_token`, `auth_api_key`, `auth_username`, `auth_password`)
- `--allow-insecure-http` / `ALLOW_INSECURE_HTTP` to permit HTTP URLs (default: HTTPS only)
- `--allow-private-networks` / `ALLOW_PRIVATE_NETWORKS` to permit private/loopback IPs (default: blocked)
- `--allowed-spec-dirs` / `ALLOWED_SPEC_DIRS` to restrict `spec_path` to specific directories
- New `SECURITY.md` documenting security model, SSRF protections, and responsible disclosure

## Breaking Changes

- Additional specs no longer inherit primary API credentials. Each entry must specify its own `auth_type`/`auth_token` or defaults to no authentication. See CHANGELOG.md Migration Guide.
- `http://` URLs for spec/base URLs are now rejected by default (add `--allow-insecure-http` to restore).
- Private/loopback/link-local IPs are now rejected by default (add `--allow-private-networks` to restore).

## Dependencies

- Bumped `fastmcp` to `>=3.3.1` (includes SSRF utilities)
- Updated `boto3>=1.43.0`, `typing-extensions>=4.15.0`
- Widened `cachetools<8` and `bcrypt<6` for forward compatibility

## Testing

- 468 tests passing (28 new: 17 SSRF + 11 prompt format)
- Coverage: 91% (up from 90% baseline)
- `detect-secrets scan` clean — no secrets detected
- `ruff check` + `ruff format` clean

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (468 tests, 91% coverage)
* [x] Changes are documented (CHANGELOG.md, README.md, SECURITY.md)
* [x] Security scan passed (detect-secrets baseline up to date)

Is this a breaking change? **Yes** — additional specs credential inheritance removed (security fix).

## Acknowledgments

- @gmishkin — reported the prompt handler schema bug (FastMCP 3.x Message compatibility)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).