### PR TITLE
fix(aws-transform-mcp-server): Confine write path and block sensitive filenames on writes

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
@@ -19,7 +19,7 @@ from loguru import logger
 from typing import Optional
 
 
-# File basenames that must never be read.
+# File basenames that must never be read or written.
 BLOCKED_FILENAMES: frozenset[str] = frozenset(
     {
         '.env',
@@ -59,6 +59,11 @@ BLOCKED_READ_DIRS: tuple[str, ...] = (
     '/etc/passwd',
 )
 
+# Allowed base directory for write operations. All writes must resolve under
+# the current working directory at import time. This prevents LLM-controlled
+# savePath from writing to arbitrary filesystem locations.
+_ALLOWED_WRITE_BASE: str = os.path.realpath(os.getcwd())
+
 
 def _is_blocked_name(path: str) -> bool:
     return os.path.basename(path).lower() in BLOCKED_FILENAMES
@@ -95,12 +100,23 @@ def validate_write_path(save_path: str, file_name: Optional[str] = None) -> str:
 
     Prevents path traversal by stripping directory components from *file_name*
     via os.path.basename(), ensuring the write stays within *save_path*.
-    Also blocks writes into sensitive directories.
+    Confines all writes to the allowed base directory (CWD at startup).
+    Blocks writes into sensitive directories and to sensitive filenames.
 
     Returns the resolved absolute write path.
     Raises ValueError on any policy violation.
     """
     resolved_dir = os.path.realpath(os.path.expanduser(save_path))
+
+    # Confine writes to the allowed base directory.
+    if resolved_dir != _ALLOWED_WRITE_BASE and not resolved_dir.startswith(
+        _ALLOWED_WRITE_BASE + os.sep
+    ):
+        logger.warning('[security] Blocked write outside allowed base: {}', save_path)
+        raise ValueError(
+            f'Write path must be within the working directory '
+            f'({_ALLOWED_WRITE_BASE}), got: {save_path}'
+        )
 
     if _in_blocked_dir(resolved_dir):
         logger.warning('[security] Blocked write to sensitive directory: {}', save_path)
@@ -113,6 +129,15 @@ def validate_write_path(save_path: str, file_name: Optional[str] = None) -> str:
     else:
         safe_name = None
 
-    if safe_name:
-        return os.path.join(resolved_dir, safe_name)
-    return resolved_dir
+    final_path = os.path.join(resolved_dir, safe_name) if safe_name else resolved_dir
+
+    # Enforce blocked filename list on writes (not just reads).
+    if _is_blocked_name(final_path):
+        logger.warning(
+            '[security] Blocked write of sensitive filename: {}', os.path.basename(final_path)
+        )
+        raise ValueError(
+            f'Blocked filename: {os.path.basename(final_path)} cannot be written.'
+        )
+
+    return final_path

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
@@ -136,8 +136,6 @@ def validate_write_path(save_path: str, file_name: Optional[str] = None) -> str:
         logger.warning(
             '[security] Blocked write of sensitive filename: {}', os.path.basename(final_path)
         )
-        raise ValueError(
-            f'Blocked filename: {os.path.basename(final_path)} cannot be written.'
-        )
+        raise ValueError(f'Blocked filename: {os.path.basename(final_path)} cannot be written.')
 
     return final_path

--- a/src/aws-transform-mcp-server/tests/test_file_validation.py
+++ b/src/aws-transform-mcp-server/tests/test_file_validation.py
@@ -105,66 +105,115 @@ class TestValidateReadPath:
 
 
 class TestValidateWritePath:
-    """Tests for validate_write_path — path traversal, blocked dirs, edge cases."""
+    """Tests for validate_write_path — path traversal, blocked dirs, base confinement, blocked filenames."""
 
     def test_traversal_in_filename_stripped(self):
-        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
-
-        result = validate_write_path('/tmp/downloads', '../../etc/passwd')
-        assert result == '/tmp/downloads/passwd'
-
-    def test_deep_traversal_stripped(self):
-        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
-
-        result = validate_write_path('/tmp/downloads', '../../../../root/.ssh/authorized_keys')
-        assert result == '/tmp/downloads/authorized_keys'
-
-    def test_legitimate_filename_unchanged(self):
-        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
-
-        result = validate_write_path('/tmp/downloads', 'artifact.json')
-        assert result == '/tmp/downloads/artifact.json'
-
-    def test_no_filename_returns_resolved_dir(self):
+        from awslabs.aws_transform_mcp_server import file_validation
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            result = validate_write_path(tmpdir)
-            assert result == os.path.realpath(tmpdir)
+            downloads = os.path.join(tmpdir, 'downloads')
+            os.makedirs(downloads)
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                result = validate_write_path(downloads, '../../etc/passwd')
+                assert result == os.path.join(os.path.realpath(downloads), 'passwd')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_deep_traversal_stripped(self):
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads = os.path.join(tmpdir, 'downloads')
+            os.makedirs(downloads)
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                # 'authorized_keys' is in BLOCKED_FILENAMES, so this should now raise
+                with pytest.raises(ValueError, match='Blocked filename'):
+                    validate_write_path(downloads, '../../../../root/.ssh/authorized_keys')
+                # Non-blocked filename with deep traversal should still work (basename stripped)
+                result = validate_write_path(downloads, '../../../../tmp/safe_file.txt')
+                assert result == os.path.join(os.path.realpath(downloads), 'safe_file.txt')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_legitimate_filename_unchanged(self):
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads = os.path.join(tmpdir, 'downloads')
+            os.makedirs(downloads)
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                result = validate_write_path(downloads, 'artifact.json')
+                assert result == os.path.join(os.path.realpath(downloads), 'artifact.json')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_no_filename_returns_resolved_dir(self):
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                result = validate_write_path(tmpdir)
+                assert result == os.path.realpath(tmpdir)
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
 
     def test_blocked_dir_raises_valueerror(self):
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
         home = os.path.expanduser('~')
-        with pytest.raises(ValueError, match='sensitive directory'):
+        with pytest.raises(ValueError):
             validate_write_path(os.path.join(home, '.ssh'), 'authorized_keys')
 
     def test_blocked_dir_aws_raises_valueerror(self):
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
         home = os.path.expanduser('~')
-        with pytest.raises(ValueError, match='sensitive directory'):
+        with pytest.raises(ValueError):
             validate_write_path(os.path.join(home, '.aws'), 'credentials')
 
     def test_dotdot_filename_raises_valueerror(self):
+        from awslabs.aws_transform_mcp_server import file_validation
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
-        with pytest.raises(ValueError, match='Invalid file name'):
-            validate_write_path('/tmp', '..')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                with pytest.raises(ValueError, match='Invalid file name'):
+                    validate_write_path(tmpdir, '..')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
 
     def test_slash_filename_raises_valueerror(self):
+        from awslabs.aws_transform_mcp_server import file_validation
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
-        with pytest.raises(ValueError, match='Invalid file name'):
-            validate_write_path('/tmp', '/')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                with pytest.raises(ValueError, match='Invalid file name'):
+                    validate_write_path(tmpdir, '/')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
 
     def test_tilde_expansion_in_save_path(self):
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
-        with pytest.raises(ValueError, match='sensitive directory'):
+        with pytest.raises(ValueError, match='working directory'):
             validate_write_path('~/.ssh', 'key')
-        result = validate_write_path('/tmp', 'file.txt')
-        assert result == '/tmp/file.txt'
 
     def test_blocked_dir_logs_warning(self):
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
@@ -176,3 +225,72 @@ class TestValidateWritePath:
         ):
             validate_write_path(os.path.join(home, '.ssh'), 'authorized_keys')
         mock_logger.warning.assert_called_once()
+
+    def test_write_outside_allowed_base_raises_valueerror(self):
+        """savePath outside CWD must be rejected — prevents arbitrary file write."""
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with pytest.raises(ValueError, match='working directory'):
+            validate_write_path('/etc/cron.d', 'backdoor')
+
+    def test_write_to_home_dir_raises_valueerror(self):
+        """Writing to ~ (home directory) must be blocked — not within CWD."""
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with pytest.raises(ValueError, match='working directory'):
+            validate_write_path('~', '.bashrc')
+
+    def test_write_to_autostart_raises_valueerror(self):
+        """Writing to autostart folder must be blocked."""
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with pytest.raises(ValueError, match='working directory'):
+            validate_write_path(os.path.expanduser('~/.config/autostart'), 'evil.desktop')
+
+    def test_blocked_filename_on_write_raises_valueerror(self):
+        """Sensitive filenames must be blocked on writes, not just reads."""
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                with pytest.raises(ValueError, match='Blocked filename'):
+                    validate_write_path(tmpdir, '.bashrc')
+                with pytest.raises(ValueError, match='Blocked filename'):
+                    validate_write_path(tmpdir, '.env')
+                with pytest.raises(ValueError, match='Blocked filename'):
+                    validate_write_path(tmpdir, 'credentials')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_write_within_cwd_allowed(self):
+        """Writes within CWD should succeed."""
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                result = validate_write_path(tmpdir, 'artifact.json')
+                assert result == os.path.join(os.path.realpath(tmpdir), 'artifact.json')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_write_within_cwd_subdir_allowed(self):
+        """Writes to subdirectories of CWD should succeed."""
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, 'downloads')
+            os.makedirs(subdir)
+            original_base = file_validation._ALLOWED_WRITE_BASE
+            try:
+                file_validation._ALLOWED_WRITE_BASE = os.path.realpath(tmpdir)
+                result = validate_write_path(subdir, 'output.zip')
+                assert result == os.path.join(os.path.realpath(subdir), 'output.zip')
+            finally:
+                file_validation._ALLOWED_WRITE_BASE = original_base

--- a/src/aws-transform-mcp-server/tests/test_file_validation.py
+++ b/src/aws-transform-mcp-server/tests/test_file_validation.py
@@ -227,7 +227,7 @@ class TestValidateWritePath:
         mock_logger.warning.assert_called_once()
 
     def test_write_outside_allowed_base_raises_valueerror(self):
-        """savePath outside CWD must be rejected — prevents arbitrary file write."""
+        """SavePath outside CWD must be rejected — prevents arbitrary file write."""
         from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
         with pytest.raises(ValueError, match='working directory'):

--- a/src/aws-transform-mcp-server/tests/test_tool_utils.py
+++ b/src/aws-transform-mcp-server/tests/test_tool_utils.py
@@ -45,7 +45,7 @@ def _allow_tmp_writes(monkeypatch):
     """Disable write-path confinement so integration tests can use tmp_path."""
     monkeypatch.setattr(
         'awslabs.aws_transform_mcp_server.file_validation._ALLOWED_WRITE_BASE',
-        '/',
+        '',
     )
 
 

--- a/src/aws-transform-mcp-server/tests/test_tool_utils.py
+++ b/src/aws-transform-mcp-server/tests/test_tool_utils.py
@@ -18,6 +18,7 @@
 import httpx
 import json
 import os
+import tempfile
 import pytest
 from awslabs.aws_transform_mcp_server.tool_utils import (
     CREATE,
@@ -38,6 +39,15 @@ from awslabs.aws_transform_mcp_server.tool_utils import (
     text_result,
 )
 from unittest.mock import AsyncMock, patch
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_writes(monkeypatch):
+    """Allow write-path validation to accept tmp_path locations in tests."""
+    monkeypatch.setattr(
+        'awslabs.aws_transform_mcp_server.file_validation._ALLOWED_WRITE_BASE',
+        tempfile.gettempdir(),
+    )
 
 
 # ── Annotation dicts ─────────────────────────────────────────────────────

--- a/src/aws-transform-mcp-server/tests/test_tool_utils.py
+++ b/src/aws-transform-mcp-server/tests/test_tool_utils.py
@@ -18,7 +18,6 @@
 import httpx
 import json
 import os
-import tempfile
 import pytest
 from awslabs.aws_transform_mcp_server.tool_utils import (
     CREATE,
@@ -43,10 +42,10 @@ from unittest.mock import AsyncMock, patch
 
 @pytest.fixture(autouse=True)
 def _allow_tmp_writes(monkeypatch):
-    """Allow write-path validation to accept tmp_path locations in tests."""
+    """Disable write-path confinement so integration tests can use tmp_path."""
     monkeypatch.setattr(
         'awslabs.aws_transform_mcp_server.file_validation._ALLOWED_WRITE_BASE',
-        tempfile.gettempdir(),
+        '/',
     )
 
 
@@ -512,9 +511,9 @@ class TestDownloadS3ContentPathTraversal:
             result = await download_s3_content(
                 'https://s3.example.com/artifact',
                 save_path=save_dir,
-                file_name='../../../../root/.ssh/authorized_keys',
+                file_name='../../../../root/documents/report.txt',
             )
-            assert result['savedTo'] == os.path.join(str(tmp_path), 'authorized_keys')
+            assert result['savedTo'] == os.path.join(str(tmp_path), 'report.txt')
 
     @pytest.mark.asyncio
     async def test_blocked_save_path_raises(self):


### PR DESCRIPTION
## Summary

Fixes arbitrary file write vulnerability in `validate_write_path` where:
1. `savePath` was not confined to an allowed base directory — any directory outside the 7 hardcoded blocked dirs was writable
2. `BLOCKED_FILENAMES` blocklist was not enforced on write operations (only reads)

The `get_resource` tool exposes `savePath` and `fileName` as LLM-controlled parameters. Without confinement, writes could escape to `~/.bashrc`, autostart folders, `/etc/cron.d`, etc.

## Changes

**`file_validation.py`:**
- Added `_ALLOWED_WRITE_BASE` (resolved CWD at import) — all writes must resolve under this directory
- Added blocked filename check on the final write path (not just reads)

**`test_file_validation.py`:**
- Updated existing tests to work with base directory confinement
- Added 6 new security tests covering the exact attack vectors reported

## Attack vectors blocked

| Before (vulnerable) | After (blocked) |
|---------------------|-----------------|
| `savePath="~", fileName=".bashrc"` | Rejected: outside CWD |
| `savePath="~/.config/autostart", fileName="evil.desktop"` | Rejected: outside CWD |
| `savePath="/etc/cron.d", fileName="backdoor"` | Rejected: outside CWD |
| `savePath=<within CWD>, fileName=".env"` | Rejected: blocked filename |

## Testing

All 24 tests pass: `pytest tests/test_file_validation.py -v`

## Related

- Incomplete fix of PR #3604 (sanitized fileName but left savePath unconfined)
- Security report: P444337248
- Ticket: D464432980

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).