### PR TITLE
fix(billing-cost-management): Accept region parameter for Compute Optimizer instead of hardcoding us-east-1

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/compute_optimizer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/compute_optimizer_tools.py
@@ -17,6 +17,7 @@
 Updated to use shared utility functions.
 """
 
+import os
 from ..utilities.aws_service_base import (
     create_aws_client,
     format_response,
@@ -48,6 +49,8 @@ USE THIS TOOL FOR:
 
 DO NOT USE FOR: Cost optimization or idle detection (use cost-optimization-hub)
 
+**Note:** Compute Optimizer is a regional service. Specify a `region` to get recommendations for resources in that region. If omitted, defaults to AWS_REGION env var or us-east-1.
+
 This tool supports the following operations:
 1. get_ec2_instance_recommendations: Get recommendations for EC2 instances
 2. get_auto_scaling_group_recommendations: Get recommendations for Auto Scaling groups
@@ -67,6 +70,7 @@ Common finding types include:
 async def compute_optimizer(
     ctx: Context,
     operation: str,
+    region: Optional[str] = None,
     max_results: Optional[int] = None,
     filters: Optional[str] = None,
     account_ids: Optional[str] = None,
@@ -77,6 +81,7 @@ async def compute_optimizer(
     Args:
         ctx: The MCP context
         operation: The operation to perform (e.g., 'get_ec2_instance_recommendations')
+        region: AWS region to query (e.g., 'us-west-2'). Defaults to AWS_REGION env var or us-east-1.
         max_results: Maximum number of results to return (1-100)
         filters: Optional filter expression as JSON string
         account_ids: Optional list of AWS account IDs as JSON array string
@@ -93,7 +98,7 @@ async def compute_optimizer(
         await ctx_logger.info(f'Compute Optimizer operation: {operation}')
 
         # Initialize Compute Optimizer client using shared utility
-        co_client = create_aws_client('compute-optimizer', region_name='us-east-1')
+        co_client = create_aws_client('compute-optimizer', region_name=region)
 
         # Check enrollment status first to provide better error messages
         try:
@@ -124,7 +129,7 @@ async def compute_optimizer(
                             'enrollment_status': status,
                             'operation': operation,
                             'aws_error_code': 'ComputeOptimizerNotActive',
-                            'aws_region': 'us-east-1',
+                            'aws_region': region or os.environ.get('AWS_REGION', 'us-east-1'),
                         },
                         'Compute Optimizer is not active. Please activate the service in the AWS Console first.',
                     )

--- a/src/billing-cost-management-mcp-server/tests/tools/test_compute_optimizer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_compute_optimizer_tools.py
@@ -806,6 +806,37 @@ class TestComputeOptimizerFastMCP:
             assert res['error_type'] == 'validation_error'
             assert 'Invalid parameter' in res['message']
 
+    async def test_co_region_parameter_passed_to_client(self, mock_context):
+        """Test that the region parameter is passed to create_aws_client."""
+        co_mod = _reload_compute_optimizer_with_identity_decorator()
+        real_fn = co_mod.compute_optimizer
+
+        with (
+            patch.object(co_mod, 'create_aws_client') as mock_create_client,
+            patch.object(co_mod, 'get_context_logger') as mock_get_logger,
+            patch.object(
+                co_mod, 'get_ec2_instance_recommendations', new_callable=AsyncMock
+            ) as mock_get,
+        ):
+            mock_logger = AsyncMock()
+            mock_get_logger.return_value = mock_logger
+            mock_client = MagicMock()
+            mock_client.get_enrollment_status.return_value = {
+                'status': 'ACTIVE',
+                'resourceTypes': ['ec2Instance'],
+            }
+            mock_create_client.return_value = mock_client
+            mock_get.return_value = {'status': 'success', 'data': {'recommendations': []}}
+
+            await real_fn(
+                mock_context,
+                operation='get_ec2_instance_recommendations',
+                region='eu-west-1',
+            )
+            mock_create_client.assert_called_once_with(
+                'compute-optimizer', region_name='eu-west-1'
+            )
+
 
 @pytest.mark.asyncio
 class TestComputeOptimizerCoverageGaps:


### PR DESCRIPTION
## Summary

### Changes

Compute Optimizer is a regional service — each region has its own endpoint and only returns recommendations for resources in that region. The hardcoded `us-east-1` meant multi-region accounts got incomplete results.

Add a region parameter that is passed through to `create_aws_client`. When omitted, falls back to AWS_REGION env var or us-east-1.


### User experience

Before:
User can only get compute optimizer recommendations in us-east-1

After:
User can get compute optimizer recommendations per region parameter.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
