### PR TITLE
fix(billing-cost-management): clarify end_date inclusive semantics for cost-anomaly tool

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_anomaly_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_anomaly_tools.py
@@ -48,6 +48,8 @@ You can filter anomalies by:
 - Feedback status (optional)
 - Total impact (optional)
 
+Note: Both start_date and end_date are INCLUSIVE. To get anomalies including today, use today's date as end_date.
+
 Feedback status options:
 - YES: Anomalies marked as accurate
 - NO: Anomalies marked as inaccurate
@@ -68,8 +70,8 @@ async def cost_anomaly(
 
     Args:
         ctx: The MCP context object
-        start_date: Start date in YYYY-MM-DD format. Required.
-        end_date: End date in YYYY-MM-DD format. Required.
+        start_date: Start date in YYYY-MM-DD format (inclusive). Required.
+        end_date: End date in YYYY-MM-DD format (inclusive — use today's date to include today's anomalies). Required.
         monitor_arn: Optional ARN of a specific cost anomaly monitor to filter results.
         feedback: Optional filter for anomalies by feedback status (YES, NO, PLANNED_ACTIVITY).
         max_results: Optional maximum number of results to return.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
The `cost-anomaly` tool did not document whether `end_date` is inclusive or exclusive.
  Agents assumed exclusive (Cost Explorer `DateInterval` convention) and passed `today+1`,
  which was correctly rejected as a future date.
  
  The `GetAnomalies` API uses `AnomalyDateInterval` (not `DateInterval`), where `EndDate`
  means "the last date an anomaly was observed" — i.e., inclusive.
### Changes
- Added inclusive/exclusive note to tool description
  - Updated `start_date` and `end_date` docstrings with explicit semantics
  - Added unit test confirming today's date is accepted as `end_date`

> Please provide a summary of what's being changed

### User experience

**Before:** Agent passes `today+1` as `end_date` → tool rejects with "Cannot request anomalies for future dates" error.
  
  **After:** Agent passes `today` as `end_date` (guided by the explicit inclusive documentation) → succeeds.

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ X] I have performed a self-review of this change
* [ X] Changes have been tested
* [ X ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
