### PR TITLE
fix(billing-cost-management): Increase SQLite busy_timeout to 30s

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -46,6 +46,9 @@ SQL_CONVERSION_THRESHOLD = int(
     os.getenv('MCP_SQL_THRESHOLD', 25 * 1024)
 )  # 25KB default (lowered from 50KB)
 FORCE_SQL_CONVERSION = os.getenv('MCP_FORCE_SQL', 'false').lower() == 'true'
+BUSY_TIMEOUT_MS = int(
+    os.getenv('BCM_MCP_SQLITE_TIMEOUT_MS', 30000)
+)  # 30s default — handles concurrent subagent writes
 
 # Session database path singleton
 _SESSION_DB_PATH = None
@@ -129,7 +132,7 @@ def get_db_connection() -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
     # Create connection and cursor
     conn = sqlite3.connect(db_path)
     conn.execute('PRAGMA journal_mode=WAL')
-    conn.execute('PRAGMA busy_timeout=5000')
+    conn.execute(f'PRAGMA busy_timeout={BUSY_TIMEOUT_MS}')
     cursor = conn.cursor()
 
     # Create schema_info table to track created tables if it doesn't exist

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
@@ -1407,6 +1407,27 @@ class TestEnvironmentVariables:
         assert should_convert_to_sql(15000) is True  # 15KB > 10KB
         assert should_convert_to_sql(5000) is False  # 5KB < 10KB
 
+    @patch('os.getenv')
+    def test_busy_timeout_custom(self, mock_getenv):
+        """Test custom SQLite busy timeout via environment variable."""
+        import sys
+
+        def mock_env_side_effect(key, default=None):
+            if key == 'BCM_MCP_SQLITE_TIMEOUT_MS':
+                return '60000'
+            return default
+
+        mock_getenv.side_effect = mock_env_side_effect
+
+        if 'awslabs.billing_cost_management_mcp_server.utilities.sql_utils' in sys.modules:
+            del sys.modules['awslabs.billing_cost_management_mcp_server.utilities.sql_utils']
+
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            BUSY_TIMEOUT_MS,
+        )
+
+        assert BUSY_TIMEOUT_MS == 60000
+
 
 @pytest.mark.asyncio
 async def test_get_context_logger_import():


### PR DESCRIPTION

## Summary

### Changes

Increase SQLite busy_timeout to 30s for concurrent subagents

SQLite's write lock is database-wide in WAL mode. When 3+ concurrent subagent tool calls run convert_api_response_to_table simultaneously, one holds the write lock while inserting rows and others timeout after 5 seconds with 'database is locked'.

Increase busy_timeout from 5s to 30s and make it configurable via `BCM_MCP_SQLITE_TIMEOUT_MS` environment variable.

### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
