### PR TITLE
feat(cloudwatch-applicationsignals): add per-call profile support

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/audit_utils.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/audit_utils.py
@@ -29,9 +29,17 @@ FUZZY_MATCH_THRESHOLD = 30  # Minimum similarity score for fuzzy matching
 HIGH_CONFIDENCE_MATCH_THRESHOLD = 85  # High confidence threshold for exact fuzzy matches
 
 
-async def execute_audit_api(input_obj: Dict[str, Any], region: str, banner: str) -> str:
+async def execute_audit_api(
+    input_obj: Dict[str, Any],
+    region: str,
+    banner: str,
+    applicationsignals_client_override=None,
+) -> str:
     """Execute the Application Signals audit API call with the given input object."""
-    from .aws_clients import applicationsignals_client
+    if applicationsignals_client_override is None:
+        from .aws_clients import applicationsignals_client
+    else:
+        applicationsignals_client = applicationsignals_client_override
 
     # File log path
     desired_log_path = os.environ.get('AUDITOR_LOG_PATH', tempfile.gettempdir())

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/aws_clients.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/aws_clients.py
@@ -19,6 +19,7 @@ import os
 from . import __version__
 from botocore.config import Config
 from loguru import logger
+from typing import Any, Optional, cast
 
 
 # Get AWS region from environment variable or use default
@@ -26,15 +27,70 @@ AWS_REGION = os.environ.get('AWS_REGION', 'us-east-1')
 logger.debug(f'Using AWS region: {AWS_REGION}')
 
 
-def _initialize_aws_clients():
-    """Initialize AWS clients with proper configuration."""
-    # Add caller suffix if MCP_RUN_FROM is set
+ENDPOINT_ENV_BY_SERVICE = {
+    'application-signals': 'MCP_APPLICATIONSIGNALS_ENDPOINT',
+    'logs': 'MCP_LOGS_ENDPOINT',
+    'cloudwatch': 'MCP_CLOUDWATCH_ENDPOINT',
+    'xray': 'MCP_XRAY_ENDPOINT',
+    'synthetics': 'MCP_SYNTHETICS_ENDPOINT',
+    'rum': 'MCP_RUM_ENDPOINT',
+}
+
+
+def _get_config():
+    """Create the shared botocore Config used for AppSignals AWS clients."""
     mcp_source = os.environ.get('MCP_RUN_FROM')
     user_agent_suffix = f'/{mcp_source}' if mcp_source else ''
 
-    config = Config(
+    return Config(
         user_agent_extra=f'awslabs.cloudwatch-applicationsignals-mcp-server/{__version__}{user_agent_suffix}'
     )
+
+
+def get_aws_client(
+    service_name: str,
+    region_name: Optional[str] = None,
+    profile_name: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+):
+    """Create an AWS client with optional per-call profile support.
+
+    Args:
+        service_name: AWS service name, for example 'application-signals' or 'cloudwatch'.
+        region_name: AWS region. Defaults to AWS_REGION or us-east-1.
+        profile_name: AWS CLI profile name. Falls back to AWS_PROFILE when not specified.
+        endpoint_url: Optional endpoint override. Falls back to service-specific MCP_* env vars.
+
+    Returns:
+        boto3 client for the requested service.
+    """
+    if profile_name is None:
+        profile_name = os.environ.get('AWS_PROFILE')
+
+    region = region_name or AWS_REGION
+    config = _get_config()
+
+    if endpoint_url is None:
+        endpoint_env = ENDPOINT_ENV_BY_SERVICE.get(service_name)
+        endpoint_url = os.environ.get(endpoint_env) if endpoint_env else None
+
+    if profile_name:
+        logger.debug(f'Using AWS profile: {profile_name}')
+        session = boto3.Session(profile_name=profile_name, region_name=region)
+    else:
+        session = boto3.Session(region_name=region)
+
+    return session.client(
+        cast(Any, service_name),
+        region_name=region,
+        config=config,
+        endpoint_url=endpoint_url,
+    )
+
+
+def _initialize_aws_clients():
+    """Initialize AWS clients with proper configuration."""
+    config = _get_config()
 
     # Get endpoint URLs from environment variables
     applicationsignals_endpoint = os.environ.get('MCP_APPLICATIONSIGNALS_ENDPOINT')

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/canary_utils.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/canary_utils.py
@@ -577,9 +577,12 @@ async def analyze_canary_logs_with_time_window(
     canary: dict,
     window_minutes: int = 3,
     region: str = 'us-east-1',
+    logs_client_override=None,
 ) -> dict:
     """Analyze canary logs within a specific time window around failure."""
     try:
+        logs = logs_client_override or logs_client
+
         # Calculate time window around failure
         if isinstance(failure_time, str):
             failure_time = datetime.fromisoformat(failure_time.replace('Z', '+00:00'))
@@ -598,7 +601,7 @@ async def analyze_canary_logs_with_time_window(
 
         # Get log events in the time window
         try:
-            response = logs_client.filter_log_events(
+            response = logs.filter_log_events(
                 logGroupName=log_group_name,
                 startTime=start_timestamp,
                 endTime=end_timestamp,
@@ -671,11 +674,19 @@ async def analyze_canary_logs_with_time_window(
         return {'status': 'error', 'insights': [f'Log analysis failed: {str(e)[:200]}']}
 
 
-async def extract_disk_memory_usage_metrics(canary_name: str, region: str = 'us-east-1') -> dict:
+async def extract_disk_memory_usage_metrics(
+    canary_name: str,
+    region: str = 'us-east-1',
+    synthetics_client_override=None,
+    logs_client_override=None,
+) -> dict:
     """Extract disk and memory usage metrics from canary log group."""
     try:
+        synthetics = synthetics_client_override or synthetics_client
+        logs = logs_client_override or logs_client
+
         # Get canary details to find the Lambda function name
-        canary_response = synthetics_client.get_canary(Name=canary_name)
+        canary_response = synthetics.get_canary(Name=canary_name)
         canary = canary_response['Canary']
 
         # Handle both EngineArn and EngineConfigs
@@ -699,7 +710,7 @@ async def extract_disk_memory_usage_metrics(canary_name: str, region: str = 'us-
         | limit 20
         """
 
-        response = logs_client.start_query(
+        response = logs.start_query(
             logGroupName=log_group_name,
             startTime=int(start_time.timestamp()),
             endTime=int(end_time.timestamp()),
@@ -714,7 +725,7 @@ async def extract_disk_memory_usage_metrics(canary_name: str, region: str = 'us-
         delay = 1
         result = None
         while wait_time < max_wait:
-            result = logs_client.get_query_results(queryId=query_id)
+            result = logs.get_query_results(queryId=query_id)
             if result['status'] == 'Complete':
                 break
             await asyncio.sleep(delay)
@@ -761,9 +772,13 @@ async def extract_disk_memory_usage_metrics(canary_name: str, region: str = 'us-
         return {'error': f'Resource analysis failed: {str(e)[:200]}'}
 
 
-async def get_canary_code(canary: dict, region: str = 'us-east-1') -> dict:
+async def get_canary_code(
+    canary: dict, region: str = 'us-east-1', lambda_client_override=None
+) -> dict:
     """Extract and analyze canary code from Lambda layers."""
     try:
+        lambda_client_for_call = lambda_client_override or lambda_client
+
         engine_arn = canary.get('EngineArn', '')
         if not engine_arn:
             engine_configs = canary.get('EngineConfigs', [])
@@ -774,7 +789,7 @@ async def get_canary_code(canary: dict, region: str = 'us-east-1') -> dict:
         function_name = engine_arn.split(':function:')[1].split(':')[0]
 
         # Get function configuration
-        function_response = lambda_client.get_function(FunctionName=function_name)
+        function_response = lambda_client_for_call.get_function(FunctionName=function_name)
         config = function_response['Configuration']
 
         result = {
@@ -789,7 +804,9 @@ async def get_canary_code(canary: dict, region: str = 'us-east-1') -> dict:
         source_location_arn = canary.get('Code', {}).get('SourceLocationArn', '')
         if source_location_arn and ':layer:' in source_location_arn:
             try:
-                layer_response = lambda_client.get_layer_version_by_arn(Arn=source_location_arn)
+                layer_response = lambda_client_for_call.get_layer_version_by_arn(
+                    Arn=source_location_arn
+                )
                 if 'Location' in layer_response['Content']:
                     with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as tmp_file:
                         import requests
@@ -831,7 +848,9 @@ async def get_canary_code(canary: dict, region: str = 'us-east-1') -> dict:
 
             for layer in custom_layers:
                 try:
-                    layer_response = lambda_client.get_layer_version_by_arn(Arn=layer['Arn'])
+                    layer_response = lambda_client_for_call.get_layer_version_by_arn(
+                        Arn=layer['Arn']
+                    )
                     if 'Location' in layer_response['Content']:
                         with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as tmp_file:
                             import requests
@@ -892,10 +911,18 @@ async def get_canary_code(canary: dict, region: str = 'us-east-1') -> dict:
 
 
 async def check_canaries_for_service(
-    normalized_targets, unix_start, unix_end, region: str = 'us-east-1'
+    normalized_targets,
+    unix_start,
+    unix_end,
+    region: str = 'us-east-1',
+    applicationsignals_client_override=None,
+    synthetics_client_override=None,
 ):
     """Check Synthetics canaries associated with audited services via list_service_dependents."""
     try:
+        appsignals_client = applicationsignals_client_override or applicationsignals_client
+        synthetics = synthetics_client_override or synthetics_client
+
         canary_names = set()
         for target in normalized_targets:
             svc = (target.get('Data') or {}).get('Service') or {}
@@ -913,7 +940,7 @@ async def check_canaries_for_service(
                     }
                     if next_token:
                         kwargs['NextToken'] = next_token
-                    resp = applicationsignals_client.list_service_dependents(**kwargs)
+                    resp = appsignals_client.list_service_dependents(**kwargs)
                     for dep in resp.get('ServiceDependents', []):
                         dep_attrs = dep.get('DependentKeyAttributes', {})
                         if dep_attrs.get('ResourceType') == 'AWS::Synthetics::Canary':
@@ -933,7 +960,7 @@ async def check_canaries_for_service(
             if not name:
                 continue
             try:
-                runs_resp = synthetics_client.get_canary_runs(Name=name, MaxResults=5)
+                runs_resp = synthetics.get_canary_runs(Name=name, MaxResults=5)
                 runs = runs_resp.get('CanaryRuns', [])
                 if not runs:
                     canary_statuses.append((name, 'no_data', 0, 0))
@@ -971,7 +998,9 @@ async def check_canaries_for_service(
         return ''
 
 
-async def get_canary_metrics_and_service_insights(canary_name: str, region: str) -> str:
+async def get_canary_metrics_and_service_insights(
+    canary_name: str, region: str, applicationsignals_client_override=None
+) -> str:
     """Get canary metrics and service insights using Application Signals audit API."""
     import time
 
@@ -985,7 +1014,12 @@ async def get_canary_metrics_and_service_insights(canary_name: str, region: str)
             'AuditTargets': [{'Type': 'canary', 'Data': {'Canary': {'CanaryName': canary_name}}}],
             'Auditors': ['canary', 'operation_metric', 'trace'],
         }
-        return await execute_audit_api(audit_input, region, f'Canary Analysis for {canary_name}\n')
+        return await execute_audit_api(
+            audit_input,
+            region,
+            f'Canary Analysis for {canary_name}\n',
+            applicationsignals_client_override,
+        )
 
     except Exception as e:
         return f'ListAuditFindings API unavailable: {str(e)}'

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/change_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/change_tools.py
@@ -15,12 +15,27 @@
 """Change tracking tools for AWS Application Signals MCP Server."""
 
 import json
-from .aws_clients import AWS_REGION, applicationsignals_client
+from .aws_clients import AWS_REGION, applicationsignals_client, get_aws_client
 from .utils import parse_timestamp
 from botocore.exceptions import ClientError, NoCredentialsError
 from datetime import datetime, timezone
 from pydantic import Field
-from typing import Dict, List, Optional
+from typing import Annotated, Dict, List, Optional
+
+
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
+def _get_applicationsignals_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped Application Signals client."""
+    if profile_name is None:
+        return applicationsignals_client
+    return get_aws_client('application-signals', region_name=AWS_REGION, profile_name=profile_name)
 
 
 def _filter_service_states_by_attributes(
@@ -109,6 +124,7 @@ async def _list_change_events(
     max_results: int = 100,
     region: Optional[str] = None,
     comprehensive_history: bool = True,
+    profile_name: Optional[str] = None,
 ) -> str:
     """Retrieve change events for AWS resources within specified time range.
 
@@ -120,11 +136,14 @@ async def _list_change_events(
         region: AWS region (optional, defaults to configured region)
         comprehensive_history: If True, retrieves complete change history using ListEntityEvents (requires service_key_attributes).
                              If False, retrieves only latest service states using ListServiceStates (service_key_attributes optional).
+        profile_name: Optional AWS CLI profile name for this tool call.
 
     Returns:
         JSON string containing change events with timeline analysis
     """
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         # Validate time parameters
         start_dt = parse_timestamp(start_time)
         end_dt = parse_timestamp(end_time)
@@ -160,7 +179,7 @@ async def _list_change_events(
         # Use appropriate API based on comprehensive_history flag
         if comprehensive_history:
             return await _list_entity_events(
-                applicationsignals_client,
+                appsignals_client,
                 start_timestamp,
                 end_timestamp,
                 service_key_attributes,
@@ -168,7 +187,7 @@ async def _list_change_events(
             )
         else:
             return await _list_service_states(
-                applicationsignals_client,
+                appsignals_client,
                 start_timestamp,
                 end_timestamp,
                 service_key_attributes,
@@ -370,6 +389,7 @@ async def list_change_events(
         default=True,
         description='If True, uses ListEntityEvents API for complete change history (REQUIRES service_key_attributes). If False, uses ListServiceStates API for current service state information (service_key_attributes optional).',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """Query AWS Application Signals change events to correlate infrastructure and application changes with service performance issues.
 
@@ -443,6 +463,7 @@ async def list_change_events(
         max_results: Maximum number of events to return (1-250, default: 100)
         region: AWS region to query (defaults to configured region)
         comprehensive_history: If True, uses ListEntityEvents for complete change history. If False, uses ListServiceStates for current service states.
+        profile_name: Optional AWS CLI profile name for this tool call.
 
     Returns:
         JSON string containing change events with timeline analysis and correlation insights for incident investigation
@@ -454,4 +475,5 @@ async def list_change_events(
         max_results=max_results,
         region=region,
         comprehensive_history=comprehensive_history,
+        profile_name=profile_name,
     )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/group_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/group_tools.py
@@ -25,7 +25,7 @@ Tools:
 - list_grouping_attribute_definitions: List all custom grouping attribute definitions
 """
 
-from .aws_clients import AWS_REGION, applicationsignals_client, cloudwatch_client
+from .aws_clients import AWS_REGION, applicationsignals_client, cloudwatch_client, get_aws_client
 from .canary_utils import check_canaries_for_service
 from .sli_report_client import AWSConfig, SLIReportClient
 from .utils import (
@@ -44,12 +44,41 @@ from datetime import datetime
 from loguru import logger
 from pydantic import Field
 from time import perf_counter as timer
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Annotated, Any, Dict, List, Optional, Tuple
 
 
 # =============================================================================
 # SHARED HELPER FUNCTIONS
 # =============================================================================
+
+
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
+def _get_applicationsignals_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped Application Signals client."""
+    if profile_name is None:
+        return applicationsignals_client
+    return get_aws_client('application-signals', region_name=AWS_REGION, profile_name=profile_name)
+
+
+def _get_cloudwatch_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped CloudWatch client."""
+    if profile_name is None:
+        return cloudwatch_client
+    return get_aws_client('cloudwatch', region_name=AWS_REGION, profile_name=profile_name)
+
+
+def _get_synthetics_client(profile_name: Optional[str] = None):
+    """Return the profile-scoped Synthetics client used for group canary checks."""
+    if profile_name is None:
+        return None
+    return get_aws_client('synthetics', region_name=AWS_REGION, profile_name=profile_name)
 
 
 def _matches_group(service_groups: List[Dict], group_name: str) -> bool:
@@ -78,6 +107,7 @@ async def _discover_services_by_group(
     group_name: str,
     start_time: datetime,
     end_time: datetime,
+    applicationsignals_client_override=None,
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     """Discover all services belonging to a specific group.
 
@@ -92,6 +122,8 @@ async def _discover_services_by_group(
                    Can also match GroupName. Supports wildcards like '*payment*'.
         start_time: Start time for service discovery
         end_time: End time for service discovery
+        applicationsignals_client_override: Optional Application Signals client to use instead
+            of the module-level default.
 
     Returns:
         Tuple of (list of services in the group, discovery stats)
@@ -106,7 +138,8 @@ async def _discover_services_by_group(
     }
 
     try:
-        all_services = list_services_paginated(applicationsignals_client, start_time, end_time)
+        appsignals_client = applicationsignals_client_override or applicationsignals_client
+        all_services = list_services_paginated(appsignals_client, start_time, end_time)
 
         for service in all_services:
             stats['total_services_scanned'] += 1
@@ -192,6 +225,7 @@ async def _setup_group_tool(
     emoji: str,
     title: str,
     default_hours: int = 3,
+    profile_name: Optional[str] = None,
 ) -> Tuple[Optional[List[Dict]], Optional[datetime], Optional[datetime], str, Optional[Dict]]:
     """Common setup: parse time, discover services, build header or error message.
 
@@ -203,7 +237,7 @@ async def _setup_group_tool(
         return None, None, None, 'Error: end_time must be greater than start_time.', None
 
     group_services, discovery_stats = await _discover_services_by_group(
-        group_name, start_dt, end_dt
+        group_name, start_dt, end_dt, _get_applicationsignals_client(profile_name)
     )
     if not group_services:
         return None, None, None, _format_no_services_found(group_name, discovery_stats), None
@@ -230,6 +264,7 @@ async def list_group_services(
         default=None,
         description="End time (unix seconds or 'YYYY-MM-DD HH:MM:SS'). Defaults to now UTC.",
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """SERVICE DISCOVERY TOOL - Find all services belonging to a group.
 
@@ -260,7 +295,7 @@ async def list_group_services(
 
     try:
         group_services, _, _, result, discovery_stats = await _setup_group_tool(
-            group_name, start_time, end_time, '📋', 'SERVICES IN GROUP'
+            group_name, start_time, end_time, '📋', 'SERVICES IN GROUP', profile_name=profile_name
         )
         if group_services is None or discovery_stats is None:
             return result
@@ -369,6 +404,7 @@ async def audit_group_health(
         default=LATENCY_P99_THRESHOLD_CRITICAL,
         description='Latency P99 threshold in milliseconds for CRITICAL when using metrics fallback (default: 5000.0)',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """HEALTH AUDIT TOOL - Detect anomalies and unhealthy services in a group.
 
@@ -406,8 +442,17 @@ async def audit_group_health(
     logger.debug(f'Starting audit_group_health for group: {group_name}')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+        profile_cloudwatch_client = _get_cloudwatch_client(profile_name)
+        profile_synthetics_client = _get_synthetics_client(profile_name)
+
         group_services, start_dt, end_dt, result, _ = await _setup_group_tool(
-            group_name, start_time, end_time, '🔍', 'GROUP HEALTH AUDIT'
+            group_name,
+            start_time,
+            end_time,
+            '🔍',
+            'GROUP HEALTH AUDIT',
+            profile_name=profile_name,
         )
         if group_services is None or start_dt is None or end_dt is None:
             return result
@@ -461,7 +506,11 @@ async def audit_group_health(
                     service_name=svc_name,
                     key_attributes=key_attrs,
                 )
-                sli_client = SLIReportClient(config)
+                sli_client = SLIReportClient(
+                    config,
+                    signals_client=appsignals_client,
+                    cloudwatch_client_override=profile_cloudwatch_client,
+                )
                 sli_report = sli_client.generate_sli_report()
 
                 # Check if we have any SLOs configured
@@ -504,7 +553,7 @@ async def audit_group_health(
 
                 try:
                     # Get service detail for metric references
-                    service_response = applicationsignals_client.get_service(
+                    service_response = appsignals_client.get_service(
                         StartTime=start_dt,
                         EndTime=end_dt,
                         KeyAttributes=key_attrs,
@@ -520,7 +569,7 @@ async def audit_group_health(
 
                         if metric_type == 'Fault':
                             stats = fetch_metric_stats(
-                                cloudwatch_client,
+                                profile_cloudwatch_client,
                                 namespace,
                                 metric_name,
                                 dimensions,
@@ -560,7 +609,7 @@ async def audit_group_health(
 
                         elif metric_type == 'Error':
                             stats = fetch_metric_stats(
-                                cloudwatch_client,
+                                profile_cloudwatch_client,
                                 namespace,
                                 metric_name,
                                 dimensions,
@@ -600,7 +649,7 @@ async def audit_group_health(
 
                         elif metric_type == 'Latency':
                             stats = fetch_metric_stats(
-                                cloudwatch_client,
+                                profile_cloudwatch_client,
                                 namespace,
                                 metric_name,
                                 dimensions,
@@ -739,7 +788,12 @@ async def audit_group_health(
             unix_start = int(start_dt.timestamp())
             unix_end = int(end_dt.timestamp())
             canary_result = await check_canaries_for_service(
-                normalized_targets, unix_start, unix_end, AWS_REGION
+                normalized_targets,
+                unix_start,
+                unix_end,
+                AWS_REGION,
+                appsignals_client if profile_name is not None else None,
+                profile_synthetics_client,
             )
             if canary_result:
                 result += '\n' + '=' * 50 + '\n'
@@ -794,6 +848,7 @@ async def get_group_dependencies(
         default=None,
         description="End time (unix seconds or 'YYYY-MM-DD HH:MM:SS'). Defaults to now UTC.",
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """DEPENDENCY MAPPING TOOL - Analyze dependencies within and across groups.
 
@@ -824,8 +879,15 @@ async def get_group_dependencies(
     logger.debug(f'Starting get_group_dependencies for group: {group_name}')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         group_services, start_dt, end_dt, result, _ = await _setup_group_tool(
-            group_name, start_time, end_time, '🔗', 'GROUP DEPENDENCIES'
+            group_name,
+            start_time,
+            end_time,
+            '🔗',
+            'GROUP DEPENDENCIES',
+            profile_name=profile_name,
         )
         if group_services is None or start_dt is None or end_dt is None:
             return result
@@ -852,7 +914,7 @@ async def get_group_dependencies(
 
             # Get dependencies
             try:
-                response = applicationsignals_client.list_service_dependencies(
+                response = appsignals_client.list_service_dependencies(
                     StartTime=start_dt,
                     EndTime=end_dt,
                     KeyAttributes=key_attrs,
@@ -887,7 +949,7 @@ async def get_group_dependencies(
                         cache_key = (dep_name.lower(), dep_env.lower())
                         if cache_key not in dep_group_cache:
                             try:
-                                dep_svc_response = applicationsignals_client.get_service(
+                                dep_svc_response = appsignals_client.get_service(
                                     StartTime=start_dt,
                                     EndTime=end_dt,
                                     KeyAttributes=dep_key_attrs,
@@ -1009,6 +1071,7 @@ async def get_group_changes(
         default=None,
         description="End time (unix seconds or 'YYYY-MM-DD HH:MM:SS'). Defaults to now UTC.",
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """CHANGE TRACKING TOOL - Monitor deployments in a group.
 
@@ -1037,8 +1100,10 @@ async def get_group_changes(
     logger.debug(f'Starting get_group_changes for group: {group_name}')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         group_services, start_dt, end_dt, result, _ = await _setup_group_tool(
-            group_name, start_time, end_time, '📦', 'GROUP CHANGES'
+            group_name, start_time, end_time, '📦', 'GROUP CHANGES', profile_name=profile_name
         )
         if group_services is None or start_dt is None or end_dt is None:
             return result
@@ -1065,7 +1130,7 @@ async def get_group_changes(
                 if next_token:
                     list_params['NextToken'] = next_token
 
-                response = applicationsignals_client.list_service_states(**list_params)
+                response = appsignals_client.list_service_states(**list_params)
                 service_states = response.get('ServiceStates', [])
                 next_token = response.get('NextToken')
 
@@ -1190,7 +1255,9 @@ async def get_group_changes(
 # =============================================================================
 
 
-async def list_grouping_attribute_definitions() -> str:
+async def list_grouping_attribute_definitions(
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
+) -> str:
     """GROUPING CONFIGURATION TOOL - List all custom grouping attribute definitions.
 
     Use this tool when users ask:
@@ -1221,6 +1288,8 @@ async def list_grouping_attribute_definitions() -> str:
     logger.debug('Starting list_grouping_attribute_definitions')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         all_definitions = []
         next_token = None
         updated_at = None
@@ -1230,7 +1299,7 @@ async def list_grouping_attribute_definitions() -> str:
             if next_token:
                 list_params['NextToken'] = next_token
 
-            response = applicationsignals_client.list_grouping_attribute_definitions(**list_params)
+            response = appsignals_client.list_grouping_attribute_definitions(**list_params)
             definitions = response.get('GroupingAttributeDefinitions', [])
             all_definitions.extend(definitions)
 

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/rum_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/rum_tools.py
@@ -27,6 +27,7 @@ from .aws_clients import (
     AWS_REGION,
     applicationsignals_client,
     cloudwatch_client,
+    get_aws_client,
     logs_client,
     rum_client,
     sts_client,
@@ -36,7 +37,8 @@ from .utils import remove_null_values
 from datetime import datetime, timezone
 from functools import lru_cache
 from loguru import logger
-from typing import Any, Callable, Optional
+from pydantic import Field
+from typing import Annotated, Any, Callable, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +79,14 @@ _PLATFORM_DETECT_WINDOW_MS = 24 * 60 * 60 * 1000
 _PLATFORM_DETECT_SAMPLE_LIMIT = 10
 
 
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
 async def query_rum_events(
     action: str,
     app_monitor_name: Optional[str] = None,
@@ -97,6 +107,7 @@ async def query_rum_events(
     bucket: Optional[str] = None,
     compare_previous: Optional[bool] = None,
     limit: Optional[int] = None,
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """CloudWatch RUM – monitor real user experience across web and mobile apps.
 
@@ -153,6 +164,8 @@ async def query_rum_events(
                 'available_actions': sorted(_ACTION_MAP.keys()),
             }
         )
+    clients = _get_rum_clients(profile_name) if profile_name else None
+
     # Build kwargs from non-None values (excluding 'action')
     _all_kwargs = {
         'app_monitor_name': app_monitor_name,
@@ -175,6 +188,8 @@ async def query_rum_events(
         'limit': limit,
     }
     kwargs = {k: v for k, v in _all_kwargs.items() if v is not None}
+    if clients:
+        kwargs['_clients'] = clients
     try:
         return await handler(**kwargs)
     except (TypeError, ValueError) as e:
@@ -187,6 +202,24 @@ async def query_rum_events(
 
 
 # --- Internal helpers ---
+
+
+def _get_rum_clients(profile_name: Optional[str] = None) -> Optional[dict[str, Any]]:
+    """Return profile-scoped clients for the RUM action dispatcher."""
+    if profile_name is None:
+        return None
+    return {
+        'applicationsignals': get_aws_client(
+            'application-signals', region_name=AWS_REGION, profile_name=profile_name
+        ),
+        'cloudwatch': get_aws_client(
+            'cloudwatch', region_name=AWS_REGION, profile_name=profile_name
+        ),
+        'logs': get_aws_client('logs', region_name=AWS_REGION, profile_name=profile_name),
+        'rum': get_aws_client('rum', region_name=AWS_REGION, profile_name=profile_name),
+        'sts': get_aws_client('sts', region_name=AWS_REGION, profile_name=profile_name),
+        'xray': get_aws_client('xray', region_name=AWS_REGION, profile_name=profile_name),
+    }
 
 
 @lru_cache(maxsize=1)
@@ -205,11 +238,16 @@ def _get_partition() -> str:
     return 'aws'
 
 
-def _log_group_arn(log_group_name: str) -> str:
+def _get_account_id_for_clients(clients: Optional[dict[str, Any]] = None) -> str:
+    """Return the account ID for either the default or profile-scoped STS client."""
+    if clients:
+        return clients['sts'].get_caller_identity()['Account']
+    return _get_account_id()
+
+
+def _log_group_arn(log_group_name: str, clients: Optional[dict[str, Any]] = None) -> str:
     """Compose a CloudWatch Logs log group ARN from its name."""
-    return (
-        f'arn:{_get_partition()}:logs:{AWS_REGION}:{_get_account_id()}:log-group:{log_group_name}'
-    )
+    return f'arn:{_get_partition()}:logs:{AWS_REGION}:{_get_account_id_for_clients(clients)}:log-group:{log_group_name}'
 
 
 def _clear_module_caches() -> None:
@@ -258,7 +296,31 @@ def _get_rum_app_info_confident_cached(app_monitor_name: str) -> tuple[str, str,
     return log_group, 'unknown', False
 
 
-def _get_rum_app_info_sync(app_monitor_name: str) -> tuple[str, str]:
+def _get_rum_app_info_sync(
+    app_monitor_name: str, clients: Optional[dict[str, Any]] = None
+) -> tuple[str, str]:
+    if clients:
+        resp = clients['rum'].get_app_monitor(Name=app_monitor_name)
+        app_monitor = resp['AppMonitor']
+        cw_log = app_monitor.get('DataStorage', {}).get('CwLog', {})
+        if not cw_log.get('CwLogEnabled', False):
+            raise ValueError(
+                f"App monitor '{app_monitor_name}' does not have CloudWatch Logs enabled. "
+                f'To enable it, run: aws rum update-app-monitor --name {app_monitor_name} --cw-log-enabled. '
+                f'Once enabled, new events will be sent to CW Logs (existing events are not backfilled). '
+                f'Recommended log retention: 30 days.'
+            )
+        log_group = cw_log.get('CwLogGroup')
+        if not log_group:
+            raise ValueError(
+                f"App monitor '{app_monitor_name}' has CW Logs enabled but no log group found. "
+                f'This may indicate the app monitor was recently created. Wait a few minutes and retry.'
+            )
+        raw_platform = app_monitor.get('Platform')
+        if raw_platform:
+            return log_group, ('web' if raw_platform == 'Web' else 'mobile')
+        return log_group, _detect_platform_from_logs(log_group, clients)
+
     log_group, platform, confident = _get_rum_app_info_confident_cached(app_monitor_name)
     if confident:
         return log_group, platform
@@ -266,7 +328,7 @@ def _get_rum_app_info_sync(app_monitor_name: str) -> tuple[str, str]:
     return log_group, _detect_platform_from_logs(log_group)
 
 
-def _detect_platform_from_logs(log_group: str) -> str:
+def _detect_platform_from_logs(log_group: str, clients: Optional[dict[str, Any]] = None) -> str:
     """Fallback platform detection by sampling recent log events.
 
     Mobile (OTel) events have a top-level ``resource`` key or ``scope`` key;
@@ -278,9 +340,10 @@ def _detect_platform_from_logs(log_group: str) -> str:
     silently being routed as 'web'.
     """
     try:
+        logs = clients['logs'] if clients else logs_client
         end_ms = int(time.time() * 1000)
         start_ms = end_ms - _PLATFORM_DETECT_WINDOW_MS
-        resp = logs_client.filter_log_events(
+        resp = logs.filter_log_events(
             logGroupName=log_group,
             startTime=start_ms,
             endTime=end_ms,
@@ -310,9 +373,11 @@ def _detect_platform_from_logs(log_group: str) -> str:
         return 'unknown'
 
 
-async def _get_rum_app_info(app_monitor_name: str) -> tuple[str, str]:
+async def _get_rum_app_info(
+    app_monitor_name: str, clients: Optional[dict[str, Any]] = None
+) -> tuple[str, str]:
     """Async wrapper: returns (log_group, platform)."""
-    return await asyncio.to_thread(_get_rum_app_info_sync, app_monitor_name)
+    return await asyncio.to_thread(_get_rum_app_info_sync, app_monitor_name, clients)
 
 
 _UNKNOWN_PLATFORM_HINT = (
@@ -353,9 +418,11 @@ def _run_logs_insights_query_sync(
     max_results: int = 1000,
     poll_interval: float = 1.0,
     max_poll_seconds: float = 60.0,
+    clients: Optional[dict[str, Any]] = None,
 ) -> dict:
     """Run a CW Logs Insights query and poll for results (synchronous)."""
-    resp = logs_client.start_query(
+    logs = clients['logs'] if clients else logs_client
+    resp = logs.start_query(
         logGroupName=log_group,
         startTime=int(start_time.timestamp()),
         endTime=int(end_time.timestamp()),
@@ -369,7 +436,7 @@ def _run_logs_insights_query_sync(
     result = None
     timed_out = True
     while time.monotonic() < deadline:
-        result = logs_client.get_query_results(queryId=query_id)
+        result = logs.get_query_results(queryId=query_id)
         status = result['status']
         if status in ('Complete', 'Failed', 'Cancelled'):
             timed_out = False
@@ -379,7 +446,7 @@ def _run_logs_insights_query_sync(
     if timed_out or result is None:
         # Free the concurrency slot — otherwise the query keeps running server-side.
         try:
-            logs_client.stop_query(queryId=query_id)
+            logs.stop_query(queryId=query_id)
         except Exception as e:
             logger.debug(f'stop_query failed for {query_id}: {e}')
         return {'status': 'Timeout', 'results': [], 'statistics': {}, 'queryId': query_id}
@@ -403,6 +470,7 @@ async def _run_logs_insights_query(
     max_results: int = 1000,
     poll_interval: float = 1.0,
     max_poll_seconds: float = 60.0,
+    clients: Optional[dict[str, Any]] = None,
 ) -> dict:
     """Async wrapper around the sync Logs Insights poll loop.
 
@@ -418,6 +486,7 @@ async def _run_logs_insights_query(
         max_results,
         poll_interval,
         max_poll_seconds,
+        clients,
     )
 
 
@@ -452,10 +521,13 @@ def _platform_mismatch(requested: str, monitor_platform: str) -> Optional[str]:
 # --- Wave 1: Foundation tools ---
 
 
-async def check_rum_data_access(app_monitor_name: str) -> str:
+async def check_rum_data_access(
+    app_monitor_name: str, _clients: Optional[dict[str, Any]] = None
+) -> str:
     """Check an app monitor's configuration and data access capabilities."""
+    rum = _clients['rum'] if _clients else rum_client
     try:
-        resp = await asyncio.to_thread(rum_client.get_app_monitor, Name=app_monitor_name)
+        resp = await asyncio.to_thread(rum.get_app_monitor, Name=app_monitor_name)
     except rum_client.exceptions.ResourceNotFoundException:
         return json.dumps(
             {'error': f"App monitor '{app_monitor_name}' not found.", 'error_type': 'bad_request'}
@@ -567,12 +639,15 @@ async def check_rum_data_access(app_monitor_name: str) -> str:
 # --- Wave 2: App Monitor CRUD tools ---
 
 
-async def list_rum_app_monitors(max_results: int = 25) -> str:
+async def list_rum_app_monitors(
+    max_results: int = 25, _clients: Optional[dict[str, Any]] = None
+) -> str:
     """List all CloudWatch RUM app monitors in the account."""
+    rum = _clients['rum'] if _clients else rum_client
 
     def _list() -> list:
         out = []
-        paginator = rum_client.get_paginator('list_app_monitors')
+        paginator = rum.get_paginator('list_app_monitors')
         for page in paginator.paginate(PaginationConfig={'MaxItems': max_results}):
             for m in page.get('AppMonitorSummaries', []):
                 out.append(remove_null_values(m))
@@ -582,28 +657,35 @@ async def list_rum_app_monitors(max_results: int = 25) -> str:
     return json.dumps({'app_monitors': monitors, 'count': len(monitors)}, default=str)
 
 
-async def get_rum_app_monitor(app_monitor_name: str) -> str:
+async def get_rum_app_monitor(
+    app_monitor_name: str, _clients: Optional[dict[str, Any]] = None
+) -> str:
     """Get full configuration of a CloudWatch RUM app monitor."""
+    rum = _clients['rum'] if _clients else rum_client
     try:
-        resp = await asyncio.to_thread(rum_client.get_app_monitor, Name=app_monitor_name)
+        resp = await asyncio.to_thread(rum.get_app_monitor, Name=app_monitor_name)
         return json.dumps(remove_null_values(resp['AppMonitor']), default=str)
     except Exception as e:
         return json.dumps({'error': str(e), 'error_type': 'service_error'})
 
 
-async def list_rum_tags(resource_arn: str) -> str:
+async def list_rum_tags(resource_arn: str, _clients: Optional[dict[str, Any]] = None) -> str:
     """List tags for a RUM resource (app monitor)."""
+    rum = _clients['rum'] if _clients else rum_client
     try:
-        resp = await asyncio.to_thread(rum_client.list_tags_for_resource, ResourceArn=resource_arn)
+        resp = await asyncio.to_thread(rum.list_tags_for_resource, ResourceArn=resource_arn)
         return json.dumps({'tags': resp.get('Tags', {})})
     except Exception as e:
         return json.dumps({'error': str(e), 'error_type': 'service_error'})
 
 
-async def get_rum_resource_policy(app_monitor_name: str) -> str:
+async def get_rum_resource_policy(
+    app_monitor_name: str, _clients: Optional[dict[str, Any]] = None
+) -> str:
     """Get the resource-based policy for a RUM app monitor."""
+    rum = _clients['rum'] if _clients else rum_client
     try:
-        resp = await asyncio.to_thread(rum_client.get_resource_policy, Name=app_monitor_name)
+        resp = await asyncio.to_thread(rum.get_resource_policy, Name=app_monitor_name)
         policy = resp.get('PolicyDocument', '{}')
         return json.dumps({'policy': json.loads(policy) if policy else None})
     except Exception as e:
@@ -619,6 +701,7 @@ async def run_rum_query(
     start_time: str,
     end_time: str,
     max_results: int = 100,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Run an arbitrary CloudWatch Logs Insights query against a RUM app monitor's log group.
 
@@ -632,7 +715,7 @@ async def run_rum_query(
     bound response size; this does not bound the data scanned.
     """
     try:
-        log_group, _platform = await _get_rum_app_info(app_monitor_name)
+        log_group, _platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -652,6 +735,7 @@ async def run_rum_query(
             start_time=_parse_time(start_time),
             end_time=_parse_time(end_time),
             max_results=capped,
+            clients=_clients,
         )
         return json.dumps(
             {
@@ -675,6 +759,7 @@ async def audit_rum_health(
     start_time: str,
     end_time: str,
     compare_previous: bool = False,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Quick health check: errors, slowest pages, and sessions with most errors.
 
@@ -682,7 +767,7 @@ async def audit_rum_health(
     the prior period of equal length for period-over-period comparison.
     """
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -700,7 +785,9 @@ async def audit_rum_health(
 
     async def _run(q):
         try:
-            return await _run_logs_insights_query(log_group, q, st, et, max_results=10)
+            return await _run_logs_insights_query(
+                log_group, q, st, et, max_results=10, clients=_clients
+            )
         except Exception as e:
             return {'status': 'Failed', 'error': str(e), 'results': []}
 
@@ -722,7 +809,7 @@ async def audit_rum_health(
         async def _run_prev(q):
             try:
                 return await _run_logs_insights_query(
-                    log_group, q, prev_st, prev_et, max_results=10
+                    log_group, q, prev_st, prev_et, max_results=10, clients=_clients
                 )
             except Exception as e:
                 return {'status': 'Failed', 'error': str(e), 'results': []}
@@ -742,10 +829,11 @@ async def get_rum_errors(
     end_time: str,
     page_url: Optional[str] = None,
     group_by: Optional[str] = None,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get JS and HTTP errors grouped by message and page."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -754,7 +842,7 @@ async def get_rum_errors(
 
     query = rum_queries.errors_query(page_url=page_url, group_by=group_by)
     result = await _run_logs_insights_query(
-        log_group, query, _parse_time(start_time), _parse_time(end_time)
+        log_group, query, _parse_time(start_time), _parse_time(end_time), clients=_clients
     )
     return json.dumps(
         {
@@ -771,10 +859,11 @@ async def get_rum_performance(
     start_time: str,
     end_time: str,
     page_url: Optional[str] = None,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get page load performance and Core Web Vitals (LCP, FID, CLS, INP)."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -786,10 +875,14 @@ async def get_rum_performance(
 
     nav_result, vitals_result = await asyncio.gather(
         _run_logs_insights_query(
-            log_group, rum_queries.performance_navigation_query(page_url), st, et
+            log_group, rum_queries.performance_navigation_query(page_url), st, et, clients=_clients
         ),
         _run_logs_insights_query(
-            log_group, rum_queries.performance_web_vitals_query(page_url), st, et
+            log_group,
+            rum_queries.performance_web_vitals_query(page_url),
+            st,
+            et,
+            clients=_clients,
         ),
     )
 
@@ -832,10 +925,11 @@ async def get_rum_sessions(
     app_monitor_name: str,
     start_time: str,
     end_time: str,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get recent sessions with browser, OS, device type, and event counts."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -845,7 +939,7 @@ async def get_rum_sessions(
     st = _parse_time(start_time)
     et = _parse_time(end_time)
     query = rum_queries.SESSIONS_QUERY if platform == 'web' else rum_queries.MOBILE_SESSIONS_QUERY
-    result = await _run_logs_insights_query(log_group, query, st, et)
+    result = await _run_logs_insights_query(log_group, query, st, et, clients=_clients)
     return json.dumps(
         {'app_monitor': app_monitor_name, 'platform': platform, **result}, default=str
     )
@@ -855,10 +949,11 @@ async def get_rum_page_views(
     app_monitor_name: str,
     start_time: str,
     end_time: str,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get top pages by view count."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -866,7 +961,11 @@ async def get_rum_page_views(
         return _unknown_platform_response(app_monitor_name)
 
     result = await _run_logs_insights_query(
-        log_group, rum_queries.PAGE_VIEWS_QUERY, _parse_time(start_time), _parse_time(end_time)
+        log_group,
+        rum_queries.PAGE_VIEWS_QUERY,
+        _parse_time(start_time),
+        _parse_time(end_time),
+        clients=_clients,
     )
     return json.dumps({'app_monitor': app_monitor_name, **result}, default=str)
 
@@ -881,10 +980,11 @@ async def get_rum_timeseries(
     metric: str = 'errors',
     bucket: str = '1h',
     page_url: Optional[str] = None,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get time-bucketed trends for errors, performance, or sessions."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -915,7 +1015,7 @@ async def get_rum_timeseries(
             }
         )
 
-    result = await _run_logs_insights_query(log_group, query, st, et)
+    result = await _run_logs_insights_query(log_group, query, st, et, clients=_clients)
     return json.dumps(
         {
             'app_monitor': app_monitor_name,
@@ -933,10 +1033,11 @@ async def get_rum_locations(
     start_time: str,
     end_time: str,
     page_url: Optional[str] = None,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get session counts and performance by country."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -946,8 +1047,12 @@ async def get_rum_locations(
     st = _parse_time(start_time)
     et = _parse_time(end_time)
     sessions_result, perf_result = await asyncio.gather(
-        _run_logs_insights_query(log_group, rum_queries.geo_sessions_query(page_url), st, et),
-        _run_logs_insights_query(log_group, rum_queries.geo_performance_query(page_url), st, et),
+        _run_logs_insights_query(
+            log_group, rum_queries.geo_sessions_query(page_url), st, et, clients=_clients
+        ),
+        _run_logs_insights_query(
+            log_group, rum_queries.geo_performance_query(page_url), st, et, clients=_clients
+        ),
     )
 
     return json.dumps(
@@ -965,10 +1070,11 @@ async def get_rum_http_requests(
     start_time: str,
     end_time: str,
     page_url: Optional[str] = None,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get top HTTP requests by URL with latency and error rates."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -980,6 +1086,7 @@ async def get_rum_http_requests(
         rum_queries.http_requests_query(page_url),
         _parse_time(start_time),
         _parse_time(end_time),
+        clients=_clients,
     )
     return json.dumps({'app_monitor': app_monitor_name, **result}, default=str)
 
@@ -990,10 +1097,11 @@ async def get_rum_session_detail(
     start_time: str,
     end_time: str,
     limit: int = 100,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get all events for a single session in chronological order."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -1013,7 +1121,7 @@ async def get_rum_session_detail(
         if platform == 'web'
         else rum_queries.mobile_session_detail_query(session_id, limit=capped_limit)
     )
-    result = await _run_logs_insights_query(log_group, query, st, et)
+    result = await _run_logs_insights_query(log_group, query, st, et, clients=_clients)
     return json.dumps(
         {
             'app_monitor': app_monitor_name,
@@ -1032,10 +1140,11 @@ async def get_rum_resources(
     start_time: str,
     end_time: str,
     page_url: Optional[str] = None,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get top resource requests by duration and size."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -1047,6 +1156,7 @@ async def get_rum_resources(
         rum_queries.resource_requests_query(page_url),
         _parse_time(start_time),
         _parse_time(end_time),
+        clients=_clients,
     )
     return json.dumps({'app_monitor': app_monitor_name, **result}, default=str)
 
@@ -1055,10 +1165,11 @@ async def get_rum_page_flows(
     app_monitor_name: str,
     start_time: str,
     end_time: str,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get page-to-page navigation flows (approximates user journey)."""
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -1070,6 +1181,7 @@ async def get_rum_page_flows(
         rum_queries.PAGE_FLOWS_QUERY,
         _parse_time(start_time),
         _parse_time(end_time),
+        clients=_clients,
     )
     return json.dumps({'app_monitor': app_monitor_name, **result}, default=str)
 
@@ -1082,6 +1194,7 @@ async def get_rum_crashes(
     start_time: str,
     end_time: str,
     platform: str = 'all',
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get mobile crashes and stability issues.
 
@@ -1097,7 +1210,7 @@ async def get_rum_crashes(
         )
 
     try:
-        log_group, monitor_platform = await _get_rum_app_info(app_monitor_name)
+        log_group, monitor_platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -1125,17 +1238,17 @@ async def get_rum_crashes(
 
     if platform in ('ios', 'all'):
         tasks['ios_crashes'] = _run_logs_insights_query(
-            log_group, rum_queries.MOBILE_CRASHES_IOS, st, et
+            log_group, rum_queries.MOBILE_CRASHES_IOS, st, et, clients=_clients
         )
         tasks['ios_hangs'] = _run_logs_insights_query(
-            log_group, rum_queries.MOBILE_HANGS_IOS, st, et
+            log_group, rum_queries.MOBILE_HANGS_IOS, st, et, clients=_clients
         )
     if platform in ('android', 'all'):
         tasks['android'] = _run_logs_insights_query(
-            log_group, rum_queries.MOBILE_CRASHES_ANDROID, st, et
+            log_group, rum_queries.MOBILE_CRASHES_ANDROID, st, et, clients=_clients
         )
         tasks['android_anrs'] = _run_logs_insights_query(
-            log_group, rum_queries.MOBILE_ANRS_ANDROID, st, et
+            log_group, rum_queries.MOBILE_ANRS_ANDROID, st, et, clients=_clients
         )
 
     names = list(tasks.keys())
@@ -1157,6 +1270,7 @@ async def get_rum_app_launches(
     start_time: str,
     end_time: str,
     platform: str = 'all',
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get mobile app launch performance (cold/warm/pre-warm)."""
     if platform not in ('ios', 'android', 'all'):
@@ -1168,7 +1282,7 @@ async def get_rum_app_launches(
         )
 
     try:
-        log_group, monitor_platform = await _get_rum_app_info(app_monitor_name)
+        log_group, monitor_platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -1196,11 +1310,11 @@ async def get_rum_app_launches(
 
     if platform in ('ios', 'all'):
         tasks['ios'] = _run_logs_insights_query(
-            log_group, rum_queries.MOBILE_APP_LAUNCHES_IOS, st, et
+            log_group, rum_queries.MOBILE_APP_LAUNCHES_IOS, st, et, clients=_clients
         )
     if platform in ('android', 'all'):
         tasks['android'] = _run_logs_insights_query(
-            log_group, rum_queries.MOBILE_APP_LAUNCHES_ANDROID, st, et
+            log_group, rum_queries.MOBILE_APP_LAUNCHES_ANDROID, st, et, clients=_clients
         )
 
     names = list(tasks.keys())
@@ -1221,22 +1335,24 @@ async def analyze_rum_log_group(
     app_monitor_name: str,
     start_time: str,
     end_time: str,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Analyze a RUM log group for anomalies and common patterns."""
     try:
-        log_group, _platform = await _get_rum_app_info(app_monitor_name)
+        log_group, _platform = await _get_rum_app_info(app_monitor_name, _clients)
         st = _parse_time(start_time)
         et = _parse_time(end_time)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
-    log_group_arn = _log_group_arn(log_group)
+    log_group_arn = _log_group_arn(log_group, _clients)
+    logs = _clients['logs'] if _clients else logs_client
 
     anomaly_info: dict[str, Any] = {'detectors': [], 'anomalies': []}
 
     def _fetch_anomaly_detectors() -> tuple[list, Optional[str]]:
         try:
-            resp = logs_client.list_log_anomaly_detectors(filterLogGroupArn=log_group_arn)
+            resp = logs.list_log_anomaly_detectors(filterLogGroupArn=log_group_arn)
             return resp.get('anomalyDetectors', []), None
         except Exception as e:
             return [], str(e)
@@ -1247,9 +1363,9 @@ async def analyze_rum_log_group(
             token: Optional[str] = None
             for _ in range(_ANOMALY_PAGE_CAP):
                 if token:
-                    resp = logs_client.list_anomalies(anomalyDetectorArn=arn, nextToken=token)
+                    resp = logs.list_anomalies(anomalyDetectorArn=arn, nextToken=token)
                 else:
-                    resp = logs_client.list_anomalies(anomalyDetectorArn=arn)
+                    resp = logs.list_anomalies(anomalyDetectorArn=arn)
                 out.extend(resp.get('anomalies', []))
                 token = resp.get('nextToken')
                 if not token:
@@ -1287,8 +1403,12 @@ async def analyze_rum_log_group(
         anomaly_info['page_cap'] = _ANOMALY_PAGE_CAP
 
     top_patterns, error_patterns = await asyncio.gather(
-        _run_logs_insights_query(log_group, rum_queries.TOP_PATTERNS_QUERY, st, et),
-        _run_logs_insights_query(log_group, rum_queries.ERROR_PATTERNS_QUERY, st, et),
+        _run_logs_insights_query(
+            log_group, rum_queries.TOP_PATTERNS_QUERY, st, et, clients=_clients
+        ),
+        _run_logs_insights_query(
+            log_group, rum_queries.ERROR_PATTERNS_QUERY, st, et, clients=_clients
+        ),
     )
 
     return json.dumps(
@@ -1311,13 +1431,14 @@ async def correlate_rum_to_backend(
     start_time: str,
     end_time: str,
     max_traces: int = 10,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Correlate frontend RUM events to backend X-Ray traces.
 
     ``max_traces`` is capped at 100 to bound X-Ray BatchGetTraces fan-out.
     """
     try:
-        log_group, platform = await _get_rum_app_info(app_monitor_name)
+        log_group, platform = await _get_rum_app_info(app_monitor_name, _clients)
     except ValueError as e:
         return json.dumps({'error': str(e), 'error_type': 'bad_request'})
 
@@ -1339,7 +1460,12 @@ async def correlate_rum_to_backend(
     raw_limit = capped_traces * _CORRELATE_OVERSAMPLE_FACTOR
     query = rum_queries.trace_ids_for_page_query(page_url, limit=raw_limit)
     logs_result = await _run_logs_insights_query(
-        log_group, query, _parse_time(start_time), _parse_time(end_time), max_results=raw_limit
+        log_group,
+        query,
+        _parse_time(start_time),
+        _parse_time(end_time),
+        max_results=raw_limit,
+        clients=_clients,
     )
 
     raw_trace_ids = [
@@ -1369,8 +1495,9 @@ async def correlate_rum_to_backend(
     batches = [trace_ids[i : i + 5] for i in range(0, len(trace_ids), 5)]
 
     def _get_batch(batch):
+        xray = _clients['xray'] if _clients else xray_client
         try:
-            return xray_client.batch_get_traces(TraceIds=batch).get('Traces', []), None
+            return xray.batch_get_traces(TraceIds=batch).get('Traces', []), None
         except Exception as e:
             logger.warning(f'Failed to get traces {batch}: {e}')
             return [], str(e)
@@ -1445,6 +1572,7 @@ async def get_rum_metrics(
     end_time: str,
     statistic: str = 'Average',
     period: int = 300,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get vended CloudWatch metrics from the AWS/RUM namespace."""
     # Caller-input parsing — return a 'bad_request' shape so callers can distinguish.
@@ -1489,6 +1617,7 @@ async def get_rum_metrics(
     # Capped at _METRIC_DATA_PAGE_CAP to bound worker-thread time and memory;
     # returns (pages, truncated) where truncated=True means more data existed.
     def _paginate() -> tuple[list, bool]:
+        cloudwatch = _clients['cloudwatch'] if _clients else cloudwatch_client
         pages = []
         token = None
         for _ in range(_METRIC_DATA_PAGE_CAP):
@@ -1499,7 +1628,7 @@ async def get_rum_metrics(
             }
             if token:
                 kwargs['NextToken'] = token
-            page = cloudwatch_client.get_metric_data(**kwargs)
+            page = cloudwatch.get_metric_data(**kwargs)
             pages.append(page)
             token = page.get('NextToken')
             if not token:
@@ -1566,6 +1695,7 @@ async def get_rum_slo_health(
     app_monitor_name: str,
     start_time: str,
     end_time: str,
+    _clients: Optional[dict[str, Any]] = None,
 ) -> str:
     """Get SLO health status for a RUM app monitor.
 
@@ -1573,10 +1703,11 @@ async def get_rum_slo_health(
     is not used — the SLO budget report is evaluated at ``end_time`` only.
     """
     et = _parse_time(end_time)
+    appsignals = _clients['applicationsignals'] if _clients else applicationsignals_client
 
     def _list_slos() -> list:
         out = []
-        paginator = applicationsignals_client.get_paginator('list_service_level_objectives')
+        paginator = appsignals.get_paginator('list_service_level_objectives')
         for page in paginator.paginate(
             KeyAttributes={
                 'Type': 'AWS::Resource',
@@ -1623,7 +1754,7 @@ async def get_rum_slo_health(
         slo_id = slo_arn or slo_name
         try:
             resp = await asyncio.to_thread(
-                applicationsignals_client.get_service_level_objective,
+                appsignals.get_service_level_objective,
                 Id=slo_id,
             )
             slo_detail = resp.get('Slo', {})
@@ -1631,7 +1762,7 @@ async def get_rum_slo_health(
             attainment = goal.get('AttainmentGoal')
 
             budget_resp = await asyncio.to_thread(
-                applicationsignals_client.batch_get_service_level_objective_budget_report,
+                appsignals.batch_get_service_level_objective_budget_report,
                 Timestamp=et,
                 SloIds=[slo_id],
             )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
@@ -30,6 +30,7 @@ from .audit_utils import (
 from .aws_clients import (
     AWS_REGION,
     applicationsignals_client,
+    get_aws_client,
     iam_client,
     s3_client,
     synthetics_client,
@@ -74,7 +75,7 @@ from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 from time import perf_counter as timer
-from typing import Optional
+from typing import Annotated, Optional
 
 
 # Constants
@@ -118,6 +119,58 @@ logger.debug(f'CloudWatch applicationsignals MCP Server initialized with log lev
 logger.debug(f'File logging enabled: {aws_cli_log_path}')
 
 logger.debug(f'Using AWS region: {AWS_REGION}')
+
+
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
+def _get_applicationsignals_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped Application Signals client."""
+    if profile_name is None:
+        return applicationsignals_client
+    return get_aws_client('application-signals', region_name=AWS_REGION, profile_name=profile_name)
+
+
+def _get_synthetics_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the default or profile-scoped Synthetics client."""
+    if profile_name is None:
+        return synthetics_client
+    return get_aws_client(
+        'synthetics', region_name=region or AWS_REGION, profile_name=profile_name
+    )
+
+
+def _get_s3_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the default or profile-scoped S3 client."""
+    if profile_name is None:
+        return s3_client
+    return get_aws_client('s3', region_name=region or AWS_REGION, profile_name=profile_name)
+
+
+def _get_iam_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the default or profile-scoped IAM client."""
+    if profile_name is None:
+        return iam_client
+    return get_aws_client('iam', region_name=region or AWS_REGION, profile_name=profile_name)
+
+
+def _get_logs_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the profile-scoped CloudWatch Logs client."""
+    if profile_name is None:
+        return None
+    return get_aws_client('logs', region_name=region or AWS_REGION, profile_name=profile_name)
+
+
+def _get_lambda_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the profile-scoped Lambda client."""
+    if profile_name is None:
+        return None
+    return get_aws_client('lambda', region_name=region or AWS_REGION, profile_name=profile_name)
 
 
 def _filter_operation_targets(provided):
@@ -186,6 +239,7 @@ async def audit_services(
         default=5,
         description='Optional. Maximum number of services to process per call when using wildcard patterns (default: 5, max: 10). This controls pagination size for service discovery.',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """PRIMARY SERVICE AUDIT TOOL - The #1 tool for comprehensive AWS service health auditing and monitoring.
 
@@ -334,6 +388,8 @@ async def audit_services(
     try:
         # Region defaults
         region = AWS_REGION.strip()
+        appsignals_client = _get_applicationsignals_client(profile_name)
+        profile_synthetics_client = _get_synthetics_client(profile_name)
 
         # Time range (fill missing with defaults)
         start_dt = (
@@ -398,7 +454,7 @@ async def audit_services(
                     unix_end,
                     next_token,
                     max_services,
-                    applicationsignals_client,
+                    appsignals_client,
                 )
             )
             logger.debug(f'Paginated wildcard expansion completed - {len(provided)} total targets')
@@ -416,7 +472,7 @@ async def audit_services(
 
         # Validate and enrich targets using shared utility
         normalized_targets = validate_and_enrich_service_targets(
-            normalized_targets, applicationsignals_client, unix_start, unix_end
+            normalized_targets, appsignals_client, unix_start, unix_end
         )
 
         # Parse auditors with service-specific defaults
@@ -448,12 +504,27 @@ async def audit_services(
             input_obj['Auditors'] = auditors_list
 
         # Execute audit API using shared utility
-        result = await execute_audit_api(input_obj, region, banner)
+        result = await execute_audit_api(
+            input_obj,
+            region,
+            banner,
+            appsignals_client if profile_name is not None else None,
+        )
 
         # Check Synthetics canaries linked to the audited services
-        canary_result = await check_canaries_for_service(
-            normalized_targets, unix_start, unix_end, region
-        )
+        if profile_name is None:
+            canary_result = await check_canaries_for_service(
+                normalized_targets, unix_start, unix_end, region
+            )
+        else:
+            canary_result = await check_canaries_for_service(
+                normalized_targets,
+                unix_start,
+                unix_end,
+                region,
+                appsignals_client,
+                profile_synthetics_client,
+            )
         if canary_result:
             result += canary_result
 
@@ -505,6 +576,7 @@ async def audit_slos(
         default=5,
         description='Optional. Maximum number of SLOs to process per call when using wildcard patterns (default: 5, max: 10). This controls pagination size for SLO discovery.',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """PRIMARY SLO AUDIT TOOL - The #1 tool for comprehensive SLO compliance monitoring and breach analysis.
 
@@ -609,6 +681,7 @@ async def audit_slos(
     try:
         # Region defaults
         region = AWS_REGION.strip()
+        appsignals_client = _get_applicationsignals_client(profile_name)
 
         # Time range (fill missing with defaults)
         start_dt = (
@@ -663,9 +736,7 @@ async def audit_slos(
             try:
                 # Use the paginated utility function
                 expanded_slo_targets, returned_next_token, slo_names_in_batch = (
-                    expand_slo_wildcard_patterns(
-                        provided, next_token, max_slos, applicationsignals_client
-                    )
+                    expand_slo_wildcard_patterns(provided, next_token, max_slos, appsignals_client)
                 )
                 # Filter to get only SLO targets
                 slo_only_targets = [
@@ -709,7 +780,12 @@ async def audit_slos(
             input_obj['Auditors'] = auditors_list
 
         # Execute audit API using shared utility
-        result = await execute_audit_api(input_obj, region, banner)
+        result = await execute_audit_api(
+            input_obj,
+            region,
+            banner,
+            appsignals_client if profile_name is not None else None,
+        )
 
         # Add prominent pagination information when wildcards were used
         result += format_pagination_info(
@@ -759,6 +835,7 @@ async def audit_service_operations(
         default=5,
         description='Optional. Maximum number of services to process per call when using wildcard patterns (default: 5, max: 10). This controls pagination size for service discovery.',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """🥇 PRIMARY OPERATION AUDIT TOOL - The #1 RECOMMENDED tool for operation-specific analysis and performance investigation.
 
@@ -874,6 +951,7 @@ async def audit_service_operations(
     try:
         # Region defaults
         region = AWS_REGION.strip()
+        appsignals_client = _get_applicationsignals_client(profile_name)
 
         # Time range (fill missing with defaults)
         start_dt = (
@@ -922,7 +1000,7 @@ async def audit_service_operations(
                 unix_end,
                 next_token,
                 max_services,
-                applicationsignals_client,
+                appsignals_client,
             )
             logger.debug(
                 f'Paginated wildcard expansion completed - {len(operation_only_targets)} total targets'
@@ -965,7 +1043,12 @@ async def audit_service_operations(
             input_obj['Auditors'] = auditors_list
 
         # Execute audit API using shared utility
-        result = await execute_audit_api(input_obj, region, banner)
+        result = await execute_audit_api(
+            input_obj,
+            region,
+            banner,
+            appsignals_client if profile_name is not None else None,
+        )
 
         # Add prominent pagination information when wildcards were used
         result += format_pagination_info(
@@ -991,7 +1074,10 @@ async def audit_service_operations(
 
 @mcp.tool()
 async def analyze_canary_failures(
-    canary_name: str, region: str = AWS_REGION, description: str = ''
+    canary_name: str,
+    region: str = AWS_REGION,
+    description: str = '',
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """Comprehensive canary failure analysis with deep dive into issues.
 
@@ -1033,6 +1119,7 @@ async def analyze_canary_failures(
             even when the canary error logs alone may not contain enough context.
             Examples: "missing runs in console", "visual monitoring baseline keeps resetting",
             "CloudFormation rollback failed after runtime upgrade".
+        profile_name (str, optional): AWS CLI profile name to use for this tool call.
 
     Returns:
         dict: Comprehensive failure analysis containing:
@@ -1043,6 +1130,13 @@ async def analyze_canary_failures(
             - Historical pattern analysis and trend insights
     """
     try:
+        synthetics_client = _get_synthetics_client(profile_name, region)
+        s3_client = _get_s3_client(profile_name, region)
+        iam_client = _get_iam_client(profile_name, region)
+        appsignals_client = _get_applicationsignals_client(profile_name)
+        logs_client_override = _get_logs_client(profile_name, region)
+        lambda_client_override = _get_lambda_client(profile_name, region)
+
         # Get recent canary runs
         response = synthetics_client.get_canary_runs(Name=canary_name, MaxResults=5)
         runs = response.get('CanaryRuns', [])
@@ -1053,7 +1147,11 @@ async def analyze_canary_failures(
 
         # Get telemetry and service insights
         try:
-            telemetry_insights = await get_canary_metrics_and_service_insights(canary_name, region)
+            telemetry_insights = await get_canary_metrics_and_service_insights(
+                canary_name,
+                region,
+                appsignals_client if profile_name is not None else None,
+            )
         except Exception as e:
             telemetry_insights = f'Telemetry API unavailable: {str(e)}'
 
@@ -1338,7 +1436,12 @@ async def analyze_canary_failures(
             failure_time = selected_failure.get('Timeline', {}).get('Started')
             if failure_time:
                 cw_log_analysis = await analyze_canary_logs_with_time_window(
-                    canary_name, failure_time, canary, window_minutes=5, region=region
+                    canary_name,
+                    failure_time,
+                    canary,
+                    window_minutes=5,
+                    region=region,
+                    logs_client_override=logs_client_override,
                 )
 
                 if cw_log_analysis.get('status') == 'success':
@@ -1365,7 +1468,12 @@ async def analyze_canary_failures(
             if failure_time:
                 try:
                     cw_log_analysis = await analyze_canary_logs_with_time_window(
-                        canary_name, failure_time, canary, window_minutes=5, region=region
+                        canary_name,
+                        failure_time,
+                        canary,
+                        window_minutes=5,
+                        region=region,
+                        logs_client_override=logs_client_override,
                     )
                     if cw_log_analysis.get('status') == 'success':
                         for evt in cw_log_analysis.get('error_events', []):
@@ -1456,7 +1564,14 @@ async def analyze_canary_failures(
             for pattern in ['enospc', 'no space left on device']
         ):
             try:
-                telemetry_data = await extract_disk_memory_usage_metrics(canary_name, region)
+                telemetry_data = await extract_disk_memory_usage_metrics(
+                    canary_name,
+                    region,
+                    synthetics_client_override=synthetics_client
+                    if profile_name is not None
+                    else None,
+                    logs_client_override=logs_client_override,
+                )
                 if 'error' not in telemetry_data:
                     result += '\n🔍 DISK USAGE ROOT CAUSE ANALYSIS:\n'
                     result += f'• Storage: {telemetry_data.get("maxEphemeralStorageUsageInMb", 0):.1f} MB peak\n'
@@ -1478,7 +1593,14 @@ async def analyze_canary_failures(
             ]
         ):
             try:
-                telemetry_data = await extract_disk_memory_usage_metrics(canary_name, region)
+                telemetry_data = await extract_disk_memory_usage_metrics(
+                    canary_name,
+                    region,
+                    synthetics_client_override=synthetics_client
+                    if profile_name is not None
+                    else None,
+                    logs_client_override=logs_client_override,
+                )
                 if 'error' not in telemetry_data:
                     result += '\n🔍 MEMORY USAGE ROOT CAUSE ANALYSIS:\n'
                     result += f'• Memory: {telemetry_data.get("maxSyntheticsMemoryUsageInMB", 0):.1f} MB peak\n'
@@ -1553,7 +1675,9 @@ async def analyze_canary_failures(
 
         # Add canary code if available
         try:
-            code_analysis = await get_canary_code(canary, region)
+            code_analysis = await get_canary_code(
+                canary, region, lambda_client_override=lambda_client_override
+            )
             if 'error' not in code_analysis and code_analysis.get('code_content'):
                 result += f'\ncanary code:\n{code_analysis["code_content"]}\n'
         except Exception as e:
@@ -1604,7 +1728,11 @@ async def analyze_canary_failures(
 
 
 @mcp.tool()
-async def list_canaries(region: str = AWS_REGION, max_results: int = 20) -> str:
+async def list_canaries(
+    region: str = AWS_REGION,
+    max_results: int = 20,
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
+) -> str:
     """List all CloudWatch Synthetics canaries in the account.
 
     Use this tool to discover canaries before analyzing them with analyze_canary_failures().
@@ -1613,6 +1741,7 @@ async def list_canaries(region: str = AWS_REGION, max_results: int = 20) -> str:
     Args:
         region: AWS region to query (defaults to configured region).
         max_results: Maximum number of canaries to display (default: 20, max: 200).
+        profile_name: Optional AWS CLI profile name for this tool call.
 
     Returns:
         Formatted list of all canaries with their current status and configuration.
@@ -1622,6 +1751,8 @@ async def list_canaries(region: str = AWS_REGION, max_results: int = 20) -> str:
     max_results = min(max(max_results, 1), 200)
 
     try:
+        synthetics_client = _get_synthetics_client(profile_name, region)
+
         canaries: list = []
         paginator_token = None
 
@@ -1714,7 +1845,8 @@ def main():
     """Run the MCP server."""
     logger.debug('Starting CloudWatch Application Signals MCP server')
     try:
-        mcp.run(transport='stdio')
+        current_mcp = getattr(sys.modules.get(__name__), 'mcp', mcp)
+        current_mcp.run(transport='stdio')
     except KeyboardInterrupt:
         logger.debug('Server shutdown by user')
     except Exception as e:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_tools.py
@@ -14,15 +14,40 @@
 
 """CloudWatch Application Signals MCP Server - Service-related tools."""
 
-from .aws_clients import applicationsignals_client, cloudwatch_client
+from .aws_clients import AWS_REGION, applicationsignals_client, cloudwatch_client, get_aws_client
 from botocore.exceptions import ClientError
 from datetime import datetime, timedelta, timezone
 from loguru import logger
 from pydantic import Field
 from time import perf_counter as timer
+from typing import Annotated, Optional
 
 
-async def list_monitored_services() -> str:
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
+def _get_applicationsignals_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped Application Signals client."""
+    if profile_name is None:
+        return applicationsignals_client
+    return get_aws_client('application-signals', region_name=AWS_REGION, profile_name=profile_name)
+
+
+def _get_cloudwatch_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped CloudWatch client."""
+    if profile_name is None:
+        return cloudwatch_client
+    return get_aws_client('cloudwatch', region_name=AWS_REGION, profile_name=profile_name)
+
+
+async def list_monitored_services(
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
+) -> str:
     """OPTIONAL TOOL for service discovery - audit_services() can automatically discover services using wildcard patterns.
 
     **IMPORTANT: For service auditing and operation analysis, use audit_services() as the PRIMARY tool instead.**
@@ -73,13 +98,15 @@ async def list_monitored_services() -> str:
     logger.debug('Starting list_application_signals_services request')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         # Calculate time range (last 24 hours)
         end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(hours=24)
 
         # Get all services
         logger.debug(f'Querying services for time range: {start_time} to {end_time}')
-        response = applicationsignals_client.list_services(
+        response = appsignals_client.list_services(
             StartTime=start_time, EndTime=end_time, MaxResults=100
         )
         services = response.get('ServiceSummaries', [])
@@ -126,6 +153,7 @@ async def get_service_detail(
     service_name: str = Field(
         ..., description='Name of the service to get details for (case-sensitive)'
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """Get detailed information about a specific Application Signals service.
 
@@ -163,12 +191,14 @@ async def get_service_detail(
     logger.debug(f'Starting get_service_healthy_detail request for service: {service_name}')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         # Calculate time range (last 24 hours)
         end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(hours=24)
 
         # First, get all services to find the one we want
-        services_response = applicationsignals_client.list_services(
+        services_response = appsignals_client.list_services(
             StartTime=start_time, EndTime=end_time, MaxResults=100
         )
 
@@ -186,7 +216,7 @@ async def get_service_detail(
 
         # Get detailed service information
         logger.debug(f'Getting detailed information for service: {service_name}')
-        service_response = applicationsignals_client.get_service(
+        service_response = appsignals_client.get_service(
             StartTime=start_time, EndTime=end_time, KeyAttributes=target_service['KeyAttributes']
         )
 
@@ -270,6 +300,7 @@ async def query_service_metrics(
     hours: int = Field(
         default=1, description='Number of hours to look back (default 1, max 168 for 1 week)'
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """Get CloudWatch metrics for a specific Application Signals service.
 
@@ -300,12 +331,15 @@ async def query_service_metrics(
     )
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+        cw_client = _get_cloudwatch_client(profile_name)
+
         # Calculate time range
         end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(hours=hours)
 
         # Get service details to find metrics
-        services_response = applicationsignals_client.list_services(
+        services_response = appsignals_client.list_services(
             StartTime=start_time, EndTime=end_time, MaxResults=100
         )
 
@@ -322,7 +356,7 @@ async def query_service_metrics(
             return f"Service '{service_name}' not found in Application Signals."
 
         # Get detailed service info for metric references
-        service_response = applicationsignals_client.get_service(
+        service_response = appsignals_client.get_service(
             StartTime=start_time, EndTime=end_time, KeyAttributes=target_service['KeyAttributes']
         )
 
@@ -362,7 +396,7 @@ async def query_service_metrics(
             period = 3600  # 1 hour
 
         # Get both standard and extended statistics in a single call
-        response = cloudwatch_client.get_metric_statistics(
+        response = cw_client.get_metric_statistics(
             Namespace=target_metric['Namespace'],
             MetricName=target_metric['MetricName'],
             Dimensions=target_metric.get('Dimensions', []),
@@ -466,6 +500,7 @@ async def list_service_operations(
         default=24,
         description='Number of hours to look back for operation discovery (default 24, max 24 for Application Signals operation discovery)',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """OPERATION DISCOVERY TOOL - For operation inventory only. Use audit_services() as PRIMARY tool for operation auditing.
 
@@ -519,13 +554,15 @@ async def list_service_operations(
     logger.debug(f'Starting list_service_operations request for service: {service_name}')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         # Calculate time range - enforce 24 hour maximum for Application Signals operation discovery
         end_time = datetime.now(timezone.utc)
         hours = min(hours, 24)  # Enforce maximum of 24 hours
         start_time = end_time - timedelta(hours=hours)
 
         # First, get the service to find its key attributes
-        services_response = applicationsignals_client.list_services(
+        services_response = appsignals_client.list_services(
             StartTime=start_time, EndTime=end_time, MaxResults=100
         )
 
@@ -543,7 +580,7 @@ async def list_service_operations(
 
         # Get operations for the service using ListServiceOperations API
         logger.debug(f'Getting operations for service: {service_name}')
-        operations_response = applicationsignals_client.list_service_operations(
+        operations_response = appsignals_client.list_service_operations(
             StartTime=start_time,
             EndTime=end_time,
             KeyAttributes=target_service['KeyAttributes'],

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/sli_report_client.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/sli_report_client.py
@@ -181,11 +181,13 @@ class SLIReportClient:
     Handles interaction with AWS services to collect and analyze SLO data.
     """
 
-    def __init__(self, config: AWSConfig):
+    def __init__(self, config: AWSConfig, signals_client=None, cloudwatch_client_override=None):
         """Initialize SLIReportClient with AWS configuration.
 
         Args:
             config: AWSConfig instance containing region, period, and service settings
+            signals_client: Optional Application Signals client override
+            cloudwatch_client_override: Optional CloudWatch client override
         """
         self.config = config
         logger.info(
@@ -193,8 +195,8 @@ class SLIReportClient:
         )
 
         # Use shared AWS clients from aws_clients module
-        self.signals_client = applicationsignals_client
-        self.cloudwatch_client = cloudwatch_client
+        self.signals_client = signals_client or applicationsignals_client
+        self.cloudwatch_client = cloudwatch_client_override or cloudwatch_client
         logger.debug('Using shared AWS clients')
 
     def get_slo_summaries(self) -> List[SLOSummary]:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/slo_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/slo_tools.py
@@ -15,15 +15,32 @@
 """CloudWatch Application Signals MCP Server - SLO-related tools."""
 
 import json
-from .aws_clients import applicationsignals_client
+from .aws_clients import AWS_REGION, applicationsignals_client, get_aws_client
 from botocore.exceptions import ClientError
 from loguru import logger
 from pydantic import Field
 from time import perf_counter as timer
+from typing import Annotated, Optional
+
+
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
+def _get_applicationsignals_client(profile_name: Optional[str] = None):
+    """Return the default or profile-scoped Application Signals client."""
+    if profile_name is None:
+        return applicationsignals_client
+    return get_aws_client('application-signals', region_name=AWS_REGION, profile_name=profile_name)
 
 
 async def get_slo(
     slo_id: str = Field(..., description='The ARN or name of the SLO to retrieve'),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """Get detailed information about a specific Service Level Objective (SLO).
 
@@ -62,7 +79,9 @@ async def get_slo(
     logger.info(f'Starting get_service_level_objective request for SLO: {slo_id}')
 
     try:
-        response = applicationsignals_client.get_service_level_objective(Id=slo_id)
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
+        response = appsignals_client.get_service_level_objective(Id=slo_id)
         slo = response.get('Slo', {})
 
         if not slo:
@@ -286,6 +305,7 @@ async def list_slos(
     max_results: int = Field(
         default=50, description='Maximum number of SLOs to return (default: 50, max: 50)'
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """List all Service Level Objectives (SLOs) in Application Signals.
 
@@ -311,6 +331,8 @@ async def list_slos(
     logger.debug('Starting list_slos request')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+
         # Parse key_attributes JSON string
         try:
             key_attrs_dict = json.loads(key_attributes) if key_attributes else {}
@@ -333,7 +355,7 @@ async def list_slos(
         logger.debug(f'Listing SLOs with parameters: {request_params}')
 
         # Call the Application Signals API
-        response = applicationsignals_client.list_service_level_objectives(**request_params)
+        response = appsignals_client.list_service_level_objectives(**request_params)
         slo_summaries = response.get('SloSummaries', [])
 
         logger.debug(f'Retrieved {len(slo_summaries)} SLO summaries')

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/trace_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/trace_tools.py
@@ -17,14 +17,21 @@
 import asyncio
 import json
 import re
-from .aws_clients import applicationsignals_client, logs_client, xray_client
+from .aws_clients import (
+    AWS_REGION,
+    applicationsignals_client,
+    cloudwatch_client,
+    get_aws_client,
+    logs_client,
+    xray_client,
+)
 from .sli_report_client import AWSConfig, SLIReportClient
 from .utils import remove_null_values
 from datetime import datetime, timedelta, timezone
 from loguru import logger
 from pydantic import Field
 from time import perf_counter as timer
-from typing import Dict, Optional
+from typing import Annotated, Dict, Optional
 
 
 OTEL_TRACE_DATA_FORMAT = 'AWS-OTEL-TRACE-V1'
@@ -37,6 +44,48 @@ _LOG_GROUP_IGNORED_REASON = (
     "not accept a separate logGroupNames parameter. The user's SOURCE scope was used "
     'instead. Remove log_group_name or the SOURCE clause to eliminate this ambiguity.'
 )
+
+
+def _profile_name_field():
+    """Create the shared profile_name field used by profile-aware tools."""
+    return Field(
+        default=None,
+        description='Optional AWS CLI profile name to use for this tool call. Defaults to AWS_PROFILE or the default credential chain.',
+    )
+
+
+def _get_applicationsignals_client(
+    profile_name: Optional[str] = None, region: Optional[str] = None
+):
+    """Return the default or profile-scoped Application Signals client."""
+    if profile_name is None:
+        return applicationsignals_client
+    return get_aws_client(
+        'application-signals', region_name=region or AWS_REGION, profile_name=profile_name
+    )
+
+
+def _get_logs_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the default or profile-scoped CloudWatch Logs client."""
+    if profile_name is None:
+        return logs_client
+    return get_aws_client('logs', region_name=region or AWS_REGION, profile_name=profile_name)
+
+
+def _get_xray_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the default or profile-scoped X-Ray client."""
+    if profile_name is None:
+        return xray_client
+    return get_aws_client('xray', region_name=region or AWS_REGION, profile_name=profile_name)
+
+
+def _get_cloudwatch_client(profile_name: Optional[str] = None, region: Optional[str] = None):
+    """Return the profile-scoped CloudWatch client used by SLI reports."""
+    if profile_name is None:
+        return cloudwatch_client
+    return get_aws_client(
+        'cloudwatch', region_name=region or AWS_REGION, profile_name=profile_name
+    )
 
 
 def _user_query_has_source_clause(user_query: str) -> bool:
@@ -141,14 +190,17 @@ def get_trace_summaries_paginated(
         return all_traces
 
 
-def check_transaction_search_enabled(region: str = 'us-east-1') -> tuple[bool, str, str]:
+def check_transaction_search_enabled(
+    region: str = 'us-east-1', xray_client_override=None
+) -> tuple[bool, str, str]:
     """Internal function to check if AWS X-Ray Transaction Search is enabled.
 
     Returns:
         tuple: (is_enabled: bool, destination: str, status: str)
     """
     try:
-        response = xray_client.get_trace_segment_destination()
+        xray = xray_client_override or xray_client
+        response = xray.get_trace_segment_destination()
 
         destination = response.get('Destination', 'Unknown')
         status = response.get('Status', 'Unknown')
@@ -187,6 +239,7 @@ async def search_transaction_spans(
     max_timeout: int = Field(
         default=30, description='Maximum time in seconds to wait for query completion'
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> Dict:
     """Executes a CloudWatch Logs Insights query against trace span records stored in CloudWatch Logs with the OpenTelemetry semantic-convention schema (@data_format = "AWS-OTEL-TRACE-V1").
 
@@ -250,8 +303,13 @@ async def search_transaction_spans(
             ),
         }
 
+    profile_logs_client = _get_logs_client(profile_name)
+    profile_xray_client = _get_xray_client(profile_name)
+
     # Check if transaction search is enabled
-    is_enabled, destination, status = check_transaction_search_enabled()
+    is_enabled, destination, status = check_transaction_search_enabled(
+        xray_client_override=profile_xray_client
+    )
 
     if not is_enabled:
         logger.warning(
@@ -297,14 +355,14 @@ async def search_transaction_spans(
             )
 
         logger.debug(f'Starting CloudWatch Logs query with limit: {limit}')
-        start_response = logs_client.start_query(**remove_null_values(kwargs))
+        start_response = profile_logs_client.start_query(**remove_null_values(kwargs))
         query_id = start_response['queryId']
         logger.info(f'Started CloudWatch Logs query with ID: {query_id}')
 
         # Seconds
         poll_start = timer()
         while poll_start + max_timeout > timer():
-            response = logs_client.get_query_results(queryId=query_id)
+            response = profile_logs_client.get_query_results(queryId=query_id)
             status = response['status']
 
             if status in {'Complete', 'Failed', 'Cancelled'}:
@@ -439,6 +497,7 @@ async def query_sampled_traces(
     region: Optional[str] = Field(
         default=None, description='AWS region (defaults to AWS_REGION environment variable)'
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """SECONDARY TRACE TOOL - Query AWS X-Ray traces (5% sampled data) for trace investigation.
 
@@ -517,9 +576,8 @@ async def query_sampled_traces(
 
     # Use AWS_REGION environment variable if region not provided
     if not region:
-        from .aws_clients import AWS_REGION
-
         region = AWS_REGION
+    profile_xray_client = _get_xray_client(profile_name, region)
 
     logger.info(f'Starting query_sampled_traces - region: {region}, filter: {filter_expression}')
 
@@ -554,7 +612,7 @@ async def query_sampled_traces(
 
         # Use pagination helper with a reasonable limit
         traces = get_trace_summaries_paginated(
-            xray_client,
+            profile_xray_client,
             start_datetime,
             end_datetime,
             filter_expression or '',
@@ -663,7 +721,9 @@ async def query_sampled_traces(
                     seen_faults[fault_msg] = {'count': 1}
 
         # Check transaction search status
-        is_tx_search_enabled, tx_destination, tx_status = check_transaction_search_enabled(region)
+        is_tx_search_enabled, tx_destination, tx_status = check_transaction_search_enabled(
+            region, profile_xray_client
+        )
 
         # Build response with original format but deduplicated traces
         result_data = {
@@ -706,6 +766,7 @@ async def list_slis(
         default=24,
         description='Number of hours to look back (default 24, typically use 24 for daily checks)',
     ),
+    profile_name: Annotated[Optional[str], _profile_name_field()] = None,
 ) -> str:
     """SPECIALIZED TOOL - Use audit_service_health() as the PRIMARY tool for service auditing.
 
@@ -737,13 +798,16 @@ async def list_slis(
     logger.info(f'Starting get_sli_status request for last {hours} hours')
 
     try:
+        appsignals_client = _get_applicationsignals_client(profile_name)
+        profile_xray_client = _get_xray_client(profile_name)
+
         # Calculate time range
         end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(hours=hours)
         logger.debug(f'Time range: {start_time} to {end_time}')
 
         # Get all services
-        services_response = applicationsignals_client.list_services(
+        services_response = appsignals_client.list_services(
             StartTime=start_time,  # type: ignore
             EndTime=end_time,  # type: ignore
             MaxResults=100,
@@ -769,7 +833,14 @@ async def list_slis(
                 )
 
                 # Generate SLI report
-                client = SLIReportClient(config)
+                if profile_name is None:
+                    client = SLIReportClient(config)
+                else:
+                    client = SLIReportClient(
+                        config,
+                        signals_client=appsignals_client,
+                        cloudwatch_client_override=_get_cloudwatch_client(profile_name),
+                    )
                 sli_report = client.generate_sli_report()
 
                 # Convert to expected format
@@ -806,7 +877,9 @@ async def list_slis(
                 reports.append(report)
 
         # Check transaction search status
-        is_tx_search_enabled, tx_destination, tx_status = check_transaction_search_enabled()
+        is_tx_search_enabled, tx_destination, tx_status = check_transaction_search_enabled(
+            xray_client_override=profile_xray_client
+        )
 
         # Build response
         result = f'SLI Status Report - Last {hours} hours\n'

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_profile_name_support.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_profile_name_support.py
@@ -1,0 +1,284 @@
+"""Tests for per-call AWS profile support."""
+
+import inspect
+import pytest
+from awslabs.cloudwatch_applicationsignals_mcp_server import __version__
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_get_aws_client_with_profile_name():
+    """Explicit profile_name should create a profile-scoped boto3 session."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import get_aws_client
+
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_session.client.return_value = mock_client
+
+    with patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.boto3.Session',
+        return_value=mock_session,
+    ) as mock_session_class:
+        result = get_aws_client(
+            'application-signals', region_name='us-west-2', profile_name='prod-profile'
+        )
+
+    mock_session_class.assert_called_once_with(
+        profile_name='prod-profile', region_name='us-west-2'
+    )
+    mock_session.client.assert_called_once()
+    call_args = mock_session.client.call_args
+    assert call_args.args[0] == 'application-signals'
+    assert call_args.kwargs['region_name'] == 'us-west-2'
+    assert result == mock_client
+
+
+def test_get_aws_client_profile_name_takes_precedence_over_env():
+    """Explicit profile_name should override AWS_PROFILE."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import get_aws_client
+
+    mock_session = MagicMock()
+    mock_session.client.return_value = MagicMock()
+
+    with patch.dict('os.environ', {'AWS_PROFILE': 'env-profile'}):
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.boto3.Session',
+            return_value=mock_session,
+        ) as mock_session_class:
+            get_aws_client('logs', profile_name='explicit-profile')
+
+    mock_session_class.assert_called_once_with(
+        profile_name='explicit-profile', region_name='us-east-1'
+    )
+
+
+def test_get_aws_client_uses_aws_profile_env():
+    """Missing profile_name should fall back to AWS_PROFILE."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import get_aws_client
+
+    mock_session = MagicMock()
+    mock_session.client.return_value = MagicMock()
+
+    with patch.dict('os.environ', {'AWS_PROFILE': 'env-profile'}):
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.boto3.Session',
+            return_value=mock_session,
+        ) as mock_session_class:
+            get_aws_client('cloudwatch')
+
+    mock_session_class.assert_called_once_with(profile_name='env-profile', region_name='us-east-1')
+
+
+def test_get_aws_client_without_profile_uses_default_credential_chain():
+    """Missing profile_name and AWS_PROFILE should use a default boto3 session."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import get_aws_client
+
+    mock_session = MagicMock()
+    mock_session.client.return_value = MagicMock()
+
+    with patch.dict('os.environ', {}, clear=True):
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.boto3.Session',
+            return_value=mock_session,
+        ) as mock_session_class:
+            get_aws_client('xray', region_name='eu-west-1')
+
+    mock_session_class.assert_called_once_with(region_name='eu-west-1')
+
+
+def test_get_aws_client_preserves_user_agent_and_endpoint_override():
+    """Profile-scoped clients should keep existing user-agent and endpoint behavior."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients import get_aws_client
+
+    mock_session = MagicMock()
+    mock_session.client.return_value = MagicMock()
+
+    with patch.dict(
+        'os.environ',
+        {'MCP_RUN_FROM': 'test-caller', 'MCP_RUM_ENDPOINT': 'https://rum.test.local'},
+        clear=True,
+    ):
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients.boto3.Session',
+            return_value=mock_session,
+        ):
+            get_aws_client('rum')
+
+    call_args = mock_session.client.call_args
+    assert call_args.kwargs['endpoint_url'] == 'https://rum.test.local'
+    assert (
+        call_args.kwargs['config'].user_agent_extra
+        == f'awslabs.cloudwatch-applicationsignals-mcp-server/{__version__}/test-caller'
+    )
+
+
+def test_issue_tools_expose_profile_name():
+    """AWS-backed AppSignals tools should include profile_name in MCP-derived signatures."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.change_tools import list_change_events
+    from awslabs.cloudwatch_applicationsignals_mcp_server.group_tools import (
+        audit_group_health,
+        get_group_changes,
+        get_group_dependencies,
+        list_group_services,
+        list_grouping_attribute_definitions,
+    )
+    from awslabs.cloudwatch_applicationsignals_mcp_server.rum_tools import query_rum_events
+    from awslabs.cloudwatch_applicationsignals_mcp_server.server import (
+        analyze_canary_failures,
+        audit_service_operations,
+        audit_services,
+        audit_slos,
+        list_canaries,
+    )
+    from awslabs.cloudwatch_applicationsignals_mcp_server.service_tools import (
+        get_service_detail,
+        list_monitored_services,
+        list_service_operations,
+        query_service_metrics,
+    )
+    from awslabs.cloudwatch_applicationsignals_mcp_server.slo_tools import get_slo, list_slos
+    from awslabs.cloudwatch_applicationsignals_mcp_server.trace_tools import (
+        list_slis,
+        query_sampled_traces,
+        search_transaction_spans,
+    )
+
+    tools = [
+        audit_services,
+        audit_slos,
+        audit_service_operations,
+        analyze_canary_failures,
+        list_canaries,
+        list_monitored_services,
+        get_service_detail,
+        query_service_metrics,
+        list_service_operations,
+        get_slo,
+        list_slos,
+        search_transaction_spans,
+        query_sampled_traces,
+        list_slis,
+        list_change_events,
+        list_group_services,
+        audit_group_health,
+        get_group_dependencies,
+        get_group_changes,
+        list_grouping_attribute_definitions,
+        query_rum_events,
+    ]
+
+    for tool in tools:
+        assert 'profile_name' in inspect.signature(tool).parameters
+
+
+@pytest.mark.asyncio
+async def test_audit_slos_passes_profile_scoped_client_to_audit_api():
+    """audit_slos should route AWS calls through the profile-scoped client."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.server import audit_slos
+
+    mock_client = MagicMock()
+    mock_execute = AsyncMock(return_value='audit result')
+
+    with patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.server.get_aws_client',
+        return_value=mock_client,
+    ) as mock_get_client:
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.server.execute_audit_api',
+            mock_execute,
+        ):
+            result = await audit_slos(
+                slo_targets='[{"Type":"slo","Data":{"Slo":{"SloName":"checkout-slo"}}}]',
+                start_time=None,
+                end_time=None,
+                auditors=None,
+                next_token=None,
+                max_slos=5,
+                profile_name='prod-profile',
+            )
+
+    mock_get_client.assert_called_once_with(
+        'application-signals', region_name='us-east-1', profile_name='prod-profile'
+    )
+    assert mock_execute.call_args.args[3] == mock_client
+    assert result == 'audit result'
+
+
+@pytest.mark.asyncio
+async def test_get_service_detail_uses_profile_scoped_client():
+    """Service tools should use the profile-scoped client when profile_name is provided."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.service_tools import get_service_detail
+
+    mock_client = MagicMock()
+    mock_client.list_services.return_value = {
+        'ServiceSummaries': [{'KeyAttributes': {'Name': 'checkout', 'Type': 'Service'}}]
+    }
+    mock_client.get_service.return_value = {
+        'Service': {'KeyAttributes': {'Name': 'checkout'}, 'MetricReferences': []}
+    }
+
+    with patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_tools.get_aws_client',
+        return_value=mock_client,
+    ) as mock_get_client:
+        result = await get_service_detail('checkout', profile_name='prod-profile')
+
+    mock_get_client.assert_called_once_with(
+        'application-signals', region_name='us-east-1', profile_name='prod-profile'
+    )
+    assert 'Service Details: checkout' in result
+
+
+@pytest.mark.asyncio
+async def test_get_slo_uses_profile_scoped_client():
+    """SLO tools should use the profile-scoped client when profile_name is provided."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.slo_tools import get_slo
+
+    mock_client = MagicMock()
+    mock_client.get_service_level_objective.return_value = {
+        'Slo': {'Name': 'checkout-slo', 'Arn': 'arn:test'}
+    }
+
+    with patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.slo_tools.get_aws_client',
+        return_value=mock_client,
+    ) as mock_get_client:
+        result = await get_slo('checkout-slo', profile_name='prod-profile')
+
+    mock_get_client.assert_called_once_with(
+        'application-signals', region_name='us-east-1', profile_name='prod-profile'
+    )
+    assert 'checkout-slo' in result
+
+
+@pytest.mark.asyncio
+async def test_query_rum_events_passes_profile_scoped_client_bundle():
+    """RUM dispatcher should route actions through profile-scoped clients."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server import rum_tools
+
+    async def handler(_clients=None):
+        assert _clients is not None
+        return str(sorted(_clients.keys()))
+
+    mock_clients = [MagicMock(name=f'client-{i}') for i in range(6)]
+
+    with patch.dict(rum_tools._ACTION_MAP, {'test_action': handler}):
+        with patch(
+            'awslabs.cloudwatch_applicationsignals_mcp_server.rum_tools.get_aws_client',
+            side_effect=mock_clients,
+        ) as mock_get_client:
+            result = await rum_tools.query_rum_events(
+                action='test_action', profile_name='prod-profile'
+            )
+
+    requested_services = [call.args[0] for call in mock_get_client.call_args_list]
+    assert requested_services == [
+        'application-signals',
+        'cloudwatch',
+        'logs',
+        'rum',
+        'sts',
+        'xray',
+    ]
+    assert 'applicationsignals' in result
+    assert 'cloudwatch' in result
+    assert 'xray' in result


### PR DESCRIPTION
Fixes #2940

Related: #481, #2217

## Summary

Adds optional per-call `profile_name` support to the AWS-backed CloudWatch Application Signals tools.

### Changes

The implementation adds a profile-aware `get_aws_client(...)` helper and threads profile-scoped clients through the service, SLO, audit, canary, trace, group, change, and RUM paths. When `profile_name` is not provided, the existing shared-client behavior is preserved.

`get_enablement_guide` is unchanged because it reads local guide files and does not call AWS.

### User experience

Before this change, Application Signals tools used the MCP server startup credential context. Switching accounts during a conversation required restarting the server with a different profile or using another tool path.

After this change, callers can pass `profile_name='prod'` directly on the tool call. Calls without `profile_name` continue to use the existing `AWS_PROFILE` / default credential chain path.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Validation

- Focused profile test
- Focused affected-area pytest coverage
- Canary/audit pytest coverage
- Live read-only MCP stdio smoke with a configured AWS profile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
