### PR TITLE
feat(redshift-mcp-server): add describe_execution_plan tool

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -119,6 +119,7 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 2. **List Databases**: Explore databases in a specific cluster
 3. **Browse Database Structures**: Navigate through schemas, tables, columns
 4. **Query Data**: Execute SQL queries safely with a natural language prompt
+5. **Analyze Performance**: Get execution plans to optimize query performance
 
 ### Simple Examples
 
@@ -126,6 +127,7 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 - "List databases in cluster 'my-redshift-cluster'"
 - "What tables are in the 'public' schema of database 'analytics'?"
 - "Execute: SELECT COUNT(*) FROM users WHERE created_date > '2024-01-01'"
+- "Explain the execution plan for my query to identify performance issues"
 
 ### Advanced Examples
 
@@ -275,6 +277,90 @@ ORDER BY saletime DESC, salesid DESC
 LIMIT 10;
 ```
 
+#### Query Performance Analysis
+
+```log
+> Explain the execution plan for: SELECT s.salesid, s.pricepaid, e.eventname
+  FROM tickit.sales s JOIN tickit.event e ON s.eventid = e.eventid
+  WHERE s.saletime > '2008-06-01' ORDER BY s.pricepaid DESC LIMIT 50
+
+...skipping auto-discovery logs (cluster: redshift-cluster-1, database: sample_data_dev, schema: tickit)...
+
+Here's the execution plan breakdown:
+
+XN Limit  (rows=50)
+└─ XN Merge  (rows=432,650)
+   └─ XN Network  (Send to leader)
+      └─ XN Sort  (Sort Key: s.pricepaid DESC)
+         └─ XN Hash Join DS_BCAST_INNER  (rows=432,650)
+            ├─ XN Seq Scan on sales s  (rows=209,317)
+            │     Filter: saletime > '2008-06-01'
+            └─ XN Hash
+               └─ XN Seq Scan on event e  (rows=17,596)
+
+Step-by-step execution (bottom-up):
+
+1. Seq Scan on event (cost: 175.96) — Full table scan of the event table, reading all
+   17,596 rows. No filter needed since every event row is a potential join match.
+
+2. Hash (cost: 175.96) — Builds an in-memory hash table from the event rows, keyed on
+   eventid. This is the "inner" side of the join.
+
+3. Seq Scan on sales (cost: 4,311.40) — Full table scan of the sales table with a filter
+   on saletime > '2008-06-01'. The planner estimates ~209,317 rows pass the filter out of
+   344,912 total (~61%).
+
+4. Hash Join DS_BCAST_INNER (cost: 5,630,735,660.65) — Joins sales and event on eventid.
+   The DS_BCAST_INNER distribution means the event table (inner side) is broadcast to all
+   compute nodes. This happens because the tables have different distribution keys (sales
+   is distributed on listid, event on eventid).
+
+5. Sort (cost: 1,005,630,776,162.84) — Each compute node sorts its local join results by
+   pricepaid DESC. This is the most expensive step.
+
+6. Network — Sends sorted results from compute nodes to the leader node.
+
+7. Merge — Leader node merge-sorts the pre-sorted streams from each node.
+
+8. Limit — Returns only the top 50 rows.
+
+Table design details:
+
+| Table         | Rows    | DISTKEY          | SORTKEY |
+|---------------|---------|------------------|---------|
+| tickit.sales  | 344,912 | listid (KEY)     | dateid  |
+| tickit.event  | 17,596  | eventid (KEY)    | dateid  |
+
+Column planner statistics (from pg_stats; negative n_distinct = fraction of rows that are distinct):
+
+| Column            | Correlation | n_distinct | Encoding | SORTKEY |
+|-------------------|-------------|------------|----------|---------|
+| sales.pricepaid   | 0.005       | 4,485      | az64     | —       |
+| sales.saletime    | 0.467       | -0.490     | az64     | —       |
+| sales.dateid      | 0.469       | 367        | none     | 1       |
+| sales.eventid     | 0.003       | 8,202      | az64     | —       |
+| event.eventid     | 0.003       | -0.484     | az64     | —       |
+
+Key observations:
+
+- DS_BCAST_INNER on Hash Join — The event table is being broadcast to all nodes because
+  sales.eventid doesn't match the sales DISTKEY (listid). With only 17K rows this is
+  tolerable, but it's still unnecessary data movement.
+- Sort is the dominant cost — Sorting 432K joined rows across nodes accounts for the vast
+  majority of the query cost. The pricepaid column has very low correlation (0.005).
+- No SORTKEY benefit for the WHERE filter — saletime is not a sort key on the sales table
+  (the sort key is dateid), so Redshift can't skip blocks via zone maps.
+
+Optimization recommendations:
+
+1. Change event to DISTSTYLE ALL — Since event is a small dimension table (17K rows),
+   replicating it to all nodes would eliminate the broadcast entirely.
+2. Add saletime as a SORTKEY on sales — This would let Redshift use zone maps to skip
+   blocks that don't match the WHERE saletime > '2008-06-01' filter.
+3. Add compression to dateid columns — Both tables have dateid with ENCODE none. Using
+   ENCODE AUTO or az64 would reduce storage and I/O.
+```
+
 ## Tools
 
 ### list_clusters
@@ -349,8 +435,16 @@ list_tables(cluster_identifier: str, table_database_name: str, table_schema_name
 **Returns**: List of table information including:
 
 - Table name and type (TABLE/VIEW/EXTERNAL TABLE)
-- Access permissions
-- Remarks and metadata
+- Access permissions and remarks
+- Redshift-specific metadata (from pg_catalog tables):
+  - Distribution style (KEY, EVEN, ALL, AUTO)
+  - Estimated row count
+- Table activity statistics (from pg_stat_user_tables):
+  - Sequential scan counts and tuples read
+  - DML activity (rows inserted, updated, deleted)
+- External table properties (for Spectrum tables):
+  - S3 location
+  - JSON parameters (partition columns, etc.)
 
 ### list_columns
 
@@ -379,6 +473,11 @@ list_columns(
 - Numeric precision and scale
 - Character length limits
 - Ordinal position and remarks
+- Redshift-specific properties (encoding, distkey, sortkey position)
+- External table column properties (external type, partition key)
+
+Note: Column planner statistics (n_distinct, null_frac, avg_width, correlation from pg_stats)
+are only populated when columns are returned as part of `describe_execution_plan` table designs.
 
 ### execute_query
 
@@ -400,6 +499,32 @@ execute_query(cluster_identifier: str, database_name: str, sql: str) -> QueryRes
 - Result rows with proper type conversion
 - Row count and execution time
 - Query ID for reference
+
+### describe_execution_plan
+
+Generates the query execution plan for a SQL statement without executing the query.
+
+```python
+describe_execution_plan(cluster_identifier: str, database_name: str, sql: str) -> ExecutionPlan
+```
+
+**Parameters**:
+
+- `cluster_identifier`: The cluster identifier from `list_clusters`
+- `database_name`: Database where the query would run against
+- `sql`: SQL statement to explain (do not include EXPLAIN keyword)
+
+**Returns**: Execution plan including:
+
+- Structured plan nodes with costs, rows, and distribution info
+- Table design information (DISTKEY, SORTKEY, encoding) for referenced tables
+- Column planner statistics (n_distinct, null_frac, correlation, most_common_vals, histogram_bounds) for referenced columns
+- Raw EXPLAIN output text (records joined with newlines, exactly as Redshift emits them)
+- Rule-based performance optimization suggestions derived from plan analysis, table design, and column statistics
+
+**Permissions note**: Column planner statistics from `pg_stats` require SELECT privilege on the table for the statistics to be visible. Table activity statistics from `pg_stat_user_tables` are visible to all users regardless of permissions.
+
+**Response size note**: `plan_text` and `plan_nodes` carry the complete EXPLAIN output without truncation. For programmatic analysis prefer `plan_nodes` (typed, more compact); reach for `plan_text` only when rendering the plan to a human.
 
 ## Permissions
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -66,7 +66,7 @@ REDSHIFT_BEST_PRACTICES = """
 
 # SQL queries
 
-SVV_REDSHIFT_DATABASES_QUERY = """
+DATABASES_SQL = """
 SELECT
     database_name,
     database_owner,
@@ -78,7 +78,7 @@ FROM pg_catalog.svv_redshift_databases
 ORDER BY database_name;
 """
 
-SVV_ALL_SCHEMAS_QUERY = """
+SCHEMAS_SQL = """
 SELECT
     database_name,
     schema_name,
@@ -92,20 +92,68 @@ WHERE database_name = :database_name
 ORDER BY schema_name;
 """
 
-SVV_ALL_TABLES_QUERY = """
+TABLES_SQL = """
 SELECT
     database_name,
     schema_name,
     table_name,
     table_acl,
     table_type,
-    remarks
-FROM pg_catalog.svv_all_tables
+    remarks,
+    NULL AS external_location,
+    NULL AS external_parameters
+FROM pg_catalog.svv_redshift_tables
 WHERE database_name = :database_name AND schema_name = :schema_name
+
+UNION ALL
+
+SELECT
+    redshift_database_name AS database_name,
+    schemaname AS schema_name,
+    tablename AS table_name,
+    NULL AS table_acl,
+    'EXTERNAL TABLE' AS table_type,
+    NULL AS remarks,
+    location AS external_location,
+    parameters AS external_parameters
+FROM pg_catalog.svv_external_tables
+WHERE redshift_database_name = :database_name AND schemaname = :schema_name
+
 ORDER BY table_name;
 """
 
-SVV_ALL_COLUMNS_QUERY = """
+# Any user can query pg_stat_user_tables — no privilege filtering.
+# Redshift's pg_stat_user_tables only has: seq_scan, seq_tup_read, n_tup_ins, n_tup_upd, n_tup_del.
+# PostgreSQL-only columns (n_live_tup, n_dead_tup, last_analyze, etc.) do NOT exist in Redshift.
+TABLES_EXTRA_SQL = """
+SELECT
+    n.nspname AS schema_name,
+    c.relname AS table_name,
+    CASE
+        WHEN ci.releffectivediststyle = 0 THEN 'EVEN'
+        WHEN ci.releffectivediststyle = 1 THEN 'KEY'
+        WHEN ci.releffectivediststyle = 8 THEN 'ALL'
+        WHEN ci.releffectivediststyle = 10 THEN 'AUTO(ALL)'
+        WHEN ci.releffectivediststyle = 11 THEN 'AUTO(EVEN)'
+        WHEN ci.releffectivediststyle = 12 THEN 'AUTO(KEY)'
+        ELSE 'UNKNOWN'
+    END AS diststyle,
+    c.reltuples::bigint AS estimated_row_count,
+    s.seq_scan AS sequential_scans,
+    s.seq_tup_read AS sequential_tuples_read,
+    s.n_tup_ins AS rows_inserted,
+    s.n_tup_upd AS rows_updated,
+    s.n_tup_del AS rows_deleted
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_catalog.pg_class_info ci ON c.oid = ci.reloid
+LEFT JOIN pg_catalog.pg_stat_user_tables s ON c.oid = s.relid
+WHERE n.nspname = :schema_name
+  AND c.relkind = 'r'
+ORDER BY c.relname;
+"""
+
+COLUMNS_SQL = """
 SELECT
     database_name,
     schema_name,
@@ -115,13 +163,161 @@ SELECT
     column_default,
     is_nullable,
     data_type,
-    character_maximum_length,
-    numeric_precision,
-    numeric_scale,
-    remarks
-FROM pg_catalog.svv_all_columns
+    NULL AS character_maximum_length,
+    NULL AS numeric_precision,
+    NULL AS numeric_scale,
+    remarks,
+    encoding AS redshift_encoding,
+    distkey AS redshift_is_distkey,
+    sortkey AS redshift_sortkey_position,
+    NULL AS external_type,
+    NULL AS external_partition_key
+FROM pg_catalog.svv_redshift_columns
 WHERE database_name = :database_name AND schema_name = :schema_name AND table_name = :table_name
+
+UNION ALL
+
+SELECT
+    redshift_database_name AS database_name,
+    schemaname AS schema_name,
+    tablename AS table_name,
+    columnname AS column_name,
+    columnnum AS ordinal_position,
+    NULL AS column_default,
+    is_nullable,
+    external_type AS data_type,
+    NULL AS character_maximum_length,
+    NULL AS numeric_precision,
+    NULL AS numeric_scale,
+    NULL AS remarks,
+    NULL AS redshift_encoding,
+    NULL AS redshift_is_distkey,
+    NULL AS redshift_sortkey_position,
+    external_type AS external_type,
+    part_key AS external_partition_key
+FROM pg_catalog.svv_external_columns
+WHERE redshift_database_name = :database_name AND schemaname = :schema_name AND tablename = :table_name
+
 ORDER BY ordinal_position;
+"""
+
+# Fetches column planner statistics from pg_stats for multiple tables in
+# a single batched query. Parameterized with a {schema_table_pairs} slot.
+# Statistics are visible only for tables the connected user has SELECT on.
+COLUMN_STATS_SQL = """
+SELECT
+    schemaname AS schema_name,
+    tablename AS table_name,
+    attname AS column_name,
+    n_distinct,
+    null_frac,
+    avg_width,
+    correlation,
+    array_to_string(most_common_vals, ',') AS most_common_vals,
+    array_to_string(most_common_freqs, ',') AS most_common_freqs,
+    array_to_string(histogram_bounds, ',') AS histogram_bounds
+FROM pg_catalog.pg_stats
+WHERE (schemaname, tablename) IN ({schema_table_pairs})
+ORDER BY schemaname, tablename, attname;
+"""
+
+# Resolves bare table-name references to candidate (schema, table) pairs
+# from pg_class joined with pg_namespace, restricted to ordinary tables
+# (relkind='r'). Parameterized with a {names_list} slot.
+BARE_TABLE_CANDIDATES_SQL = """
+SELECT
+    n.nspname AS schema_name,
+    c.relname AS table_name
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE c.relname = ANY (ARRAY[{names_list}])
+  AND c.relkind = 'r'
+ORDER BY n.nspname, c.relname;
+"""
+
+# Fetches table design metadata (diststyle, estimated row count) and
+# activity stats from pg_class, pg_class_info and pg_stat_user_tables for
+# multiple tables in a single batched query. Parameterized with a
+# {schema_table_pairs} slot.
+TABLES_EXTRA_BY_PAIRS_SQL = """
+SELECT
+    n.nspname AS schema_name,
+    c.relname AS table_name,
+    CASE
+        WHEN ci.releffectivediststyle = 0 THEN 'EVEN'
+        WHEN ci.releffectivediststyle = 1 THEN 'KEY'
+        WHEN ci.releffectivediststyle = 8 THEN 'ALL'
+        WHEN ci.releffectivediststyle = 10 THEN 'AUTO(ALL)'
+        WHEN ci.releffectivediststyle = 11 THEN 'AUTO(EVEN)'
+        WHEN ci.releffectivediststyle = 12 THEN 'AUTO(KEY)'
+        ELSE 'UNKNOWN'
+    END AS diststyle,
+    c.reltuples::bigint AS estimated_row_count,
+    s.seq_scan AS sequential_scans,
+    s.seq_tup_read AS sequential_tuples_read,
+    s.n_tup_ins AS rows_inserted,
+    s.n_tup_upd AS rows_updated,
+    s.n_tup_del AS rows_deleted
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_catalog.pg_class_info ci ON c.oid = ci.reloid
+LEFT JOIN pg_catalog.pg_stat_user_tables s ON c.oid = s.relid
+WHERE (n.nspname, c.relname) IN ({schema_table_pairs})
+ORDER BY n.nspname, c.relname;
+"""
+
+# Fetches per-column metadata for multiple tables in a single batched
+# query, unioning svv_redshift_columns and svv_external_columns.
+# Parameterized with a {schema_table_pairs} slot and a :database_name
+# bind parameter that scopes the result to the connected database.
+COLUMNS_BY_PAIRS_SQL = """
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    column_name,
+    ordinal_position,
+    column_default,
+    is_nullable,
+    data_type,
+    NULL AS character_maximum_length,
+    NULL AS numeric_precision,
+    NULL AS numeric_scale,
+    remarks,
+    encoding AS redshift_encoding,
+    distkey AS redshift_is_distkey,
+    sortkey AS redshift_sortkey_position,
+    NULL AS external_type,
+    NULL AS external_partition_key
+FROM pg_catalog.svv_redshift_columns
+WHERE database_name = :database_name
+  AND (schema_name, table_name) IN ({schema_table_pairs})
+
+UNION ALL
+
+SELECT
+    redshift_database_name AS database_name,
+    schemaname AS schema_name,
+    tablename AS table_name,
+    columnname AS column_name,
+    columnnum AS ordinal_position,
+    NULL AS column_default,
+    is_nullable,
+    external_type AS data_type,
+    NULL AS character_maximum_length,
+    NULL AS numeric_precision,
+    NULL AS numeric_scale,
+    NULL AS remarks,
+    NULL AS redshift_encoding,
+    NULL AS redshift_is_distkey,
+    NULL AS redshift_sortkey_position,
+    external_type AS external_type,
+    part_key AS external_partition_key
+FROM pg_catalog.svv_external_columns
+WHERE redshift_database_name = :database_name
+  AND (schemaname, tablename) IN ({schema_table_pairs})
+
+ORDER BY database_name, schema_name, table_name, ordinal_position;
 """
 
 # SQL guardrails

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
@@ -15,11 +15,24 @@
 """Redshift MCP Server Pydantic models."""
 
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
 from typing import Dict, Optional
 
 
-class RedshiftCluster(BaseModel):
+class BaseSchema(BaseModel):
+    """Base model that excludes None and unset values from serialization to reduce token usage.
+
+    Uses model_serializer to ensure None exclusion works regardless of how the caller
+    serializes the model (including pydantic_core.to_json used by FastMCP).
+    """
+
+    @model_serializer(mode='wrap')
+    def _serialize_exclude_none(self, handler: SerializerFunctionWrapHandler) -> dict:
+        """Custom serializer that excludes None values at the core level."""
+        return {k: v for k, v in handler(self).items() if v is not None}
+
+
+class RedshiftCluster(BaseSchema):
     """Information about a Redshift cluster or serverless workgroup."""
 
     identifier: str = Field(..., description='Unique identifier for the cluster/workgroup')
@@ -40,7 +53,7 @@ class RedshiftCluster(BaseModel):
     )
 
 
-class RedshiftDatabase(BaseModel):
+class RedshiftDatabase(BaseSchema):
     """Information about a database in a Redshift cluster.
 
     Based on the SVV_REDSHIFT_DATABASES system view.
@@ -61,7 +74,7 @@ class RedshiftDatabase(BaseModel):
     )
 
 
-class RedshiftSchema(BaseModel):
+class RedshiftSchema(BaseSchema):
     """Information about a schema in a Redshift database.
 
     Based on the SVV_ALL_SCHEMAS system view.
@@ -84,29 +97,10 @@ class RedshiftSchema(BaseModel):
     )
 
 
-class RedshiftTable(BaseModel):
-    """Information about a table in a Redshift database.
-
-    Based on the SVV_ALL_TABLES system view.
-    """
-
-    database_name: str = Field(..., description='The name of the database where the table exists')
-    schema_name: str = Field(..., description='The schema name for the table')
-    table_name: str = Field(..., description='The name of the table')
-    table_acl: Optional[str] = Field(
-        None, description='The permissions for the specified user or user group for the table'
-    )
-    table_type: Optional[str] = Field(
-        None,
-        description='The type of the table (views, base tables, external tables, shared tables)',
-    )
-    remarks: Optional[str] = Field(None, description='Remarks about the table')
-
-
-class RedshiftColumn(BaseModel):
+class RedshiftColumn(BaseSchema):
     """Information about a column in a Redshift table.
 
-    Based on the SVV_ALL_COLUMNS system view.
+    Based on SVV_REDSHIFT_COLUMNS and SVV_EXTERNAL_COLUMNS with UNION ALL.
     """
 
     database_name: str = Field(..., description='The name of the database')
@@ -127,9 +121,103 @@ class RedshiftColumn(BaseModel):
     numeric_precision: Optional[int] = Field(None, description='The numeric precision')
     numeric_scale: Optional[int] = Field(None, description='The numeric scale')
     remarks: Optional[str] = Field(None, description='Remarks about the column')
+    # Redshift-specific properties
+    redshift_encoding: Optional[str] = Field(None, description='Compression encoding')
+    redshift_is_distkey: Optional[bool] = Field(
+        None, description='Whether this column is the distribution key'
+    )
+    redshift_sortkey_position: Optional[int] = Field(
+        None, description='Sort key position (0 if not a sort key, 1+ for position)'
+    )
+    # External table properties
+    external_type: Optional[str] = Field(None, description='External column type')
+    external_partition_key: Optional[int] = Field(
+        None,
+        description='Partition key order (0 if not a partition key, 1+ for partition key position)',
+    )
+    # Column-level planner statistics (from pg_stats, only populated in execution plan analysis)
+    stats_n_distinct: Optional[float] = Field(
+        None,
+        description='Number of distinct values. Negative means fraction of rows (e.g., -0.5 = 50% unique)',
+    )
+    stats_null_frac: Optional[float] = Field(
+        None, description='Fraction of column values that are NULL (0.0 to 1.0)'
+    )
+    stats_avg_width: Optional[int] = Field(
+        None, description='Average width in bytes of column values'
+    )
+    stats_correlation: Optional[float] = Field(
+        None,
+        description='Physical vs logical ordering correlation (-1.0 to 1.0). '
+        'High absolute value means zone maps can skip blocks effectively',
+    )
+    stats_most_common_vals: Optional[str] = Field(
+        None, description='Most common values as text (helps identify data skew)'
+    )
+    stats_most_common_freqs: Optional[str] = Field(
+        None, description='Frequencies of most common values as text'
+    )
+    stats_histogram_bounds: Optional[str] = Field(
+        None,
+        description='Histogram bucket bounds as comma-separated text. First value is MIN, last is MAX. '
+        'Used with most_common_vals to understand value distribution beyond the MCV list',
+    )
 
 
-class QueryResult(BaseModel):
+class RedshiftTable(BaseSchema):
+    """Information about a table in a Redshift database.
+
+    Based on SVV_REDSHIFT_TABLES and SVV_EXTERNAL_TABLES with UNION ALL.
+    Additional metadata from TABLES_EXTRA_SQL is fetched separately and merged.
+    """
+
+    database_name: str = Field(..., description='The name of the database where the table exists')
+    schema_name: str = Field(..., description='The schema name for the table')
+    table_name: str = Field(..., description='The name of the table')
+    table_acl: Optional[str] = Field(
+        None, description='The permissions for the specified user or user group for the table'
+    )
+    table_type: Optional[str] = Field(
+        None,
+        description='The type of the table (TABLE, EXTERNAL TABLE)',
+    )
+    remarks: Optional[str] = Field(None, description='Remarks about the table')
+    # Redshift-specific properties (from TABLES_EXTRA_SQL using pg_catalog tables)
+    redshift_diststyle: Optional[str] = Field(
+        None, description='Distribution style (KEY, EVEN, ALL, AUTO)'
+    )
+    redshift_estimated_row_count: Optional[int] = Field(
+        None, description='Estimated number of rows from pg_class.reltuples'
+    )
+    # Table activity stats (from pg_stat_user_tables, since the last statistics reset)
+    stats_sequential_scans: Optional[int] = Field(
+        None, description='Number of sequential scans initiated since the last statistics reset'
+    )
+    stats_sequential_tuples_read: Optional[int] = Field(
+        None,
+        description='Number of live rows fetched by sequential scans since the last statistics reset',
+    )
+    stats_rows_inserted: Optional[int] = Field(
+        None, description='Number of rows inserted since the last statistics reset'
+    )
+    stats_rows_updated: Optional[int] = Field(
+        None, description='Number of rows updated since the last statistics reset'
+    )
+    stats_rows_deleted: Optional[int] = Field(
+        None, description='Number of rows deleted since the last statistics reset'
+    )
+    # External table properties (from SVV_EXTERNAL_TABLES)
+    external_location: Optional[str] = Field(None, description='External table location (S3 path)')
+    external_parameters: Optional[str] = Field(
+        None, description='External table parameters (JSON)'
+    )
+    # Column design information (only populated in execution plan analysis)
+    columns: Optional[list[RedshiftColumn]] = Field(
+        None, description='Column design information (only populated in execution plan analysis)'
+    )
+
+
+class QueryResult(BaseSchema):
     """Result of a SQL query execution."""
 
     columns: list[str] = Field(..., description='List of column names in the result set')
@@ -139,3 +227,62 @@ class QueryResult(BaseModel):
         None, description='Query execution time in milliseconds'
     )
     query_id: str = Field(..., description='Unique identifier for the query execution')
+
+
+class ExecutionPlanNode(BaseSchema):
+    """Individual node in the query execution plan tree."""
+
+    level: int = Field(..., description='Tree depth (0 = root)')
+    operation: str = Field(..., description='Operation type')
+    relation_name: Optional[str] = Field(default=None, description='Table or view name')
+    alias: Optional[str] = Field(default=None, description='Table alias')
+    distribution_type: Optional[str] = Field(default=None, description='Data distribution method')
+    cost_startup: Optional[float] = Field(default=None, description='Startup cost')
+    cost_total: Optional[float] = Field(default=None, description='Total cost')
+    rows: Optional[int] = Field(default=None, description='Estimated rows')
+    width: Optional[int] = Field(default=None, description='Row width in bytes')
+    join_condition: Optional[str] = Field(default=None, description='Join condition')
+    join_filter: Optional[str] = Field(default=None, description='Join filter')
+    filter_condition: Optional[str] = Field(default=None, description='Filter condition')
+    index_condition: Optional[str] = Field(default=None, description='Index Scan index condition')
+    inner_dist_key: Optional[str] = Field(
+        default=None, description='Inner-side distribution key for redistribution joins'
+    )
+    outer_dist_key: Optional[str] = Field(
+        default=None, description='Outer-side distribution key for redistribution joins'
+    )
+    sort_key: Optional[str] = Field(default=None, description='Sort key info')
+    merge_key: Optional[str] = Field(default=None, description='Merge key info')
+    partition_key: Optional[str] = Field(
+        default=None, description='Window function PARTITION BY columns'
+    )
+    order_key: Optional[str] = Field(default=None, description='Window function ORDER BY columns')
+    agg_strategy: Optional[str] = Field(default=None, description='Aggregation strategy')
+    data_movement: Optional[str] = Field(default=None, description='Data movement type')
+
+
+class ExecutionPlan(BaseSchema):
+    """Result of an EXPLAIN query execution."""
+
+    query_id: str = Field(..., description='Explain execution identifier')
+    explained_query: str = Field(..., description='Original SQL query')
+    planning_time_ms: Optional[int] = Field(
+        default=None, description='Planning time in milliseconds'
+    )
+    plan_text: str = Field(
+        ...,
+        description='Raw EXPLAIN output text from the Redshift Data API, '
+        'with records joined by newlines',
+    )
+    plan_nodes: list[ExecutionPlanNode] = Field(..., description='Execution plan nodes')
+    table_designs: list[RedshiftTable] = Field(
+        default_factory=list, description='Table design information for referenced tables'
+    )
+    notes: list[str] = Field(
+        default_factory=list,
+        description='Advisory annotations such as ambiguity warnings or parse errors',
+    )
+    rule_based_suggestions: list[str] = Field(
+        default_factory=list,
+        description='Rule-based performance optimization suggestions derived from plan analysis',
+    )

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -21,23 +21,30 @@ import regex
 import time
 from awslabs.redshift_mcp_server import __version__
 from awslabs.redshift_mcp_server.consts import (
+    BARE_TABLE_CANDIDATES_SQL,
     CLIENT_CONNECT_TIMEOUT,
     CLIENT_READ_TIMEOUT,
     CLIENT_RETRIES,
     CLIENT_USER_AGENT_NAME,
+    COLUMN_STATS_SQL,
+    COLUMNS_BY_PAIRS_SQL,
+    COLUMNS_SQL,
+    DATABASES_SQL,
     QUERY_POLL_INTERVAL,
     QUERY_TIMEOUT,
+    SCHEMAS_SQL,
     SESSION_KEEPALIVE,
     SUSPICIOUS_QUERY_MAX_LEN,
     SUSPICIOUS_QUERY_REGEXP,
     SUSPICIOUS_QUERY_TIMEOUT,
-    SVV_ALL_COLUMNS_QUERY,
-    SVV_ALL_SCHEMAS_QUERY,
-    SVV_ALL_TABLES_QUERY,
-    SVV_REDSHIFT_DATABASES_QUERY,
+    TABLES_EXTRA_BY_PAIRS_SQL,
+    TABLES_EXTRA_SQL,
+    TABLES_SQL,
 )
+from awslabs.redshift_mcp_server.models import ExecutionPlanNode
 from botocore.config import Config
 from loguru import logger
+from typing import Iterable, NamedTuple, Optional, cast
 
 
 # Compile once; the pattern uses recursive subroutines so compilation is non-trivial.
@@ -59,6 +66,1042 @@ def _is_suspicious(sql: str) -> bool:
             f'treating SQL as suspicious (length={len(sql)})'
         )
         return True
+
+
+# Category labels for ``TableReference``: how a table is named in user SQL.
+# ``BARE`` = ``table``; ``SCHEMA_QUALIFIED`` = ``schema.table``;
+# ``DATABASE_QUALIFIED`` = ``database.schema.table``.
+TABLE_REF_BARE = 'bare'
+TABLE_REF_SCHEMA_QUALIFIED = 'schema_qualified'
+TABLE_REF_DATABASE_QUALIFIED = 'database_qualified'
+
+
+class TableReference(NamedTuple):
+    """A categorized table reference extracted from user SQL.
+
+    Identifier case is preserved as written; hashable so the extractor
+    can deduplicate via a ``set``.
+    """
+
+    category: str
+    table_name: str
+    schema_name: Optional[str] = None
+    database_name: Optional[str] = None
+
+
+# Captures relation name (group 1) and optional alias (group 2) from a
+# Seq/Tid/Index Scan operation line. Redshift emits one of three shapes:
+# ``Seq Scan on <rel>``, ``Tid Scan on <rel>``, or
+# ``Index Scan[ Backward] using <indname>[, <indname>]* on <rel>``.
+_OP_RELATION_ALIAS_PATTERN = regex.compile(
+    r'(?:Seq Scan|Tid Scan|Index Scan(?: Backward)?(?: using [^\s,]+(?:, [^\s,]+)*)?)'
+    r' on (\S+)(?:\s+([a-zA-Z_]\w*))?'
+)
+
+# Captures the cost block as (startup, total, rows, width).
+_OP_COST_PATTERN = regex.compile(
+    r'cost=(\d+(?:\.\d+)?)\.\.(\d+(?:\.\d+)?)\s+rows=(\d+)\s+width=(\d+)'
+)
+
+# Captures any DS_* distribution token. Longer alternatives first.
+_OP_DISTRIBUTION_PATTERN = regex.compile(
+    r'\b('
+    r'DS_DIST_ALL_INNER'
+    r'|DS_DIST_ALL_NONE'
+    r'|DS_BCAST_INNER'
+    r'|DS_DIST_INNER'
+    r'|DS_DIST_NONE'
+    r'|DS_DIST_OUTER'
+    r')\b'
+)
+
+
+# Detail-line label → ``ExecutionPlanNode`` field. Longer labels first so
+# ``Join Filter:`` matches before ``Filter:``.
+_DETAIL_LINE_LABELS: tuple[tuple[str, str], ...] = (
+    ('Hash Cond:', 'join_condition'),
+    ('Merge Cond:', 'join_condition'),
+    ('Join Filter:', 'join_filter'),
+    ('Inner Dist Key:', 'inner_dist_key'),
+    ('Outer Dist Key:', 'outer_dist_key'),
+    ('Sort Key:', 'sort_key'),
+    ('Merge Key:', 'merge_key'),
+    ('Index Cond:', 'index_condition'),
+    ('Partition:', 'partition_key'),
+    ('Order:', 'order_key'),
+    ('Filter:', 'filter_condition'),
+)
+
+# Label-less detail strings emitted by Network nodes describing the
+# data-movement direction. Matched exactly (no colon, no value).
+_DATA_MOVEMENT_VALUES: frozenset[str] = frozenset(
+    {
+        'Send to leader',
+        'Send to slice 0',
+        'Distribute',
+        'Broadcast',
+        'Distribute Round Robin',
+    }
+)
+
+
+def _apply_detail_line(node: ExecutionPlanNode, line_text: str) -> None:
+    """Apply any recognized detail-line field to ``node`` in place.
+
+    Args:
+        node: The most recently seen operation node. Mutated in place.
+        line_text: The raw text of the detail line.
+    """
+    stripped = line_text.lstrip()
+    for label, field in _DETAIL_LINE_LABELS:
+        if stripped.startswith(label):
+            value = stripped[len(label) :].strip()
+            setattr(node, field, value)
+            return
+    if stripped in _DATA_MOVEMENT_VALUES:
+        node.data_movement = stripped
+        return
+    # GROUPING SETS(...) line on aggregate nodes; stored verbatim.
+    if stripped.startswith('GROUPING SETS('):
+        node.agg_strategy = stripped
+        return
+
+
+def _extract_operation_name(op_line: str) -> str:
+    """Extract the operation name from an operation-line text.
+
+    Strips any leading ``->`` arrow, the ``using <indname>...`` segment
+    on Index Scan lines, and everything from `` on <relation>`` or
+    ``(cost=`` onward. Returns the cleaned operation name.
+
+    Args:
+        op_line: The operation-line text after :meth:`str.lstrip`.
+
+    Returns:
+        The operation name (e.g., ``XN Seq Scan`` or
+        ``XN Hash Join DS_BCAST_INNER``).
+    """
+    text = op_line
+    if text.startswith('->'):
+        text = text[len('->') :].lstrip()
+
+    # Drop the ``using <indname>...`` tail Redshift appends to Index Scan lines.
+    using_idx = text.find(' using ')
+    if using_idx >= 0:
+        text = text[:using_idx]
+
+    cut_points: list[int] = []
+    on_idx = text.find(' on ')
+    if on_idx >= 0:
+        cut_points.append(on_idx)
+    cost_idx = text.find('(cost=')
+    if cost_idx >= 0:
+        cut_points.append(cost_idx)
+    if cut_points:
+        text = text[: min(cut_points)]
+
+    return text.strip()
+
+
+def _build_operation_node(stripped_line: str, level: int) -> ExecutionPlanNode:
+    """Allocate one :class:`ExecutionPlanNode` from an operation-line text.
+
+    Args:
+        stripped_line: The operation-line text after :meth:`str.lstrip`.
+        level: The level assigned by :func:`_parse_plan_text`'s indent-stack walk.
+
+    Returns:
+        A populated :class:`ExecutionPlanNode`. Optional fields are
+        ``None`` when the corresponding information is not present.
+    """
+    operation = _extract_operation_name(stripped_line)
+
+    relation_name: Optional[str] = None
+    alias: Optional[str] = None
+    relation_match = _OP_RELATION_ALIAS_PATTERN.search(stripped_line)
+    if relation_match:
+        relation_name = relation_match.group(1)
+        alias = relation_match.group(2)
+
+    cost_startup: Optional[float] = None
+    cost_total: Optional[float] = None
+    rows: Optional[int] = None
+    width: Optional[int] = None
+    cost_match = _OP_COST_PATTERN.search(stripped_line)
+    if cost_match:
+        cost_startup = float(cost_match.group(1))
+        cost_total = float(cost_match.group(2))
+        rows = int(cost_match.group(3))
+        width = int(cost_match.group(4))
+
+    distribution_type: Optional[str] = None
+    dist_match = _OP_DISTRIBUTION_PATTERN.search(stripped_line)
+    if dist_match:
+        distribution_type = dist_match.group(1)
+
+    return ExecutionPlanNode(
+        level=level,
+        operation=operation,
+        relation_name=relation_name,
+        alias=alias,
+        distribution_type=distribution_type,
+        cost_startup=cost_startup,
+        cost_total=cost_total,
+        rows=rows,
+        width=width,
+    )
+
+
+def _parse_plan_text(raw_records: list[str]) -> list[ExecutionPlanNode]:
+    """Parse raw EXPLAIN records into structured :class:`ExecutionPlanNode` list.
+
+    Walks the records once, allocating one node per operation line
+    (root + ``->``-prefixed lines) and folding detail lines (``Hash Cond:``,
+    ``Filter:`` …) into the most recent operation node. Blank lines are
+    ignored. Node levels are derived from a stack of operation-line indent
+    widths so the level sequence stays contiguous regardless of Redshift's
+    actual indent step (2 / 8 / 14 / 20 / ...).
+
+    Args:
+        raw_records: One string per Data API record from the EXPLAIN
+            response, in source order. Empty list returns ``[]``.
+
+    Returns:
+        One :class:`ExecutionPlanNode` per operation line in document order.
+    """
+    if not raw_records:
+        return []
+
+    plan_nodes: list[ExecutionPlanNode] = []
+    current_node: Optional[ExecutionPlanNode] = None
+    # Stack of (indent_width, level) for currently-open ancestors.
+    op_stack: list[tuple[int, int]] = []
+
+    for text in raw_records:
+        stripped = text.lstrip()
+        if not stripped:
+            continue
+
+        is_operation_line = not op_stack or stripped.startswith('->')
+
+        if is_operation_line:
+            indent_width = len(text) - len(stripped)
+            while op_stack and op_stack[-1][0] >= indent_width:
+                op_stack.pop()
+            node_level = 0 if not op_stack else op_stack[-1][1] + 1
+            op_stack.append((indent_width, node_level))
+
+            node = _build_operation_node(stripped, node_level)
+            plan_nodes.append(node)
+            current_node = node
+        else:
+            if current_node is None:
+                continue
+            _apply_detail_line(current_node, text)
+
+    return plan_nodes
+
+
+# Tokenizer keywords (case-insensitive). Compared after uppercasing.
+_SQL_KEYWORDS: frozenset[str] = frozenset({'WITH', 'AS', 'FROM', 'JOIN'})
+
+
+class _SqlToken(NamedTuple):
+    """A single token emitted by :func:`_tokenize_sql`.
+
+    Attributes:
+        kind: One of ``'identifier'``, ``'keyword'``, ``'punctuation'``,
+            ``'dot'``.
+        value: Token text — original case for identifiers, uppercase for
+            keywords, raw character for punctuation/dot.
+    """
+
+    kind: str
+    value: str
+
+
+class SqlReferenceExtractError(Exception):
+    """Raised when :func:`_extract_sql_references` cannot parse its input."""
+
+
+# Unquoted identifier character classes (Redshift dialect).
+_ID_START_CHARS: frozenset[str] = frozenset(
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'  # pragma: allowlist secret
+)
+_ID_CONT_CHARS: frozenset[str] = frozenset(
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789$'  # pragma: allowlist secret
+)
+
+
+def _tokenize_sql(sql: str) -> list[_SqlToken]:
+    """Tokenize ``sql`` for reference extraction.
+
+    Single-pass scanner. Skips whitespace, line/block comments, and
+    single-quoted string literals. Emits ``'identifier'``, ``'keyword'``
+    (``WITH``/``AS``/``FROM``/``JOIN``), ``'punctuation'`` (``(``, ``)``,
+    ``,``, ``;``), and ``'dot'`` (``.``) tokens. Double-quoted identifiers
+    are emitted as ``'identifier'`` with original case preserved.
+
+    Args:
+        sql: The SQL string to tokenize. May be empty.
+
+    Returns:
+        A list of :class:`_SqlToken` records in source order.
+    """
+    tokens: list[_SqlToken] = []
+    n = len(sql)
+    i = 0
+
+    while i < n:
+        ch = sql[i]
+
+        # Whitespace.
+        if ch.isspace():
+            i += 1
+            continue
+
+        # Line comment ``-- ...`` to end of line. Redshift accepts
+        # ``--foo`` without a trailing space, so we don't require
+        # one.
+        if ch == '-' and i + 1 < n and sql[i + 1] == '-':
+            i += 2
+            while i < n and sql[i] != '\n':
+                i += 1
+            continue
+
+        # Block comment ``/* ... */``, NON-nested per Redshift
+        # dialect: the first ``*/`` closes the comment regardless of
+        # inner ``/*`` sequences. An unterminated block comment
+        # consumes the rest of the input silently.
+        if ch == '/' and i + 1 < n and sql[i + 1] == '*':
+            i += 2
+            while i < n:
+                if sql[i] == '*' and i + 1 < n and sql[i + 1] == '/':
+                    i += 2
+                    break
+                i += 1
+            continue
+
+        # Single-quoted string literal ``'...'`` with ``''`` escape.
+        # Inside a literal, no tokens are emitted. An unterminated
+        # literal consumes the rest of the input.
+        if ch == "'":
+            i += 1
+            while i < n:
+                if sql[i] == "'":
+                    if i + 1 < n and sql[i + 1] == "'":
+                        # Escaped quote: stay inside the literal.
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            continue
+
+        # Double-quoted identifier ``"..."`` with ``""`` escape. Emits
+        # a single ``'identifier'`` token preserving the original
+        # case.
+        if ch == '"':
+            i += 1
+            buf: list[str] = []
+            while i < n:
+                if sql[i] == '"':
+                    if i + 1 < n and sql[i + 1] == '"':
+                        buf.append('"')
+                        i += 2
+                        continue
+                    # Closing quote.
+                    i += 1
+                    break
+                buf.append(sql[i])
+                i += 1
+            tokens.append(_SqlToken(kind='identifier', value=''.join(buf)))
+            continue
+
+        # Grouping/separator punctuation.
+        if ch == '.':
+            tokens.append(_SqlToken(kind='dot', value='.'))
+            i += 1
+            continue
+        if ch in '(),;':
+            tokens.append(_SqlToken(kind='punctuation', value=ch))
+            i += 1
+            continue
+
+        # Unquoted identifier or keyword. Identifier start: ASCII
+        # letter or underscore (Redshift rule). The continuation set
+        # additionally includes ASCII digits and ``$``. Keyword check
+        # uses the uppercase form; misses fall through to
+        # ``'identifier'`` with original case preserved.
+        if ch in _ID_START_CHARS:
+            start = i
+            i += 1
+            while i < n and sql[i] in _ID_CONT_CHARS:
+                i += 1
+            word = sql[start:i]
+            upper = word.upper()
+            if upper in _SQL_KEYWORDS:
+                tokens.append(_SqlToken(kind='keyword', value=upper))
+            else:
+                tokens.append(_SqlToken(kind='identifier', value=word))
+            continue
+
+        # Anything else (operators, unknown characters): skip
+        # silently. Operators like ``=``, ``<``, ``+`` are not
+        # relevant to table-reference extraction.
+        i += 1
+
+    return tokens
+
+
+def _skip_to_matching_paren(tokens: list[_SqlToken], open_idx: int) -> int:
+    """Return the index just past the ``)`` that matches ``tokens[open_idx]``.
+
+    Tracks nested parens via ``(``/``)`` punctuation tokens; other
+    tokens do not affect depth (string literals and comments do not
+    emit tokens, so they cannot perturb the count).
+
+    Args:
+        tokens: The token stream from :func:`_tokenize_sql`.
+        open_idx: Index of the opening ``(`` to start from.
+
+    Returns:
+        The index immediately after the matching ``)``, or ``-1`` when
+        no matching close paren is found before end of input.
+    """
+    n = len(tokens)
+    j = open_idx + 1
+    inner_depth = 1
+    while j < n:
+        tok = tokens[j]
+        if tok.kind == 'punctuation':
+            if tok.value == '(':
+                inner_depth += 1
+            elif tok.value == ')':
+                inner_depth -= 1
+                if inner_depth == 0:
+                    return j + 1
+        j += 1
+    return -1
+
+
+def _collect_cte_names(tokens: list[_SqlToken], start_idx: int) -> set[str]:
+    """Collect CTE names from a ``WITH`` clause via look-ahead.
+
+    Walks each comma-separated ``<name> [(<col-list>)] [AS] (<body>)``
+    definition until the trailing main statement (``SELECT`` / ``INSERT``
+    / ``UPDATE`` / ``DELETE``). Pure look-ahead; does not modify caller
+    state. An optional ``RECURSIVE`` modifier after ``WITH`` is skipped.
+
+    Args:
+        tokens: The token stream from :func:`_tokenize_sql`.
+        start_idx: Index of the first token after ``WITH``.
+
+    Returns:
+        The set of CTE names declared by this ``WITH`` clause. May be
+        empty for malformed input.
+    """
+    names: set[str] = set()
+    n = len(tokens)
+    j = start_idx
+
+    # Optional ``RECURSIVE`` modifier (not a recognized keyword,
+    # appears as an identifier).
+    if j < n and tokens[j].kind == 'identifier' and tokens[j].value.upper() == 'RECURSIVE':
+        j += 1
+
+    while j < n:
+        tok = tokens[j]
+
+        # Trailing main statement terminator. ``SELECT`` / ``INSERT`` /
+        # ``UPDATE`` / ``DELETE`` are not in the recognized keyword
+        # set, so they show up as identifiers.
+        if tok.kind == 'identifier' and tok.value.upper() in (
+            'SELECT',
+            'INSERT',
+            'UPDATE',
+            'DELETE',
+        ):
+            break
+
+        # Anything else that isn't an identifier here is malformed;
+        # stop collecting and let the main loop handle it.
+        if tok.kind != 'identifier':
+            break
+
+        # Record the CTE name (original case preserved).
+        names.add(tok.value)
+        j += 1
+
+        # Optional column list ``(col1, col2, ...)``.
+        if j < n and tokens[j].kind == 'punctuation' and tokens[j].value == '(':
+            end = _skip_to_matching_paren(tokens, j)
+            if end < 0:
+                break
+            j = end
+
+        # Optional ``AS`` keyword.
+        if j < n and tokens[j].kind == 'keyword' and tokens[j].value == 'AS':
+            j += 1
+
+        # Body ``(...)``.
+        if j < n and tokens[j].kind == 'punctuation' and tokens[j].value == '(':
+            end = _skip_to_matching_paren(tokens, j)
+            if end < 0:
+                break
+            j = end
+        else:
+            # No body — malformed; stop collecting.
+            break
+
+        # Optional ``,`` for the next CTE in the list.
+        if j < n and tokens[j].kind == 'punctuation' and tokens[j].value == ',':
+            j += 1
+            continue
+        break
+
+    return names
+
+
+def _extract_sql_references(sql: str) -> list[TableReference]:
+    """Extract categorized table references from a raw user SQL string.
+
+    Walks the token stream from :func:`_tokenize_sql` and emits one
+    :class:`TableReference` per dotted-identifier sequence at a
+    ``FROM``/``JOIN`` position. Categorizes 1 part as BARE, 2 parts as
+    SCHEMA_QUALIFIED, 3 parts as DATABASE_QUALIFIED. CTE names declared
+    in active ``WITH`` scopes are excluded from BARE references.
+    Subquery and column aliases are consumed but not emitted.
+    Identifier case is preserved; results are deduplicated by exact
+    tuple equality with first-occurrence ordering.
+
+    Args:
+        sql: The original SQL query passed to ``describe_execution_plan``.
+
+    Returns:
+        A list of :class:`TableReference` records in source order.
+
+    Raises:
+        SqlReferenceExtractError: When the input is empty / comment-only,
+            or a ``FROM``/``JOIN`` position is followed by a 0-part or
+            4+-part dotted-identifier sequence.
+    """
+    tokens = _tokenize_sql(sql)
+
+    # Empty / whitespace / comment-only SQL: an empty token stream is
+    # a sufficient signal — whitespace and comments are consumed
+    # silently by the scanner.
+    if not tokens:
+        raise SqlReferenceExtractError(
+            'Cannot extract table references from empty or comment-only SQL.'
+        )
+
+    refs: list[TableReference] = []
+    # Order-preserving dedup set keyed on the full TableReference
+    # tuple. ``TableReference`` is frozen and hashable on all four
+    # fields.
+    seen: set[TableReference] = set()
+
+    def _emit(ref: TableReference) -> None:
+        """Append ``ref`` to ``refs`` only if not previously seen."""
+        if ref not in seen:
+            seen.add(ref)
+            refs.append(ref)
+
+    n = len(tokens)
+    i = 0
+    expecting_table = False
+    depth = 0
+    # Stack of (entry_depth, cte_names) frames; popped when paren depth drops.
+    cte_frames: list[tuple[int, set[str]]] = []
+    # Parallel to paren depth: True at indices where ``(`` opened a subquery.
+    subquery_open_stack: list[bool] = []
+
+    def _is_cte_name(name: str) -> bool:
+        """True iff ``name`` is in any active CTE frame."""
+        for _, names in reversed(cte_frames):
+            if name in names:
+                return True
+        return False
+
+    while i < n:
+        tok = tokens[i]
+
+        # ``WITH`` opens a CTE-name frame at the current paren depth.
+        if tok.kind == 'keyword' and tok.value == 'WITH':
+            i += 1
+            cte_names = _collect_cte_names(tokens, i)
+            cte_frames.append((depth, cte_names))
+            continue
+
+        # ``FROM`` / ``JOIN`` re-arms the next position as a table reference.
+        if tok.kind == 'keyword' and tok.value in ('FROM', 'JOIN'):
+            expecting_table = True
+            i += 1
+            continue
+
+        if expecting_table:
+            # ``FROM (`` / ``JOIN (`` — derived-table subquery.
+            if tok.kind == 'punctuation' and tok.value == '(':
+                expecting_table = False
+                depth += 1
+                subquery_open_stack.append(True)
+                i += 1
+                continue
+
+            if tok.kind != 'identifier':
+                raise SqlReferenceExtractError(
+                    f"Expected table reference at FROM/JOIN position, got {tok.kind} '{tok.value}'"
+                )
+
+            # Read a dotted identifier sequence ``<id>(.<id>)*``; 4+ parts → reject.
+            parts: list[str] = [tok.value]
+            i += 1
+            while i + 1 < n and tokens[i].kind == 'dot' and tokens[i + 1].kind == 'identifier':
+                parts.append(tokens[i + 1].value)
+                i += 2
+
+            if len(parts) == 1:
+                # BARE — only check active CTE frames here; qualified refs are never CTEs.
+                if not _is_cte_name(parts[0]):
+                    _emit(
+                        TableReference(
+                            category=TABLE_REF_BARE,
+                            table_name=parts[0],
+                        )
+                    )
+            elif len(parts) == 2:
+                _emit(
+                    TableReference(
+                        category=TABLE_REF_SCHEMA_QUALIFIED,
+                        schema_name=parts[0],
+                        table_name=parts[1],
+                    )
+                )
+            elif len(parts) == 3:
+                _emit(
+                    TableReference(
+                        category=TABLE_REF_DATABASE_QUALIFIED,
+                        database_name=parts[0],
+                        schema_name=parts[1],
+                        table_name=parts[2],
+                    )
+                )
+            else:
+                raise SqlReferenceExtractError(
+                    f'Malformed table reference with {len(parts)} parts: {".".join(parts)}'
+                )
+
+            expecting_table = False
+
+            # Optional ``[AS] <identifier>`` column alias — consumed but not emitted.
+            if i < n and tokens[i].kind == 'keyword' and tokens[i].value == 'AS':
+                i += 1
+            if i < n and tokens[i].kind == 'identifier':
+                i += 1
+
+            # Trailing comma re-arms the FROM list for the next table.
+            if i < n and tokens[i].kind == 'punctuation' and tokens[i].value == ',':
+                expecting_table = True
+                i += 1
+
+            continue
+
+        # Track paren depth so CTE frames pop when their scope ends.
+        if tok.kind == 'punctuation' and tok.value == '(':
+            depth += 1
+            subquery_open_stack.append(False)
+            i += 1
+            continue
+        elif tok.kind == 'punctuation' and tok.value == ')':
+            depth -= 1
+            while cte_frames and cte_frames[-1][0] > depth:
+                cte_frames.pop()
+            was_subquery = subquery_open_stack.pop() if subquery_open_stack else False
+            i += 1
+            if was_subquery:
+                # Consume optional ``[AS] <alias>`` after the subquery; trailing
+                # comma re-arms the FROM list.
+                if i < n and tokens[i].kind == 'keyword' and tokens[i].value == 'AS':
+                    i += 1
+                if i < n and tokens[i].kind == 'identifier':
+                    i += 1
+                if i < n and tokens[i].kind == 'punctuation' and tokens[i].value == ',':
+                    expecting_table = True
+                    i += 1
+            continue
+
+        i += 1
+
+    return refs
+
+
+def _render_schema_table_pairs(pairs: Iterable[tuple[str, str]]) -> str:
+    """Render ``(schema, table)`` pairs as a SQL pair-list literal.
+
+    Produces ``('s1','t1'),('s2','t2'),...`` (no outer parens) for the
+    ``{schema_table_pairs}`` slot in ``TABLES_EXTRA_BY_PAIRS_SQL``.
+    Single quotes in either component are doubled per Redshift's
+    string-literal escape rule. Pairs are sorted ascending for
+    deterministic output.
+
+    Args:
+        pairs: An iterable of ``(schema, table)`` 2-tuples.
+
+    Returns:
+        The pair-list SQL fragment, or an empty string when ``pairs``
+        is empty.
+    """
+    sorted_pairs = sorted(pairs)
+    if not sorted_pairs:
+        return ''
+
+    def _escape(value: str) -> str:
+        return value.replace("'", "''")
+
+    return ','.join(f"('{_escape(schema)}','{_escape(table)}')" for schema, table in sorted_pairs)
+
+
+async def _fetch_table_metadata(
+    cluster_identifier: str,
+    database_name: str,
+    pairs: set[tuple[str, str]],
+) -> dict[tuple[str, str], dict]:
+    """Fetch batched table metadata for a set of ``(schema, table)`` pairs.
+
+    Issues a single ``TABLES_EXTRA_BY_PAIRS_SQL`` call covering every
+    pair. Returns ``{}`` on empty input or on any error so the
+    ``describe_execution_plan`` pipeline keeps running.
+
+    Args:
+        cluster_identifier: The cluster identifier to query.
+        database_name: Database to execute the metadata query against.
+        pairs: Set of ``(schema, table)`` tuples to look up.
+
+    Returns:
+        Mapping from ``(schema, table)`` to a metadata dict with
+        ``redshift_diststyle``, ``redshift_estimated_row_count``, and
+        the ``stats_*`` activity counters.
+    """
+    if not pairs:
+        return {}
+
+    rendered = _render_schema_table_pairs(pairs)
+    if not rendered:
+        return {}
+
+    sql = TABLES_EXTRA_BY_PAIRS_SQL.format(schema_table_pairs=rendered)
+
+    try:
+        results_response, _ = await _execute_protected_statement(
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            sql=sql,
+        )
+
+        # Field order from TABLES_EXTRA_BY_PAIRS_SQL: schema_name(0),
+        # table_name(1), diststyle(2), estimated_row_count(3),
+        # sequential_scans(4), sequential_tuples_read(5),
+        # rows_inserted(6), rows_updated(7), rows_deleted(8).
+        metadata: dict[tuple[str, str], dict] = {}
+        for record in results_response.get('Records', []):
+            schema_value = record[0].get('stringValue')
+            table_value = record[1].get('stringValue')
+            if schema_value is None or table_value is None:
+                continue
+            metadata[(schema_value, table_value)] = {
+                'redshift_diststyle': record[2].get('stringValue'),
+                'redshift_estimated_row_count': record[3].get('longValue'),
+                'stats_sequential_scans': record[4].get('longValue'),
+                'stats_sequential_tuples_read': record[5].get('longValue'),
+                'stats_rows_inserted': record[6].get('longValue'),
+                'stats_rows_updated': record[7].get('longValue'),
+                'stats_rows_deleted': record[8].get('longValue'),
+            }
+
+        return metadata
+    except Exception as fetch_error:
+        # Non-fatal: keep the column-stats and table-design paths alive.
+        logger.warning(
+            f'_fetch_table_metadata: batched metadata fetch failed; '
+            f'returning empty mapping. Error: {fetch_error}'
+        )
+        return {}
+
+
+async def _fetch_columns_by_pairs(
+    cluster_identifier: str,
+    database_name: str,
+    pairs: set[tuple[str, str]],
+) -> dict[tuple[str, str], list[dict]]:
+    """Fetch batched per-column metadata for a set of ``(schema, table)`` pairs.
+
+    Issues a single ``COLUMNS_BY_PAIRS_SQL`` call covering every pair.
+    Returns ``{}`` on empty input or on any error so the
+    ``describe_execution_plan`` pipeline keeps running.
+
+    Args:
+        cluster_identifier: The cluster identifier to query.
+        database_name: Database to execute the columns query against.
+        pairs: Set of ``(schema, table)`` tuples to look up.
+
+    Returns:
+        Mapping from ``(schema, table)`` to a list of column dicts. Each
+        column dict carries the same keys as :func:`discover_columns`
+        records.
+    """
+    if not pairs:
+        return {}
+
+    rendered = _render_schema_table_pairs(pairs)
+    if not rendered:
+        return {}
+
+    sql = COLUMNS_BY_PAIRS_SQL.format(schema_table_pairs=rendered)
+
+    try:
+        results_response, _ = await _execute_protected_statement(
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            sql=sql,
+            parameters=[{'name': 'database_name', 'value': database_name}],
+        )
+
+        # Field order from COLUMNS_BY_PAIRS_SQL: database_name(0),
+        # schema_name(1), table_name(2), column_name(3),
+        # ordinal_position(4), column_default(5), is_nullable(6),
+        # data_type(7), character_maximum_length(8), numeric_precision(9),
+        # numeric_scale(10), remarks(11), redshift_encoding(12),
+        # redshift_is_distkey(13), redshift_sortkey_position(14),
+        # external_type(15), external_partition_key(16).
+        columns_by_pair: dict[tuple[str, str], list[dict]] = {}
+        for record in results_response.get('Records', []):
+            schema_value = record[1].get('stringValue')
+            table_value = record[2].get('stringValue')
+            if schema_value is None or table_value is None:
+                continue
+            column_info = {
+                'database_name': record[0].get('stringValue'),
+                'schema_name': schema_value,
+                'table_name': table_value,
+                'column_name': record[3].get('stringValue'),
+                'ordinal_position': record[4].get('longValue'),
+                'column_default': record[5].get('stringValue'),
+                'is_nullable': record[6].get('stringValue'),
+                'data_type': record[7].get('stringValue'),
+                'character_maximum_length': record[8].get('longValue'),
+                'numeric_precision': record[9].get('longValue'),
+                'numeric_scale': record[10].get('longValue'),
+                'remarks': record[11].get('stringValue'),
+                'redshift_encoding': record[12].get('stringValue'),
+                'redshift_is_distkey': record[13].get('booleanValue'),
+                'redshift_sortkey_position': record[14].get('longValue'),
+                'external_type': record[15].get('stringValue'),
+                'external_partition_key': record[16].get('longValue'),
+            }
+            columns_by_pair.setdefault((schema_value, table_value), []).append(column_info)
+
+        return columns_by_pair
+    except Exception as fetch_error:
+        # Non-fatal: keep the rest of the response alive.
+        logger.warning(
+            f'_fetch_columns_by_pairs: batched columns fetch failed; '
+            f'returning empty mapping. Error: {fetch_error}'
+        )
+        return {}
+
+
+def _render_name_list(names: Iterable[str]) -> str:
+    """Render bare table names as a SQL name-list literal.
+
+    Produces ``'n1','n2',...`` for the ``{names_list}`` slot in
+    ``BARE_TABLE_CANDIDATES_SQL``. Single quotes are doubled per
+    Redshift's string-literal escape rule. Names are sorted ascending
+    and deduplicated.
+
+    Args:
+        names: An iterable of bare table-name strings.
+
+    Returns:
+        The name-list SQL fragment, or an empty string when ``names``
+        is empty.
+    """
+    sorted_names = sorted(set(names))
+    if not sorted_names:
+        return ''
+
+    def _escape(value: str) -> str:
+        return value.replace("'", "''")
+
+    return ','.join(f"'{_escape(name)}'" for name in sorted_names)
+
+
+async def _lookup_bare_table_candidates(
+    cluster_identifier: str,
+    database_name: str,
+    bare_names: set[str],
+) -> dict[str, list[tuple[str, str]]]:
+    """Resolve bare table-name references to candidate (schema, table) pairs.
+
+    Issues a single ``BARE_TABLE_CANDIDATES_SQL`` call covering every
+    distinct bare name. Returns ``{}`` on empty input or on any error
+    so the ``describe_execution_plan`` pipeline keeps running.
+
+    Args:
+        cluster_identifier: The cluster identifier to query.
+        database_name: Database to execute the candidate-lookup query
+            against.
+        bare_names: Set of bare (unqualified) table-name strings.
+
+    Returns:
+        Mapping from each bare name to a list of ``(schema, table)``
+        candidate pairs. Names with zero matches map to an empty list.
+    """
+    if not bare_names:
+        return {}
+
+    rendered = _render_name_list(bare_names)
+    if not rendered:
+        return {}
+
+    sql = BARE_TABLE_CANDIDATES_SQL.format(names_list=rendered)
+
+    try:
+        results_response, _ = await _execute_protected_statement(
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            sql=sql,
+        )
+
+        # Pre-populate so callers can distinguish "looked up, not found"
+        # from "not looked up at all".
+        candidates: dict[str, list[tuple[str, str]]] = {name: [] for name in bare_names}
+
+        for record in results_response.get('Records', []):
+            schema_value = record[0].get('stringValue')
+            table_value = record[1].get('stringValue')
+            if schema_value is None or table_value is None:
+                continue
+            if table_value in candidates:
+                candidates[table_value].append((schema_value, table_value))
+
+        return candidates
+    except Exception as lookup_error:
+        logger.warning(
+            f'_lookup_bare_table_candidates: batched candidate lookup '
+            f'failed; returning empty mapping. Error: {lookup_error}'
+        )
+        return {}
+
+
+async def _resolve_ambiguities(
+    cluster_identifier: str,
+    connected_database_name: str,
+    references: list[TableReference],
+    *,
+    lookup_fn=_lookup_bare_table_candidates,
+) -> tuple[set[tuple[str, str]], list[str]]:
+    """Resolve a list of ``TableReference`` records into pairs and notes.
+
+    Per-category dispatch over :func:`_extract_sql_references` output:
+
+    - SCHEMA_QUALIFIED → bind directly, no note.
+    - DATABASE_QUALIFIED matching the connected database → bind directly.
+    - DATABASE_QUALIFIED targeting a different database → cross-database
+      note, no metadata fetch.
+    - BARE with 0 candidates → not-found note.
+    - BARE with 1 candidate → bind to that pair.
+    - BARE with ≥2 candidates → ambiguity note + all matching pairs.
+
+    Bare names are resolved in a single batched call to ``lookup_fn``.
+    Notes are deduplicated by exact string equality (first-occurrence
+    order preserved).
+
+    Args:
+        cluster_identifier: The cluster identifier to query.
+        connected_database_name: The ``database_name`` from
+            ``describe_execution_plan``.
+        references: Output of :func:`_extract_sql_references`.
+        lookup_fn: Async callable used to resolve bare names. Defaults
+            to :func:`_lookup_bare_table_candidates`; tests inject a
+            stub or mock.
+
+    Returns:
+        Tuple ``(resolved_pairs, notes)``. ``resolved_pairs`` feeds
+        into :func:`_fetch_table_metadata`; ``notes`` surfaces on
+        ``ExecutionPlan.notes``.
+    """
+    resolved_pairs: set[tuple[str, str]] = set()
+    notes: list[str] = []
+
+    # SCHEMA_QUALIFIED and DATABASE_QUALIFIED resolve in memory; only
+    # BARE needs a network round-trip.
+    schema_qualified_refs: list[TableReference] = []
+    database_qualified_refs: list[TableReference] = []
+    bare_refs: list[TableReference] = []
+    for ref in references:
+        if ref.category == TABLE_REF_SCHEMA_QUALIFIED:
+            schema_qualified_refs.append(ref)
+        elif ref.category == TABLE_REF_DATABASE_QUALIFIED:
+            database_qualified_refs.append(ref)
+        elif ref.category == TABLE_REF_BARE:
+            bare_refs.append(ref)
+
+    for ref in schema_qualified_refs:
+        resolved_pairs.add((cast(str, ref.schema_name), ref.table_name))
+
+    for ref in database_qualified_refs:
+        if ref.database_name == connected_database_name:
+            resolved_pairs.add((cast(str, ref.schema_name), ref.table_name))
+        else:
+            notes.append(
+                f'Table "{ref.database_name}.{ref.schema_name}.{ref.table_name}" '
+                f'targets database "{ref.database_name}" but the tool is connected '
+                f'to database "{connected_database_name}"; cross-database table '
+                f'metadata cannot be retrieved through the connected database.'
+            )
+
+    if bare_refs:
+        unique_bare_names: set[str] = {ref.table_name for ref in bare_refs}
+
+        candidates_by_name = await lookup_fn(
+            cluster_identifier=cluster_identifier,
+            database_name=connected_database_name,
+            bare_names=unique_bare_names,
+        )
+
+        for ref in bare_refs:
+            matches = candidates_by_name.get(ref.table_name, [])
+            match_count = len(matches)
+
+            if match_count == 0:
+                notes.append(
+                    f'Table "{ref.table_name}" was not found in any schema '
+                    f'in database "{connected_database_name}".'
+                )
+            elif match_count == 1:
+                resolved_pairs.add(matches[0])
+            else:
+                # ≥2 matches: ambiguity note + all matching pairs so
+                # each appears in ``table_designs``.
+                matching_schemas = sorted({schema for schema, _ in matches})
+                notes.append(
+                    f'Table "{ref.table_name}" is ambiguous: matches schemas '
+                    f'{matching_schemas} in database '
+                    f'"{connected_database_name}".'
+                )
+                for pair in matches:
+                    resolved_pairs.add(pair)
+
+    # Deduplicate notes preserving first-occurrence order.
+    deduped_notes: list[str] = []
+    seen_notes: set[str] = set()
+    for note in notes:
+        if note not in seen_notes:
+            seen_notes.add(note)
+            deduped_notes.append(note)
+
+    return resolved_pairs, deduped_notes
 
 
 class RedshiftClientManager:
@@ -249,6 +1292,8 @@ async def _execute_protected_statement(
     Returns:
         Tuple containing:
         - Dictionary with the raw results_response from get_statement_result.
+          When the result spans multiple Data API pages, every page's
+          ``Records`` are concatenated into a single list.
         - String with the query_id.
 
     Raises:
@@ -330,10 +1375,18 @@ async def _execute_protected_statement(
     if user_sql_error:
         raise user_sql_error
 
-    # Get results from user query
+    # Get results from user query. Follow NextToken so the full result
+    # set is returned even when it spans multiple Data API pages.
     data_client = client_manager.redshift_data_client()
     assert user_query_id is not None, 'user_query_id should not be None at this point'
+
     results_response = data_client.get_statement_result(Id=user_query_id)
+    next_token = results_response.get('NextToken')
+    while next_token:
+        next_page = data_client.get_statement_result(Id=user_query_id, NextToken=next_token)
+        results_response['Records'].extend(next_page.get('Records', []))
+        next_token = next_page.get('NextToken')
+
     return results_response, user_query_id
 
 
@@ -523,7 +1576,7 @@ async def discover_databases(cluster_identifier: str, database_name: str = 'dev'
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=database_name,
-            sql=SVV_REDSHIFT_DATABASES_QUERY,
+            sql=DATABASES_SQL,
         )
 
         databases = []
@@ -568,7 +1621,7 @@ async def discover_schemas(cluster_identifier: str, schema_database_name: str) -
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=schema_database_name,
-            sql=SVV_ALL_SCHEMAS_QUERY,
+            sql=SCHEMAS_SQL,
             parameters=[{'name': 'database_name', 'value': schema_database_name}],
         )
 
@@ -618,11 +1671,11 @@ async def discover_tables(
             f'Discovering tables in schema {table_schema_name} in database {table_database_name} in cluster {cluster_identifier}'
         )
 
-        # Execute the query using the common function
+        # Execute the main tables query
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=table_database_name,
-            sql=SVV_ALL_TABLES_QUERY,
+            sql=TABLES_SQL,
             parameters=[
                 {'name': 'database_name', 'value': table_database_name},
                 {'name': 'schema_name', 'value': table_schema_name},
@@ -633,7 +1686,6 @@ async def discover_tables(
         records = results_response.get('Records', [])
 
         for record in records:
-            # Extract values from the record
             table_info = {
                 'database_name': record[0].get('stringValue'),
                 'schema_name': record[1].get('stringValue'),
@@ -641,8 +1693,63 @@ async def discover_tables(
                 'table_acl': record[3].get('stringValue'),
                 'table_type': record[4].get('stringValue'),
                 'remarks': record[5].get('stringValue'),
+                'external_location': record[6].get('stringValue'),
+                'external_parameters': record[7].get('stringValue'),
+                # Initialize Redshift-specific fields as None
+                'redshift_diststyle': None,
+                'redshift_estimated_row_count': None,
+                'stats_sequential_scans': None,
+                'stats_sequential_tuples_read': None,
+                'stats_rows_inserted': None,
+                'stats_rows_updated': None,
+                'stats_rows_deleted': None,
             }
             tables.append(table_info)
+
+        # Try to fetch table info separately
+        try:
+            table_info_response, _ = await _execute_protected_statement(
+                cluster_identifier=cluster_identifier,
+                database_name=table_database_name,
+                sql=TABLES_EXTRA_SQL,
+                parameters=[
+                    {'name': 'schema_name', 'value': table_schema_name},
+                ],
+            )
+
+            # Create a lookup dictionary for table info
+            # TABLES_EXTRA_SQL returns: schema_name(0), table_name(1), diststyle(2),
+            # estimated_row_count(3), sequential_scans(4), sequential_tuples_read(5),
+            # rows_inserted(6), rows_updated(7), rows_deleted(8)
+            table_info_map: dict[str, dict[str, str | int | float | None]] = {}
+            for record in table_info_response.get('Records', []):
+                table_name = record[1].get('stringValue')  # table_name at index 1
+                table_info_map[table_name] = {
+                    'redshift_diststyle': record[2].get('stringValue'),
+                    'redshift_estimated_row_count': record[3].get('longValue'),
+                    'stats_sequential_scans': record[4].get('longValue'),
+                    'stats_sequential_tuples_read': record[5].get('longValue'),
+                    'stats_rows_inserted': record[6].get('longValue'),
+                    'stats_rows_updated': record[7].get('longValue'),
+                    'stats_rows_deleted': record[8].get('longValue'),
+                }
+
+            # Merge table info into tables
+            for table in tables:
+                table_name = table['table_name']
+                if table_name in table_info_map:
+                    table.update(table_info_map[table_name])
+
+            logger.debug(
+                f'Successfully enriched {len(table_info_map)} tables with extra stats data'
+            )
+
+        except Exception as table_info_error:
+            # TABLES_EXTRA_SQL uses pg_class, pg_class_info, and pg_stat_user_tables which are
+            # accessible to all users on both provisioned and serverless clusters.
+            # If this fails, it's an unexpected error that should be raised.
+            logger.error(f'Failed to fetch table extra stats: {table_info_error}')
+            raise
 
         logger.info(
             f'Found {len(tables)} tables in schema {table_schema_name} in database {table_database_name} in cluster {cluster_identifier}'
@@ -678,11 +1785,10 @@ async def discover_columns(
             f'Discovering columns in table {column_table_name} in schema {column_schema_name} in database {column_database_name} in cluster {cluster_identifier}'
         )
 
-        # Execute the query using the common function
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=column_database_name,
-            sql=SVV_ALL_COLUMNS_QUERY,
+            sql=COLUMNS_SQL,
             parameters=[
                 {'name': 'database_name', 'value': column_database_name},
                 {'name': 'schema_name', 'value': column_schema_name},
@@ -694,7 +1800,6 @@ async def discover_columns(
         records = results_response.get('Records', [])
 
         for record in records:
-            # Extract values from the record
             column_info = {
                 'database_name': record[0].get('stringValue'),
                 'schema_name': record[1].get('stringValue'),
@@ -708,6 +1813,11 @@ async def discover_columns(
                 'numeric_precision': record[9].get('longValue'),
                 'numeric_scale': record[10].get('longValue'),
                 'remarks': record[11].get('stringValue'),
+                'redshift_encoding': record[12].get('stringValue'),
+                'redshift_is_distkey': record[13].get('booleanValue'),
+                'redshift_sortkey_position': record[14].get('longValue'),
+                'external_type': record[15].get('stringValue'),
+                'external_partition_key': record[16].get('longValue'),
             }
             columns.append(column_info)
 
@@ -796,6 +1906,525 @@ async def execute_query(cluster_identifier: str, database_name: str, sql: str) -
 
     except Exception as e:
         logger.error(f'Error executing query on cluster {cluster_identifier}: {str(e)}')
+        raise
+
+
+def _generate_performance_suggestions(
+    parsed_nodes: list[dict], table_designs: list[dict]
+) -> list[str]:
+    """Generate performance optimization suggestions based on execution plan analysis.
+
+    Args:
+        parsed_nodes: List of parsed execution plan nodes.
+        table_designs: List of table design information dictionaries.
+
+    Returns:
+        List of performance suggestion strings.
+    """
+    suggestions = []
+
+    # Fixed-width types (int, bigint, date, timestamp) are excluded — compression
+    # gain is small and avg_width is a poor signal for them.
+    VARIABLE_LENGTH_TYPES = {
+        'character varying',
+        'varchar',
+        'text',
+        'super',
+        'varbyte',
+        'nvarchar',
+    }
+    # Character-length differences (e.g. varchar(10) = varchar(20)) don't
+    # trigger implicit casts, so they're safe to skip in the join check below.
+    CHAR_TYPES = {
+        'character',
+        'character varying',
+        'varchar',
+        'text',
+        'nvarchar',
+        'char',
+        'bpchar',
+    }
+    # Numeric-type mismatches (e.g. integer = bigint) force implicit casts
+    # that can defeat co-located joins.
+    NUMERIC_TYPES = {
+        'smallint',
+        'integer',
+        'bigint',
+        'real',
+        'double precision',
+        'numeric',
+        'decimal',
+        'int2',
+        'int4',
+        'int8',
+        'float4',
+        'float8',
+    }
+
+    # Analyze distribution strategies in plan nodes
+    for node in parsed_nodes:
+        dist_type = node.get('distribution_type')
+        operation = node.get('operation', '')
+
+        # Check for data redistribution (expensive operations)
+        if dist_type == 'DS_BCAST_INNER':
+            suggestions.append(
+                f'Data broadcast detected in {operation}. Consider using a common DISTKEY '
+                'on join columns to co-locate data and avoid broadcasting.'
+            )
+        elif dist_type == 'DS_DIST_INNER':
+            suggestions.append(
+                f'Data redistribution detected in {operation}. Review DISTKEY choices '
+                'to ensure joined tables are distributed on the join column.'
+            )
+        elif dist_type == 'DS_DIST_ALL_INNER':
+            # DS_DIST_ALL_INNER means full table redistribution to all nodes
+            # This is expensive for large tables but acceptable for small dimension tables
+            suggestions.append(
+                f'Full table redistribution detected in {operation}. '
+                'For small dimension tables (< 1-2M rows), consider DISTSTYLE ALL to replicate data. '
+                'For larger tables, align DISTKEYs on join columns to avoid redistribution.'
+            )
+        elif dist_type is None:
+            # Keyword-fallback path: when distribution_type is unset
+            # but the operation text contains an unambiguous
+            # redistribution keyword, emit the corresponding
+            # suggestion. Keywords are matched case-sensitively because
+            # Redshift's EXPLAIN output capitalizes them as proper-noun
+            # operation tokens (e.g. "XN Network Broadcast",
+            # "XN Network Distribute", "Gather Motion").
+            if 'Broadcast' in operation:
+                suggestions.append(
+                    f'Data broadcast detected in {operation}. Consider using a common DISTKEY '
+                    'on join columns to co-locate data and avoid broadcasting.'
+                )
+            elif 'Distribute' in operation:
+                suggestions.append(
+                    f'Data redistribution detected in {operation}. Review DISTKEY choices '
+                    'to ensure joined tables are distributed on the join column.'
+                )
+            elif 'Gather' in operation:
+                suggestions.append(
+                    f'Data gather detected in {operation}. Review DISTKEY choices '
+                    'to ensure joined tables are distributed on the join column.'
+                )
+
+        # Check for nested loops (often indicates missing join condition)
+        if 'Nested Loop' in operation:
+            suggestions.append(
+                'Nested Loop join detected. Verify join conditions are correct. '
+                'For large tables, Hash Join or Merge Join are typically more efficient.'
+            )
+
+    # Build a column name -> (table, data_type) lookup for the join type-
+    # mismatch check below. Join conditions expose only column names, so we
+    # index by name; ambiguous matches are skipped.
+    col_type_index: dict[str, list[tuple[str, str]]] = {}
+    for td in table_designs:
+        td_table = td.get('table_name', '')
+        for col in td.get('columns', []):
+            c_name = col.get('column_name')
+            c_type = (col.get('data_type') or '').strip()
+            if c_name and c_type:
+                col_type_index.setdefault(c_name, []).append((td_table, c_type))
+
+    # Check join-column data-type mismatches (force implicit casts).
+    if col_type_index:
+        join_eq_pattern = regex.compile(
+            r'(?:"?(\w+)"?\.)?"?(\w+)"?\s*=\s*(?:"?(\w+)"?\.)?"?(\w+)"?'
+        )
+        for node in parsed_nodes:
+            cond = node.get('join_condition') or ''
+            filt = node.get('join_filter') or ''
+            combined = f'{cond} {filt}'.strip()
+            if not combined:
+                continue
+            for m in join_eq_pattern.finditer(combined):
+                lcol, rcol = m.group(2), m.group(4)
+                ltypes = col_type_index.get(lcol, [])
+                rtypes = col_type_index.get(rcol, [])
+                if not ltypes or not rtypes:
+                    continue
+                _, ltype = ltypes[0]
+                _, rtype = rtypes[0]
+                if ltype == rtype:
+                    continue
+                lbase = ltype.split('(')[0].strip().lower()
+                rbase = rtype.split('(')[0].strip().lower()
+                if lbase in CHAR_TYPES and rbase in CHAR_TYPES:
+                    continue
+                if lbase in NUMERIC_TYPES and rbase in NUMERIC_TYPES:
+                    suggestions.append(
+                        f'Join columns {lcol} ({ltype}) and {rcol} ({rtype}) '
+                        'have mismatched numeric types. The planner will insert '
+                        'implicit casts which can degrade join performance and '
+                        'prevent co-located joins. Consider aligning the column types.'
+                    )
+
+    # Analyze table designs
+    for table in table_designs:
+        schema_name = table.get('schema_name', '')
+        table_name = table.get('table_name', '')
+        redshift_diststyle = table.get('redshift_diststyle', '')
+        redshift_tbl_rows = table.get('redshift_estimated_row_count')
+        columns = table.get('columns', [])
+
+        full_name = f'{schema_name}.{table_name}' if schema_name else table_name
+
+        # Suggest DISTSTYLE ALL for small dimension tables
+        # Small tables benefit from replication to avoid redistribution during joins
+        if redshift_tbl_rows is not None and redshift_tbl_rows < 2000000:  # < 2M rows
+            if redshift_diststyle in ('EVEN', 'KEY', 'AUTO(EVEN)', 'AUTO(KEY)'):
+                suggestions.append(
+                    f'Table {full_name} is small ({redshift_tbl_rows:,} rows) and uses {redshift_diststyle} distribution. '
+                    'Consider DISTSTYLE ALL to replicate this dimension table and eliminate redistribution during joins.'
+                )
+        # Check for EVEN distribution on larger tables (may cause redistribution)
+        elif redshift_diststyle == 'EVEN':
+            suggestions.append(
+                f'Table {full_name} uses EVEN distribution. If this table is frequently '
+                'joined, consider using DISTKEY on the join column to improve performance.'
+            )
+
+        # NOTE: The "no SORTKEY" rule is implemented in the
+        # table-activity-stats pass below (driven by
+        # stats_sequential_scans). Emitting a SORTKEY suggestion here
+        # unconditionally would bypass the documented suppressions
+        # (DISTSTYLE ALL/AUTO(ALL), small tables, zero scans).
+
+        # Check for low correlation on non-sortkey columns (poor zone map effectiveness).
+        # Suppress for small tables and low-cardinality columns where zone maps
+        # are effective regardless of correlation.
+        for col in columns:
+            correlation = col.get('stats_correlation')
+            sortkey_pos = col.get('redshift_sortkey_position', 0)
+            col_name = col.get('column_name', '')
+            if correlation is None or sortkey_pos != 0:
+                continue
+            if not (-0.2 < correlation < 0.2):
+                continue
+            if redshift_tbl_rows is not None and redshift_tbl_rows < 100000:
+                continue
+            n_distinct = col.get('stats_n_distinct')
+            if n_distinct is not None:
+                effective_distinct = (
+                    n_distinct if n_distinct > 0 else abs(n_distinct) * (redshift_tbl_rows or 0)
+                )
+                if 0 < effective_distinct < 20:
+                    continue
+            suggestions.append(
+                f'Column {col_name} in {full_name} has low correlation '
+                f'({correlation:.2f}), meaning physical row order does not match value order. '
+                'If this column is frequently used in range filters or WHERE clauses, '
+                'consider adding it as a SORTKEY for better zone map block skipping.'
+            )
+
+        # Check for low-cardinality DISTKEY columns (selectivity-based to avoid
+        # flagging small tables with proportionally few distinct values).
+        for col in columns:
+            n_distinct = col.get('stats_n_distinct')
+            is_distkey = col.get('redshift_is_distkey')
+            col_name = col.get('column_name', '')
+            if not (is_distkey and n_distinct is not None):
+                continue
+            # Positive n_distinct = absolute count, negative = fraction of rows
+            effective_distinct = (
+                n_distinct if n_distinct > 0 else abs(n_distinct) * (redshift_tbl_rows or 0)
+            )
+            if n_distinct < 0:
+                selectivity = abs(n_distinct)
+            elif redshift_tbl_rows and redshift_tbl_rows > 0:
+                selectivity = n_distinct / redshift_tbl_rows
+            else:
+                selectivity = None
+            # Flag only if absolute count is low AND selectivity < 0.1%.
+            if 0 < effective_distinct < 100 and selectivity is not None and selectivity < 0.001:
+                suggestions.append(
+                    f'DISTKEY column {col_name} in {full_name} has low cardinality '
+                    f'(~{int(effective_distinct)} distinct values across '
+                    f'{redshift_tbl_rows:,} rows), which causes data skew across slices. '
+                    'Consider choosing a higher-cardinality column as DISTKEY.'
+                )
+
+        # Check for high NULL fraction on SORTKEY columns.
+        # A SORTKEY on a mostly-NULL column provides little zone map benefit.
+        for col in columns:
+            null_frac = col.get('stats_null_frac')
+            sortkey_pos = col.get('redshift_sortkey_position', 0)
+            col_name = col.get('column_name', '')
+            if null_frac is not None and sortkey_pos > 0 and null_frac > 0.9:
+                suggestions.append(
+                    f'SORTKEY column {col_name} in {full_name} is {null_frac:.0%} NULL. '
+                    'Zone maps are less effective on mostly-NULL sort keys. '
+                    'Consider choosing a less sparse column as SORTKEY.'
+                )
+
+        # Check for wide uncompressed variable-length columns (high storage/IO impact).
+        wide_raw_columns = [
+            col['column_name']
+            for col in columns
+            if col.get('redshift_encoding') == 'none'
+            and col.get('stats_avg_width') is not None
+            and col.get('stats_avg_width') > 200
+            and (col.get('data_type') or '').lower() in VARIABLE_LENGTH_TYPES
+        ]
+        if wide_raw_columns:
+            suggestions.append(
+                f'Wide columns {", ".join(wide_raw_columns)} in {full_name} have no compression '
+                'and high average width (>200 bytes). Compressing these columns would significantly '
+                'reduce storage and improve I/O performance.'
+            )
+
+        # Check for RAW encoding (no compression). Exclude the first SORTKEY
+        # column (must stay RAW for zone maps) and BOOLEAN columns (cannot be
+        # encoded in Redshift).
+        raw_columns = [
+            col['column_name']
+            for col in columns
+            if col.get('redshift_encoding') == 'none'
+            and col.get('redshift_sortkey_position', 0) != 1
+            and (col.get('data_type') or '').lower() != 'boolean'
+        ]
+        if raw_columns and len(raw_columns) <= 3:
+            suggestions.append(
+                f'Columns {", ".join(raw_columns)} in {full_name} have no compression. '
+                'Consider using ENCODE AUTO or specific encodings to reduce storage and improve I/O.'
+            )
+        elif raw_columns:
+            suggestions.append(
+                f'{len(raw_columns)} columns in {full_name} have no compression. '
+                'Consider using ENCODE AUTO to improve storage efficiency.'
+            )
+
+    # Analyze table activity stats for performance insights
+    for table in table_designs:
+        schema_name = table.get('schema_name', '')
+        table_name = table.get('table_name', '')
+        redshift_diststyle = table.get('redshift_diststyle', '')
+        redshift_tbl_rows = table.get('redshift_estimated_row_count')
+        full_name = f'{schema_name}.{table_name}' if schema_name else table_name
+
+        # High sequential scans without sort key. Suppress for small tables
+        # and DISTSTYLE ALL (seq scan is the expected access pattern there).
+        seq_scans = table.get('stats_sequential_scans')
+        columns = table.get('columns', [])
+        has_sortkey = any(col.get('redshift_sortkey_position', 0) > 0 for col in columns)
+        if (
+            seq_scans is not None
+            and seq_scans > 1000
+            and not has_sortkey
+            and columns
+            and (redshift_tbl_rows is None or redshift_tbl_rows >= 100000)
+            and redshift_diststyle not in ('ALL', 'AUTO(ALL)')
+        ):
+            suggestions.append(
+                f'Table {full_name} has {seq_scans:,} sequential scans and no SORTKEY. '
+                'Adding a SORTKEY on frequently filtered columns can reduce scan I/O.'
+            )
+
+    # Remove duplicates while preserving order. If deduplication
+    # raises for any reason, fall back to returning all generated
+    # suggestions including duplicates rather than raising or omitting
+    # suggestions.
+    try:
+        seen = set()
+        unique_suggestions = []
+        for s in suggestions:
+            if s not in seen:
+                seen.add(s)
+                unique_suggestions.append(s)
+        return unique_suggestions
+    except Exception:
+        return suggestions
+
+
+async def describe_execution_plan(cluster_identifier: str, database_name: str, sql: str) -> dict:
+    """Get the execution plan for a SQL query using plain ``EXPLAIN``.
+
+    Runs ``EXPLAIN <sql>`` against the cluster, parses the output into
+    structured plan nodes, resolves the user's table references against
+    the connected database, batch-fetches design metadata and column
+    statistics, and runs the rule-based suggestion engine.
+
+    Args:
+        cluster_identifier: The cluster identifier to query.
+        database_name: The database to execute the query against.
+        sql: The SQL statement to explain. Must not begin with
+            ``EXPLAIN``; the tool prepends it.
+
+    Returns:
+        Dictionary matching the :class:`ExecutionPlan` schema:
+        ``query_id``, ``explained_query``, ``planning_time_ms``,
+        ``plan_text``, ``plan_nodes``, ``table_designs``, ``notes``,
+        ``rule_based_suggestions``.
+    """
+    try:
+        logger.info(
+            f'Getting execution plan for query on cluster {cluster_identifier} in database {database_name}'
+        )
+        logger.debug(f'SQL to explain: {sql}')
+
+        # Reject empty/whitespace-only SQL before any cluster call.
+        if not sql or not sql.strip():
+            raise Exception('SQL is required and must not be empty or whitespace.')
+
+        # The tool prepends EXPLAIN itself; user SQL must not already contain it.
+        sql_trimmed = sql.strip().upper()
+        if sql_trimmed.startswith('EXPLAIN'):
+            raise Exception(
+                'SQL already contains EXPLAIN. Please provide the query without EXPLAIN.'
+            )
+
+        explain_sql = f'EXPLAIN {sql}'
+
+        start_time = time.time()
+
+        results_response, query_id = await _execute_protected_statement(
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            sql=explain_sql,
+        )
+
+        planning_time_ms = int((time.time() - start_time) * 1000)
+
+        # Collect raw records; they feed both the human-readable
+        # ``plan_text`` and the structured ``plan_nodes``.
+        raw_records: list[str] = []
+        for record in results_response.get('Records', []):
+            if record and len(record) > 0:
+                raw_records.append(record[0].get('stringValue', '') or '')
+
+        plan_text = '\n'.join(raw_records)
+
+        notes: list[str] = []
+
+        plan_nodes = _parse_plan_text(raw_records)
+
+        # Extract table references from the user's SQL (not the EXPLAIN
+        # output); soft-fail so plan_text/plan_nodes still surface.
+        try:
+            references = _extract_sql_references(sql)
+        except SqlReferenceExtractError as ref_error:
+            logger.warning(
+                f'SQL reference extraction failed: {ref_error}; '
+                'continuing with empty reference list.'
+            )
+            references = []
+
+        resolved_pairs, detector_notes = await _resolve_ambiguities(
+            cluster_identifier=cluster_identifier,
+            connected_database_name=database_name,
+            references=references,
+        )
+        notes.extend(detector_notes)
+
+        metadata_by_pair = await _fetch_table_metadata(
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            pairs=resolved_pairs,
+        )
+
+        # Sort for deterministic output. _resolve_ambiguities already deduplicated.
+        sorted_pairs = sorted(resolved_pairs)
+
+        # Single batched column-stats fetch across all resolved pairs;
+        # failure here MUST NOT cancel the rest of the response.
+        col_stats_map: dict[tuple[str, str], dict[str, dict]] = {}
+        if sorted_pairs:
+            try:
+                rendered_pairs = _render_schema_table_pairs(sorted_pairs)
+                stats_sql = COLUMN_STATS_SQL.format(schema_table_pairs=rendered_pairs)
+                stats_response, _ = await _execute_protected_statement(
+                    cluster_identifier=cluster_identifier,
+                    database_name=database_name,
+                    sql=stats_sql,
+                )
+                # COLUMN_STATS_SQL fields: schema_name(0), table_name(1),
+                # column_name(2), n_distinct(3), null_frac(4), avg_width(5),
+                # correlation(6), most_common_vals(7), most_common_freqs(8),
+                # histogram_bounds(9).
+                for record in stats_response.get('Records', []):
+                    schema_v = record[0].get('stringValue')
+                    table_v = record[1].get('stringValue')
+                    col_v = record[2].get('stringValue')
+                    if schema_v and table_v and col_v:
+                        key = (schema_v, table_v)
+                        if key not in col_stats_map:
+                            col_stats_map[key] = {}
+                        col_stats_map[key][col_v] = {
+                            'stats_n_distinct': record[3].get('doubleValue'),
+                            'stats_null_frac': record[4].get('doubleValue'),
+                            'stats_avg_width': record[5].get('longValue'),
+                            'stats_correlation': record[6].get('doubleValue'),
+                            'stats_most_common_vals': record[7].get('stringValue'),
+                            'stats_most_common_freqs': record[8].get('stringValue'),
+                            'stats_histogram_bounds': record[9].get('stringValue'),
+                        }
+                logger.debug(f'Fetched column stats for {len(col_stats_map)} tables in one batch')
+            except Exception as stats_error:
+                logger.warning(f'Could not fetch batch column stats: {stats_error}')
+
+        # Single batched columns fetch across all resolved pairs;
+        # failure here MUST NOT cancel the rest of the response.
+        columns_by_pair = await _fetch_columns_by_pairs(
+            cluster_identifier=cluster_identifier,
+            database_name=database_name,
+            pairs=resolved_pairs,
+        )
+
+        table_designs: list[dict] = []
+        for schema_name, table_name in sorted_pairs:
+            columns = columns_by_pair.get((schema_name, table_name), [])
+
+            # Enrich columns with pre-fetched planner statistics.
+            table_col_stats = col_stats_map.get((schema_name, table_name), {})
+            for col in columns:
+                col_name = col.get('column_name')
+                if col_name and col_name in table_col_stats:
+                    col.update(table_col_stats[col_name])
+
+            # Merge batched table metadata; emit even on miss so every
+            # referenced table appears in the response.
+            metadata = metadata_by_pair.get((schema_name, table_name), {})
+            table_design: dict = {
+                'database_name': database_name,
+                'schema_name': schema_name,
+                'table_name': table_name,
+                **metadata,
+                'columns': columns,
+            }
+            table_designs.append(table_design)
+            logger.debug(
+                f'Built design for {schema_name}.{table_name}: '
+                f'{table_design.get("redshift_diststyle")} with {len(columns)} columns'
+            )
+
+        # Suggestion engine consumes dict-shaped nodes.
+        plan_nodes_dicts = [node.model_dump() for node in plan_nodes]
+        rule_based_suggestions = _generate_performance_suggestions(plan_nodes_dicts, table_designs)
+
+        execution_plan = {
+            'query_id': query_id,
+            'explained_query': sql,
+            'planning_time_ms': planning_time_ms,
+            'plan_text': plan_text,
+            'plan_nodes': plan_nodes_dicts,
+            'table_designs': table_designs,
+            'notes': notes,
+            'rule_based_suggestions': rule_based_suggestions,
+        }
+
+        logger.info(
+            f'Execution plan generated successfully: {query_id}, '
+            f'{len(raw_records)} plan records, {len(plan_nodes)} plan nodes, '
+            f'{len(table_designs)} table designs, '
+            f'{len(rule_based_suggestions)} suggestions, '
+            f'{len(notes)} notes in {planning_time_ms}ms'
+        )
+        return execution_plan
+
+    except Exception as e:
+        logger.error(f'Error getting execution plan for cluster {cluster_identifier}: {str(e)}')
         raise
 
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -22,6 +22,7 @@ from awslabs.redshift_mcp_server.consts import (
     REDSHIFT_BEST_PRACTICES,
 )
 from awslabs.redshift_mcp_server.models import (
+    ExecutionPlan,
     QueryResult,
     RedshiftCluster,
     RedshiftColumn,
@@ -30,6 +31,7 @@ from awslabs.redshift_mcp_server.models import (
     RedshiftTable,
 )
 from awslabs.redshift_mcp_server.redshift import (
+    describe_execution_plan,
     discover_clusters,
     discover_columns,
     discover_databases,
@@ -65,23 +67,27 @@ This tool provides essential information needed to connect to and query your Red
 
 ### list_databases
 Lists all databases in a specified Redshift cluster.
-This tool queries the SVV_REDSHIFT_DATABASES system view to discover available databases.
+This tool discovers available databases in the cluster.
 
 ### list_schemas
 Lists all schemas in a specified database within a Redshift cluster.
-This tool queries the SVV_ALL_SCHEMAS system view to discover available schemas.
+This tool discovers available schemas including local, external, and shared schemas.
 
 ### list_tables
 Lists all tables in a specified schema within a Redshift database.
-This tool queries the SVV_ALL_TABLES system view to discover available tables.
+This tool discovers available tables and enriches them with pg_catalog metadata when available.
 
 ### list_columns
 Lists all columns in a specified table within a Redshift schema.
-This tool queries the SVV_ALL_COLUMNS system view to discover available columns.
+This tool discovers available columns with data types, constraints, and Redshift-specific properties.
 
 ### execute_query
 Executes SQL queries against a Redshift cluster or serverless workgroup.
 This tool uses the Redshift Data API to run queries and return results.
+
+### describe_execution_plan
+Generates and analyzes the execution plan for a SQL query without executing it.
+Returns structured plan nodes for performance optimization analysis.
 
 ## Getting Started
 
@@ -175,9 +181,8 @@ async def list_databases_tool(
 ) -> list[RedshiftDatabase]:
     """List all databases in a specified Amazon Redshift cluster.
 
-    This tool queries the SVV_REDSHIFT_DATABASES system view to discover all databases
-    that the user has access to in the specified cluster, including local databases
-    and databases created from datashares.
+    This tool discovers all databases that the user has access to in the specified cluster,
+    including local databases and databases created from datashares.
 
     ## Usage Requirements
 
@@ -254,9 +259,8 @@ async def list_schemas_tool(
 ) -> list[RedshiftSchema]:
     """List all schemas in a specified database within a Redshift cluster.
 
-    This tool queries the SVV_ALL_SCHEMAS system view to discover all schemas
-    that the user has access to in the specified database, including local schemas,
-    external schemas, and shared schemas from datashares.
+    This tool discovers all schemas that the user has access to in the specified database,
+    including local schemas, external schemas, and shared schemas from datashares.
 
     ## Usage Requirements
 
@@ -345,9 +349,10 @@ async def list_tables_tool(
 ) -> list[RedshiftTable]:
     """List all tables in a specified schema within a Redshift database.
 
-    This tool queries the SVV_ALL_TABLES system view to discover all tables
-    that the user has access to in the specified schema, including base tables,
-    views, external tables, and shared tables.
+    This tool discovers all tables that the user has access to in the specified schema,
+    including base tables, views, external tables, and shared tables.
+
+    Enhanced metadata from pg_catalog tables is fetched separately and merged when available.
 
     ## Usage Requirements
 
@@ -373,8 +378,20 @@ async def list_tables_tool(
     - schema_name: The schema name for the table.
     - table_name: The name of the table.
     - table_acl: The permissions for the specified user or user group for the table.
-    - table_type: The type of the table (views, base tables, external tables, shared tables).
+    - table_type: The type of the table (TABLE, VIEW, EXTERNAL TABLE, SHARED TABLE).
     - remarks: Remarks about the table.
+
+    Redshift-specific properties (from pg_catalog):
+    - redshift_diststyle: Distribution style (KEY, EVEN, ALL, AUTO).
+    - redshift_estimated_row_count: Estimated number of rows.
+
+    Table activity statistics (from pg_stat_user_tables):
+    - stats_sequential_scans, stats_sequential_tuples_read: Sequential scan activity.
+    - stats_rows_inserted, stats_rows_updated, stats_rows_deleted: DML activity.
+
+    External table properties:
+    - external_location: S3 location for external tables (Spectrum).
+    - external_parameters: JSON parameters for external tables (e.g., partition columns).
 
     ## Usage Tips
 
@@ -383,6 +400,7 @@ async def list_tables_tool(
     3. Then use list_schemas to get valid schema names for the database.
     4. Ensure the cluster status is 'available' before querying tables.
     5. Note table types to understand if they are base tables, views, external tables, or shared tables.
+    6. Review table statistics to identify tables that may need ANALYZE. Suggest the user running ANALYZE when statistics appear stale.
 
     ## Interpretation Best Practices
 
@@ -392,6 +410,7 @@ async def list_tables_tool(
     4. 'SHARED TABLE' types indicate tables from datashares.
     5. Use table names for subsequent column discovery and query operations.
     6. Consider table permissions (table_acl) for access planning.
+    7. Monitor table statistics and suggest the user running ANALYZE when statistics appear stale.
     """
     try:
         logger.info(
@@ -444,9 +463,8 @@ async def list_columns_tool(
 ) -> list[RedshiftColumn]:
     """List all columns in a specified table within a Redshift schema.
 
-    This tool queries the SVV_ALL_COLUMNS system view to discover all columns
-    that the user has access to in the specified table, including detailed information
-    about data types, constraints, and column properties.
+    This tool discovers all columns that the user has access to in the specified table,
+    including detailed information about data types, constraints, and column properties.
 
     ## Usage Requirements
 
@@ -482,6 +500,14 @@ async def list_columns_tool(
     - numeric_precision: The numeric precision.
     - numeric_scale: The numeric scale.
     - remarks: Remarks about the column.
+    - redshift_encoding: Compression encoding for Redshift columns.
+    - redshift_is_distkey: Whether this column is the distribution key.
+    - redshift_sortkey_position: Sort key position (0 if not a sort key, 1+ for position).
+    - external_type: Data type for external table columns (Spectrum).
+    - external_partition_key: Partition key position (0 if not a partition key, 1+ for position).
+
+    Note: Column planner statistics (n_distinct, null_frac, avg_width, correlation from pg_stats)
+    are only populated when columns are returned as part of describe_execution_plan table_designs.
 
     ## Usage Tips
 
@@ -619,6 +645,106 @@ async def execute_query_tool(
         logger.error(f'Error in execute_query_tool: {str(e)}')
         await ctx.error(
             f'Failed to execute query on cluster {cluster_identifier} in database {database_name}: {str(e)}'
+        )
+        raise
+
+
+@mcp.tool(name='describe_execution_plan')
+async def describe_execution_plan_tool(
+    ctx: Context,
+    cluster_identifier: str = Field(
+        ...,
+        description='The cluster identifier to explain the query on. Must be a valid cluster identifier from the list_clusters tool.',
+    ),
+    database_name: str = Field(
+        ...,
+        description='The database name to explain the query against. Must be a valid database name from the list_databases tool.',
+    ),
+    sql: str = Field(
+        ...,
+        description='The SQL statement to generate an execution plan for. Should be a single SQL statement without the EXPLAIN prefix.',
+    ),
+) -> ExecutionPlan:
+    """Get the execution plan for a SQL query without executing it.
+
+    Uses EXPLAIN to generate a structured execution plan for query optimization analysis.
+    This tool provides insights into query performance without running the actual query.
+
+    ## Usage Requirements
+
+    - Ensure your AWS credentials are properly configured (via AWS_PROFILE or default credentials).
+    - The cluster must be available and accessible.
+    - Required IAM permissions: redshift-data:ExecuteStatement, redshift-data:DescribeStatement, redshift-data:GetStatementResult.
+    - The user must have appropriate permissions to execute queries in the specified database.
+
+    ## Parameters
+
+    - cluster_identifier: The Redshift cluster identifier from list_clusters.
+    - database_name: The database name from list_databases.
+    - sql: SQL statement to explain (do not include EXPLAIN keyword).
+
+    ## Permissions
+
+    - For non-superuser users, column planner statistics (from pg_stats) are only returned for tables the user has SELECT permission on.
+    - Table activity statistics (from pg_stat_user_tables) are visible to all users regardless of permissions.
+
+    ## Response Structure
+
+    Returns an ExecutionPlan with:
+    - query_id: Unique identifier for this explain execution.
+    - explained_query: The original SQL query, unchanged.
+    - planning_time_ms: Time to generate the plan.
+    - plan_text: Raw EXPLAIN output text (records joined with newlines, exactly as Redshift emits them).
+    - plan_nodes: List of ExecutionPlanNode objects (level + operation + costs + distribution_type + relation/alias + join/filter/sort/merge keys).
+    - table_designs: List of table design info (DISTKEY, SORTKEY, encoding, column planner statistics) for referenced tables.
+    - notes: Advisory annotations (cross-database, not-found, ambiguity) for SQL references that need clarification.
+    - rule_based_suggestions: Rule-based performance optimization suggestions derived from plan analysis, table design, and column statistics.
+
+    ## Usage Tips
+
+    1. First use list_clusters to get valid cluster identifiers.
+    2. Then use list_databases to get valid database names for the cluster.
+    3. Do NOT include EXPLAIN keyword in your SQL - the tool adds it automatically.
+    4. Suggest the user running ANALYZE on tables before checking execution plans for accurate cost estimates.
+    5. Ask the user if they want to compare plans before and after schema changes to measure optimization impact.
+    6. Use this tool to validate query performance before running expensive queries.
+    7. The full EXPLAIN output is returned without truncation. For programmatic analysis prefer plan_nodes (typed, more compact); reach for plan_text only when rendering the plan to a human.
+
+    ## Interpretation Best Practices
+
+    1. Read the plan bottom-up: leaf nodes execute first, results flow upward.
+    2. Focus on high-cost nodes first - they have the biggest optimization potential.
+    3. Check distribution_type for data movement: DS_DIST_NONE is optimal, DS_BCAST_INNER/DS_DIST_INNER indicate redistribution.
+    4. Look for Nested Loop joins on large tables - usually indicates missing join condition.
+    5. High row estimates with Seq Scan suggest missing or ineffective SORTKEY.
+    6. Review rule_based_suggestions for actionable optimization recommendations.
+    7. Check table_designs to verify DISTKEY/SORTKEY alignment with query patterns.
+    8. Review column planner statistics (n_distinct, correlation, histogram_bounds) to identify data skew or poor zone map effectiveness.
+
+    Note: Redshift does NOT support indexes. Focus on DISTKEY, SORTKEY, and compression optimization.
+    """
+    try:
+        logger.info(
+            f'Getting execution plan for query on cluster {cluster_identifier} in database {database_name}'
+        )
+
+        plan_result_data = await describe_execution_plan(
+            cluster_identifier=cluster_identifier, database_name=database_name, sql=sql
+        )
+
+        # Convert to ExecutionPlan model
+        execution_plan = ExecutionPlan(**plan_result_data)
+
+        logger.info(
+            f'Successfully generated execution plan on cluster {cluster_identifier}: '
+            f'{len(execution_plan.plan_nodes)} nodes in {execution_plan.planning_time_ms}ms'
+        )
+        return execution_plan
+
+    except Exception as e:
+        logger.error(f'Error in describe_execution_plan_tool: {str(e)}')
+        await ctx.error(
+            f'Failed to get execution plan on cluster {cluster_identifier} in database {database_name}: {str(e)}'
         )
         raise
 

--- a/src/redshift-mcp-server/scripts/e2e-test.sh
+++ b/src/redshift-mcp-server/scripts/e2e-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# End-to-end test for the Redshift MCP Server tools, driven via kiro-cli.
+# Run from the package root before raising a PR:  ./scripts/e2e-test.sh
+set -euo pipefail
+
+MODEL="${MODEL:-claude-opus-4.8}"
+REQUEST_FILE="$(mktemp)"
+trap 'rm -f "$REQUEST_FILE"' EXIT
+
+cat > "$REQUEST_FILE" <<'EOF'
+Test if all the Redshift MCP Server tools available to you are working. Check both
+provisioned and serverless clusters, including database schema exploration in both.
+Check the SQL read-only protection, transaction breaker protection, and failed user
+SQL behavior. Test the new tool describe_execution_plan and return the explain result.
+Also, check BaseSchema regarding optimization of token usage.
+Get test scenario ideas from the unit tests under the project directory. Provide a
+short testing summary, one line per tool.
+EOF
+
+kiro-cli chat --model "$MODEL" \
+  --no-interactive \
+  --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
+  "$(cat "$REQUEST_FILE")"

--- a/src/redshift-mcp-server/tests/test_models.py
+++ b/src/redshift-mcp-server/tests/test_models.py
@@ -1,0 +1,313 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the models module — BaseSchema exclude_none behavior."""
+
+import json
+import pydantic_core
+from awslabs.redshift_mcp_server.models import BaseSchema
+from pydantic import Field
+from typing import Optional
+
+
+class DummySchema(BaseSchema):
+    """Minimal test schema to verify BaseSchema behavior."""
+
+    required_field: str = Field(..., description='Always present')
+    optional_field: Optional[str] = Field(None, description='May be None')
+    optional_int: Optional[int] = Field(None, description='May be None')
+
+
+class TestBaseSchemaExcludeNone:
+    """Tests for BaseSchema exclude_none serialization."""
+
+    def test_model_dump_excludes_none(self):
+        """Test that model_dump excludes None fields."""
+        obj = DummySchema(required_field='hello', optional_field=None, optional_int=None)
+        dumped = obj.model_dump()
+
+        assert dumped == {'required_field': 'hello'}
+        assert 'optional_field' not in dumped
+        assert 'optional_int' not in dumped
+
+    def test_model_dump_json_excludes_none(self):
+        """Test that model_dump_json excludes None fields."""
+        obj = DummySchema(required_field='hello', optional_field=None, optional_int=None)
+        parsed = json.loads(obj.model_dump_json())
+
+        assert parsed == {'required_field': 'hello'}
+        assert 'optional_field' not in parsed
+
+    def test_pydantic_core_to_json_excludes_none(self):
+        """Test that pydantic_core.to_json also excludes None fields.
+
+        This is the serialization path used by FastMCP when converting tool results
+        to TextContent. Without the model_serializer, this would include all None fields.
+        """
+        obj = DummySchema(required_field='hello', optional_field=None, optional_int=None)
+        raw_json = pydantic_core.to_json(obj, indent=2)
+        parsed = json.loads(raw_json)
+
+        assert parsed == {'required_field': 'hello'}
+        assert 'optional_field' not in parsed
+        assert 'optional_int' not in parsed
+
+    def test_model_dump_preserves_non_none(self):
+        """Test that non-None optional fields are preserved."""
+        obj = DummySchema(required_field='hello', optional_field='world', optional_int=42)
+        dumped = obj.model_dump()
+
+        assert dumped == {'required_field': 'hello', 'optional_field': 'world', 'optional_int': 42}
+
+    def test_json_size_reduction(self):
+        """Test that excluding None reduces JSON size."""
+        obj = DummySchema(required_field='hello', optional_field=None, optional_int=None)
+
+        json_without = pydantic_core.to_json(obj)
+        json_with = json.dumps(
+            {'required_field': 'hello', 'optional_field': None, 'optional_int': None}
+        ).encode()
+
+        assert len(json_without) < len(json_with)
+
+    def test_nested_model_excludes_none_recursively(self):
+        """Nested BaseSchema models also exclude None when serialized together."""
+
+        class Inner(BaseSchema):
+            name: str = Field(...)
+            value: Optional[int] = Field(default=None)
+
+        class Outer(BaseSchema):
+            label: str = Field(...)
+            items: list[Inner] = Field(default_factory=list)
+            note: Optional[str] = Field(default=None)
+
+        obj = Outer(
+            label='test',
+            items=[Inner(name='a', value=None), Inner(name='b', value=42)],
+        )
+        dumped = obj.model_dump()
+
+        assert 'note' not in dumped
+        assert dumped['items'][0] == {'name': 'a'}
+        assert dumped['items'][1] == {'name': 'b', 'value': 42}
+
+    def test_false_and_zero_values_preserved(self):
+        """Falsy non-None values (False, 0, empty string) are preserved."""
+        obj = DummySchema(required_field='', optional_field='', optional_int=0)
+        dumped = obj.model_dump()
+
+        assert dumped['required_field'] == ''
+        assert dumped['optional_field'] == ''
+        assert dumped['optional_int'] == 0
+
+
+class TestExecutionPlanModels:
+    """Tests for the ExecutionPlan/ExecutionPlanNode models."""
+
+    # ExecutionPlan default factories ---------------------------------------------
+
+    def test_execution_plan_notes_defaults_to_empty_list(self):
+        """`notes` defaults to an empty list."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        plan = ExecutionPlan(
+            query_id='q1',
+            explained_query='SELECT 1',
+            plan_text='',
+            plan_nodes=[],
+        )
+
+        assert plan.notes == []
+
+    def test_execution_plan_table_designs_defaults_to_empty_list(self):
+        """`table_designs` defaults to an empty list."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        plan = ExecutionPlan(
+            query_id='q1',
+            explained_query='SELECT 1',
+            plan_text='',
+            plan_nodes=[],
+        )
+
+        assert plan.table_designs == []
+
+    def test_execution_plan_rule_based_suggestions_defaults_to_empty_list(self):
+        """`rule_based_suggestions` defaults to an empty list."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        plan = ExecutionPlan(
+            query_id='q1',
+            explained_query='SELECT 1',
+            plan_text='',
+            plan_nodes=[],
+        )
+
+        assert plan.rule_based_suggestions == []
+
+    def test_execution_plan_default_factories_produce_independent_lists(self):
+        """Each ExecutionPlan instance gets its own list (no mutable-default sharing)."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        plan_a = ExecutionPlan(
+            query_id='qa',
+            explained_query='SELECT 1',
+            plan_text='',
+            plan_nodes=[],
+        )
+        plan_b = ExecutionPlan(
+            query_id='qb',
+            explained_query='SELECT 2',
+            plan_text='',
+            plan_nodes=[],
+        )
+
+        plan_a.notes.append('note-a')
+        plan_a.table_designs.append(None)  # type: ignore[arg-type]
+        plan_a.rule_based_suggestions.append('sug-a')
+
+        assert plan_b.notes == []
+        assert plan_b.table_designs == []
+        assert plan_b.rule_based_suggestions == []
+
+    # plan_text behavior ----------------------------------------------------------
+
+    def test_execution_plan_plan_text_round_trip_preserves_newlines_and_indent(self):
+        """`plan_text` is a single string preserved byte-for-byte across model_dump."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        text = (
+            'XN Limit  (cost=0.00..0.10 rows=5 width=231)\n'
+            '  ->  XN Index Scan using pg_class_oid_index on pg_class  '
+            '(cost=0.00..29.79 rows=1466 width=231)\n'
+            '        Index Cond: (oid > 1000::oid)'
+        )
+        plan = ExecutionPlan(
+            query_id='q1',
+            explained_query='SELECT 1',
+            plan_text=text,
+            plan_nodes=[],
+        )
+
+        dumped = plan.model_dump()
+        assert dumped['plan_text'] == text
+
+        restored = ExecutionPlan.model_validate(dumped)
+        assert restored.plan_text == text
+
+    def test_execution_plan_plan_text_empty_string_preserved(self):
+        """An empty `plan_text` survives serialization (not stripped as None)."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        plan = ExecutionPlan(
+            query_id='q1',
+            explained_query='SELECT 1',
+            plan_text='',
+            plan_nodes=[],
+        )
+        dumped = plan.model_dump()
+
+        # Empty string is a falsy *non-None* value: BaseSchema's
+        # exclude-None serializer must keep it.
+        assert dumped['plan_text'] == ''
+
+    # Removed fields --------------------------------------------------------------
+
+    def test_execution_plan_field_set_matches_design(self):
+        """ExecutionPlan field set matches the contract."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        expected = {
+            'query_id',
+            'explained_query',
+            'planning_time_ms',
+            'plan_text',
+            'plan_nodes',
+            'table_designs',
+            'notes',
+            'rule_based_suggestions',
+        }
+        assert set(ExecutionPlan.model_fields.keys()) == expected
+
+    # BaseSchema exclude-None behavior on new models ------------------------------
+
+    def test_execution_plan_node_excludes_none_on_serialization(self):
+        """ExecutionPlanNode inherits BaseSchema's exclude-None behavior."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlanNode
+
+        node = ExecutionPlanNode(level=0, operation='Seq Scan')
+        dumped = node.model_dump()
+
+        # Required fields present, all None-valued optional fields stripped.
+        assert dumped == {'level': 0, 'operation': 'Seq Scan'}
+        for none_field in (
+            'relation_name',
+            'alias',
+            'distribution_type',
+            'cost_startup',
+            'cost_total',
+            'rows',
+            'width',
+            'join_condition',
+            'filter_condition',
+            'sort_key',
+            'merge_key',
+            'agg_strategy',
+            'data_movement',
+        ):
+            assert none_field not in dumped
+
+    def test_execution_plan_node_preserves_set_optional_fields(self):
+        """ExecutionPlanNode keeps non-None optional fields in the dump."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlanNode
+
+        node = ExecutionPlanNode(
+            level=1,
+            operation='Hash Join',
+            distribution_type='DS_BCAST_INNER',
+            cost_total=42.0,
+            rows=100,
+        )
+        dumped = node.model_dump()
+
+        assert dumped['distribution_type'] == 'DS_BCAST_INNER'
+        assert dumped['cost_total'] == 42.0
+        assert dumped['rows'] == 100
+        # Optional fields left as None must not leak through.
+        assert 'relation_name' not in dumped
+        assert 'filter_condition' not in dumped
+
+    def test_execution_plan_excludes_none_on_serialization(self):
+        """ExecutionPlan inherits BaseSchema's exclude-None behavior."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlan
+
+        plan = ExecutionPlan(
+            query_id='q-1',
+            explained_query='SELECT 1',
+            plan_text='',
+            plan_nodes=[],
+        )
+        dumped = plan.model_dump()
+
+        # `planning_time_ms` was left None and must be stripped.
+        assert 'planning_time_ms' not in dumped
+        # Required and default-factory fields remain.
+        assert dumped['query_id'] == 'q-1'
+        assert dumped['explained_query'] == 'SELECT 1'
+        assert dumped['plan_text'] == ''
+        assert dumped['plan_nodes'] == []
+        assert dumped['table_designs'] == []
+        assert dumped['notes'] == []
+        assert dumped['rule_based_suggestions'] == []

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -15,12 +15,15 @@
 """Tests for the redshift module."""
 
 import pytest
+import regex
 import time
 from awslabs.redshift_mcp_server.redshift import (
     RedshiftClientManager,
     RedshiftSessionManager,
     _execute_protected_statement,
     _execute_statement,
+    _generate_performance_suggestions,
+    describe_execution_plan,
     discover_clusters,
     discover_columns,
     discover_databases,
@@ -560,6 +563,93 @@ class TestExecuteProtectedStatement:
             await _execute_protected_statement(
                 'test-cluster', 'test-db', 'SELECT invalid_syntax', allow_read_write=False
             )
+
+    @pytest.mark.asyncio
+    async def test_execute_protected_follows_next_token_across_pages(self, mocker):
+        """Multi-page Data API results are concatenated into one Records list."""
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
+
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+
+        mock_execute_statement = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement'
+        )
+        mock_execute_statement.side_effect = ['begin-stmt-id', 'user-stmt-id', 'end-stmt-id']
+
+        # Three Data API pages: first two carry NextToken, the third closes
+        # the iteration. Records from every page must end up concatenated.
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.side_effect = [
+            {
+                'Records': [[{'stringValue': 'row-1'}]],
+                'NextToken': 'tok-1',
+                'ColumnMetadata': [],
+            },
+            {
+                'Records': [[{'stringValue': 'row-2'}]],
+                'NextToken': 'tok-2',
+            },
+            {
+                'Records': [[{'stringValue': 'row-3'}]],
+            },
+        ]
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        response, query_id = await _execute_protected_statement(
+            'test-cluster', 'test-db', 'SELECT * FROM big_table', allow_read_write=False
+        )
+
+        assert query_id == 'user-stmt-id'
+        # All three pages' Records are present in source order.
+        assert [r[0]['stringValue'] for r in response['Records']] == [
+            'row-1',
+            'row-2',
+            'row-3',
+        ]
+        # Three GetStatementResult calls: initial + 2 follow-ups.
+        assert mock_data_client.get_statement_result.call_count == 3
+        assert mock_data_client.get_statement_result.call_args_list[1][1]['NextToken'] == 'tok-1'
+        assert mock_data_client.get_statement_result.call_args_list[2][1]['NextToken'] == 'tok-2'
+
+    @pytest.mark.asyncio
+    async def test_execute_protected_single_page_does_not_call_get_result_again(self, mocker):
+        """No NextToken on the first page → exactly one GetStatementResult call."""
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
+
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+
+        mock_execute_statement = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement'
+        )
+        mock_execute_statement.side_effect = ['begin-stmt-id', 'user-stmt-id', 'end-stmt-id']
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'stringValue': 'only-row'}]],
+            'ColumnMetadata': [],
+        }
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        response, _ = await _execute_protected_statement(
+            'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+        )
+
+        assert mock_data_client.get_statement_result.call_count == 1
+        assert [r[0]['stringValue'] for r in response['Records']] == ['only-row']
 
 
 class TestExecuteStatement:
@@ -1121,21 +1211,44 @@ class TestDiscoverFunctions:
         mock_execute_protected = mocker.patch(
             'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
         )
-        mock_execute_protected.return_value = (
-            {
-                'Records': [
-                    [
-                        {'stringValue': 'dev'},
-                        {'stringValue': 'public'},
-                        {'stringValue': 'users'},
-                        {'stringValue': 'user=admin'},
-                        {'stringValue': 'TABLE'},
-                        {'stringValue': 'User data table'},
+        # First call: TABLES_SQL, Second call: TABLES_EXTRA_SQL
+        mock_execute_protected.side_effect = [
+            (
+                {
+                    'Records': [
+                        [
+                            {'stringValue': 'dev'},
+                            {'stringValue': 'public'},
+                            {'stringValue': 'users'},
+                            {'stringValue': 'user=admin'},
+                            {'stringValue': 'TABLE'},
+                            {'stringValue': 'User data table'},
+                            {'stringValue': None},
+                            {'stringValue': None},
+                        ]
                     ]
-                ]
-            },
-            'query-789',
-        )
+                },
+                'query-789',
+            ),
+            (
+                {
+                    'Records': [
+                        [
+                            {'stringValue': 'public'},
+                            {'stringValue': 'users'},
+                            {'stringValue': 'KEY'},
+                            {'longValue': 1000},
+                            {'longValue': 50},
+                            {'longValue': 5000},
+                            {'longValue': 100},
+                            {'longValue': 20},
+                            {'longValue': 5},
+                        ]
+                    ]
+                },
+                'query-extra',
+            ),
+        ]
 
         result = await discover_tables('test-cluster', 'dev', 'public')
 
@@ -1144,15 +1257,19 @@ class TestDiscoverFunctions:
         assert result[0]['schema_name'] == 'public'
         assert result[0]['table_name'] == 'users'
         assert result[0]['table_type'] == 'TABLE'
+        # Verify extra stats were merged
+        assert result[0]['redshift_diststyle'] == 'KEY'
+        assert result[0]['redshift_estimated_row_count'] == 1000
+        assert result[0]['stats_sequential_scans'] == 50
+        assert result[0]['stats_rows_inserted'] == 100
 
-        # Verify parameters were passed correctly
-        mock_execute_protected.assert_called_once()
-        call_args = mock_execute_protected.call_args
+        # Verify parameters were passed correctly for first call
+        first_call_args = mock_execute_protected.call_args_list[0]
         expected_params = [
             {'name': 'database_name', 'value': 'dev'},
             {'name': 'schema_name', 'value': 'public'},
         ]
-        assert call_args[1]['parameters'] == expected_params
+        assert first_call_args[1]['parameters'] == expected_params
 
     @pytest.mark.asyncio
     async def test_discover_tables_error(self, mocker):
@@ -1163,6 +1280,37 @@ class TestDiscoverFunctions:
         mock_execute_protected.side_effect = Exception('Table discovery failed')
 
         with pytest.raises(Exception, match='Table discovery failed'):
+            await discover_tables('test-cluster', 'dev', 'public')
+
+    @pytest.mark.asyncio
+    async def test_discover_tables_extra_stats_failure(self, mocker):
+        """Test that TABLES_EXTRA_SQL failure raises an error."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        # First call (TABLES_SQL) succeeds, second call (TABLES_EXTRA_SQL) fails
+        mock_execute_protected.side_effect = [
+            (
+                {
+                    'Records': [
+                        [
+                            {'stringValue': 'dev'},
+                            {'stringValue': 'public'},
+                            {'stringValue': 'users'},
+                            {'stringValue': None},
+                            {'stringValue': 'TABLE'},
+                            {'stringValue': None},
+                            {'stringValue': None},
+                            {'stringValue': None},
+                        ]
+                    ]
+                },
+                'query-tables',
+            ),
+            Exception('pg_class_info not accessible'),
+        ]
+
+        with pytest.raises(Exception, match='pg_class_info not accessible'):
             await discover_tables('test-cluster', 'dev', 'public')
 
     @pytest.mark.asyncio
@@ -1188,6 +1336,11 @@ class TestDiscoverFunctions:
                         {'longValue': 32},
                         {'longValue': 0},
                         {'stringValue': 'Primary key'},
+                        {'stringValue': 'lzo'},
+                        {'booleanValue': True},
+                        {'longValue': 1},
+                        {'stringValue': None},
+                        {'longValue': None},
                     ]
                 ]
             },
@@ -1203,6 +1356,10 @@ class TestDiscoverFunctions:
         assert result[0]['column_name'] == 'id'
         assert result[0]['ordinal_position'] == 1
         assert result[0]['data_type'] == 'integer'
+        assert result[0]['redshift_encoding'] == 'lzo'
+        assert result[0]['redshift_is_distkey'] is True
+        assert result[0]['redshift_sortkey_position'] == 1
+        assert result[0]['external_partition_key'] is None
 
         # Verify parameters were passed correctly
         mock_execute_protected.assert_called_once()
@@ -1289,3 +1446,6082 @@ class TestExecuteQuery:
 
         with pytest.raises(Exception, match='Query execution failed'):
             await execute_query('test-cluster', 'dev', 'SELECT * FROM nonexistent')
+
+
+class TestExecuteQueryDataTypes:
+    """Tests for execute_query data type handling."""
+
+    @pytest.mark.asyncio
+    async def test_execute_query_with_boolean_values(self, mocker):
+        """Test execute_query with boolean data types."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'ColumnMetadata': [{'name': 'is_active'}],
+                'Records': [[{'booleanValue': True}], [{'booleanValue': False}]],
+            },
+            'query-123',
+        )
+
+        result = await execute_query('test-cluster', 'dev', 'SELECT is_active FROM users')
+
+        assert result['columns'] == ['is_active']
+        assert result['rows'] == [[True], [False]]
+        assert result['row_count'] == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_query_with_unknown_field_type(self, mocker):
+        """Test execute_query with unknown field types (fallback to str)."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'ColumnMetadata': [{'name': 'data'}],
+                'Records': [[{'unknownType': 'some_value'}]],
+            },
+            'query-123',
+        )
+
+        result = await execute_query('test-cluster', 'dev', 'SELECT data FROM test')
+
+        assert result['columns'] == ['data']
+        assert len(result['rows']) == 1
+        assert isinstance(result['rows'][0][0], str)
+
+
+class TestDescribeExecutionPlan:
+    """Tests for ``describe_execution_plan`` and its internal pipeline.
+
+    Covers the public tool plus every internal helper it composes:
+    plan-text parser, SQL reference extractor, table metadata fetcher,
+    bare-name candidate lookup, ambiguity resolver, suggestion engine,
+    and the SQL constants and rendering helpers used along the way.
+    """
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_already_has_explain(self, mocker):
+        """SQL starting with EXPLAIN is rejected."""
+        with pytest.raises(
+            Exception,
+            match='SQL already contains EXPLAIN. Please provide the query without EXPLAIN.',
+        ):
+            await describe_execution_plan('test-cluster', 'dev', 'EXPLAIN SELECT * FROM users')
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_already_has_explain_lowercase(self, mocker):
+        """Lowercase 'explain' must also be rejected (case-insensitive)."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        with pytest.raises(
+            Exception,
+            match='SQL already contains EXPLAIN. Please provide the query without EXPLAIN.',
+        ):
+            await describe_execution_plan('test-cluster', 'dev', 'explain select * from users')
+        mock_execute_protected.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('bad_sql', ['', ' ', '\t', '\n', '   \n\t  '])
+    async def test_describe_execution_plan_rejects_empty_sql(self, mocker, bad_sql):
+        """Empty/whitespace SQL is rejected before any cluster call."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        with pytest.raises(
+            Exception,
+            match='SQL is required and must not be empty or whitespace.',
+        ):
+            await describe_execution_plan('test-cluster', 'dev', bad_sql)
+        mock_execute_protected.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_error_handling(self, mocker):
+        """Underlying execution failure propagates as a top-level error."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('EXPLAIN query failed')
+
+        with pytest.raises(Exception, match='EXPLAIN query failed'):
+            await describe_execution_plan('test-cluster', 'dev', 'SELECT * FROM invalid_table')
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_returns_full_response_shape(self, mocker):
+        """Smoke test for the full describe_execution_plan pipeline."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        # Plain-EXPLAIN output (no VERBOSE syntax — no ``{ NODETYPE``
+        # block, no column-0 ``:property`` lines).
+        explain_response = (
+            {
+                'Records': [
+                    [{'stringValue': 'XN Limit  (cost=0.00..0.07 rows=5 width=27)'}],
+                    [
+                        {
+                            'stringValue': '  ->  XN Seq Scan on users  '
+                            '(cost=0.00..1.00 rows=100 width=27)'
+                        }
+                    ],
+                ]
+            },
+            'explain-query-id',
+        )
+        # Bare-candidate lookup: ``users`` resolves to a single
+        # (schema, table) pair — public.users.
+        candidates_response = (
+            {
+                'Records': [
+                    [{'stringValue': 'public'}, {'stringValue': 'users'}],
+                ]
+            },
+            'candidates-query-id',
+        )
+        # Batched table-extra metadata for (public, users).
+        tables_extra_response = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'KEY'},
+                        {'longValue': 1000},
+                        {'longValue': 5},
+                        {'longValue': 100},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                    ]
+                ]
+            },
+            'tables-extra-query-id',
+        )
+        # Column stats batched fetch (returns no stats — empty result).
+        column_stats_response = ({'Records': []}, 'column-stats-query-id')
+
+        # Batched columns fetch for (public, users) — single column.
+        columns_by_pairs_response = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'dev'},
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'id'},
+                        {'longValue': 1},
+                        {'stringValue': None},
+                        {'stringValue': 'YES'},
+                        {'stringValue': 'integer'},
+                        {'longValue': None},
+                        {'longValue': None},
+                        {'longValue': None},
+                        {'stringValue': None},
+                        {'stringValue': 'lzo'},
+                        {'booleanValue': False},
+                        {'longValue': 0},
+                        {'stringValue': None},
+                        {'longValue': None},
+                    ],
+                ]
+            },
+            'columns-query-id',
+        )
+
+        mock_execute_protected.side_effect = [
+            explain_response,
+            candidates_response,
+            tables_extra_response,
+            column_stats_response,
+            columns_by_pairs_response,
+        ]
+
+        result = await describe_execution_plan(
+            'test-cluster', 'dev', 'SELECT * FROM users LIMIT 5'
+        )
+
+        # Query identity + timing.
+        assert result['query_id'] == 'explain-query-id'
+        # explained_query is the user's original SQL, unchanged.
+        assert result['explained_query'] == 'SELECT * FROM users LIMIT 5'
+        assert result['planning_time_ms'] >= 0
+
+        # plan_text preserves the EXPLAIN output byte-for-byte (records
+        # joined by newlines).
+        assert result['plan_text'] == (
+            'XN Limit  (cost=0.00..0.07 rows=5 width=27)\n'
+            '  ->  XN Seq Scan on users  (cost=0.00..1.00 rows=100 width=27)'
+        )
+
+        # plan_nodes are reconstructed from operation lines
+        # (root + ``->`` lines).
+        assert len(result['plan_nodes']) == 2
+        assert result['plan_nodes'][0]['operation'] == 'XN Limit'
+        assert result['plan_nodes'][1]['operation'] == 'XN Seq Scan'
+        assert result['plan_nodes'][1].get('relation_name') == 'users'
+
+        # table_designs carries the bare reference resolved to
+        # public.users with metadata + columns merged.
+        assert len(result['table_designs']) == 1
+        td = result['table_designs'][0]
+        assert td['schema_name'] == 'public'
+        assert td['table_name'] == 'users'
+        assert td['redshift_diststyle'] == 'KEY'
+        assert td['redshift_estimated_row_count'] == 1000
+        assert len(td['columns']) == 1
+        assert td['columns'][0]['column_name'] == 'id'
+
+        # notes is a list (empty here — bare reference resolved cleanly).
+        assert isinstance(result['notes'], list)
+
+        # rule_based_suggestions is a list (carry-over).
+        assert isinstance(result['rule_based_suggestions'], list)
+
+    def test_suggestions_for_data_broadcast(self):
+        """DS_BCAST_INNER on a join emits a broadcast suggestion."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_BCAST_INNER',
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert len(suggestions) == 1
+        assert 'broadcast' in suggestions[0].lower()
+        assert 'DISTKEY' in suggestions[0]
+
+    def test_suggestions_for_data_redistribution(self):
+        """DS_DIST_INNER on a join emits a redistribution suggestion."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Merge Join',
+                'distribution_type': 'DS_DIST_INNER',
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert len(suggestions) == 1
+        assert 'redistribution' in suggestions[0].lower()
+
+    def test_suggestions_for_nested_loop(self):
+        """Nested Loop join emits a Nested-Loop suggestion."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Nested Loop',
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert len(suggestions) == 1
+        assert 'Nested Loop' in suggestions[0]
+
+    def test_suggestions_for_even_distribution(self):
+        """EVEN-distributed tables emit a DISTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'EVEN',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert len(suggestions) >= 1
+        assert any('EVEN distribution' in s for s in suggestions)
+
+    def test_suggestions_for_missing_sortkey(self):
+        """SORTKEY suggestion emits only when seq_scans > 1000, no SORTKEY,."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 5_000_000,
+                'stats_sequential_scans': 5000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                    {
+                        'column_name': 'name',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('5,000 sequential scans' in s and 'SORTKEY' in s for s in suggestions)
+
+    def test_no_sortkey_suggestion_when_seq_scans_unknown(self):
+        """No SORTKEY suggestion when stats_sequential_scans is unknown."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 5_000_000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('SORTKEY' in s for s in suggestions)
+
+    def test_no_sortkey_suggestion_when_seq_scans_zero(self):
+        """No SORTKEY suggestion when stats_sequential_scans == 0."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 5_000_000,
+                'stats_sequential_scans': 0,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('SORTKEY' in s for s in suggestions)
+
+    def test_suggestions_for_no_compression(self):
+        """Uncompressed columns emit a compression suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'users',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 1,
+                    },
+                    {
+                        'column_name': 'name',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert len(suggestions) >= 1
+        assert any('compression' in s.lower() for s in suggestions)
+
+    def test_no_duplicate_suggestions(self):
+        """Duplicate suggestion text is deduplicated."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_BCAST_INNER',
+            },
+            {
+                'node_id': 2,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_BCAST_INNER',
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert len(suggestions) == 1
+        assert 'broadcast' in suggestions[0].lower()
+
+    def test_empty_inputs(self):
+        """Empty inputs yield an empty suggestion list."""
+        suggestions = _generate_performance_suggestions([], [])
+        assert suggestions == []
+
+    def test_optimal_plan_no_suggestions(self):
+        """Optimal plans produce no suggestions."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Seq Scan',
+                'distribution_type': 'DS_DIST_NONE',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'users',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+
+        assert suggestions == []
+
+    def test_suggestions_for_dist_all_inner(self):
+        """DS_DIST_ALL_INNER on a join emits a redistribution suggestion."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_ALL_INNER',
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert len(suggestions) == 1
+        assert 'Full table redistribution detected' in suggestions[0]
+        assert 'DISTSTYLE ALL' in suggestions[0]
+        assert '< 1-2M rows' in suggestions[0]
+
+    def test_suggestions_for_small_table_diststyle_all(self):
+        """Small dimension tables emit a DISTSTYLE ALL suggestion."""
+        tables = [
+            {
+                'schema_name': 'public',
+                'table_name': 'dim_date',
+                'redshift_diststyle': 'EVEN',
+                'redshift_estimated_row_count': 365,
+                'columns': [],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], tables)
+
+        assert len(suggestions) == 1
+        assert 'dim_date' in suggestions[0]
+        assert '365 rows' in suggestions[0]
+        assert 'DISTSTYLE ALL' in suggestions[0]
+        assert 'dimension table' in suggestions[0]
+
+    def test_suggestions_for_dist_inner(self):
+        """DS_DIST_INNER on a Hash Join with a real table emits a redistribution suggestion."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Merge Join',
+                'distribution_type': 'DS_DIST_INNER',
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert len(suggestions) == 1
+        assert 'Data redistribution' in suggestions[0]
+        assert 'DISTKEY' in suggestions[0]
+
+    def test_suggestions_for_many_uncompressed_columns(self):
+        """Tables with many uncompressed columns emit a roll-up compression suggestion."""
+        columns = [{'column_name': f'col{i}', 'redshift_encoding': 'none'} for i in range(10)]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'large_table',
+                'redshift_diststyle': 'KEY',
+                'columns': columns,
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert len(suggestions) >= 1
+        assert any('columns' in s and 'compression' in s.lower() for s in suggestions)
+
+    def test_suggestions_for_high_sequential_scans_no_sortkey(self):
+        """High sequential scans without a SORTKEY emit a SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'stats_sequential_scans': 5000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                    {
+                        'column_name': 'ts',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('5,000 sequential scans' in s and 'SORTKEY' in s for s in suggestions)
+
+    def test_suggestions_for_low_correlation(self):
+        """Low-correlation non-SORTKEY columns emit a SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'order_date',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'stats_correlation': 0.05,
+                    },
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                        'stats_correlation': 0.99,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        # Should suggest SORTKEY for order_date (low correlation, not a sortkey)
+        assert any(
+            'order_date' in s and 'correlation' in s and 'SORTKEY' in s for s in suggestions
+        )
+        # Should NOT suggest for id (already a sortkey)
+        assert not any('column id' in s.lower() for s in suggestions)
+
+    def test_no_correlation_suggestion_when_already_sortkey(self):
+        """SORTKEY columns are not flagged for low correlation."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'event_time',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                        'stats_correlation': 0.01,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        # No correlation suggestion since column is already a sortkey
+        assert not any('correlation' in s for s in suggestions)
+
+    def test_no_correlation_suggestion_when_high_correlation(self):
+        """High-correlation columns are not flagged for low correlation."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'stats_correlation': 0.95,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('correlation' in s for s in suggestions)
+
+    def test_suggestions_for_low_cardinality_distkey(self):
+        """Very low-cardinality DISTKEY columns emit a cardinality suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 1000000,
+                'columns': [
+                    {
+                        'column_name': 'status',
+                        'redshift_encoding': 'lzo',
+                        'redshift_is_distkey': True,
+                        'redshift_sortkey_position': 0,
+                        'stats_n_distinct': 5,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('DISTKEY column status' in s and 'low cardinality' in s for s in suggestions)
+
+    def test_no_distkey_suggestion_when_high_cardinality(self):
+        """High-cardinality DISTKEY columns are not flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 1000000,
+                'columns': [
+                    {
+                        'column_name': 'order_id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_is_distkey': True,
+                        'redshift_sortkey_position': 0,
+                        'stats_n_distinct': -1.0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('low cardinality' in s for s in suggestions)
+
+    def test_suggestions_for_high_null_sortkey(self):
+        """Mostly-NULL SORTKEY columns emit a NULL-fraction suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'deleted_at',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                        'stats_null_frac': 0.95,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('SORTKEY column deleted_at' in s and '95% NULL' in s for s in suggestions)
+
+    def test_no_null_suggestion_when_low_null_frac(self):
+        """SORTKEY columns with low NULL fraction are not flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'event_time',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                        'stats_null_frac': 0.01,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('NULL' in s and 'SORTKEY' in s for s in suggestions)
+
+    def test_suggestions_for_wide_uncompressed_columns(self):
+        """Wide uncompressed variable-length columns emit a compression suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'logs',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'message',
+                        'data_type': 'character varying',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                        'stats_avg_width': 256,
+                    },
+                    {
+                        'column_name': 'id',
+                        'data_type': 'integer',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                        'stats_avg_width': 4,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any(
+            'Wide columns' in s and 'message' in s and '>200 bytes' in s for s in suggestions
+        )
+
+    def test_no_wide_uncompressed_for_fixed_width_types(self):
+        """Fixed-width types (int/bigint/date) should not be flagged as wide even with high avg_width."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'data_type': 'bigint',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                        'stats_avg_width': 250,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        # No "Wide columns" suggestion since bigint is fixed-width
+        assert not any('Wide columns' in s for s in suggestions)
+
+    def test_no_wide_uncompressed_below_threshold(self):
+        """Variable-length columns under 200 bytes should not be flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'logs',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'code',
+                        'data_type': 'varchar',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                        'stats_avg_width': 100,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('Wide columns' in s for s in suggestions)
+
+    def test_no_suggestion_for_ds_dist_none(self):
+        """DS_DIST_NONE (co-located join) should not generate redistribution suggestions."""
+        nodes = [
+            {'node_id': 1, 'operation': 'Hash Join', 'distribution_type': 'DS_DIST_NONE'},
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+        assert len(suggestions) == 0
+
+    def test_no_suggestion_for_ds_dist_all_none(self):
+        """DS_DIST_ALL_NONE (DISTSTYLE ALL join) should not generate suggestions."""
+        nodes = [
+            {'node_id': 1, 'operation': 'Hash Join', 'distribution_type': 'DS_DIST_ALL_NONE'},
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+        assert len(suggestions) == 0
+
+    def test_suggestion_for_small_table_auto_diststyle(self):
+        """Small tables with AUTO(EVEN) or AUTO(KEY) get DISTSTYLE ALL suggestion."""
+        for style in ('AUTO(EVEN)', 'AUTO(KEY)'):
+            table_designs = [
+                {
+                    'schema_name': 'tickit',
+                    'table_name': 'venue',
+                    'redshift_diststyle': style,
+                    'redshift_estimated_row_count': 202,
+                    'columns': [
+                        {
+                            'column_name': 'venueid',
+                            'redshift_encoding': 'lzo',
+                            'redshift_sortkey_position': 1,
+                        },
+                    ],
+                }
+            ]
+            suggestions = _generate_performance_suggestions([], table_designs)
+            assert any('DISTSTYLE ALL' in s for s in suggestions), (
+                f'{style} small table should get DISTSTYLE ALL suggestion'
+            )
+
+    def test_no_diststyle_all_for_large_key_table(self):
+        """Tables >= 2M rows with KEY distribution should not get DISTSTYLE ALL suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'tpch',
+                'table_name': 'lineitem',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 6001215,
+                'columns': [
+                    {
+                        'column_name': 'l_orderkey',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                    {
+                        'column_name': 'l_shipdate',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 1,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('DISTSTYLE ALL' in s for s in suggestions)
+
+    def test_suggestion_for_table_with_no_row_count(self):
+        """Table with None row count should not crash or suggest DISTSTYLE ALL."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'mystery',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': None,
+                'columns': [],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('DISTSTYLE ALL' in s for s in suggestions)
+
+    def test_combined_node_and_table_suggestions(self):
+        """Both node-level and table-level suggestions are generated together."""
+        nodes = [
+            {'node_id': 1, 'operation': 'Hash Join', 'distribution_type': 'DS_BCAST_INNER'},
+        ]
+        table_designs = [
+            {
+                'schema_name': 'tickit',
+                'table_name': 'category',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 11,
+                'columns': [
+                    {
+                        'column_name': 'catid',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert any('broadcast' in s.lower() for s in suggestions)
+        assert any('DISTSTYLE ALL' in s for s in suggestions)
+
+    def test_no_correlation_suggestion_for_small_table(self):
+        """Low correlation on a <100K row table should NOT trigger a SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'small_table',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 50000,
+                'columns': [
+                    {
+                        'column_name': 'col1',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'stats_correlation': 0.05,
+                        'stats_n_distinct': 10000,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('correlation' in s for s in suggestions)
+
+    def test_no_correlation_suggestion_for_low_cardinality_column(self):
+        """Low correlation on a very low-cardinality column should NOT trigger a SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'big_table',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 10000000,
+                'columns': [
+                    {
+                        'column_name': 'flag',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'stats_correlation': 0.05,
+                        # Only 5 distinct values — zone maps are fine regardless
+                        'stats_n_distinct': 5,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('correlation' in s for s in suggestions)
+
+    def test_correlation_suggestion_for_large_high_cardinality_table(self):
+        """Low correlation on a large, high-cardinality column should trigger a SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 10000000,
+                'columns': [
+                    {
+                        'column_name': 'order_date',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'stats_correlation': 0.05,
+                        'stats_n_distinct': 365,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert any(
+            'order_date' in s and 'correlation' in s and 'SORTKEY' in s for s in suggestions
+        )
+
+    def test_no_low_cardinality_distkey_for_small_table(self):
+        """Low distinct-count on a small table (high selectivity) should NOT be flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'tiny',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 100,
+                'columns': [
+                    {
+                        'column_name': 'status',
+                        'redshift_encoding': 'lzo',
+                        'redshift_is_distkey': True,
+                        'redshift_sortkey_position': 0,
+                        'stats_n_distinct': 50,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        # 50 distinct / 100 rows = 0.5 selectivity — not low-cardinality
+        assert not any('low cardinality' in s for s in suggestions)
+
+    def test_no_low_cardinality_distkey_when_absolute_count_high(self):
+        """Many distinct values should not be flagged even if selectivity is low."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'big',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 1000000000,
+                'columns': [
+                    {
+                        'column_name': 'cust_id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_is_distkey': True,
+                        'redshift_sortkey_position': 0,
+                        # 5000 distinct is above the 100 absolute-count threshold
+                        'stats_n_distinct': 5000,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('low cardinality' in s for s in suggestions)
+
+    def test_no_encoding_suggestion_for_first_sortkey(self):
+        """First column of compound SORTKEY must be RAW and should not be flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'event_time',
+                        'data_type': 'timestamp without time zone',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 1,  # first sortkey — must stay RAW
+                    },
+                    {
+                        'column_name': 'user_id',
+                        'data_type': 'bigint',
+                        'redshift_encoding': 'az64',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        # No compression suggestion since the only RAW column is the first sortkey
+        assert not any('compression' in s.lower() for s in suggestions)
+
+    def test_no_encoding_suggestion_for_boolean(self):
+        """BOOLEAN columns cannot be encoded and should not be flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'flags',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'is_active',
+                        'data_type': 'boolean',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                    },
+                    {
+                        'column_name': 'id',
+                        'data_type': 'bigint',
+                        'redshift_encoding': 'az64',
+                        'redshift_sortkey_position': 1,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        # No compression suggestion — is_active is boolean (excluded), id has a sortkey
+        assert not any('compression' in s.lower() for s in suggestions)
+
+    def test_encoding_suggestion_for_non_sortkey_non_boolean(self):
+        """Regular RAW columns (not sortkey[1], not boolean) should still be flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 't',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'name',
+                        'data_type': 'character varying',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert any('name' in s and 'compression' in s.lower() for s in suggestions)
+
+    def test_no_seq_scan_suggestion_for_small_table(self):
+        """High seq_scans on a small table (<100K rows) should not be flagged."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'small',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 50000,
+                'stats_sequential_scans': 10000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('sequential scans' in s for s in suggestions)
+
+    def test_no_seq_scan_suggestion_for_diststyle_all(self):
+        """DISTSTYLE ALL tables are expected to be seq-scanned locally on each node."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'dim_country',
+                'redshift_diststyle': 'ALL',
+                'redshift_estimated_row_count': 1000000,
+                'stats_sequential_scans': 10000,
+                'columns': [
+                    {
+                        'column_name': 'country_id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('sequential scans' in s for s in suggestions)
+
+    def test_no_seq_scan_suggestion_for_auto_all(self):
+        """AUTO(ALL) should also be suppressed like ALL."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'dim',
+                'redshift_diststyle': 'AUTO(ALL)',
+                'redshift_estimated_row_count': 1000000,
+                'stats_sequential_scans': 10000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+        assert not any('sequential scans' in s for s in suggestions)
+
+    def test_join_numeric_type_mismatch_flagged(self):
+        """Join between integer and bigint columns should flag numeric-type mismatch."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_NONE',
+                'join_condition': '(orders.cust_id = customers.id)',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'cust_id',
+                        'data_type': 'integer',
+                        'redshift_encoding': 'az64',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            },
+            {
+                'schema_name': 'public',
+                'table_name': 'customers',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'data_type': 'bigint',
+                        'redshift_encoding': 'az64',
+                        'redshift_sortkey_position': 1,
+                    },
+                ],
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert any(
+            'mismatched numeric types' in s and 'cust_id' in s and 'id' in s for s in suggestions
+        )
+
+    def test_join_filter_numeric_type_mismatch_flagged(self):
+        """Mismatched numeric types in ``join_filter`` should flag numeric-type mismatch."""
+        nodes = [
+            {
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_NONE',
+                'join_condition': '(orders.id = customers.id)',
+                'join_filter': '(orders.cust_id = customers.cust_id_big)',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'columns': [
+                    {'column_name': 'id', 'data_type': 'integer'},
+                    {'column_name': 'cust_id', 'data_type': 'integer'},
+                ],
+            },
+            {
+                'schema_name': 'public',
+                'table_name': 'customers',
+                'columns': [
+                    {'column_name': 'id', 'data_type': 'integer'},
+                    {'column_name': 'cust_id_big', 'data_type': 'bigint'},
+                ],
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert any(
+            'mismatched numeric types' in s and 'cust_id' in s and 'cust_id_big' in s
+            for s in suggestions
+        )
+
+    def test_join_filter_range_predicate_not_flagged(self):
+        """Range predicate in ``join_filter`` should NOT be flagged."""
+        nodes = [
+            {
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_NONE',
+                'join_condition': '(orders.id = customers.id)',
+                'join_filter': '(orders.amount > customers.threshold)',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'columns': [
+                    {'column_name': 'id', 'data_type': 'integer'},
+                    {'column_name': 'amount', 'data_type': 'integer'},
+                ],
+            },
+            {
+                'schema_name': 'public',
+                'table_name': 'customers',
+                'columns': [
+                    {'column_name': 'id', 'data_type': 'integer'},
+                    {'column_name': 'threshold', 'data_type': 'bigint'},
+                ],
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert not any('mismatched numeric types' in s for s in suggestions)
+
+    def test_join_char_length_difference_not_flagged(self):
+        """Join between varchar(10) and varchar(20) should NOT be flagged (no cast)."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_NONE',
+                'join_condition': '(a.code = b.code)',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'a',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'code',
+                        'data_type': 'character varying(10)',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            },
+            {
+                'schema_name': 'public',
+                'table_name': 'b',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'code',
+                        'data_type': 'character varying(20)',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert not any('mismatched numeric types' in s for s in suggestions)
+
+    def test_join_same_numeric_type_not_flagged(self):
+        """Join between columns with the same numeric type should not be flagged."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_NONE',
+                'join_condition': '(a.x = b.y)',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'a',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'x',
+                        'data_type': 'bigint',
+                        'redshift_encoding': 'az64',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            },
+            {
+                'schema_name': 'public',
+                'table_name': 'b',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'y',
+                        'data_type': 'bigint',
+                        'redshift_encoding': 'az64',
+                        'redshift_sortkey_position': 1,
+                    },
+                ],
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert not any('mismatched numeric types' in s for s in suggestions)
+
+    def test_join_condition_without_types_not_flagged(self):
+        """Missing data_type info on one side should silently skip the mismatch check."""
+        nodes = [
+            {
+                'node_id': 1,
+                'operation': 'Hash Join',
+                'distribution_type': 'DS_DIST_NONE',
+                'join_condition': '(a.x = b.y)',
+            }
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'a',
+                'columns': [{'column_name': 'x'}],  # no data_type
+            },
+            {
+                'schema_name': 'public',
+                'table_name': 'b',
+                'columns': [{'column_name': 'y', 'data_type': 'bigint'}],
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, table_designs)
+        assert not any('mismatched numeric types' in s for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_mixed_categories_returns_full_response_shape(self, mocker):
+        """SQL mixing every reference category yields the full response shape."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        # Call 1: plain EXPLAIN. Two operation lines (root + ``->``)
+        # produce two ``plan_nodes`` entries.
+        explain_response = (
+            {
+                'Records': [
+                    [
+                        {
+                            'stringValue': 'XN Hash Join DS_DIST_NONE  '
+                            '(cost=10.00..50.00 rows=200 width=64)'
+                        }
+                    ],
+                    [
+                        {
+                            'stringValue': '  ->  XN Seq Scan on users  '
+                            '(cost=0.00..10.00 rows=1000 width=27)'
+                        }
+                    ],
+                ]
+            },
+            'explain-query-id',
+        )
+
+        # Call 2: BARE_TABLE_CANDIDATES_SQL.
+        candidates_response = (
+            {
+                'Records': [
+                    [{'stringValue': 'public'}, {'stringValue': 'orders'}],
+                    [{'stringValue': 'public'}, {'stringValue': 'users'}],
+                    [{'stringValue': 'tpch'}, {'stringValue': 'orders'}],
+                ]
+            },
+            'candidates-query-id',
+        )
+
+        # Call 3: TABLES_EXTRA_BY_PAIRS_SQL — batched metadata for the resolved pair set.
+        tables_extra_response = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'public'},
+                        {'stringValue': 'orders'},
+                        {'stringValue': 'KEY'},
+                        {'longValue': 5_000_000},
+                        {'longValue': 5000},
+                        {'longValue': 1_000_000},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                    ],
+                    [
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'KEY'},
+                        {'longValue': 1000},
+                        {'longValue': 5},
+                        {'longValue': 100},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                    ],
+                    [
+                        {'stringValue': 'tpch'},
+                        {'stringValue': 'orders'},
+                        {'stringValue': 'KEY'},
+                        {'longValue': 2_000_000},
+                        {'longValue': 50},
+                        {'longValue': 500_000},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                    ],
+                ]
+            },
+            'tables-extra-query-id',
+        )
+
+        # Call 4: COLUMN_STATS_SQL. Empty result is fine for the
+        # integration assertions; ``test_smoke`` already covers
+        # column-stats merging.
+        column_stats_response = ({'Records': []}, 'column-stats-query-id')
+
+        # Call 5: COLUMNS_BY_PAIRS_SQL — batched columns for all three
+        # resolved pairs. Each row has the 17 fields the helper unpacks.
+        def _columns_row(schema: str, table: str) -> list[dict]:
+            return [
+                {'stringValue': 'dev'},
+                {'stringValue': schema},
+                {'stringValue': table},
+                {'stringValue': f'{table}_id'},
+                {'longValue': 1},
+                {'stringValue': None},
+                {'stringValue': 'YES'},
+                {'stringValue': 'integer'},
+                {'longValue': None},
+                {'longValue': None},
+                {'longValue': None},
+                {'stringValue': None},
+                {'stringValue': 'lzo'},
+                {'booleanValue': False},
+                {'longValue': 0},
+                {'stringValue': None},
+                {'longValue': None},
+            ]
+
+        columns_by_pairs_response = (
+            {
+                'Records': [
+                    _columns_row('public', 'orders'),
+                    _columns_row('public', 'users'),
+                    _columns_row('tpch', 'orders'),
+                ]
+            },
+            'columns-query-id',
+        )
+
+        mock_execute_protected.side_effect = [
+            explain_response,
+            candidates_response,
+            tables_extra_response,
+            column_stats_response,
+            columns_by_pairs_response,
+        ]
+
+        sql = (
+            'SELECT u.id FROM tpch.orders o '
+            'JOIN users u ON u.id = o.user_id '
+            'JOIN orders o2 ON o2.id = o.parent_id '
+            'JOIN prod_db.tpch.line_items li ON li.order_id = o.id'
+        )
+
+        result = await describe_execution_plan('test-cluster', 'dev', sql)
+
+        # ----- Plan path assertions -----
+        assert result['query_id'] == 'explain-query-id'
+        assert result['explained_query'] == sql
+        assert result['planning_time_ms'] >= 0
+        assert result['plan_text'] == (
+            'XN Hash Join DS_DIST_NONE  (cost=10.00..50.00 rows=200 width=64)\n'
+            '  ->  XN Seq Scan on users  (cost=0.00..10.00 rows=1000 width=27)'
+        )
+        assert len(result['plan_nodes']) == 2
+        assert result['plan_nodes'][0]['operation'] == 'XN Hash Join DS_DIST_NONE'
+        assert result['plan_nodes'][1]['operation'] == 'XN Seq Scan'
+        assert result['plan_nodes'][1].get('relation_name') == 'users'
+
+        # ----- Notes: exactly one cross-database + one ambiguity -----
+        notes = result['notes']
+        assert isinstance(notes, list)
+        cross_db_notes = [n for n in notes if 'cross-database' in n]
+        ambiguity_notes = [n for n in notes if 'ambiguous' in n]
+        not_found_notes = [n for n in notes if 'was not found' in n]
+
+        assert len(cross_db_notes) == 1, f'expected exactly one cross-database note; got {notes!r}'
+        assert 'prod_db.tpch.line_items' in cross_db_notes[0]
+        assert '"dev"' in cross_db_notes[0]
+        assert len(ambiguity_notes) == 1, f'expected exactly one ambiguity note; got {notes!r}'
+        assert 'orders' in ambiguity_notes[0]
+        # Both schemas should be named in the ambiguity note.
+        assert 'public' in ambiguity_notes[0]
+        assert 'tpch' in ambiguity_notes[0]
+        assert not_found_notes == [], f'no reference should be not-found here; got {notes!r}'
+
+        # ----- table_designs -----
+        # Three pairs: (public, orders), (public, users), (tpch, orders).
+        # The cross-database reference is absent.
+        designs = result['table_designs']
+        pair_set = {(td['schema_name'], td['table_name']) for td in designs}
+        assert pair_set == {
+            ('public', 'orders'),
+            ('public', 'users'),
+            ('tpch', 'orders'),
+        }
+        # No design entry for the cross-database table.
+        assert not any(td['table_name'] == 'line_items' for td in designs)
+
+        # Metadata merged from TABLES_EXTRA_BY_PAIRS_SQL.
+        public_users = next(
+            td for td in designs if td['schema_name'] == 'public' and td['table_name'] == 'users'
+        )
+        assert public_users['redshift_diststyle'] == 'KEY'
+        assert public_users['redshift_estimated_row_count'] == 1000
+        assert len(public_users['columns']) == 1
+        assert public_users['columns'][0]['column_name'] == 'users_id'
+
+        # ----- rule_based_suggestions ----- ``public.orders`` has 1M sequential scans, no SORTKEY, 5M estimated rows, KEY diststyle — every condition for the SORTKEY emission rule is met.
+        assert isinstance(result['rule_based_suggestions'], list)
+        sortkey_suggestions = [
+            s
+            for s in result['rule_based_suggestions']
+            if 'SORTKEY' in s and 'sequential scans' in s
+        ]
+        assert any('public.orders' in s for s in sortkey_suggestions), (
+            f'expected a SORTKEY suggestion for public.orders; '
+            f'got {result["rule_based_suggestions"]!r}'
+        )
+
+        # ----- Call-count audit: cross-database reference triggers no
+        # additional metadata fetch. Five protected statements run:
+        # EXPLAIN, BARE_TABLE_CANDIDATES_SQL, TABLES_EXTRA_BY_PAIRS_SQL,
+        # COLUMN_STATS_SQL, and COLUMNS_BY_PAIRS_SQL.
+        assert mock_execute_protected.call_count == 5
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'sql',
+        [
+            'EXPLAIN SELECT * FROM users',
+            'explain SELECT * FROM users',
+            'Explain SELECT * FROM users',
+            'eXpLaIn SELECT * FROM users',
+            '   EXPLAIN SELECT 1',
+            '\tEXPLAIN SELECT 1',
+        ],
+    )
+    async def test_explain_prefixed_sql_rejected_no_statement_executed(self, mocker, sql):
+        """SQL prefixed with ``EXPLAIN`` (case-insensitive) raises and runs no statement."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_discover_columns = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_columns'
+        )
+
+        with pytest.raises(
+            Exception,
+            match='SQL already contains EXPLAIN. Please provide the query without EXPLAIN.',
+        ):
+            await describe_execution_plan('test-cluster', 'dev', sql)
+
+        mock_execute_protected.assert_not_called()
+        mock_discover_columns.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'sql',
+        ['', ' ', '   ', '\t', '\n', '\r\n', '   \n\t  '],
+    )
+    async def test_empty_or_whitespace_sql_rejected_no_statement_executed(self, mocker, sql):
+        """Empty / whitespace-only SQL raises and runs no statement."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_discover_columns = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_columns'
+        )
+
+        with pytest.raises(
+            Exception,
+            match='SQL is required and must not be empty or whitespace.',
+        ):
+            await describe_execution_plan('test-cluster', 'dev', sql)
+
+        mock_execute_protected.assert_not_called()
+        mock_discover_columns.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_explain_output_returns_empty_plan_text_and_nodes(self, mocker):
+        """Empty ``EXPLAIN`` output → response with empty plan_text and plan_nodes."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        # Empty EXPLAIN output.
+        empty_explain_response = ({'Records': []}, 'empty-explain-query-id')
+        mock_execute_protected.side_effect = [empty_explain_response]
+
+        mock_discover_columns = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_columns'
+        )
+
+        result = await describe_execution_plan('test-cluster', 'dev', 'SELECT 1')
+
+        assert result['plan_text'] == ''
+        assert result['plan_nodes'] == []
+        assert result['query_id'] == 'empty-explain-query-id'
+        assert result['explained_query'] == 'SELECT 1'
+        # No tables → no table_designs and no metadata fetch.
+        assert result['table_designs'] == []
+        # No reference → no ambiguity / not-found / cross-db notes.
+        assert result['notes'] == []
+        # Carry-over rule-based suggestions are still a list (empty).
+        assert isinstance(result['rule_based_suggestions'], list)
+
+        # Only the ``EXPLAIN`` ran. No bare references → no candidates
+        # call. No resolved pairs → no tables_extra call and no
+        # column_stats call.
+        assert mock_execute_protected.call_count == 1
+        mock_discover_columns.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cross_database_reference_emits_note_skips_metadata_fetch(self, mocker):
+        """Database-qualified ref to a different DB emits a note, no metadata fetch."""
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        explain_response = (
+            {
+                'Records': [
+                    [
+                        {
+                            'stringValue': 'XN Seq Scan on line_items  '
+                            '(cost=0.00..1.00 rows=10 width=8)'
+                        }
+                    ],
+                ]
+            },
+            'cross-db-explain-query-id',
+        )
+        mock_execute_protected.side_effect = [explain_response]
+
+        mock_discover_columns = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_columns'
+        )
+
+        sql = 'SELECT id FROM prod_db.tpch.line_items'
+        result = await describe_execution_plan('test-cluster', 'dev', sql)
+
+        # ----- Notes: exactly one cross-database note -----
+        notes = result['notes']
+        cross_db_notes = [n for n in notes if 'cross-database' in n]
+        assert len(cross_db_notes) == 1
+        assert 'prod_db.tpch.line_items' in cross_db_notes[0]
+        assert '"dev"' in cross_db_notes[0]
+
+        # ----- No metadata fetched for the cross-database reference -----
+        assert result['table_designs'] == []
+
+        # ----- Call-count audit: only the EXPLAIN ran.
+        assert mock_execute_protected.call_count == 1
+        mock_discover_columns.assert_not_called()
+
+        # Plan path still works.
+        assert (
+            result['plan_text'] == 'XN Seq Scan on line_items  (cost=0.00..1.00 rows=10 width=8)'
+        )
+        assert len(result['plan_nodes']) == 1
+
+    def test_tables_extra_by_pairs_sql_constant_is_importable_and_non_empty(self):
+        """The constant must be importable and contain SQL text."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+
+        assert isinstance(TABLES_EXTRA_BY_PAIRS_SQL, str)
+        assert TABLES_EXTRA_BY_PAIRS_SQL.strip() != ''
+
+    def test_format_with_schema_table_pairs_renders_without_keyerror(self):
+        """Formatting with ``schema_table_pairs`` must not raise ``KeyError``."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+
+        rendered = TABLES_EXTRA_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+
+        assert isinstance(rendered, str)
+        assert rendered.strip() != ''
+
+    def test_tables_extra_by_pairs_sql_format_leaves_no_unfilled_placeholders(self):
+        """The rendered SQL must have no leftover ``{...}`` placeholders."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+
+        rendered = TABLES_EXTRA_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+
+        # No bare format placeholders like {foo} should remain. This is a
+        # broader check than a specific name lookup so any future stray
+        # placeholder is also caught.
+        leftovers = regex.findall(r'\{[^{}]*\}', rendered)
+        assert leftovers == [], f'Rendered SQL still contains unfilled placeholders: {leftovers!r}'
+
+    def test_format_substitutes_pair_list_into_query(self):
+        """The rendered text must contain the substituted pair-list literal."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+
+        rendered = TABLES_EXTRA_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+
+        assert "('s','t')" in rendered
+
+    def test_rendered_sql_looks_like_a_select_statement(self):
+        """The rendered SQL must look like a real SELECT against catalog tables."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+
+        rendered = TABLES_EXTRA_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+        upper = rendered.upper()
+
+        assert 'SELECT' in upper
+        assert 'FROM' in upper
+        assert 'IN' in upper
+
+    def test_columns_by_pairs_sql_constant_is_importable_and_non_empty(self):
+        """The constant must be importable and contain SQL text."""
+        from awslabs.redshift_mcp_server.consts import COLUMNS_BY_PAIRS_SQL
+
+        assert isinstance(COLUMNS_BY_PAIRS_SQL, str)
+        assert COLUMNS_BY_PAIRS_SQL.strip() != ''
+
+    def test_columns_by_pairs_sql_format_renders_without_keyerror(self):
+        """Formatting with ``schema_table_pairs`` must not raise ``KeyError``."""
+        from awslabs.redshift_mcp_server.consts import COLUMNS_BY_PAIRS_SQL
+
+        rendered = COLUMNS_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+
+        assert isinstance(rendered, str)
+        assert rendered.strip() != ''
+
+    def test_columns_by_pairs_sql_format_leaves_no_unfilled_placeholders(self):
+        """The rendered SQL must have no leftover ``{...}`` placeholders."""
+        from awslabs.redshift_mcp_server.consts import COLUMNS_BY_PAIRS_SQL
+
+        rendered = COLUMNS_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+
+        leftovers = regex.findall(r'\{[^{}]*\}', rendered)
+        assert leftovers == [], f'Rendered SQL still contains unfilled placeholders: {leftovers!r}'
+
+    def test_columns_by_pairs_sql_substitutes_pair_list_into_query(self):
+        """The rendered text must contain the substituted pair-list literal."""
+        from awslabs.redshift_mcp_server.consts import COLUMNS_BY_PAIRS_SQL
+
+        rendered = COLUMNS_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+
+        # Both UNION branches reference the same {schema_table_pairs}
+        # slot, so the rendered literal appears in both.
+        assert rendered.count("('s','t')") >= 2
+
+    def test_columns_by_pairs_sql_unions_internal_and_external_columns(self):
+        """The rendered SQL must UNION both column views."""
+        from awslabs.redshift_mcp_server.consts import COLUMNS_BY_PAIRS_SQL
+
+        rendered = COLUMNS_BY_PAIRS_SQL.format(schema_table_pairs="('s','t')")
+        upper = rendered.upper()
+
+        assert 'SVV_REDSHIFT_COLUMNS' in upper
+        assert 'SVV_EXTERNAL_COLUMNS' in upper
+        assert 'UNION ALL' in upper
+
+    def test_one_node_per_operation_line(self):
+        """A 3-operation-line plan produces exactly 3 nodes."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join DS_BCAST_INNER  (cost=0.00..1.00 rows=1 width=8)',
+            '  Hash Cond: (a.id = b.id)',
+            '  ->  Seq Scan on a  (cost=0.00..1.00 rows=1 width=8)',
+            '        Filter: (x > 0)',
+            '  ->  Seq Scan on b  (cost=0.00..1.00 rows=1 width=8)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        # Three operation lines (root + two ``->``) → three nodes.
+        assert len(result) == 3
+
+    def test_detail_lines_attach_to_most_recent_operation_node(self):
+        """Hash Cond / Filter / Sort Key / Merge Key land on the right node."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Merge Join  (cost=0.00..1.00 rows=1 width=8)',
+            '  Merge Cond: (a.id = b.id)',
+            '  Sort Key: a.id',
+            '  ->  Seq Scan on a  (cost=0.00..1.00 rows=1 width=8)',
+            '        Filter: (a.x > 0)',
+            '  ->  Seq Scan on b  (cost=0.00..1.00 rows=1 width=8)',
+            '        Merge Key: b.id',
+        ]
+
+        result = _parse_plan_text(records)
+
+        # Three operation nodes in document order (Merge Join, Seq Scan a,
+        # Seq Scan b). Each detail line attached to the most recently
+        # seen operation node.
+        assert len(result) == 3
+        merge_join, scan_a, scan_b = result
+
+        # ``Merge Cond:`` maps to ``join_condition``; attached
+        # to the Merge Join node.
+        assert merge_join.join_condition == '(a.id = b.id)'
+        # ``Sort Key:`` also attached to the Merge Join.
+        assert merge_join.sort_key == 'a.id'
+
+        # ``Filter:`` attached to the first Seq Scan (most
+        # recent operation node when the detail line was seen).
+        assert scan_a.filter_condition == '(a.x > 0)'
+        assert scan_a.join_condition is None
+        assert scan_a.sort_key is None
+
+        # ``Merge Key:`` attached to the second Seq Scan.
+        assert scan_b.merge_key == 'b.id'
+        assert scan_b.filter_condition is None
+
+    def test_operation_name_with_cost_and_relation_segments_dropped(self):
+        """``Seq Scan on users (cost=...)`` → ``operation == 'Seq Scan'``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['Seq Scan on users  (cost=0.00..1.00 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].operation == 'Seq Scan'
+
+    def test_operation_name_without_cost_block(self):
+        """``XN Aggregate`` (no ``(cost=...)``) → ``operation == 'XN Aggregate'``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        result = _parse_plan_text(['XN Aggregate'])
+
+        assert result[0].operation == 'XN Aggregate'
+        # No cost block → all four cost fields unset.
+        node = result[0]
+        assert node.cost_startup is None
+        assert node.cost_total is None
+        assert node.rows is None
+        assert node.width is None
+
+    def test_operation_name_with_arrow_prefix_is_stripped(self):
+        """A leading ``->`` is stripped from the extracted operation name."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN root  (cost=0.00..1.00 rows=1 width=8)',
+            '  ->  XN Hash Join DS_BCAST_INNER  (cost=0..1 rows=1 width=8)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        # The arrow line is the second operation node; the ``->`` is gone from ``operation`` and the ``DS_*`` token is preserved in the operation text (the distribution_type field is also populated separately).
+        assert result[1].operation == 'XN Hash Join DS_BCAST_INNER'
+
+    def test_relation_and_alias_extraction_seq_scan(self):
+        """``Seq Scan on users u`` → ``relation_name == 'users'``, ``alias == 'u'``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['Seq Scan on users u  (cost=0.00..1.00 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.relation_name == 'users'
+        assert node.alias == 'u'
+
+    def test_relation_extraction_without_alias(self):
+        """``Seq Scan on users (cost=...)`` → relation set, alias ``None``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['Seq Scan on users  (cost=0.00..1.00 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.relation_name == 'users'
+        assert node.alias is None
+
+    def test_relation_extraction_index_scan_backward(self):
+        """``Index Scan Backward on orders`` → ``relation_name == 'orders'``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['Index Scan Backward on orders  (cost=0.00..1.00 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.relation_name == 'orders'
+
+    def test_cost_block_extraction(self):
+        """Cost block populates startup/total floats and rows/width ints."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['Hash Join  (cost=12.34..56.78 rows=100 width=64)']
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.cost_startup == 12.34
+        assert node.cost_total == 56.78
+        assert node.rows == 100
+        assert node.width == 64
+        # Cost fields are numeric, not strings.
+        assert isinstance(node.cost_startup, float)
+        assert isinstance(node.cost_total, float)
+        assert isinstance(node.rows, int)
+        assert isinstance(node.width, int)
+
+    def test_cost_block_absent_leaves_all_four_fields_unset(self):
+        """An operation line without ``cost=...`` leaves all cost fields ``None``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        # No cost block on this operation line.
+        result = _parse_plan_text(['Sort'])
+        node = result[0]
+
+        assert node.cost_startup is None
+        assert node.cost_total is None
+        assert node.rows is None
+        assert node.width is None
+
+    def test_distribution_type_extraction_bcast_inner(self):
+        """``DS_BCAST_INNER`` token populates ``distribution_type``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join DS_BCAST_INNER  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type == 'DS_BCAST_INNER'
+
+    def test_distribution_type_extraction_dist_inner(self):
+        """``DS_DIST_INNER`` token populates ``distribution_type``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join DS_DIST_INNER  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type == 'DS_DIST_INNER'
+
+    def test_distribution_type_extraction_dist_all_inner(self):
+        """``DS_DIST_ALL_INNER`` token populates ``distribution_type``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join DS_DIST_ALL_INNER  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type == 'DS_DIST_ALL_INNER'
+
+    def test_distribution_type_extraction_dist_none(self):
+        """``DS_DIST_NONE`` token populates ``distribution_type``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join DS_DIST_NONE  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type == 'DS_DIST_NONE'
+
+    def test_distribution_type_extraction_dist_all_none(self):
+        """``DS_DIST_ALL_NONE`` token populates ``distribution_type``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join DS_DIST_ALL_NONE  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type == 'DS_DIST_ALL_NONE'
+
+    def test_distribution_type_extraction_dist_outer(self):
+        """``DS_DIST_OUTER`` token populates ``distribution_type``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join DS_DIST_OUTER  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type == 'DS_DIST_OUTER'
+
+    def test_distribution_type_absent_leaves_field_unset(self):
+        """A line without any ``DS_*`` token leaves ``distribution_type`` ``None``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = ['XN Hash Join  (cost=0..1 rows=1 width=8)']
+
+        result = _parse_plan_text(records)
+
+        assert result[0].distribution_type is None
+
+    def test_detail_line_hash_cond_maps_to_join_condition(self):
+        """``Hash Cond:`` populates ``join_condition``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join  (cost=0..1 rows=1 width=8)',
+            '  Hash Cond: (a.id = b.id)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].join_condition == '(a.id = b.id)'
+
+    def test_detail_line_merge_cond_maps_to_join_condition(self):
+        """``Merge Cond:`` populates ``join_condition``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Merge Join  (cost=0..1 rows=1 width=8)',
+            '  Merge Cond: (a.id = b.id)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].join_condition == '(a.id = b.id)'
+
+    def test_detail_line_join_filter_maps_to_join_filter(self):
+        """``Join Filter:`` populates ``join_filter``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join  (cost=0..1 rows=1 width=8)',
+            '  Join Filter: (a.x > b.x)',
+        ]
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.join_filter == '(a.x > b.x)'
+        assert node.join_condition is None
+        assert node.filter_condition is None
+
+    def test_detail_line_hash_cond_and_join_filter_coexist_on_hash_join(self):
+        """``Hash Cond:`` and ``Join Filter:`` populate distinct fields on the same node."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join  (cost=0..1 rows=1 width=8)',
+            '  Hash Cond: (a.id = b.id)',
+            "  Join Filter: (a.name ~~ 'foo%'::text)",
+        ]
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.join_condition == '(a.id = b.id)'
+        assert node.join_filter == "(a.name ~~ 'foo%'::text)"
+
+    def test_detail_line_merge_cond_and_join_filter_coexist_on_merge_join(self):
+        """``Merge Cond:`` and ``Join Filter:`` populate distinct fields on the same node."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Merge Join  (cost=0..1 rows=1 width=8)',
+            '  Merge Cond: (a.id = b.id)',
+            '  Join Filter: (a.x > b.x)',
+        ]
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.join_condition == '(a.id = b.id)'
+        assert node.join_filter == '(a.x > b.x)'
+
+    def test_detail_line_filter_maps_to_filter_condition(self):
+        """``Filter:`` populates ``filter_condition``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'Seq Scan on users  (cost=0..1 rows=1 width=8)',
+            '  Filter: (id > 0)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].filter_condition == '(id > 0)'
+
+    def test_detail_line_sort_key_maps_to_sort_key(self):
+        """``Sort Key:`` populates ``sort_key``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Sort  (cost=0..1 rows=1 width=8)',
+            '  Sort Key: orders.o_orderkey',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].sort_key == 'orders.o_orderkey'
+
+    def test_detail_line_merge_key_maps_to_merge_key(self):
+        """``Merge Key:`` populates ``merge_key``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Merge  (cost=0..1 rows=1 width=8)',
+            '  Merge Key: orders.o_orderkey',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].merge_key == 'orders.o_orderkey'
+
+    @pytest.mark.parametrize(
+        'detail_text',
+        [
+            'Send to leader',
+            'Send to slice 0',
+            'Distribute',
+            'Broadcast',
+            'Distribute Round Robin',
+        ],
+    )
+    def test_detail_line_data_movement_populates_data_movement(self, detail_text):
+        """Label-less Network detail line populates ``data_movement``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Limit  (cost=0..1 rows=1 width=8)',
+            '  ->  XN Network  (cost=0..1 rows=1 width=8)',
+            f'        {detail_text}',
+        ]
+
+        result = _parse_plan_text(records)
+        network_node = next(n for n in result if n.operation == 'XN Network')
+
+        assert network_node.data_movement == detail_text
+
+    def test_unrecognized_detail_line_does_not_populate_data_movement(self):
+        """Unknown label-less detail lines leave ``data_movement`` as None."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Network  (cost=0..1 rows=1 width=8)',
+            '  Some Unknown Annotation',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].data_movement is None
+
+    def test_detail_line_index_cond_maps_to_index_condition(self):
+        """``Index Cond:`` populates ``index_condition``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Index Scan using pg_class_oid_index on pg_class  (cost=0..1 rows=1 width=8)',
+            '  Index Cond: (oid > 1000::oid)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].index_condition == '(oid > 1000::oid)'
+
+    def test_detail_line_inner_dist_key_maps_to_inner_dist_key(self):
+        """``Inner Dist Key:`` populates ``inner_dist_key``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join DS_DIST_INNER  (cost=0..1 rows=1 width=8)',
+            '  Inner Dist Key: s.eventid',
+            '  Hash Cond: ("outer".eventid = "inner".eventid)',
+        ]
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.inner_dist_key == 's.eventid'
+        # Ensure existing labels still work alongside the new one.
+        assert node.join_condition == '("outer".eventid = "inner".eventid)'
+
+    def test_detail_line_partition_and_order_populate_window_fields(self):
+        """``Partition:`` and ``Order:`` populate window-function fields."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Window  (cost=0..1 rows=1 width=8)',
+            '  Partition: v.venuestate',
+            '  Order: sum(s.pricepaid)',
+        ]
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.partition_key == 'v.venuestate'
+        assert node.order_key == 'sum(s.pricepaid)'
+
+    def test_detail_line_outer_dist_key_maps_to_outer_dist_key(self):
+        """``Outer Dist Key:`` populates ``outer_dist_key``."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join DS_DIST_BOTH  (cost=0..1 rows=1 width=8)',
+            '  Outer Dist Key: s1.buyerid',
+            '  Inner Dist Key: s2.sellerid',
+            '  Hash Cond: ("outer".buyerid = "inner".sellerid)',
+        ]
+
+        result = _parse_plan_text(records)
+        node = result[0]
+
+        assert node.outer_dist_key == 's1.buyerid'
+        # Both dist-key labels coexist on a DS_DIST_BOTH node.
+        assert node.inner_dist_key == 's2.sellerid'
+        assert node.join_condition == '("outer".buyerid = "inner".sellerid)'
+
+    def test_detail_line_grouping_sets_populates_agg_strategy(self):
+        """``GROUPING SETS(...)`` populates ``agg_strategy`` verbatim."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN HashAggregate  (cost=0..1 rows=1 width=8)',
+            '  GROUPING SETS((a),(b),(a,b))',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert result[0].agg_strategy == 'GROUPING SETS((a),(b),(a,b))'
+
+    def test_document_order_preserved_across_operation_lines(self):
+        """Operation lines appear in ``plan_nodes`` in their document order."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Hash Join  (cost=0..10 rows=1 width=8)',
+            '  Hash Cond: (a.id = b.id)',
+            '  ->  XN Seq Scan on a  (cost=0..1 rows=1 width=8)',
+            '  ->  XN Hash  (cost=0..5 rows=1 width=8)',
+            '    ->  XN Seq Scan on b  (cost=0..2 rows=1 width=8)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        # Operations appear in the same order as their operation lines
+        # in the input records.
+        assert [n.operation for n in result] == [
+            'XN Hash Join',
+            'XN Seq Scan',
+            'XN Hash',
+            'XN Seq Scan',
+        ]
+        # The two Seq Scan nodes are distinguished by their relation
+        # name in document order: ``a`` before ``b``.
+        scan_relations = [n.relation_name for n in result if n.operation == 'XN Seq Scan']
+        assert scan_relations == ['a', 'b']
+
+    def test_tree_structure_derivable_from_level_and_position(self):
+        """Three-level plan: ``[node.level for node in plan_nodes]`` matches expected."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        # Indent: 0, 2, 2, 4 → levels 0, 1, 1, 2.
+        records = [
+            'XN Hash Join  (cost=0..10 rows=1 width=8)',
+            '  ->  XN Seq Scan on a  (cost=0..1 rows=1 width=8)',
+            '  ->  XN Hash  (cost=0..5 rows=1 width=8)',
+            '    ->  XN Seq Scan on b  (cost=0..2 rows=1 width=8)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        assert [n.level for n in result] == [0, 1, 1, 2]
+        # Sanity: the deepest node's parent (per the level rule) is the most recent preceding node at level 1, which is the ``XN Hash`` node at index 2 — confirming tree structure is derivable from ``level`` + position.
+        assert result[2].operation == 'XN Hash'
+        assert result[3].level == 2
+
+    def test_level_skip_does_not_drop_plan_nodes(self):
+        """Operation lines at any indent depth all produce nodes via the stack rule."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        # Root at indent 0, then a line indented 6 spaces — under the old rule this would have been level 3 (a forbidden skip).
+        records = ['root', '      ->  child']
+
+        result = _parse_plan_text(records)
+
+        assert [n.level for n in result] == [0, 1]
+        assert len(result) == 2
+
+    def test_real_redshift_six_space_per_level_indentation(self):
+        """Real Redshift output with 2/8/14/20/..."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        records = [
+            'XN Limit  (cost=0.00..0.00 rows=1 width=8)',
+            '  ->  XN Merge  (cost=0.00..0.00 rows=1 width=8)',
+            '        Merge Key: sum(s.pricepaid)',
+            '        ->  XN Network  (cost=0.00..0.00 rows=1 width=8)',
+            '              Send to leader',
+            '              ->  XN Sort  (cost=0.00..0.00 rows=1 width=8)',
+            '                    Sort Key: sum(s.pricepaid)',
+            '                    ->  XN HashAggregate  (cost=0.00..0.00 rows=1 width=8)',
+            '                          ->  XN Hash Join DS_BCAST_INNER  (cost=0.00..0.00 rows=1 width=8)',
+            '                                Hash Cond: ("outer".buyerid = "inner".userid)',
+            '                                ->  XN Seq Scan on sales s  (cost=0.00..0.00 rows=1 width=8)',
+            '                                ->  XN Hash  (cost=0.00..0.00 rows=1 width=8)',
+            '                                      ->  XN Seq Scan on users u  (cost=0.00..0.00 rows=1 width=8)',
+        ]
+
+        result = _parse_plan_text(records)
+
+        # All 9 operation lines (root + 8 arrow lines) produce nodes
+        # with contiguous levels.
+        assert len(result) == 9
+        assert [n.level for n in result] == [0, 1, 2, 3, 4, 5, 6, 6, 7]
+
+    @pytest.mark.parametrize(
+        'raw_records',
+        [
+            pytest.param([], id='empty'),
+            pytest.param(
+                ['XN Limit  (cost=0.00..0.07 rows=5 width=27)'],
+                id='root_only',
+            ),
+            pytest.param(
+                [
+                    'XN Hash Join DS_BCAST_INNER  (cost=10.00..50.00 rows=200 width=64)',
+                    '  ->  XN Seq Scan on users  (cost=0.00..10.00 rows=1000 width=27)',
+                    '        Hash Cond: (a.id = b.id)',
+                    '',
+                    '  ->  XN Seq Scan on orders o  (cost=0.00..5.00 rows=500 width=37)',
+                    '        Filter: (id > 0)',
+                ],
+                id='join_with_detail_and_blank_lines',
+            ),
+        ],
+    )
+    def test_parse_is_idempotent(self, raw_records):
+        """Parsing the same records twice yields equal node lists."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        first = _parse_plan_text(raw_records)
+        second = _parse_plan_text(raw_records)
+
+        assert first == second
+
+    @pytest.mark.parametrize(
+        'raw_records,expected_count',
+        [
+            pytest.param([], 0, id='empty'),
+            pytest.param(['root  (cost=0..1 rows=1 width=8)'], 1, id='root_only'),
+            pytest.param(
+                [
+                    'root  (cost=0..1 rows=1 width=8)',
+                    '  ->  child  (cost=0..1 rows=1 width=8)',
+                ],
+                2,
+                id='root_plus_one_arrow',
+            ),
+            pytest.param(
+                [
+                    'root  (cost=0..1 rows=1 width=8)',
+                    '  ->  Hash Join  (cost=0..1 rows=1 width=8)',
+                    '        Hash Cond: (a.id = b.id)',
+                    '        Filter: (a.x > 0)',
+                ],
+                2,
+                id='detail_lines_do_not_count',
+            ),
+            pytest.param(
+                [
+                    'root  (cost=0..1 rows=1 width=8)',
+                    '',
+                    '   ',
+                    '  ->  child  (cost=0..1 rows=1 width=8)',
+                ],
+                2,
+                id='blank_and_whitespace_lines_do_not_count',
+            ),
+            pytest.param(
+                [
+                    'root  (cost=0..1 rows=1 width=8)',
+                    '  ->  child1  (cost=0..1 rows=1 width=8)',
+                    '        ->  grandchild  (cost=0..1 rows=1 width=8)',
+                    '  ->  child2  (cost=0..1 rows=1 width=8)',
+                ],
+                4,
+                id='nested_arrow_levels',
+            ),
+        ],
+    )
+    def test_node_count_matches_operation_line_count(self, raw_records, expected_count):
+        """``len(plan_nodes)`` equals the count of operation lines."""
+        from awslabs.redshift_mcp_server.redshift import _parse_plan_text
+
+        nodes = _parse_plan_text(raw_records)
+
+        assert len(nodes) == expected_count
+
+    def test_emits_identifier_token_for_unquoted_word(self):
+        """An unquoted regular identifier emits a single ``'identifier'``."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('orders')
+
+        assert tokens == [type(tokens[0])(kind='identifier', value='orders')]
+
+    def test_preserves_identifier_case_for_unquoted(self):
+        """Unquoted identifier case is preserved as written."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('Orders')
+
+        assert tokens[0].value == 'Orders'
+
+    def test_keywords_recognized_case_insensitively(self):
+        """``from``, ``From``, ``FROM`` all emit a ``'keyword'`` ``'FROM'``."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        for sql in ('from', 'From', 'FROM', 'fRoM'):
+            tokens = _tokenize_sql(sql)
+            assert len(tokens) == 1
+            assert tokens[0].kind == 'keyword'
+            assert tokens[0].value == 'FROM'
+
+    def test_all_four_recognized_keywords(self):
+        """``WITH``, ``AS``, ``FROM``, ``JOIN`` all emit keyword tokens."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('with as from join')
+        kinds = [t.kind for t in tokens]
+        values = [t.value for t in tokens]
+
+        assert kinds == ['keyword'] * 4
+        assert values == ['WITH', 'AS', 'FROM', 'JOIN']
+
+    def test_select_is_not_a_recognized_keyword(self):
+        """``SELECT`` is NOT in the recognized-keyword set; emits identifier."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('SELECT')
+
+        # Only ``WITH``, ``AS``, ``FROM``, ``JOIN`` are tokenized as keywords.
+        assert len(tokens) == 1
+        assert tokens[0].kind == 'identifier'
+        assert tokens[0].value == 'SELECT'
+
+    def test_dot_emits_dot_token(self):
+        """The ``.`` separator emits a ``'dot'`` token (kind != ``'punctuation'``)."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('a.b')
+
+        assert [t.kind for t in tokens] == ['identifier', 'dot', 'identifier']
+        assert [t.value for t in tokens] == ['a', '.', 'b']
+
+    def test_dotted_identifier_sequence_three_parts(self):
+        """``db.schema.table`` produces alternating identifier/dot tokens."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('prod_db.tpch.orders')
+
+        assert [t.kind for t in tokens] == [
+            'identifier',
+            'dot',
+            'identifier',
+            'dot',
+            'identifier',
+        ]
+        assert [t.value for t in tokens] == ['prod_db', '.', 'tpch', '.', 'orders']
+
+    def test_grouping_punctuation_emits_punctuation_tokens(self):
+        """``(``, ``)``, ``,``, ``;`` each emit a ``'punctuation'`` token."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('(),;')
+
+        assert [t.kind for t in tokens] == ['punctuation'] * 4
+        assert [t.value for t in tokens] == ['(', ')', ',', ';']
+
+    def test_whitespace_is_consumed_and_not_emitted(self):
+        """Spaces, tabs, and newlines emit no tokens."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('a   b\tc\nd')
+
+        assert [t.value for t in tokens] == ['a', 'b', 'c', 'd']
+        assert all(t.kind == 'identifier' for t in tokens)
+
+    def test_empty_string_produces_no_tokens(self):
+        """An empty SQL string produces an empty token list."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        assert _tokenize_sql('') == []
+
+    def test_identifier_with_dollar_and_digits(self):
+        """An identifier may contain ``$`` and digits after the first char."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('table_1$ extra2')
+
+        assert [t.value for t in tokens] == ['table_1$', 'extra2']
+        assert all(t.kind == 'identifier' for t in tokens)
+
+    def test_identifier_cannot_start_with_digit(self):
+        """An identifier cannot start with a digit; the digit is silently skipped."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        # ``9foo`` — the leading digit is not in the start-char set, so
+        # the scanner skips it; ``foo`` then begins a fresh identifier.
+        tokens = _tokenize_sql('9foo')
+
+        # Note: digits as identifier-start are not currently produced by the scanner — the current behavior is to silently skip the leading digit and pick up the trailing identifier characters as a regular identifier.
+        assert tokens == [type(tokens[0])(kind='identifier', value='foo')]
+
+    def test_single_quoted_string_literal_emits_no_tokens(self):
+        """A ``'...'`` literal emits no tokens; the literal text is consumed."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql("'abc def'")
+
+        assert tokens == []
+
+    def test_single_quoted_string_with_doubled_quote_escape(self):
+        """A ``''`` inside ``'...'`` is an escape and does not close the literal."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        # The literal contains an escaped single quote: ``can't``. The
+        # scanner must consume the entire literal and emit nothing. The
+        # ``orders`` token after it must still be tokenized.
+        tokens = _tokenize_sql("'can''t' orders")
+
+        assert tokens == [type(tokens[0])(kind='identifier', value='orders')]
+
+    def test_string_literal_does_not_produce_false_references(self):
+        """Identifier-looking text inside a string literal must not emit tokens."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql("select x from 'literal FROM tpch.orders' real_table")
+
+        # The identifier-looking text inside the literal (``literal``,
+        # ``FROM``, ``tpch``, ``orders``) must NOT appear as tokens.
+        values = [t.value for t in tokens]
+        assert 'literal' not in values
+        assert 'tpch' not in values
+        assert 'orders' not in values
+        # The identifier after the literal IS tokenized.
+        assert 'real_table' in values
+
+    def test_double_quoted_identifier_emits_one_token_with_quotes_consumed(self):
+        """``"foo"`` emits one ``'identifier'`` token with value ``foo``."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('"foo"')
+
+        assert len(tokens) == 1
+        assert tokens[0].kind == 'identifier'
+        assert tokens[0].value == 'foo'
+
+    def test_double_quoted_identifier_preserves_case(self):
+        """Double-quoted identifiers preserve original case."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('"MixedCase"')
+
+        assert tokens[0].value == 'MixedCase'
+
+    def test_double_quoted_identifier_with_embedded_doubled_quote_is_one_token(self):
+        """A ``""`` inside ``"..."`` is an escape that becomes a single ``"``."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        # The identifier is ``foo"bar`` (a quote in the middle). Encoded
+        # in SQL as ``"foo""bar"``. The scanner must emit a single
+        # identifier token with the un-escaped value.
+        tokens = _tokenize_sql('"foo""bar"')
+
+        assert len(tokens) == 1
+        assert tokens[0].kind == 'identifier'
+        assert tokens[0].value == 'foo"bar'
+
+    def test_double_quoted_identifier_can_contain_spaces(self):
+        """A double-quoted identifier may contain whitespace and punctuation."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('"my table.col"')
+
+        assert len(tokens) == 1
+        assert tokens[0].value == 'my table.col'
+
+    def test_double_quoted_keyword_is_not_tokenized_as_keyword(self):
+        """``"FROM"`` is an identifier, not the FROM keyword (case preserved)."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('"FROM"')
+
+        # Double-quoted text is always an identifier — keyword
+        # recognition only applies to unquoted words.
+        assert tokens[0].kind == 'identifier'
+        assert tokens[0].value == 'FROM'
+
+    def test_line_comment_to_end_of_line_emits_no_tokens(self):
+        """``-- ...`` consumes through the next newline and emits nothing."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('a -- ignored from tpch.orders\n b')
+
+        # ``a`` and ``b`` survive; everything between ``--`` and the
+        # newline is silently consumed.
+        assert [t.value for t in tokens] == ['a', 'b']
+
+    def test_line_comment_at_end_of_input_without_newline(self):
+        """A trailing ``-- ...`` without a newline still consumes the rest."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('a -- trailing comment with no newline')
+
+        assert [t.value for t in tokens] == ['a']
+
+    def test_block_comment_emits_no_tokens(self):
+        """``/* ... */`` consumes content and emits nothing."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('a /* ignored from tpch.orders */ b')
+
+        assert [t.value for t in tokens] == ['a', 'b']
+
+    def test_block_comment_is_not_nested_first_close_wins(self):
+        """``/* /* still in comment */`` — the first ``*/`` closes the comment."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        # Per the non-nested rule, the ``*/`` after ``still in comment`` closes the comment.
+        tokens = _tokenize_sql('/* /* still in comment */ trailing */')
+
+        # The single surviving identifier is ``trailing``. The trailing
+        # ``*/`` characters are skipped as non-identifier punctuation.
+        assert [t.value for t in tokens] == ['trailing']
+
+    def test_unterminated_block_comment_consumes_to_end(self):
+        """An unterminated ``/* ...`` consumes through end-of-input silently."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        tokens = _tokenize_sql('a /* never closes')
+
+        assert [t.value for t in tokens] == ['a']
+
+    def test_realistic_select_statement_yields_expected_token_stream(self):
+        """A realistic FROM/JOIN clause yields a recognizable token sequence."""
+        from awslabs.redshift_mcp_server.redshift import _tokenize_sql
+
+        sql = 'SELECT a FROM tpch.orders o JOIN customers AS c ON o.x = c.x;'
+        tokens = _tokenize_sql(sql)
+
+        # Build a (kind, value) projection so the assertion stays
+        # readable.
+        projection = [(t.kind, t.value) for t in tokens]
+
+        # Operators ``=`` and the column-list ``a`` are silently
+        # consumed (the scanner doesn't know about column lists; the
+        # categorization layer tracks FROM/JOIN positions).
+        assert projection == [
+            ('identifier', 'SELECT'),
+            ('identifier', 'a'),
+            ('keyword', 'FROM'),
+            ('identifier', 'tpch'),
+            ('dot', '.'),
+            ('identifier', 'orders'),
+            ('identifier', 'o'),
+            ('keyword', 'JOIN'),
+            ('identifier', 'customers'),
+            ('keyword', 'AS'),
+            ('identifier', 'c'),
+            ('identifier', 'ON'),
+            ('identifier', 'o'),
+            ('dot', '.'),
+            ('identifier', 'x'),
+            ('identifier', 'c'),
+            ('dot', '.'),
+            ('identifier', 'x'),
+            ('punctuation', ';'),
+        ]
+
+    def test_extract_returns_empty_list_placeholder(self):
+        """``extract`` on ``SELECT * FROM tpch.orders`` returns one schema-qualified reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        result = _extract_sql_references('SELECT * FROM tpch.orders')
+
+        assert result == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_sql_reference_extract_error_is_defined_and_subclass_of_exception(self):
+        """``SqlReferenceExtractError`` is exported and inherits from ``Exception``."""
+        from awslabs.redshift_mcp_server.redshift import SqlReferenceExtractError
+
+        # Defined now for use by tasks 6.2 and 6.6 to signal
+        # malformed dotted-identifier sequences and empty/whitespace
+        # SQL. Not raised by itself.
+        assert issubclass(SqlReferenceExtractError, Exception)
+
+    # -----------------------------------------------------------------
+    # Categorization
+    # -----------------------------------------------------------------
+
+    def test_bare_reference_one_part(self):
+        """``FROM orders`` emits one ``BARE`` reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM orders')
+
+        assert refs == [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+        ]
+
+    def test_schema_qualified_reference_two_parts(self):
+        """``FROM tpch.orders`` emits one ``SCHEMA_QUALIFIED`` reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM tpch.orders')
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_database_qualified_reference_three_parts(self):
+        """``FROM prod_db.tpch.orders`` emits a ``DATABASE_QUALIFIED`` reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_DATABASE_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM prod_db.tpch.orders')
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                database_name='prod_db',
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_join_clause_emits_reference(self):
+        """``JOIN <ref>`` is a FROM/JOIN position and emits a reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM tpch.orders JOIN tpch.customers'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='customers',
+            ),
+        ]
+
+    def test_comma_separated_from_list_emits_each_reference(self):
+        """``FROM a, b`` emits one reference per comma-separated table."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM orders, customers')
+
+        assert refs == [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+            TableReference(category=TABLE_REF_BARE, table_name='customers'),
+        ]
+
+    def test_comma_separated_from_list_with_alias_emits_each_reference(self):
+        """``FROM a o, b c`` emits two references; aliases are not emitted."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM orders o, customers c')
+
+        assert refs == [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+            TableReference(category=TABLE_REF_BARE, table_name='customers'),
+        ]
+
+    def test_alias_with_as_keyword_does_not_become_reference(self):
+        """``FROM a AS o`` consumes the alias and emits only ``a``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM tpch.orders AS o')
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Identifier case preservation
+    # -----------------------------------------------------------------
+
+    def test_identifier_case_preserved_unquoted(self):
+        """Unquoted identifier case is preserved exactly as written."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_DATABASE_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('select * from MyDB.MySchema.MyTable')
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                database_name='MyDB',
+                schema_name='MySchema',
+                table_name='MyTable',
+            ),
+        ]
+
+    def test_keywords_are_recognized_case_insensitively(self):
+        """``from`` and ``FROM`` both arm the FROM/JOIN position."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        for sql in (
+            'select * from tpch.orders',
+            'SELECT * FROM tpch.orders',
+            'SeLeCt * FrOm tpch.orders',
+        ):
+            refs = _extract_sql_references(sql)
+            assert refs == [
+                TableReference(
+                    category=TABLE_REF_SCHEMA_QUALIFIED,
+                    schema_name='tpch',
+                    table_name='orders',
+                ),
+            ]
+
+    # -----------------------------------------------------------------
+    # Parse-failure contract
+    # -----------------------------------------------------------------
+
+    def test_zero_part_sequence_at_from_position_raises(self):
+        """``FROM ,`` (no identifier after FROM) raises ``SqlReferenceExtractError``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        # ``FROM`` followed by a comma — the next position expects a
+        # table identifier but gets punctuation. Per the parse-failure
+        # contract, this is a 0-part sequence.
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('SELECT 1 FROM , customers')
+
+    def test_zero_part_sequence_at_join_position_raises(self):
+        """``JOIN ;`` raises ``SqlReferenceExtractError`` (0-part at JOIN)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('SELECT 1 FROM a JOIN ;')
+
+    def test_four_part_sequence_raises(self):
+        """``FROM a.b.c.d`` raises ``SqlReferenceExtractError`` (4+ parts)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('SELECT * FROM a.b.c.d')
+
+    # -----------------------------------------------------------------
+    # Deduplication () — pinned here in the
+    # categorization class because dedup is the final layer on top of
+    # FROM/JOIN-position categorization.
+    # -----------------------------------------------------------------
+
+    def test_repeated_reference_is_deduplicated(self):
+        """Identical schema-qualified references collapse to one."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM tpch.orders JOIN tpch.orders ON 1=1')
+
+        # Per the second emission is collapsed; first
+        # occurrence wins to preserve source order.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_bare_and_schema_qualified_are_not_deduplicated(self):
+        """``orders`` and ``tpch.orders`` are distinct ``TableReference`` records."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM tpch.orders JOIN orders ON 1=1')
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='orders',
+            ),
+        ]
+
+    def test_dedup_preserves_first_occurrence_source_order(self):
+        """Across multiple repeats and interleaved tables, source order is preserved."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = (
+            'SELECT * FROM tpch.orders '
+            'JOIN tpch.customers '
+            'JOIN tpch.orders ON 1=1 '
+            'JOIN tpch.customers ON 1=1'
+        )
+        refs = _extract_sql_references(sql)
+
+        # First occurrence wins: orders before customers; both repeats
+        # collapsed.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='customers',
+            ),
+        ]
+
+    def test_dedup_is_case_sensitive_on_identifiers(self):
+        """``Orders`` and ``orders`` are NOT deduplicated."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM tpch.Orders JOIN tpch.orders ON 1=1')
+
+        # Case-preserved identifiers participate in dedup
+        # under exact tuple equality — different case, no
+        # collapse.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='Orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_cte_name_excluded_after_task_6_3(self):
+        """``WITH cte AS (...)`` causes ``cte`` to be excluded as a table reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'WITH cte AS (SELECT 1) SELECT * FROM cte'
+        refs = _extract_sql_references(sql)
+
+        # ``cte`` is a CTE name, so the BARE reference at ``FROM cte``
+        # is excluded; no real-table references in this SQL.
+        assert refs == []
+        # Specifically: ``cte`` MUST NOT appear as a BARE reference.
+        assert all(ref.table_name != 'cte' for ref in refs), (
+            f'CTE name should be excluded, got: {refs}'
+        )
+        # Belt-and-braces: also confirm a hypothetical BARE ``cte`` is
+        # not in the emitted list.
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+        )
+
+        assert TableReference(category=TABLE_REF_BARE, table_name='cte') not in refs
+
+    def test_single_cte_name_excluded_at_top_level_select(self):
+        """``WITH a AS (...) SELECT * FROM a`` emits no references."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        refs = _extract_sql_references('WITH a AS (SELECT 1) SELECT * FROM a')
+
+        assert refs == []
+
+    def test_multiple_comma_separated_ctes_all_excluded(self):
+        """All names in a single ``WITH`` clause register in the same frame."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        sql = (
+            'WITH a AS (SELECT 1), b AS (SELECT 2), c AS (SELECT 3) '
+            'SELECT * FROM a JOIN b ON 1=1 JOIN c ON 1=1'
+        )
+        refs = _extract_sql_references(sql)
+
+        # All three references are CTE names; nothing emitted.
+        assert refs == []
+
+    def test_real_table_alongside_cte_still_emitted(self):
+        """Real tables in the main statement still appear; only CTE names are excluded."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'WITH cte AS (SELECT 1) SELECT * FROM cte JOIN tpch.orders ON 1=1'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_real_table_inside_cte_body_emitted(self):
+        """Tables inside a CTE body are real references and must be emitted."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'WITH recent AS (SELECT * FROM tpch.orders) SELECT * FROM recent'
+        refs = _extract_sql_references(sql)
+
+        # ``tpch.orders`` is a real schema-qualified reference inside
+        # the CTE body. ``recent`` at the top level is a CTE name and
+        # must be excluded.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_cte_name_shadows_real_table(self):
+        """A CTE name shadows a real table of the same name."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        # ``orders`` would normally be a BARE reference, but the
+        # ``WITH orders AS (...)`` clause shadows it.
+        sql = 'WITH orders AS (SELECT 1) SELECT * FROM orders'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+
+    def test_schema_qualified_reference_never_treated_as_cte(self):
+        """Even when a CTE name matches the table half, ``schema.table`` is NOT excluded."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'WITH orders AS (SELECT 1) SELECT * FROM tpch.orders'
+        refs = _extract_sql_references(sql)
+
+        # ``tpch.orders`` is schema-qualified and is therefore emitted
+        # even though ``orders`` is in scope as a CTE name.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_database_qualified_reference_never_treated_as_cte(self):
+        """``db.schema.table`` is emitted even when ``table`` is a CTE name."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_DATABASE_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'WITH orders AS (SELECT 1) SELECT * FROM prod_db.tpch.orders'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                database_name='prod_db',
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_cte_name_match_is_case_sensitive(self):
+        """CTE-name matching uses the original-case identifier value."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # ``Orders`` is registered as a CTE name (mixed case). A BARE
+        # reference to ``orders`` (lowercase) is a DIFFERENT identifier
+        # by case-sensitive comparison and therefore is NOT excluded.
+        sql = 'WITH Orders AS (SELECT 1) SELECT * FROM orders'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+        ]
+
+    def test_nested_with_inside_cte_body_pushes_inner_frame(self):
+        """A ``WITH`` inside a CTE body produces a nested frame."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # ``inner`` is a CTE in the inner WITH; ``outer`` is the outer CTE; ``tpch.orders`` is a real table referenced inside the inner CTE body.
+        sql = (
+            'WITH outer_cte AS ('
+            '    WITH inner_cte AS (SELECT * FROM tpch.orders) '
+            '    SELECT * FROM inner_cte'
+            ') '
+            'SELECT * FROM outer_cte JOIN tpch.users ON 1=1'
+        )
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='users',
+            ),
+        ]
+
+    def test_inner_cte_name_does_not_leak_to_outer_scope(self):
+        """An inner-WITH CTE name is excluded only inside its frame, not after pop."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # ``inner_cte`` is registered inside the outer CTE body.
+        sql = (
+            'WITH outer_cte AS ('
+            '    WITH inner_cte AS (SELECT 1) SELECT * FROM inner_cte'
+            ') '
+            'SELECT * FROM inner_cte'
+        )
+        refs = _extract_sql_references(sql)
+
+        # The inner ``FROM inner_cte`` is excluded (inner frame
+        # active). The outer ``FROM inner_cte`` (after inner frame
+        # popped) is emitted as a BARE reference.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='inner_cte',
+            ),
+        ]
+
+    def test_innermost_frame_wins_for_shadowing(self):
+        """When a name appears in both inner and outer frames, exclusion still applies."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        # ``a`` is defined in both the outer and inner WITH.
+        sql = 'WITH a AS (    WITH a AS (SELECT 1) SELECT * FROM a) SELECT * FROM a'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+
+    def test_with_recursive_modifier_supported(self):
+        """The optional ``RECURSIVE`` keyword between ``WITH`` and the first CTE is skipped."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        sql = 'WITH RECURSIVE r AS (SELECT 1) SELECT * FROM r'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+
+    def test_with_clause_with_column_list_collected(self):
+        """A CTE may include an optional ``(col1, col2)`` column list before ``AS``."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        sql = 'WITH a (x, y) AS (SELECT 1, 2) SELECT * FROM a'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+
+    def test_cte_in_subquery_does_not_affect_outer_scope(self):
+        """A WITH inside a parenthesized subquery only scopes inside that paren."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # The inner WITH defines ``q`` in a frame at depth 1.
+        sql = 'SELECT * FROM tpch.orders WHERE x IN (    WITH q AS (SELECT 1) SELECT * FROM q)'
+        refs = _extract_sql_references(sql)
+
+        # Outer ``FROM tpch.orders`` is emitted; inner ``FROM q`` is
+        # excluded by the inner frame.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Subquery alias
+    # -----------------------------------------------------------------
+
+    def test_subquery_alias_not_emitted_with_as(self):
+        """``FROM (SELECT ...) AS sub`` does not emit ``sub``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM (SELECT 1) AS sub'
+        refs = _extract_sql_references(sql)
+
+        # No table references: the subquery body has no FROM, and
+        # ``sub`` is a subquery alias (excluded).
+        assert refs == []
+        assert TableReference(category=TABLE_REF_BARE, table_name='sub') not in refs
+
+    def test_subquery_alias_not_emitted_without_as(self):
+        """``FROM (SELECT ...) sub`` does not emit ``sub``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM (SELECT 1) sub'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+        assert TableReference(category=TABLE_REF_BARE, table_name='sub') not in refs
+
+    def test_subquery_body_scanned_for_inner_table_references(self):
+        """Inner ``FROM tpch.orders`` is emitted; alias is not."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM (SELECT * FROM tpch.orders) AS sub'
+        refs = _extract_sql_references(sql)
+
+        # The inner table reference is emitted; the subquery alias
+        # ``sub`` is not.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_subquery_alias_in_join_position(self):
+        """``JOIN (SELECT ...) j`` does not emit ``j``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM tpch.orders o JOIN (SELECT * FROM tpch.customers) j ON o.cid = j.cid'
+        refs = _extract_sql_references(sql)
+
+        # Both inner table references are emitted; ``j`` and ``o``
+        # (column aliases) are not.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='customers',
+            ),
+        ]
+
+    def test_subquery_followed_by_comma_rearms_from_list(self):
+        """``FROM (SELECT ...) a, t`` emits ``t`` (alias-comma re-arm)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM (SELECT 1) a, tpch.orders'
+        refs = _extract_sql_references(sql)
+
+        # ``a`` is a subquery alias (not emitted); ``tpch.orders``
+        # after the comma is.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_subquery_with_no_alias_does_not_emit(self):
+        """``FROM (SELECT ...)`` with no alias still excludes inner from raising."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        # A subquery with no trailing alias is unusual but should not
+        # emit anything for the missing alias and should not raise.
+        # (The inner body has no FROM, so no references at all.)
+        sql = 'SELECT * FROM (SELECT 1)'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+
+    def test_nested_subquery_excludes_all_aliases(self):
+        """Nested ``FROM (SELECT ... FROM (SELECT ...) inner) outer`` excludes both aliases."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = (
+            'SELECT * FROM ('
+            '  SELECT * FROM ('
+            '    SELECT * FROM tpch.orders'
+            '  ) inner_alias'
+            ') outer_alias'
+        )
+        refs = _extract_sql_references(sql)
+
+        # Only the deepest table reference is emitted; both aliases
+        # are excluded.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Column alias
+    # -----------------------------------------------------------------
+
+    def test_column_alias_after_schema_qualified_not_emitted(self):
+        """``FROM tpch.orders o`` emits only ``tpch.orders``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM tpch.orders o'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+        # ``o`` is not emitted as a separate reference.
+        assert TableReference(category=TABLE_REF_BARE, table_name='o') not in refs
+
+    def test_column_alias_with_as_keyword_not_emitted(self):
+        """``FROM tpch.orders AS o`` emits only ``tpch.orders``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM tpch.orders AS o'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    def test_column_alias_after_bare_reference_not_emitted(self):
+        """``FROM orders o`` emits only ``orders``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM orders o'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='orders',
+            ),
+        ]
+
+    def test_join_with_column_aliases_emits_both_tables(self):
+        """``FROM users u JOIN orders o`` emits ``users`` and ``orders``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM users u JOIN orders o ON u.id = o.uid'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='users',
+            ),
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: Three categorized forms (bare, schema-qualified,
+    # database-qualified). 4.4, 4.5.
+    # -----------------------------------------------------------------
+
+    def test_three_forms_in_one_query_each_categorized_correctly(self):
+        """A single SQL with all three reference forms emits one of each."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TABLE_REF_DATABASE_QUALIFIED,
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM orders JOIN tpch.customers ON 1=1 JOIN prod_db.tpch.line_items ON 1=1'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='customers',
+            ),
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                database_name='prod_db',
+                schema_name='tpch',
+                table_name='line_items',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: Identifier case preserved; keywords matched
+    # case-insensitively. Validates .
+    # -----------------------------------------------------------------
+
+    def test_identifier_case_preserved_keywords_case_insensitive_at_extract_layer(self):
+        """Keywords match in any case; identifier case is preserved exactly."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_DATABASE_QUALIFIED,
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # Mixed keyword case (``SeLeCt``, ``FrOm``, ``JoIn``, ``oN``) must still recognize FROM and JOIN; identifier case (``MyDb``, ``MyTpch``, ``MyOrders``) must be preserved verbatim in the emitted references.
+        sql = 'SeLeCt * FrOm MyDb.MyTpch.MyOrders JoIn AnotherSchema.AnotherTable oN 1=1'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                database_name='MyDb',
+                schema_name='MyTpch',
+                table_name='MyOrders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='AnotherSchema',
+                table_name='AnotherTable',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: CTE name exclusion (single, multiple comma-separated,
+    # nested WITH). 5.5.
+    # -----------------------------------------------------------------
+
+    def test_cte_exclusion_single_multiple_and_nested_in_one_query(self):
+        """Single, multiple comma-separated, and nested WITH CTEs are all excluded."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = (
+            'WITH a AS (SELECT 1), b AS (SELECT 2) '
+            'SELECT * FROM ('
+            '    WITH c AS (SELECT * FROM tpch.orders) SELECT * FROM c'
+            ') sub '
+            'JOIN a ON 1=1 '
+            'JOIN b ON 1=1'
+        )
+        refs = _extract_sql_references(sql)
+
+        # ``a``, ``b``, ``c`` are all CTE names and must be excluded.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: Subquery alias exclusion (with and without ``AS``).
+    # Validates .
+    # -----------------------------------------------------------------
+
+    def test_subquery_alias_exclusion_with_and_without_as_in_one_query(self):
+        """A query mixing ``(...) AS sub`` and ``(...) sub`` excludes both aliases."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = (
+            'SELECT * FROM (SELECT * FROM tpch.orders) AS sub_with_as '
+            'JOIN (SELECT * FROM tpch.customers) sub_without_as ON 1=1'
+        )
+        refs = _extract_sql_references(sql)
+
+        # Both aliases excluded; only the real inner tables are
+        # emitted.
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='customers',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: Column alias not emitted (``FROM tpch.orders o`` →
+    # only ``tpch.orders``). Validates .
+    # -----------------------------------------------------------------
+
+    def test_column_alias_not_emitted_explicit_orders_o_case(self):
+        """The exact case from the bullet: ``FROM tpch.orders o`` emits only ``tpch.orders``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        refs = _extract_sql_references('SELECT * FROM tpch.orders o')
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: CTE name shadowing real table → CTE wins.
+    # Validates .
+    # -----------------------------------------------------------------
+
+    def test_cte_name_shadowing_real_bare_table_cte_wins(self):
+        """A CTE name shadows a same-name real table reference."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        # ``orders`` would normally be a BARE reference, but the
+        # ``WITH orders AS (...)`` clause shadows it. Per the
+        # CTE wins: no real-table reference emitted.
+        sql = 'WITH orders AS (SELECT 1) SELECT * FROM orders'
+        refs = _extract_sql_references(sql)
+
+        assert refs == []
+
+    # -----------------------------------------------------------------
+    # Bullet: Deduplication of identical references. Validates .
+    # -----------------------------------------------------------------
+
+    def test_deduplication_of_identical_references_at_extract_layer(self):
+        """Repeated identical references collapse to one."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # ``tpch.orders`` appears three times; dedup collapses to one.
+        sql = 'SELECT * FROM tpch.orders JOIN tpch.orders ON 1=1 JOIN tpch.orders ON 1=1'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                schema_name='tpch',
+                table_name='orders',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: String literals, double-quoted identifiers, line and
+    # block comments do not produce false references. Validates
+    # 4.7.
+    #
+    # The tokenizer class already pins this at the token level
+    # (string literals and comments emit no tokens; double-quoted
+    # text always emits an identifier with original case). These
+    # tests pin the same property at the ``extract()`` boundary so a
+    # regression in the categorization layer can't sneak a
+    # false-positive reference past the dedicated extract tests.
+    # -----------------------------------------------------------------
+
+    def test_string_literal_text_does_not_produce_table_reference(self):
+        """``'FROM tpch.orders'`` inside a literal emits no reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        # Only the real ``FROM real_table`` outside the literal emits a reference.
+        sql = "SELECT 'FROM tpch.orders' AS x FROM real_table"
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='real_table',
+            ),
+        ]
+
+    def test_line_comment_text_does_not_produce_table_reference(self):
+        """``-- FROM tpch.orders`` inside a line comment emits no reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * -- FROM tpch.orders\nFROM real_table'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='real_table',
+            ),
+        ]
+
+    def test_block_comment_text_does_not_produce_table_reference(self):
+        """``/* FROM tpch.orders */`` inside a block comment emits no reference."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * /* FROM tpch.orders */ FROM real_table'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='real_table',
+            ),
+        ]
+
+    def test_double_quoted_identifier_emits_real_reference_with_preserved_case(self):
+        """A double-quoted identifier participates in references with original case."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _extract_sql_references,
+        )
+
+        sql = 'SELECT * FROM "MixedCase"'
+        refs = _extract_sql_references(sql)
+
+        assert refs == [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='MixedCase',
+            ),
+        ]
+
+    # -----------------------------------------------------------------
+    # Bullet: Empty/whitespace SQL → parse error.
+    #
+    # Validates ``_extract_sql_references`` parse-failure
+    # contract: empty or whitespace-only SQL is rejected with
+    # :class:`SqlReferenceExtractError` rather than silently returning
+    # an empty list. The simplest sufficient implementation rule is
+    # "no productive tokens": the scanner consumes whitespace, line
+    # comments, and block comments silently, so an SQL that contains
+    # only those constructs produces zero tokens and is rejected at
+    # the same boundary as a truly empty input.
+    # -----------------------------------------------------------------
+
+    def test_empty_sql_raises(self):
+        """``extract('')`` raises :class:`SqlReferenceExtractError`."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('')
+
+    def test_whitespace_only_sql_raises(self):
+        """``extract('   ')`` raises :class:`SqlReferenceExtractError`."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('   ')
+
+    def test_whitespace_with_newlines_and_tabs_raises(self):
+        """Pure whitespace including newlines and tabs raises."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references(' \t\n\r\n  \t ')
+
+    def test_line_comment_only_sql_raises(self):
+        """``extract('-- only a comment')`` raises (no productive tokens)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('-- only a comment')
+
+    def test_block_comment_only_sql_raises(self):
+        """A block-comment-only SQL raises (no productive tokens)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('/* only a block comment */')
+
+    def test_mixed_whitespace_and_comments_only_raises(self):
+        """SQL containing only whitespace and comments raises."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        # Newline-separated mix of line and block comments with
+        # interleaved whitespace. None of these emit tokens, so the
+        # parse-failure contract triggers.
+        sql = '  -- a line comment\n  /* a block comment */\n   '
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references(sql)
+
+    def test_non_empty_sql_with_no_from_clause_does_not_raise(self):
+        """``SELECT 1`` has tokens (productive) but no FROM/JOIN; returns ``[]`` without raising."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        refs = _extract_sql_references('SELECT 1')
+
+        assert refs == []
+
+    # -----------------------------------------------------------------
+    # Bullet: Malformed reference (0 or 4+ parts) → parse error.
+    ## -----------------------------------------------------------------
+
+    def test_zero_part_at_from_position_raises(self):
+        """``FROM ,`` raises :class:`SqlReferenceExtractError` (0-part)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('SELECT 1 FROM , customers')
+
+    def test_four_part_at_from_position_raises(self):
+        """``FROM a.b.c.d`` raises :class:`SqlReferenceExtractError` (4+ parts)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('SELECT * FROM a.b.c.d')
+
+    def test_five_part_at_from_position_raises(self):
+        """A 5-part dotted sequence is also rejected (not silently truncated)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            SqlReferenceExtractError,
+            _extract_sql_references,
+        )
+
+        with pytest.raises(SqlReferenceExtractError):
+            _extract_sql_references('SELECT * FROM a.b.c.d.e')
+
+    @pytest.mark.parametrize(
+        'sql',
+        [
+            pytest.param('SELECT * FROM users', id='simple'),
+            pytest.param(
+                'WITH cte AS (SELECT 1 AS a) SELECT * FROM cte JOIN users ON cte.a = users.id',
+                id='cte_shadowing',
+            ),
+            pytest.param(
+                'SELECT * FROM (SELECT id FROM tickit.sales) s JOIN tickit.event e ON s.id = e.eventid',
+                id='subquery_with_schema_qualified',
+            ),
+        ],
+    )
+    def test_extract_is_stable_across_invocations(self, sql):
+        """Calling the extractor twice on the same SQL yields equal output."""
+        from awslabs.redshift_mcp_server.redshift import _extract_sql_references
+
+        first = _extract_sql_references(sql)
+        second = _extract_sql_references(sql)
+
+        assert first == second
+
+    def test_render_schema_table_pairs_empty_iterable_returns_empty_string(self):
+        """Empty input → empty string, no parentheses, no commas."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        assert _render_schema_table_pairs([]) == ''
+        assert _render_schema_table_pairs(iter(())) == ''
+        assert _render_schema_table_pairs(set()) == ''
+
+    def test_single_pair_renders_as_one_quoted_tuple(self):
+        """One pair → exactly one ``('<schema>','<table>')`` literal."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs([('public', 'orders')])
+
+        assert rendered == "('public','orders')"
+
+    def test_multiple_pairs_joined_by_comma_no_space(self):
+        """Multiple pairs are joined by ``,`` with no surrounding whitespace."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs([('public', 'orders'), ('tpch', 'lineitem')])
+
+        # Pairs are sorted ascending by (schema, table); ``public`` <
+        # ``tpch`` so ``public`` appears first.
+        assert rendered == "('public','orders'),('tpch','lineitem')"
+        assert ', ' not in rendered
+
+    def test_pairs_are_sorted_for_deterministic_output(self):
+        """Different iteration orders produce byte-identical output."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        pairs = [('zeta', 't'), ('alpha', 't'), ('beta', 't')]
+        from_list = _render_schema_table_pairs(pairs)
+        from_set = _render_schema_table_pairs(set(pairs))
+        from_reversed = _render_schema_table_pairs(reversed(pairs))
+
+        assert from_list == "('alpha','t'),('beta','t'),('zeta','t')"
+        assert from_list == from_set == from_reversed
+
+    def test_sorts_by_table_within_same_schema(self):
+        """Within a schema, pairs sort ascending by table name."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs(
+            [('s', 'orders'), ('s', 'customers'), ('s', 'lineitem')]
+        )
+
+        assert rendered == "('s','customers'),('s','lineitem'),('s','orders')"
+
+    def test_single_quote_in_schema_is_doubled(self):
+        """A literal ``'`` in the schema component is doubled (``''``)."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs([("o'reilly", 'orders')])
+
+        assert rendered == "('o''reilly','orders')"
+
+    def test_single_quote_in_table_is_doubled(self):
+        """A literal ``'`` in the table component is doubled (``''``)."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs([('public', "weird'name")])
+
+        assert rendered == "('public','weird''name')"
+
+    def test_multiple_quotes_in_one_value_each_doubled(self):
+        """Every literal ``'`` is doubled, regardless of count."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs([("a'b'c", "x'y")])
+
+        assert rendered == "('a''b''c','x''y')"
+
+    def test_render_schema_table_pairs_case_preserved_exactly(self):
+        """Identifier case is preserved as written."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        rendered = _render_schema_table_pairs([('PuBlIc', 'OrDeRs')])
+
+        assert rendered == "('PuBlIc','OrDeRs')"
+
+    def test_render_schema_table_pairs_repeated_calls_are_idempotent(self):
+        """Same input → byte-identical output across calls."""
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        pairs = [('s2', 't2'), ('s1', 't1')]
+
+        first = _render_schema_table_pairs(pairs)
+        second = _render_schema_table_pairs(pairs)
+
+        assert first == second
+
+    def test_rendered_fragment_drops_into_tables_extra_by_pairs_sql(self):
+        """The rendered fragment formats cleanly into the SQL constant."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+        from awslabs.redshift_mcp_server.redshift import _render_schema_table_pairs
+
+        fragment = _render_schema_table_pairs([('public', 'orders'), ('tpch', 'lineitem')])
+
+        rendered = TABLES_EXTRA_BY_PAIRS_SQL.format(schema_table_pairs=fragment)
+
+        # No leftover ``{...}`` placeholders, and the literal pair-list
+        # appears in the resulting SQL exactly as rendered.
+
+        assert not regex.search(r'\{[a-zA-Z_]+\}', rendered)
+        assert fragment in rendered
+
+    @pytest.mark.asyncio
+    async def test_empty_pairs_executes_zero_statements(self, mocker):
+        """Empty pair set → no batched query executed, returns ``{}``."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs=set(),
+        )
+
+        assert result == {}
+        mock_execute_protected.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_pair_executes_exactly_one_statement(self, mocker):
+        """Single pair → exactly one ``TABLES_EXTRA_BY_PAIRS_SQL`` call."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_many_pairs_still_executes_exactly_one_statement(self, mocker):
+        """50 pairs → still exactly one batched call."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        pairs = {('public', f't{i}') for i in range(50)}
+
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs=pairs,
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_invokes_tables_extra_by_pairs_sql_with_rendered_pair_list(self, mocker):
+        """SQL passed to ``_execute_protected_statement`` is the formatted constant."""
+        from awslabs.redshift_mcp_server.consts import TABLES_EXTRA_BY_PAIRS_SQL
+        from awslabs.redshift_mcp_server.redshift import (
+            _fetch_table_metadata,
+            _render_schema_table_pairs,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        pairs = {('public', 'orders'), ('tpch', 'lineitem')}
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs=pairs,
+        )
+
+        # Exactly one call, with the SQL formed from the constant and
+        # the rendered pair-list helper.
+        ((), kwargs) = (
+            mock_execute_protected.call_args.args,
+            mock_execute_protected.call_args.kwargs,
+        )
+        expected_sql = TABLES_EXTRA_BY_PAIRS_SQL.format(
+            schema_table_pairs=_render_schema_table_pairs(pairs)
+        )
+        assert kwargs['sql'] == expected_sql
+        assert kwargs['cluster_identifier'] == 'c1'
+        assert kwargs['database_name'] == 'dev'
+
+    @pytest.mark.asyncio
+    async def test_parses_response_into_pair_keyed_metadata_dict(self, mocker):
+        """Response rows parse into ``(schema, table) -> RedshiftTable-shaped`` dict."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'public'},
+                        {'stringValue': 'orders'},
+                        {'stringValue': 'KEY'},
+                        {'longValue': 12345},
+                        {'longValue': 7},
+                        {'longValue': 90000},
+                        {'longValue': 1},
+                        {'longValue': 2},
+                        {'longValue': 3},
+                    ],
+                    [
+                        {'stringValue': 'tpch'},
+                        {'stringValue': 'lineitem'},
+                        {'stringValue': 'ALL'},
+                        {'longValue': 600000},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                    ],
+                ]
+            },
+            'qid',
+        )
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders'), ('tpch', 'lineitem')},
+        )
+
+        assert set(result.keys()) == {('public', 'orders'), ('tpch', 'lineitem')}
+        assert result[('public', 'orders')] == {
+            'redshift_diststyle': 'KEY',
+            'redshift_estimated_row_count': 12345,
+            'stats_sequential_scans': 7,
+            'stats_sequential_tuples_read': 90000,
+            'stats_rows_inserted': 1,
+            'stats_rows_updated': 2,
+            'stats_rows_deleted': 3,
+        }
+        assert result[('tpch', 'lineitem')] == {
+            'redshift_diststyle': 'ALL',
+            'redshift_estimated_row_count': 600000,
+            'stats_sequential_scans': 0,
+            'stats_sequential_tuples_read': 0,
+            'stats_rows_inserted': 0,
+            'stats_rows_updated': 0,
+            'stats_rows_deleted': 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_zero_records_returns_empty_mapping(self, mocker):
+        """Non-empty pair set but zero matching rows → empty mapping, one call."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_table_metadata_swallows_execute_protected_exception_returns_empty(
+        self, mocker
+    ):
+        """``_execute_protected_statement`` failure → ``{}``, no retry."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Data API failure')
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        # No retry: the batched call is attempted exactly once per
+        # ``fetch`` invocation, even when it raises.
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_table_metadata_swallows_row_parsing_exception_returns_empty(self, mocker):
+        """Malformed response rows → ``{}`` (no propagation)."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        # Each record has only 2 columns instead of the expected 9 →
+        # ``record[2].get(...)`` raises ``IndexError`` during parsing.
+        mock_execute_protected.return_value = (
+            {'Records': [[{'stringValue': 'public'}, {'stringValue': 'orders'}]]},
+            'qid',
+        )
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_table_metadata_logs_warning_on_execute_protected_exception(self, mocker):
+        """A warning is logged when the batched call fails."""
+        from awslabs.redshift_mcp_server import redshift as redshift_module
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('boom')
+
+        warning_spy = mocker.patch.object(redshift_module.logger, 'warning')
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        assert warning_spy.call_count == 1
+        # The warning message references the underlying error so an
+        # operator can see why the metadata mapping is empty.
+        warning_text = warning_spy.call_args.args[0]
+        assert 'boom' in warning_text
+
+    # -----------------------------------------------------------------
+    # Bullet: Empty pair set → no batched query executed.
+    # Validates .
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_empty_pair_set_executes_zero_statements_at_fetcher_boundary(self, mocker):
+        """``fetch(pairs=set())`` returns ``{}`` and never calls the protected statement."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs=set(),
+        )
+
+        assert result == {}
+        mock_execute_protected.assert_not_called()
+
+    # -----------------------------------------------------------------
+    # Bullet: Non-empty pair set (1, 50 pairs) → exactly one
+    # ``TABLES_EXTRA_BY_PAIRS_SQL`` invocation per call.
+    # 7.5, 7.7.
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_one_pair_executes_exactly_one_invocation_at_fetcher_boundary(self, mocker):
+        """One pair → exactly one batched call."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fifty_pairs_still_one_invocation_at_fetcher_boundary(self, mocker):
+        """50 pairs → still exactly one batched call."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        pairs = {('public', f't{i}') for i in range(50)}
+
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs=pairs,
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    # -----------------------------------------------------------------
+    # Bullet: Pair-list rendering: ``('<schema>','<table>')`` tuples.
+    # # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_rendered_pair_list_uses_quoted_tuple_form_in_executed_sql(self, mocker):
+        """The SQL handed to the executor contains ``('<schema>','<table>')`` tuples."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders'), ('tpch', 'lineitem')},
+        )
+
+        executed_sql = mock_execute_protected.call_args.kwargs['sql']
+        # Each pair appears in the executed SQL as a quoted 2-tuple,
+        # joined by a single ``,`` (no surrounding whitespace).
+        assert "('public','orders')" in executed_sql
+        assert "('tpch','lineitem')" in executed_sql
+        # And the pair-list fragment is comma-joined inside the SQL.
+        assert "('public','orders'),('tpch','lineitem')" in executed_sql
+
+    # -----------------------------------------------------------------
+    # Bullet: Single-quote escaping by doubling.
+    # Validates .
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_single_quote_in_pair_components_doubled_in_executed_sql(self, mocker):
+        """A literal ``'`` in either component is doubled in the executed SQL."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={("o'reilly", "weird'name")},
+        )
+
+        executed_sql = mock_execute_protected.call_args.kwargs['sql']
+        # The pair is rendered with each literal ``'`` doubled.
+        assert "('o''reilly','weird''name')" in executed_sql
+        # Sanity: no raw, unescaped single quote sequence appears
+        # inside the rendered pair (which would break the surrounding
+        # SQL string-literal quoting).
+        assert "'o'reilly'" not in executed_sql
+        assert "'weird'name'" not in executed_sql
+
+    # -----------------------------------------------------------------
+    # Bullet: Query failure → empty mapping returned, no retry,
+    # ``COLUMN_STATS_SQL`` fetch unaffected.
+    # # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_query_failure_returns_empty_mapping_with_no_retry(self, mocker):
+        """Any exception → ``{}``, exactly one attempted call (no retry)."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Data API failure')
+
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        # Exactly one attempted call; no retry on failure.
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_query_failure_does_not_block_independent_column_stats_call_site(self, mocker):
+        """A fetcher-side failure is contained: an independent."""
+        from awslabs.redshift_mcp_server import redshift as redshift_module
+        from awslabs.redshift_mcp_server.consts import COLUMN_STATS_SQL
+        from awslabs.redshift_mcp_server.redshift import _fetch_table_metadata
+
+        # First call (the fetcher's batched ``TABLES_EXTRA_BY_PAIRS_SQL``) raises; second call (representing the independent ``COLUMN_STATS_SQL`` site) succeeds.
+        column_stats_response = ({'Records': [['col_stats_record_marker']]}, 'qid_stats')
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement',
+            side_effect=[Exception('fetcher failure'), column_stats_response],
+        )
+
+        # Step 1: the fetcher's batched call fails; the fetcher
+        # swallows the exception and returns ``{}``.
+        result = await _fetch_table_metadata(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+
+        # Step 2: an independent ``_execute_protected_statement`` call representing the ``COLUMN_STATS_SQL`` site is unaffected by the prior failure.
+        column_stats_sql = COLUMN_STATS_SQL.format(schema_table_pairs="('public','orders')")
+        column_stats_result = await redshift_module._execute_protected_statement(
+            cluster_identifier='c1',
+            database_name='dev',
+            sql=column_stats_sql,
+        )
+
+        assert column_stats_result == column_stats_response
+        # The mock was called exactly twice — once by the fetcher
+        # (which raised) and once by the independent column-stats site
+        # (which succeeded). No retry on either path.
+        assert mock_execute_protected.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_empty_pair_set_executes_zero_statements(self, mocker):
+        """``_fetch_columns_by_pairs(pairs=set())`` returns ``{}`` and never calls the protected statement."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        result = await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs=set(),
+        )
+
+        assert result == {}
+        mock_execute_protected.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_one_pair_executes_exactly_one_invocation(self, mocker):
+        """One pair → exactly one batched call."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_parses_response_into_pair_keyed_columns_dict(
+        self, mocker
+    ):
+        """Response rows parse into ``(schema, table) -> [column_dict]`` mapping."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        def _row(schema: str, table: str, col: str, pos: int) -> list[dict]:
+            return [
+                {'stringValue': 'dev'},
+                {'stringValue': schema},
+                {'stringValue': table},
+                {'stringValue': col},
+                {'longValue': pos},
+                {'stringValue': None},
+                {'stringValue': 'YES'},
+                {'stringValue': 'integer'},
+                {'longValue': None},
+                {'longValue': None},
+                {'longValue': None},
+                {'stringValue': None},
+                {'stringValue': 'lzo'},
+                {'booleanValue': False},
+                {'longValue': 0},
+                {'stringValue': None},
+                {'longValue': None},
+            ]
+
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    _row('public', 'orders', 'id', 1),
+                    _row('public', 'orders', 'amount', 2),
+                    _row('tpch', 'lineitem', 'orderkey', 1),
+                ]
+            },
+            'qid',
+        )
+
+        result = await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders'), ('tpch', 'lineitem')},
+        )
+
+        assert set(result.keys()) == {('public', 'orders'), ('tpch', 'lineitem')}
+        # Two columns for orders (in source order); one column for lineitem.
+        assert [c['column_name'] for c in result[('public', 'orders')]] == ['id', 'amount']
+        assert [c['column_name'] for c in result[('tpch', 'lineitem')]] == ['orderkey']
+        # Per-column dict matches the discover_columns record shape.
+        first = result[('public', 'orders')][0]
+        assert first['database_name'] == 'dev'
+        assert first['data_type'] == 'integer'
+        assert first['redshift_encoding'] == 'lzo'
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_swallows_execute_protected_exception_returns_empty(
+        self, mocker
+    ):
+        """``_execute_protected_statement`` failure → ``{}``, no retry."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Data API failure')
+
+        result = await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_swallows_row_parsing_exception_returns_empty(
+        self, mocker
+    ):
+        """Malformed response rows → ``{}`` (no propagation)."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        # Two-column row truncates field unpacking and raises IndexError.
+        mock_execute_protected.return_value = (
+            {'Records': [[{'stringValue': 'dev'}, {'stringValue': 'public'}]]},
+            'qid',
+        )
+
+        result = await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_logs_warning_on_execute_protected_exception(
+        self, mocker
+    ):
+        """A warning is logged when the batched call fails."""
+        from awslabs.redshift_mcp_server import redshift as redshift_module
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('boom')
+
+        warning_spy = mocker.patch.object(redshift_module.logger, 'warning')
+
+        result = await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='dev',
+            pairs={('public', 'orders')},
+        )
+
+        assert result == {}
+        assert warning_spy.call_count == 1
+        warning_text = warning_spy.call_args.args[0]
+        assert 'boom' in warning_text
+
+    @pytest.mark.asyncio
+    async def test_fetch_columns_by_pairs_binds_database_name_for_cross_db_isolation(self, mocker):
+        """The connected database is bound on the SQL to scope columns to one database."""
+        from awslabs.redshift_mcp_server.redshift import _fetch_columns_by_pairs
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _fetch_columns_by_pairs(
+            cluster_identifier='c1',
+            database_name='sample_data_dev',
+            pairs={('tickit', 'sales')},
+        )
+
+        kwargs = mock_execute_protected.call_args.kwargs
+        # Both UNION branches must filter by the connected database.
+        assert 'database_name = :database_name' in kwargs['sql']
+        assert 'redshift_database_name = :database_name' in kwargs['sql']
+        assert kwargs['parameters'] == [{'name': 'database_name', 'value': 'sample_data_dev'}]
+
+    def test_bare_table_candidates_sql_constant_is_importable_and_non_empty(self):
+        """The constant must be importable and contain SQL text."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+
+        assert isinstance(BARE_TABLE_CANDIDATES_SQL, str)
+        assert BARE_TABLE_CANDIDATES_SQL.strip() != ''
+
+    def test_format_with_names_list_renders_without_keyerror(self):
+        """The constant must format with ``names_list`` cleanly."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+
+        rendered = BARE_TABLE_CANDIDATES_SQL.format(names_list="'orders','customers'")
+
+        assert isinstance(rendered, str)
+
+    def test_bare_table_candidates_sql_format_leaves_no_unfilled_placeholders(self):
+        """No leftover ``{...}`` format placeholders after substitution."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+
+        rendered = BARE_TABLE_CANDIDATES_SQL.format(names_list="'orders'")
+
+        # Bare format placeholders like ``{foo}`` should not remain.
+        # ``{{`` and ``}}`` literal braces are escaped form and are
+        # acceptable; this regex matches a single-brace placeholder.
+        assert regex.search(r'(?<!\{)\{[^{}]+\}(?!\})', rendered) is None
+
+    def test_format_substitutes_names_list_into_query(self):
+        """The rendered text must contain the substituted name-list literal."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+
+        rendered = BARE_TABLE_CANDIDATES_SQL.format(names_list="'orders','customers'")
+
+        assert "'orders','customers'" in rendered
+
+    def test_rendered_sql_uses_pg_class_and_pg_namespace(self):
+        """Rendered SQL queries pg_class joined with pg_namespace."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+
+        rendered = BARE_TABLE_CANDIDATES_SQL.format(names_list="'t'")
+        upper = rendered.upper()
+
+        assert 'PG_CLASS' in upper
+        assert 'PG_NAMESPACE' in upper
+        assert 'SELECT' in upper
+
+    def test_rendered_sql_filters_by_relname(self):
+        """Rendered SQL filters by ``c.relname``."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+
+        rendered = BARE_TABLE_CANDIDATES_SQL.format(names_list="'t'")
+
+        # The candidate-lookup is filtered by table name (relname).
+        # Whitespace around the operator is allowed; exact-match the
+        # core token sequence.
+        assert 'c.relname' in rendered
+
+    def test_render_name_list_empty_iterable_returns_empty_string(self):
+        """Empty input → empty string, no quotes, no commas."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        assert _render_name_list([]) == ''
+        assert _render_name_list(iter(())) == ''
+        assert _render_name_list(set()) == ''
+
+    def test_single_name_renders_as_one_quoted_literal(self):
+        """One name → exactly one ``'<name>'`` literal."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        rendered = _render_name_list(['orders'])
+
+        assert rendered == "'orders'"
+
+    def test_multiple_names_joined_by_comma_no_space(self):
+        """Multiple names are joined by ``,`` with no surrounding whitespace."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        rendered = _render_name_list(['orders', 'customers'])
+
+        # Sorted ascending → ``'customers','orders'``.
+        assert rendered == "'customers','orders'"
+
+    def test_names_are_sorted_for_deterministic_output(self):
+        """Different iteration orders produce byte-identical output."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        names = ['zeta', 'alpha', 'beta']
+        from_list = _render_name_list(names)
+        from_set = _render_name_list(set(names))
+        from_reversed = _render_name_list(reversed(names))
+
+        assert from_list == "'alpha','beta','zeta'"
+        assert from_list == from_set == from_reversed
+
+    def test_duplicate_names_are_deduplicated(self):
+        """Repeated names render exactly once in the output."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        rendered = _render_name_list(['orders', 'orders', 'customers'])
+
+        assert rendered == "'customers','orders'"
+
+    def test_single_quote_in_name_is_doubled(self):
+        """A literal ``'`` in a name is doubled (``''``)."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        rendered = _render_name_list(["o'reilly"])
+
+        assert rendered == "'o''reilly'"
+
+    def test_multiple_quotes_in_one_name_each_doubled(self):
+        """Every literal ``'`` in a name is doubled, regardless of count."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        rendered = _render_name_list(["a'b'c"])
+
+        assert rendered == "'a''b''c'"
+
+    def test_render_name_list_case_preserved_exactly(self):
+        """Identifier case is preserved as written."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        rendered = _render_name_list(['Orders', 'customers'])
+
+        # Sort is case-sensitive (uppercase before lowercase in ASCII),
+        # but the values are emitted with original case preserved.
+        assert "'Orders'" in rendered
+        assert "'customers'" in rendered
+
+    def test_render_name_list_repeated_calls_are_idempotent(self):
+        """Same input → byte-identical output across calls."""
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        names = ['t2', 't1']
+
+        first = _render_name_list(names)
+        second = _render_name_list(names)
+
+        assert first == second
+
+    def test_rendered_fragment_drops_into_bare_table_candidates_sql(self):
+        """The rendered fragment formats cleanly into the SQL constant."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+        from awslabs.redshift_mcp_server.redshift import _render_name_list
+
+        fragment = _render_name_list(['orders', 'customers'])
+
+        rendered = BARE_TABLE_CANDIDATES_SQL.format(names_list=fragment)
+
+        # No leftover ``{...}`` placeholders, and the literal name-list
+        # appears in the rendered SQL.
+        assert "'customers','orders'" in rendered
+
+        assert regex.search(r'(?<!\{)\{[^{}]+\}(?!\})', rendered) is None
+
+    @pytest.mark.asyncio
+    async def test_empty_bare_names_executes_zero_statements(self, mocker):
+        """Empty input → no batched query executed, returns ``{}``."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names=set(),
+        )
+
+        assert result == {}
+        mock_execute_protected.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_name_executes_exactly_one_statement(self, mocker):
+        """Single bare name → exactly one ``BARE_TABLE_CANDIDATES_SQL`` call."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders'},
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_many_names_still_executes_exactly_one_statement(self, mocker):
+        """50 distinct names → still exactly one batched call (no per-name query)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        bare_names = {f't{i}' for i in range(50)}
+
+        await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names=bare_names,
+        )
+
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_invokes_bare_table_candidates_sql_with_rendered_name_list(self, mocker):
+        """SQL passed to the executor is the formatted constant."""
+        from awslabs.redshift_mcp_server.consts import BARE_TABLE_CANDIDATES_SQL
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+            _render_name_list,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        bare_names = {'orders', 'customers'}
+
+        await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names=bare_names,
+        )
+
+        kwargs = mock_execute_protected.call_args.kwargs
+        expected_sql = BARE_TABLE_CANDIDATES_SQL.format(names_list=_render_name_list(bare_names))
+        assert kwargs['sql'] == expected_sql
+        assert kwargs['cluster_identifier'] == 'c1'
+        assert kwargs['database_name'] == 'dev'
+
+    @pytest.mark.asyncio
+    async def test_parses_response_into_per_name_candidate_lists(self, mocker):
+        """Response rows parse into ``name -> [(schema, table), ...]`` mapping."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [{'stringValue': 'public'}, {'stringValue': 'orders'}],
+                    [{'stringValue': 'tpch'}, {'stringValue': 'orders'}],
+                    [{'stringValue': 'public'}, {'stringValue': 'customers'}],
+                ]
+            },
+            'qid',
+        )
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders', 'customers'},
+        )
+
+        assert set(result.keys()) == {'orders', 'customers'}
+        assert sorted(result['orders']) == [('public', 'orders'), ('tpch', 'orders')]
+        assert result['customers'] == [('public', 'customers')]
+
+    @pytest.mark.asyncio
+    async def test_zero_matches_returns_empty_list_per_name(self, mocker):
+        """Bare names with zero matching rows map to empty lists, not missing keys."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = ({'Records': []}, 'qid')
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders', 'customers'},
+        )
+
+        # Both names are present in the mapping with empty lists; the
+        # _resolve_ambiguities relies on this contract to emit the
+        # not-found note.
+        assert set(result.keys()) == {'orders', 'customers'}
+        assert result['orders'] == []
+        assert result['customers'] == []
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_partial_match_returns_empty_list_for_unmatched_names(self, mocker):
+        """A bare name with no rows still appears in output with an empty list."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [{'stringValue': 'public'}, {'stringValue': 'orders'}],
+                ]
+            },
+            'qid',
+        )
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders', 'missing_table'},
+        )
+
+        assert result['orders'] == [('public', 'orders')]
+        # ``missing_table`` is present as an empty list — it was looked
+        # up, just with zero matches.
+        assert result['missing_table'] == []
+
+    @pytest.mark.asyncio
+    async def test_lookup_bare_table_candidates_swallows_execute_protected_exception_returns_empty(
+        self, mocker
+    ):
+        """``_execute_protected_statement`` failure → ``{}``, no retry."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('Data API failure')
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders'},
+        )
+
+        assert result == {}
+        # No retry: the batched call is attempted exactly once per
+        # ``lookup`` invocation, even when it raises.
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_lookup_bare_table_candidates_swallows_row_parsing_exception_returns_empty(
+        self, mocker
+    ):
+        """Malformed response rows → ``{}`` (no propagation)."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        # Each record has zero columns → ``record[0].get(...)`` raises
+        # ``IndexError`` during parsing.
+        mock_execute_protected.return_value = (
+            {'Records': [[]]},
+            'qid',
+        )
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders'},
+        )
+
+        assert result == {}
+        assert mock_execute_protected.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_lookup_bare_table_candidates_logs_warning_on_execute_protected_exception(
+        self, mocker
+    ):
+        """A warning is logged when the batched call fails."""
+        from awslabs.redshift_mcp_server import redshift as redshift_module
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.side_effect = Exception('boom')
+
+        warning_spy = mocker.patch.object(redshift_module.logger, 'warning')
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders'},
+        )
+
+        assert result == {}
+        assert warning_spy.call_count == 1
+        warning_text = warning_spy.call_args.args[0]
+        assert 'boom' in warning_text
+
+    @pytest.mark.asyncio
+    async def test_skips_rows_missing_schema_or_table(self, mocker):
+        """Records with NULL schema or table values are skipped, not raised."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [{'stringValue': 'public'}, {'stringValue': 'orders'}],
+                    # NULL row: ``stringValue`` absent → ``.get`` returns None.
+                    [{}, {}],
+                ]
+            },
+            'qid',
+        )
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders'},
+        )
+
+        # The NULL row is silently dropped; the well-formed row is kept.
+        assert result['orders'] == [('public', 'orders')]
+
+    @pytest.mark.asyncio
+    async def test_ignores_rows_for_names_not_in_input(self, mocker):
+        """Rows for names outside the input set are not attached to output."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _lookup_bare_table_candidates,
+        )
+
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {
+                'Records': [
+                    [{'stringValue': 'public'}, {'stringValue': 'orders'}],
+                    # ``other_table`` is not in the requested set;
+                    # defensive check that it is dropped.
+                    [{'stringValue': 'public'}, {'stringValue': 'other_table'}],
+                ]
+            },
+            'qid',
+        )
+
+        result = await _lookup_bare_table_candidates(
+            cluster_identifier='c1',
+            database_name='dev',
+            bare_names={'orders'},
+        )
+
+        assert set(result.keys()) == {'orders'}
+        assert result['orders'] == [('public', 'orders')]
+
+    @staticmethod
+    def _mock_candidate_lookup(mocker, candidates_by_name=None):
+        """Build a mock async callable for injection as ``lookup_fn``.
+
+        The returned object is an :class:`AsyncMock` that, when
+        awaited, yields ``candidates_by_name`` (defaulting to ``{}``).
+        This matches the shape of the real
+        :func:`_lookup_bare_table_candidates` helper, where every
+        requested bare name is pre-populated with a (possibly empty)
+        candidate list.
+        """
+        return mocker.AsyncMock(return_value=candidates_by_name or {})
+
+    @pytest.mark.asyncio
+    async def test_schema_qualified_binds_with_no_note_and_no_lookup(self, mocker):
+        """SCHEMA_QUALIFIED → resolved pair added, no note, lookup not called."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_SCHEMA_QUALIFIED,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(mocker)
+
+        references = [
+            TableReference(
+                category=TABLE_REF_SCHEMA_QUALIFIED,
+                table_name='orders',
+                schema_name='tpch',
+            ),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        assert resolved_pairs == {('tpch', 'orders')}
+        assert notes == []
+        # No bare references → candidate lookup is never invoked.
+        mock_lookup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bare_one_schema_binds_with_no_note(self, mocker):
+        """BARE with 1 candidate match → bound, no note, single resolved pair."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(
+            mocker,
+            candidates_by_name={'orders': [('tpch', 'orders')]},
+        )
+
+        references = [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        assert resolved_pairs == {('tpch', 'orders')}
+        assert notes == []
+        mock_lookup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bare_multiple_schemas_emits_single_note_and_all_pairs(self, mocker):
+        """BARE with ≥2 candidate matches → 1 ambiguity note, ALL pairs resolved."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(
+            mocker,
+            candidates_by_name={
+                'orders': [
+                    ('public', 'orders'),
+                    ('tpch', 'orders'),
+                    ('staging', 'orders'),
+                ],
+            },
+        )
+
+        references = [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        # All matching pairs flow into resolved_pairs so each appears
+        # in the downstream table_designs list.
+        assert resolved_pairs == {
+            ('public', 'orders'),
+            ('tpch', 'orders'),
+            ('staging', 'orders'),
+        }
+        # Exactly one ambiguity note that names the bare reference and
+        # every matching schema.
+        assert len(notes) == 1
+        note = notes[0]
+        assert 'orders' in note
+        assert 'ambiguous' in note
+        assert 'public' in note
+        assert 'tpch' in note
+        assert 'staging' in note
+        # Connected database is surfaced so the user knows where we
+        # looked.
+        assert 'dev' in note
+
+    @pytest.mark.asyncio
+    async def test_bare_zero_schemas_emits_not_found_note_and_no_pair(self, mocker):
+        """BARE with 0 candidate matches → 1 not-found note, no resolved pair."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        # The real lookup pre-populates input names with empty lists.
+        # We mirror that contract here.
+        mock_lookup = self._mock_candidate_lookup(
+            mocker,
+            candidates_by_name={'missing_table': []},
+        )
+
+        references = [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='missing_table',
+            ),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        assert resolved_pairs == set()
+        assert len(notes) == 1
+        note = notes[0]
+        assert 'missing_table' in note
+        # The note should indicate the table was not found and name
+        # the connected database we looked in.
+        assert 'not found' in note
+        assert 'dev' in note
+
+    @pytest.mark.asyncio
+    async def test_database_qualified_different_database_emits_cross_database_note(self, mocker):
+        """DATABASE_QUALIFIED targeting a different database → cross-db note, no fetch."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_DATABASE_QUALIFIED,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(mocker)
+
+        references = [
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                table_name='orders',
+                schema_name='tpch',
+                database_name='prod_db',
+            ),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        # Cross-database reference is NOT added to resolved pairs and
+        # the metadata fetch in the wider pipeline therefore receives
+        # no entry for it.
+        assert resolved_pairs == set()
+        assert len(notes) == 1
+        note = notes[0]
+        assert 'prod_db' in note
+        assert 'dev' in note
+        # The fully-qualified reference appears in the note so the
+        # user can identify which reference was skipped.
+        assert 'tpch' in note
+        assert 'orders' in note
+        # No bare references → no candidate-lookup call.
+        mock_lookup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_database_qualified_connected_database_treated_as_schema_qualified(self, mocker):
+        """DATABASE_QUALIFIED with database == connected → bound, no note."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_DATABASE_QUALIFIED,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(mocker)
+
+        references = [
+            TableReference(
+                category=TABLE_REF_DATABASE_QUALIFIED,
+                table_name='orders',
+                schema_name='tpch',
+                database_name='dev',
+            ),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        # When the database matches, the reference resolves exactly
+        # like a SCHEMA_QUALIFIED one: pair added, no note emitted
+        # .
+        assert resolved_pairs == {('tpch', 'orders')}
+        assert notes == []
+        mock_lookup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_repeated_identical_references_dedupe_notes(self, mocker):
+        """Repeated identical not-found references collapse into one note."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(
+            mocker,
+            candidates_by_name={'missing_table': []},
+        )
+
+        references = [
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='missing_table',
+            ),
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='missing_table',
+            ),
+            TableReference(
+                category=TABLE_REF_BARE,
+                table_name='missing_table',
+            ),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        # Three identical bare references produce a single deduped
+        # not-found note.
+        assert resolved_pairs == set()
+        assert len(notes) == 1
+        assert 'missing_table' in notes[0]
+
+    @pytest.mark.asyncio
+    async def test_case_sensitive_distinct_names_produce_distinct_notes(self, mocker):
+        """``Orders`` and ``orders`` are not equal → two distinct notes."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        # Both names map to empty candidate lists so each fires the not-found note path.
+        mock_lookup = self._mock_candidate_lookup(
+            mocker,
+            candidates_by_name={'Orders': [], 'orders': []},
+        )
+
+        references = [
+            TableReference(category=TABLE_REF_BARE, table_name='Orders'),
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        assert resolved_pairs == set()
+        assert len(notes) == 2
+        # Both surface forms appear, exactly once each, in their own
+        # note string.
+        assert sum('"Orders"' in note for note in notes) == 1
+        assert sum('"orders"' in note for note in notes) == 1
+
+    @pytest.mark.asyncio
+    async def test_repeated_bare_references_use_single_lookup_call(self, mocker):
+        """Multiple references to the same bare name share one lookup call."""
+        from awslabs.redshift_mcp_server.redshift import (
+            TABLE_REF_BARE,
+            TableReference,
+            _resolve_ambiguities,
+        )
+
+        mock_lookup = self._mock_candidate_lookup(
+            mocker,
+            candidates_by_name={'orders': [('tpch', 'orders')]},
+        )
+
+        references = [
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+            TableReference(category=TABLE_REF_BARE, table_name='orders'),
+        ]
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=references,
+            lookup_fn=mock_lookup,
+        )
+
+        assert resolved_pairs == {('tpch', 'orders')}
+        assert notes == []
+        # The resolver collapses bare-name lookups into a single
+        # batched call regardless of how many references reuse the
+        # same name.
+        assert mock_lookup.call_count == 1
+        # The lookup was passed the connected database verbatim and
+        # the deduplicated name set.
+        kwargs = mock_lookup.call_args.kwargs
+        assert kwargs['cluster_identifier'] == 'c1'
+        assert kwargs['database_name'] == 'dev'
+        assert kwargs['bare_names'] == {'orders'}
+
+    @pytest.mark.asyncio
+    async def test_empty_references_returns_empty_outputs_no_lookup(self, mocker):
+        """Empty input → empty resolved_pairs, empty notes, no lookup call."""
+        from awslabs.redshift_mcp_server.redshift import _resolve_ambiguities
+
+        mock_lookup = self._mock_candidate_lookup(mocker)
+
+        resolved_pairs, notes = await _resolve_ambiguities(
+            cluster_identifier='c1',
+            connected_database_name='dev',
+            references=[],
+        )
+
+        assert resolved_pairs == set()
+        assert notes == []
+        mock_lookup.assert_not_called()
+
+    def test_suggestion_engine_is_idempotent_on_empty_inputs(self):
+        """Two calls on empty inputs produce equal output."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _generate_performance_suggestions,
+        )
+
+        first = _generate_performance_suggestions([], [])
+        second = _generate_performance_suggestions([], [])
+
+        assert first == second
+
+    def test_suggestion_engine_is_idempotent_on_realistic_plan(self):
+        """Two calls on a non-trivial plan produce equal output."""
+        from awslabs.redshift_mcp_server.redshift import (
+            _generate_performance_suggestions,
+        )
+
+        plan_nodes = [
+            {'operation': 'XN Hash Join', 'distribution_type': 'DS_BCAST_INNER'},
+            {'operation': 'XN Seq Scan', 'distribution_type': None},
+            {'operation': 'XN Nested Loop', 'distribution_type': None},
+        ]
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'EVEN',
+                'redshift_estimated_row_count': 5_000_000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                        'data_type': 'integer',
+                    },
+                ],
+            },
+        ]
+
+        first = _generate_performance_suggestions(plan_nodes, table_designs)
+        second = _generate_performance_suggestions(plan_nodes, table_designs)
+
+        assert first == second
+        # Sanity: the realistic input actually produces suggestions, so
+        # the equality check is non-trivial.
+        assert len(first) > 0
+
+    # ------------------------------------------------------------------
+    # SORTKEY suppression
+    # ------------------------------------------------------------------
+    def test_sortkey_suggestion_suppressed_for_small_table(self):
+        """Small table (< 100K rows) suppresses the SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'small_dim',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 50_000,
+                'stats_sequential_scans': 5_000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('sequential scans' in s and 'SORTKEY' in s for s in suggestions), (
+            f'expected no SORTKEY suggestion for small table; got {suggestions!r}'
+        )
+
+    def test_sortkey_suggestion_suppressed_for_diststyle_all(self):
+        """``DISTSTYLE ALL`` suppresses the SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'replicated_dim',
+                'redshift_diststyle': 'ALL',
+                'redshift_estimated_row_count': 5_000_000,
+                'stats_sequential_scans': 5_000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('sequential scans' in s and 'SORTKEY' in s for s in suggestions), (
+            f'expected no SORTKEY suggestion for DISTSTYLE ALL table; got {suggestions!r}'
+        )
+
+    def test_sortkey_suggestion_suppressed_for_auto_all(self):
+        """``AUTO(ALL)`` is treated like ALL and suppresses the SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'auto_replicated',
+                'redshift_diststyle': 'AUTO(ALL)',
+                'redshift_estimated_row_count': 5_000_000,
+                'stats_sequential_scans': 5_000,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('sequential scans' in s and 'SORTKEY' in s for s in suggestions), (
+            f'expected no SORTKEY suggestion for AUTO(ALL) table; got {suggestions!r}'
+        )
+
+    def test_sortkey_suggestion_suppressed_when_seq_scans_zero(self):
+        """``stats_sequential_scans == 0`` suppresses the SORTKEY suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'never_scanned',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 5_000_000,
+                'stats_sequential_scans': 0,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert not any('sequential scans' in s and 'SORTKEY' in s for s in suggestions), (
+            f'expected no SORTKEY suggestion when seq_scans == 0; got {suggestions!r}'
+        )
+
+    # ------------------------------------------------------------------
+    # SORTKEY emission with all four conditions met
+    # ------------------------------------------------------------------
+    def test_sortkey_suggestion_emitted_when_all_conditions_met(self):
+        """Emits SORTKEY suggestion when scans>1000, no SORTKEY, >=100K rows,."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 5_000_000,
+                'stats_sequential_scans': 12_345,
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        # Emission text MUST include the scan count (formatted with thousands
+        # separators by the engine).
+        assert any(
+            '12,345 sequential scans' in s and 'SORTKEY' in s and 'events' in s
+            for s in suggestions
+        ), f'expected SORTKEY suggestion naming scan count; got {suggestions!r}'
+
+    # ------------------------------------------------------------------
+    # distribution_type keyword fallback
+    # ------------------------------------------------------------------
+    def test_keyword_fallback_broadcast_emits_suggestion(self):
+        """``distribution_type`` unset + ``Broadcast`` keyword in operation."""
+        nodes = [
+            {
+                'operation': 'XN Network Broadcast',
+                'distribution_type': None,
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert any('broadcast' in s.lower() and 'DISTKEY' in s for s in suggestions), (
+            f'expected broadcast suggestion via keyword fallback; got {suggestions!r}'
+        )
+
+    def test_keyword_fallback_distribute_emits_suggestion(self):
+        """``distribution_type`` unset + ``Distribute`` keyword in operation."""
+        nodes = [
+            {
+                'operation': 'XN Network Distribute',
+                'distribution_type': None,
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert any('redistribution' in s.lower() and 'DISTKEY' in s for s in suggestions), (
+            f'expected redistribution suggestion via keyword fallback; got {suggestions!r}'
+        )
+
+    def test_keyword_fallback_gather_emits_suggestion(self):
+        """``distribution_type`` unset + ``Gather`` keyword in operation."""
+        nodes = [
+            {
+                'operation': 'Gather Motion 4:1',
+                'distribution_type': None,
+            }
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert any('gather' in s.lower() and 'DISTKEY' in s for s in suggestions), (
+            f'expected gather suggestion via keyword fallback; got {suggestions!r}'
+        )
+
+    def test_keyword_fallback_no_keyword_no_suggestion(self):
+        """``distribution_type`` unset + no redistribution keyword emits no."""
+        nodes = [
+            {
+                'operation': 'Hash Join',
+                'distribution_type': None,
+            },
+            {
+                'operation': 'Seq Scan',
+                'distribution_type': None,
+            },
+            {
+                'operation': 'XN Aggregate',
+                'distribution_type': None,
+            },
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        # None of the engine's redistribution suggestions should fire.
+        for s in suggestions:
+            lowered = s.lower()
+            assert 'broadcast' not in lowered, f'unexpected broadcast suggestion: {s!r}'
+            assert 'redistribution' not in lowered, f'unexpected redistribution suggestion: {s!r}'
+            assert 'gather' not in lowered, f'unexpected gather suggestion: {s!r}'
+
+    # ------------------------------------------------------------------
+    # Carried-over rules
+    # ------------------------------------------------------------------
+    def test_carried_over_nested_loop_rule(self):
+        """``Nested Loop`` operation still emits the existing suggestion."""
+        nodes = [{'operation': 'Nested Loop'}]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        assert any('Nested Loop' in s for s in suggestions), (
+            f'expected Nested Loop suggestion; got {suggestions!r}'
+        )
+
+    def test_carried_over_low_correlation_rule(self):
+        """Low ``stats_correlation`` on a non-sortkey column still emits the."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 5_000_000,
+                'columns': [
+                    {
+                        'column_name': 'order_date',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'stats_correlation': 0.05,
+                        'stats_n_distinct': 1_000_000,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any(
+            'order_date' in s and 'correlation' in s and 'SORTKEY' in s for s in suggestions
+        ), f'expected low-correlation suggestion; got {suggestions!r}'
+
+    def test_carried_over_low_cardinality_distkey_rule(self):
+        """Low-cardinality DISTKEY column still emits the existing."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'events',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 10_000_000,
+                'columns': [
+                    {
+                        'column_name': 'status',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 0,
+                        'redshift_is_distkey': True,
+                        'stats_n_distinct': 5,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('DISTKEY column status' in s and 'low cardinality' in s for s in suggestions), (
+            f'expected low-cardinality DISTKEY suggestion; got {suggestions!r}'
+        )
+
+    def test_carried_over_high_null_sortkey_rule(self):
+        """High-NULL SORTKEY column still emits the existing suggestion."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'orders',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'deleted_at',
+                        'redshift_encoding': 'lzo',
+                        'redshift_sortkey_position': 1,
+                        'stats_null_frac': 0.95,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('SORTKEY column deleted_at' in s and 'NULL' in s for s in suggestions), (
+            f'expected high-NULL SORTKEY suggestion; got {suggestions!r}'
+        )
+
+    def test_carried_over_wide_uncompressed_columns_rule(self):
+        """Wide uncompressed varchar columns still emit the existing."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'logs',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'payload',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                        'data_type': 'character varying',
+                        'stats_avg_width': 350,
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any(
+            'Wide columns' in s and 'payload' in s and 'compression' in s.lower()
+            for s in suggestions
+        ), f'expected wide-uncompressed-column suggestion; got {suggestions!r}'
+
+    def test_carried_over_raw_encoding_rule(self):
+        """RAW (``none``) encoding on non-first-sortkey, non-boolean columns."""
+        table_designs = [
+            {
+                'schema_name': 'public',
+                'table_name': 'users',
+                'redshift_diststyle': 'KEY',
+                'columns': [
+                    {
+                        'column_name': 'id',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 1,  # exempt: first SORTKEY
+                        'data_type': 'integer',
+                    },
+                    {
+                        'column_name': 'email',
+                        'redshift_encoding': 'none',
+                        'redshift_sortkey_position': 0,
+                        'data_type': 'character varying',
+                    },
+                ],
+            }
+        ]
+        suggestions = _generate_performance_suggestions([], table_designs)
+
+        assert any('email' in s and 'compression' in s.lower() for s in suggestions), (
+            f'expected RAW-encoding compression suggestion; got {suggestions!r}'
+        )
+
+    # ------------------------------------------------------------------
+    # Deduplication
+    # ------------------------------------------------------------------
+    def test_identical_suggestion_text_appears_at_most_once(self):
+        """Identical suggestion text emitted by multiple rule paths is."""
+        # Two nodes that produce the same broadcast suggestion text
+        # (operation strings are identical, so the ``f'... in {operation}.'``
+        # template renders to the same string).
+        nodes = [
+            {'operation': 'Hash Join', 'distribution_type': 'DS_BCAST_INNER'},
+            {'operation': 'Hash Join', 'distribution_type': 'DS_BCAST_INNER'},
+            {'operation': 'Hash Join', 'distribution_type': 'DS_BCAST_INNER'},
+        ]
+        suggestions = _generate_performance_suggestions(nodes, [])
+
+        # Exactly one broadcast suggestion despite three matching nodes.
+        broadcast_suggestions = [s for s in suggestions if 'broadcast' in s.lower()]
+        assert len(broadcast_suggestions) == 1, (
+            f'expected single deduplicated broadcast suggestion; got {broadcast_suggestions!r}'
+        )
+
+        # And the global list has no duplicates.
+        assert len(suggestions) == len(set(suggestions)), (
+            f'expected no duplicate suggestions overall; got {suggestions!r}'
+        )
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_enriches_columns_with_stats(self, mocker):
+        """A matching column-stats record is merged into the referenced table's columns."""
+        mock_execute = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        explain_response = (
+            {
+                'Records': [
+                    [{'stringValue': 'XN Seq Scan on users  (cost=0.00..1.00 rows=1 width=4)'}]
+                ]
+            },
+            'explain-query-id',
+        )
+        candidates_response = (
+            {'Records': [[{'stringValue': 'public'}, {'stringValue': 'users'}]]},
+            'candidates-query-id',
+        )
+        tables_extra_response = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'KEY'},
+                        {'longValue': 1000},
+                        {'longValue': 5},
+                        {'longValue': 100},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                        {'longValue': 0},
+                    ]
+                ]
+            },
+            'tables-extra-query-id',
+        )
+        # Non-empty column stats for public.users.id drives the stats loop and enrichment.
+        column_stats_response = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'id'},
+                        {'doubleValue': -0.5},
+                        {'doubleValue': 0.0},
+                        {'longValue': 4},
+                        {'doubleValue': 0.95},
+                        {'stringValue': None},
+                        {'stringValue': None},
+                        {'stringValue': '1,2,3'},
+                    ]
+                ]
+            },
+            'column-stats-query-id',
+        )
+        columns_by_pairs_response = (
+            {
+                'Records': [
+                    [
+                        {'stringValue': 'dev'},
+                        {'stringValue': 'public'},
+                        {'stringValue': 'users'},
+                        {'stringValue': 'id'},
+                        {'longValue': 1},
+                        {'stringValue': None},
+                        {'stringValue': 'YES'},
+                        {'stringValue': 'integer'},
+                        {'longValue': None},
+                        {'longValue': None},
+                        {'longValue': None},
+                        {'stringValue': None},
+                        {'stringValue': 'lzo'},
+                        {'booleanValue': False},
+                        {'longValue': 0},
+                        {'stringValue': None},
+                        {'longValue': None},
+                    ]
+                ]
+            },
+            'columns-query-id',
+        )
+        mock_execute.side_effect = [
+            explain_response,
+            candidates_response,
+            tables_extra_response,
+            column_stats_response,
+            columns_by_pairs_response,
+        ]
+
+        result = await describe_execution_plan('test-cluster', 'dev', 'SELECT id FROM users')
+
+        col = result['table_designs'][0]['columns'][0]
+        assert col['column_name'] == 'id'
+        assert col['stats_n_distinct'] == -0.5
+        assert col['stats_correlation'] == 0.95
+        assert col['stats_histogram_bounds'] == '1,2,3'
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_soft_fails_on_unparseable_references(self, mocker):
+        """Unparseable table references degrade gracefully; the plan still returns."""
+        mock_execute = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute.return_value = (
+            {'Records': [[{'stringValue': 'XN Seq Scan  (cost=0.00..1.00 rows=1 width=4)'}]]},
+            'explain-query-id',
+        )
+        # A 4-part dotted table name makes _extract_sql_references raise; the
+        # pipeline catches it, sets references=[], and still returns the plan.
+        result = await describe_execution_plan('test-cluster', 'dev', 'SELECT 1 FROM a.b.c.d')
+
+        assert result['query_id'] == 'explain-query-id'
+        assert result['table_designs'] == []
+        assert len(result['plan_nodes']) == 1
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_continues_when_column_stats_fetch_fails(self, mocker):
+        """A column-stats fetch failure is swallowed; the rest of the response is intact."""
+        mock_execute = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        explain_response = (
+            {
+                'Records': [
+                    [{'stringValue': 'XN Seq Scan on users  (cost=0.00..1.00 rows=1 width=4)'}]
+                ]
+            },
+            'explain-query-id',
+        )
+        candidates_response = (
+            {'Records': [[{'stringValue': 'public'}, {'stringValue': 'users'}]]},
+            'candidates-query-id',
+        )
+        empty_response = ({'Records': []}, 'empty-query-id')
+        mock_execute.side_effect = [
+            explain_response,
+            candidates_response,
+            empty_response,  # table metadata
+            Exception('column stats boom'),  # column-stats fetch fails
+            empty_response,  # columns fetch
+        ]
+
+        result = await describe_execution_plan('test-cluster', 'dev', 'SELECT id FROM users')
+
+        assert result['query_id'] == 'explain-query-id'
+        assert len(result['table_designs']) == 1

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -16,6 +16,7 @@
 
 import pytest
 from awslabs.redshift_mcp_server.models import (
+    ExecutionPlan,
     QueryResult,
     RedshiftCluster,
     RedshiftColumn,
@@ -24,6 +25,7 @@ from awslabs.redshift_mcp_server.models import (
     RedshiftTable,
 )
 from awslabs.redshift_mcp_server.server import (
+    describe_execution_plan_tool,
     execute_query_tool,
     list_clusters_tool,
     list_columns_tool,
@@ -286,7 +288,7 @@ class TestListTablesTool:
 
     @pytest.mark.asyncio
     async def test_list_tables_tool_success(self, mocker):
-        """Test successful table discovery."""
+        """Test successful table discovery including external tables."""
         mock_discover_tables = mocker.patch('awslabs.redshift_mcp_server.server.discover_tables')
         mock_discover_tables.return_value = [
             {
@@ -296,6 +298,15 @@ class TestListTablesTool:
                 'table_acl': 'user=admin',
                 'table_type': 'TABLE',
                 'remarks': 'User data table',
+                'redshift_diststyle': 'KEY',
+                'redshift_estimated_row_count': 50000,
+                'stats_sequential_scans': 120,
+                'stats_sequential_tuples_read': 6000000,
+                'stats_rows_inserted': 5000,
+                'stats_rows_updated': 200,
+                'stats_rows_deleted': 50,
+                'external_location': None,
+                'external_parameters': None,
             },
             {
                 'database_name': 'dev',
@@ -304,6 +315,32 @@ class TestListTablesTool:
                 'table_acl': 'user=admin',
                 'table_type': 'VIEW',
                 'remarks': 'User view',
+                'redshift_diststyle': None,
+                'redshift_estimated_row_count': None,
+                'stats_sequential_scans': None,
+                'stats_sequential_tuples_read': None,
+                'stats_rows_inserted': None,
+                'stats_rows_updated': None,
+                'stats_rows_deleted': None,
+                'external_location': None,
+                'external_parameters': None,
+            },
+            {
+                'database_name': 'dev',
+                'schema_name': 'public',
+                'table_name': 'ext_events',
+                'table_acl': None,
+                'table_type': 'EXTERNAL TABLE',
+                'remarks': None,
+                'redshift_diststyle': None,
+                'redshift_estimated_row_count': None,
+                'stats_sequential_scans': None,
+                'stats_sequential_tuples_read': None,
+                'stats_rows_inserted': None,
+                'stats_rows_updated': None,
+                'stats_rows_deleted': None,
+                'external_location': 's3://my-bucket/events/',
+                'external_parameters': '{"partition_columns": ["year", "month"]}',
             },
         ]
 
@@ -311,15 +348,31 @@ class TestListTablesTool:
 
         # Verify return type and structure
         assert isinstance(result, list)
-        assert len(result) == 2
+        assert len(result) == 3
         assert all(isinstance(table, RedshiftTable) for table in result)
 
-        # Verify table properties
+        # Verify regular table properties and stats
         assert result[0].table_name == 'users'
         assert result[0].table_type == 'TABLE'
         assert result[0].schema_name == 'public'
+        assert result[0].redshift_diststyle == 'KEY'
+        assert result[0].redshift_estimated_row_count == 50000
+        assert result[0].stats_sequential_scans == 120
+        assert result[0].stats_rows_inserted == 5000
+        assert result[0].external_location is None
+
+        # Verify view
         assert result[1].table_name == 'user_view'
         assert result[1].table_type == 'VIEW'
+        assert result[1].redshift_diststyle is None
+
+        # Verify external table
+        assert result[2].table_name == 'ext_events'
+        assert result[2].table_type == 'EXTERNAL TABLE'
+        assert result[2].external_location == 's3://my-bucket/events/'
+        assert result[2].external_parameters == '{"partition_columns": ["year", "month"]}'
+        assert result[2].redshift_diststyle is None
+        assert result[2].stats_sequential_scans is None
 
     @pytest.mark.asyncio
     async def test_list_tables_tool_empty(self, mocker):
@@ -527,4 +580,88 @@ class TestExecuteQueryTool:
 
         mock_ctx.error.assert_called_once_with(
             'Failed to execute query on cluster test-cluster in database test-db: Query error'
+        )
+
+
+class TestDescribeExecutionPlanTool:
+    """Tests for the describe_execution_plan MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_tool_success(self, mocker):
+        """Test successful execution plan generation with structured output."""
+        from awslabs.redshift_mcp_server.models import ExecutionPlanNode
+
+        mock_describe_execution_plan = mocker.patch(
+            'awslabs.redshift_mcp_server.server.describe_execution_plan'
+        )
+        mock_describe_execution_plan.return_value = {
+            'query_id': 'explain-123',
+            'explained_query': 'SELECT * FROM users LIMIT 5',
+            'planning_time_ms': 50,
+            'plan_nodes': [
+                {
+                    'level': 0,
+                    'operation': 'Limit',
+                    'cost_startup': 0.00,
+                    'cost_total': 0.07,
+                    'rows': 5,
+                    'width': 27,
+                },
+                {
+                    'level': 1,
+                    'operation': 'Seq Scan',
+                    'cost_startup': 0.00,
+                    'cost_total': 1.00,
+                    'rows': 100,
+                    'width': 27,
+                    'distribution_type': 'DS_DIST_NONE',
+                },
+            ],
+            'table_designs': [],
+            'plan_text': '',
+            'rule_based_suggestions': [
+                'Consider adding a SORTKEY on frequently filtered columns.'
+            ],
+        }
+
+        result = await describe_execution_plan_tool(
+            Context(),
+            cluster_identifier='test-cluster',
+            database_name='dev',
+            sql='SELECT * FROM users LIMIT 5',
+        )
+
+        assert isinstance(result, ExecutionPlan)
+        assert len(result.plan_nodes) == 2
+        assert result.explained_query == 'SELECT * FROM users LIMIT 5'
+        assert result.query_id == 'explain-123'
+        assert result.planning_time_ms == 50
+
+        assert all(isinstance(node, ExecutionPlanNode) for node in result.plan_nodes)
+        assert result.plan_nodes[0].operation == 'Limit'
+        assert result.plan_nodes[1].operation == 'Seq Scan'
+        assert result.plan_nodes[1].distribution_type == 'DS_DIST_NONE'
+
+        # Verify rule_based_suggestions are included
+        assert isinstance(result.rule_based_suggestions, list)
+        assert len(result.rule_based_suggestions) == 1
+
+    @pytest.mark.asyncio
+    async def test_describe_execution_plan_tool_error(self, mocker):
+        """Test describe_execution_plan_tool error handling."""
+        from unittest.mock import AsyncMock, Mock
+
+        mock_ctx = Mock()
+        mock_ctx.error = AsyncMock()
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.server.describe_execution_plan',
+            side_effect=Exception('Invalid SQL syntax'),
+        )
+
+        with pytest.raises(Exception, match='Invalid SQL syntax'):
+            await describe_execution_plan_tool(mock_ctx, 'test-cluster', 'test-db', 'INVALID SQL')
+
+        mock_ctx.error.assert_called_once_with(
+            'Failed to get execution plan on cluster test-cluster in database test-db: Invalid SQL syntax'
         )


### PR DESCRIPTION
Fixes #1019

## Summary

Adds a `describe_execution_plan` tool to the Redshift MCP Server. It runs Redshift's `EXPLAIN` on a SQL statement (without executing it) and returns a structured execution plan for query-performance analysis: typed plan nodes, table design + column planner statistics for the referenced tables, the raw `EXPLAIN` text, and rule-based optimization suggestions.

This supersedes the earlier, now-closed #1927, which used `EXPLAIN VERBOSE`. That approach added significant complexity, so this version uses plain `EXPLAIN` plus text parsing into structured `plan_nodes`.

### Changes

* Add the `describe_execution_plan` tool (`server.py`) and implementation (`redshift.py`): runs `EXPLAIN`, parses output into `ExecutionPlanNode`s, resolves referenced tables, batch-fetches table design + column planner statistics, and generates rule-based suggestions.
* Add `ExecutionPlan` / `ExecutionPlanNode` models (`models.py`) and supporting SQL/constants (`consts.py`).
* Update `README.md` with the tool reference and a worked example.
* Add unit tests and an end-to-end test script (`scripts/e2e-test.sh`).

### User experience

Users can request an execution plan for a query and get a structured plan plus optimization guidance without running the query — e.g. "Explain the execution plan for: SELECT … JOIN … ORDER BY … LIMIT 50" returns the plan tree, table designs (DISTKEY/SORTKEY/encoding), column stats, and suggestions (broadcast joins, DISTSTYLE ALL for small dimensions, missing SORTKEY, etc.).

## Testing

### `describe_execution_plan`

Ran five fresh mid-to-complex queries through `describe_execution_plan` only (discovery via `list_*`; no `execute_query`) against `redshift-cluster-1` / `sample_data_dev.tickit`, reconstructed each plan purely from `plan_nodes` (rendering every non-null field), and diffed it against `plan_text` to confirm `plan_nodes` carries everything `plan_text` does.

```
kiro-cli chat --model claude-opus-4.8 \
--no-interactive \
--trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
"only use describe execution plan in redshift mcp server to describe the execution plan for five queries from sample data in redshift-cluster-1 in us-east-1; Run five mid to complex queries and suggest any plan optimization. Also, for all five queries, using the returned by the describe_execution_plan tool RAW JSON structure, try reconstructing the plan based on the plan_nodes object (including all the supplied with the nodes info except nulls) only ignoring plan_text. Bring both plans. Then compare/diff the plan_nodes based on with the plan_text and show what extra info the former provides in comparison to the latter. And vice versa. Be minimal but complete."
```

<details>
<summary>Result — 5 queries (events⋈event⋈date aggregate, window RANK within category, top sellers + HAVING, 4-table venue join, listing⋈date LEFT JOIN sales + COUNT DISTINCT): plan reconstructed from plan_nodes vs plan_text</summary>

The `plan_nodes`→tree reconstruction rule: indent = 2 spaces per level, prefix child rows with `->`, append cost/rows/width, and emit the extra attribute fields (`merge_key`, `sort_key`, `join_condition`, `filter_condition`, `data_movement`, `outer_dist_key`, `partition_key`, `order_key`, `alias`) as sub-lines.

#### Q1 — Top events by revenue, Dec 2008 (sales ⋈ event ⋈ date)

```sql
SELECT e.eventname, SUM(s.pricepaid) AS total_revenue, COUNT(*) AS txns
FROM tickit.sales s
JOIN tickit.event e ON s.eventid = e.eventid
JOIN tickit.date d ON s.dateid = d.dateid
WHERE d.year = 2008 AND d.month = 'DEC'
GROUP BY e.eventname
ORDER BY total_revenue DESC
LIMIT 20;
```

Reconstructed from `plan_nodes`:

```
XN Limit  (cost=1004214350381.65..1004214350381.70 rows=20 width=33)
  ->  XN Merge  (cost=1004214350381.65..1004214350383.10 rows=581 width=33)
        Merge Key: sum(s.pricepaid)
        ->  XN Network  (cost=...381.65.....383.10 rows=581 width=33)
              Send to leader
              ->  XN Sort  (cost=...381.65.....383.10 rows=581 width=33)
                    Sort Key: sum(s.pricepaid)
                    ->  XN HashAggregate  (cost=4214350352.07..4214350354.97 rows=581 width=33)
                          ->  XN Hash Join DS_DIST_OUTER  (cost=225.51..4214349885.85 rows=62162 width=33)
                                Dist: DS_DIST_OUTER  | Outer Dist Key: "outer".eventid
                                Hash Cond: ("outer".eventid = "inner".eventid)
                                ->  XN Hash Join DS_BCAST_INNER  (cost=5.55..3848066.83 rows=30075 width=20)
                                      Dist: DS_BCAST_INNER
                                      Hash Cond: ("outer".dateid = "inner".dateid)
                                      ->  XN Seq Scan on sales s  (cost=0.00..3449.12 rows=344912 width=22)
                                      ->  XN Hash  (cost=5.47..5.47 rows=32 width=2)
                                            ->  XN Seq Scan on date d  (cost=0.00..5.47 rows=32 width=2)
                                                  Filter: (("month" = 'DEC'::bpchar) AND ("year" = 2008))
                                ->  XN Hash  (cost=175.96..175.96 rows=17596 width=21)
                                      ->  XN Seq Scan on event e  (cost=0.00..175.96 rows=17596 width=21)
```

`plan_text`: identical tree (same operators, costs, rows, widths, keys, filter). The only rendering nuance — in `plan_text`, `Outer Dist Key` and `Hash Cond` appear as two text lines; in `plan_nodes` they are the typed fields `outer_dist_key` + `join_condition` on the same node.

Optimization: the `DS_BCAST_INNER` broadcast of `date` and the `DS_DIST_OUTER` redistribution of the join output drive the ~4.2e9 cost. `date` (365 rows) and `event` (17,596) are tiny dimensions — set `DISTSTYLE ALL` on both to eliminate the broadcast/redistribution. `sales` is sorted on `dateid` (sortkey pos 1), but the Dec filter is applied on `date` and then joined, so `sales` is fully scanned; pushing a `saletime`/`dateid` range predicate directly on `sales` would let the sortkey skip blocks.

#### Q2 — Rank events within category (window + subquery filter)

```sql
SELECT catname, eventname, revenue, rnk
FROM (
  SELECT c.catname, e.eventname, SUM(s.pricepaid) AS revenue,
         RANK() OVER (PARTITION BY c.catname ORDER BY SUM(s.pricepaid) DESC) AS rnk
  FROM tickit.sales s
  JOIN tickit.event e ON s.eventid = e.eventid
  JOIN tickit.category c ON e.catid = c.catid
  GROUP BY c.catname, e.eventname
) ranked
WHERE rnk <= 5
ORDER BY catname, revenue DESC;
```

Reconstructed from `plan_nodes`:

```
XN Merge  (cost=2005632964109.12..2005632964114.45 rows=2131 width=391)
  Merge Key: catname, revenue
  ->  XN Network  (... rows=2131 width=391)  Send to leader
        ->  XN Sort  (... rows=2131 width=391)  Sort Key: catname, revenue
              ->  XN Subquery Scan ranked  (cost=1005632963815.55..1005632963991.31 rows=2131 width=391)
                    Filter: (rnk <= 5)
                    ->  XN Window  (cost=...815.55.....911.42 rows=6391 width=41)
                          Partition: c.catname  | Order: sum(s.pricepaid)
                          ->  XN Sort  (... rows=6391 width=41)  Sort Key: c.catname, sum(s.pricepaid)
                                ->  XN Network  (cost=5632963395.61..5632963411.58 rows=6391 width=41)  Distribute
                                      ->  XN HashAggregate  (... rows=6391 width=41)
                                            ->  XN Hash Join DS_BCAST_INNER  (cost=220.09..5632958048.71 rows=712919 width=41)
                                                  Hash Cond: ("outer".catid = "inner".catid)
                                                  ->  XN Hash Join DS_BCAST_INNER  (cost=219.95..5630742007.90 rows=712919 width=35)
                                                        Hash Cond: ("outer".eventid = "inner".eventid)
                                                        ->  XN Seq Scan on sales s  (... rows=344912 width=20)
                                                        ->  XN Hash  (... rows=17596 width=23)
                                                              ->  XN Seq Scan on event e  (... rows=17596 width=23)
                                                  ->  XN Hash  (... rows=11 width=10)
                                                        ->  XN Seq Scan on category c  (... rows=11 width=10)
```

`plan_text`: identical. Note the `XN Window` node carries two keys — `Partition:` and `Order:` (`plan_nodes`: `partition_key` + `order_key`), which the reconstruction renders faithfully.

Optimization: both joins broadcast (`DS_BCAST_INNER`) and there's an extra `Distribute` network step feeding the window sort. `category` (11 rows) and `event` (17,596) → `DISTSTYLE ALL`. The window function forces a full re-sort on (`catname`, `sum`); that's inherent, but co-locating the join removes the 5.6e9-cost broadcast.

#### Q3 — Top sellers (sales ⋈ users, HAVING)

```sql
SELECT u.userid, u.firstname, u.lastname, u.state,
       SUM(s.pricepaid) AS total_sold, SUM(s.qtysold) AS tickets_sold
FROM tickit.sales s
JOIN tickit.users u ON s.sellerid = u.userid
GROUP BY u.userid, u.firstname, u.lastname, u.state
HAVING SUM(s.pricepaid) > 50000
ORDER BY total_sold DESC
LIMIT 25;
```

Reconstructed from `plan_nodes`:

```
XN Limit  (cost=1019996025869.32..1019996025872.35 rows=25 width=47)
  ->  XN Merge  (... rows=1000 width=47)  Merge Key: sum(s.pricepaid)
        ->  XN Network  (... rows=48513 width=47)  Send to leader
              ->  XN Sort  (... rows=48513 width=47)  Sort Key: sum(s.pricepaid)
                    ->  XN HashAggregate  (cost=19996021608.40..19996022093.53 rows=48513 width=47)
                          Filter: (sum(pricepaid) > 50000.00)
                          ->  XN Hash Join DS_BCAST_INNER  (cost=624.88..19996015388.65 rows=355414 width=47)
                                Hash Cond: ("outer".sellerid = "inner".userid)
                                ->  XN Seq Scan on sales s  (... rows=344912 width=22)
                                ->  XN Hash  (cost=499.90..499.90 rows=49990 width=29)
                                      ->  XN Seq Scan on users u  (... rows=49990 width=29)
```

`plan_text`: identical, including the post-aggregate `Filter: (sum(pricepaid) > 50000.00)` representing the HAVING clause.

Optimization: `users` is broadcast because the join is on `sellerid` (not the `sales` DISTKEY `listid`); `users` DISTKEY is `userid`. With 49,990 rows, `DISTSTYLE ALL` on `users` removes the broadcast. The HAVING is correctly applied at the `HashAggregate` (no separate filter step), so nothing to tune there.

#### Q4 — Venue performance (4-way join sales ⋈ event ⋈ venue ⋈ category)

```sql
SELECT v.venuename, v.venuestate, c.catname,
       SUM(s.pricepaid) AS revenue, SUM(s.qtysold) AS tix
FROM tickit.sales s
JOIN tickit.event e ON s.eventid = e.eventid
JOIN tickit.venue v ON e.venueid = v.venueid
JOIN tickit.category c ON e.catid = c.catid
GROUP BY v.venuename, v.venuestate, c.catname
ORDER BY revenue DESC
LIMIT 30;
```

Reconstructed from `plan_nodes`:

```
XN Limit  (cost=1002890342823.98..1002890342824.05 rows=30 width=52)
  ->  XN Merge  (... rows=2222 width=52)  Merge Key: sum(s.pricepaid)
        ->  XN Network  (... rows=2222 width=52)  Send to leader
              ->  XN Sort  (... rows=2222 width=52)  Sort Key: sum(s.pricepaid)
                    ->  XN HashAggregate  (cost=2890342689.35..2890342700.46 rows=2222 width=52)
                          ->  XN Hash Join DS_BCAST_INNER  (cost=222.61..2890333865.23 rows=705930 width=52)
                                Hash Cond: ("outer".catid = "inner".catid)
                                ->  XN Hash Join DS_BCAST_INNER  (cost=222.48..2888117981.21 rows=705950 width=46)
                                      Hash Cond: ("outer".venueid = "inner".venueid)
                                      ->  XN Hash Join DS_BCAST_INNER  (cost=219.95..2815382007.90 rows=712919 width=22)
                                            Hash Cond: ("outer".eventid = "inner".eventid)
                                            ->  XN Seq Scan on sales s  (... rows=344912 width=22)
                                            ->  XN Hash  (... rows=17596 width=8)
                                                  ->  XN Seq Scan on event e  (... rows=17596 width=8)
                                      ->  XN Hash  (... rows=202 width=28)
                                            ->  XN Seq Scan on venue v  (... rows=202 width=28)
                                ->  XN Hash  (... rows=11 width=10)
                                      ->  XN Seq Scan on category c  (... rows=11 width=10)
```

`plan_text`: identical. Three stacked `DS_BCAST_INNER` joins.

Optimization: every dimension (`event`, `venue` 202 rows, `category` 11 rows) is broadcast. All three are excellent `DISTSTYLE ALL` candidates — that would convert all three joins to `DS_DIST_NONE` and collapse the ~2.9e9 cost dramatically.

#### Q5 — Listed vs sold tickets (listing ⋈ date LEFT JOIN sales, COUNT DISTINCT)

```sql
SELECT d.year, d.month,
       COUNT(DISTINCT l.listid) AS listings,
       SUM(l.numtickets) AS listed_tickets,
       SUM(s.qtysold) AS sold_tickets
FROM tickit.listing l
JOIN tickit.date d ON l.dateid = d.dateid
LEFT JOIN tickit.sales s ON l.listid = s.listid
GROUP BY d.year, d.month
ORDER BY d.year, d.month;
```

Reconstructed from `plan_nodes`:

```
XN Merge  (cost=1000087634540.85..1000087634626.85 rows=34403 width=41)
  Merge Key: grvar_1, grvar_2
  ->  XN Network  (... rows=34403 width=41)  Send to leader
        ->  XN Sort  (... rows=34403 width=41)  Sort Key: grvar_1, grvar_2
              ->  XN HashAggregate  (cost=87631690.51..87631948.54 rows=34403 width=41)
                    ->  XN Subquery Scan subq  (cost=87622229.88..87627390.23 rows=344023 width=41)
                          ->  XN HashAggregate  (cost=87622229.88..87623950.00 rows=344023 width=19)
                                ->  XN Hash Right Join DS_DIST_NONE  (cost=87606728.84..87617929.59 rows=344023 width=19)
                                      Hash Cond: ("outer".listid = "inner".listid)
                                      ->  XN Seq Scan on sales s_1  (... rows=344912 width=6)
                                      ->  XN Hash  (cost=87606250.22..87606250.22 rows=191448 width=17)
                                            ->  XN Hash Join DS_BCAST_INNER  (cost=4.56..87606250.22 rows=191448 width=17)
                                                  Hash Cond: ("outer".dateid = "inner".dateid)
                                                  ->  XN Seq Scan on listing l_1  (... rows=192497 width=8)
                                                  ->  XN Hash  (cost=3.65..3.65 rows=365 width=13)
                                                        ->  XN Seq Scan on date d_1  (... rows=365 width=13)
```

`plan_text`: identical. Two interesting points the reconstruction preserves: the LEFT JOIN was rewritten as `XN Hash Right Join DS_DIST_NONE` (sales/listing co-located on `listid` → no data movement, the good case), and the `COUNT(DISTINCT)` produced a double `HashAggregate` + `Subquery Scan subq` with system-generated grouping columns `grvar_1`, `grvar_2`.

Optimization: the listing ⋈ date join still broadcasts `date` (365 rows) → `DISTSTYLE ALL` on `date`. The listing ⋈ sales join is already optimal (`DS_DIST_NONE`, both DISTKEY `listid`). The `COUNT(DISTINCT listid)` is the dominant cost (two aggregation passes); since `listid` is the listing PK, `COUNT(*)` would be equivalent and cheaper.

**Cross-cutting recommendation:** every query is dominated by broadcasting small KEY-distributed dimension tables. Converting `date`, `category`, `venue`, `event`, and `users` to `DISTSTYLE ALL` would eliminate `DS_BCAST_INNER`/`DS_DIST_OUTER` movement across all five. Query 5 already demonstrates the target state (`DS_DIST_NONE`) when DISTKEYs align.

#### plan_nodes vs plan_text — what each provides

What `plan_nodes` gives that `plan_text` does not:
- **Typed, split cost fields** — `cost_startup` and `cost_total` are separate numeric fields; `plan_text` only has the fused `cost=START..TOTAL` string you must parse.
- **Explicit `level` integer** per node — direct tree depth without inferring it from leading-space indentation.
- **Named, queryable attribute keys** instead of free-text lines: `merge_key`, `sort_key`, `join_condition`, `filter_condition`, `data_movement`, `outer_dist_key`, `partition_key`, `order_key`, `distribution_type`, `relation_name`, `alias`. Programmatic analysis needs no regex.
- **`distribution_type` as a first-class field** (e.g. `DS_BCAST_INNER`) separate from the operation label.
- **`relation_name` + `alias` separated** (`sales` + `s`), whereas `plan_text` fuses them as `on sales s`.

What `plan_text` gives that `plan_nodes` does not:
- **Visual parent→child topology via indentation and `->`.** `plan_nodes` carries `level` but not an explicit parent pointer; sibling/branch grouping must be re-derived (the reconstruction above does exactly that from `level`).
- **Operator-specific label phrasing** — `plan_text` writes `Hash Cond:`, `Merge Key:`, `Sort Key:`, `Partition:`, `Order:`, `Send to leader`, `Distribute`, `on <table> <alias>`, `Filter:` as human-readable lines. `plan_nodes` stores the same data under generic key names, losing the exact operator-specific wording (e.g. `plan_text` distinguishes a join's `Hash Cond` from a sort's `Merge Key`; a `plan_nodes` consumer must know the mapping).
- **Cost-range formatting** (`1004214350381.65..1004214350383.10`) rendered exactly as Redshift emits, ready to paste.

Net: both carry the same information content for these five plans — neither dropped a node or a key. `plan_nodes` is strictly better for machine analysis (typed fields, no parsing); `plan_text` is better for direct human reading (topology + native operator vocabulary). The only thing requiring reconstruction work to go `plan_nodes` → text is re-deriving the branch structure from `level`, which is unambiguous here.

</details>

### End to end

Exercised every tool against both provisioned and serverless clusters, plus the safety guardrails, via `scripts/e2e-test.sh` (run from the package root). The script sends this request through `kiro-cli`:

```
Test if all the Redshift MCP Server tools available to you are working. Check both
provisioned and serverless clusters, including database schema exploration in both.
Check the SQL read-only protection, transaction breaker protection, and failed user
SQL behavior. Test the new tool describe_execution_plan and return the explain result.
Also, check BaseSchema regarding optimization of token usage.
Get test scenario ideas from the unit tests under the project directory. Provide a
short testing summary, one line per tool.
```

<details>
<summary>Result — all tools + guardrails pass on provisioned and serverless</summary>

| Check | Result |
|---|---|
| list_clusters / databases / schemas / tables / columns | ✅ Pass (provisioned + serverless) |
| execute_query | ✅ Pass |
| describe_execution_plan | ✅ Pass — returned full plan, table designs, column stats, 10 rule-based suggestions |
| Read-only protection | ✅ CREATE TABLE rejected (transaction is read-only) |
| Transaction-breaker protection | ✅ `SELECT 1; COMMIT;` rejected pre-execution |
| Failed user SQL | ✅ Clean `relation does not exist`, wrapper still closed with `END;` |
| BaseSchema token optimization | ✅ None keys stripped via `@model_serializer(mode='wrap')`; serverless output omitted `node_type`/`number_of_nodes`/`master_username` |

</details>

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: #1019

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

