### PR TITLE
fix(iac): parse knowledge mcp skill results

### DIFF
--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/client/aws_knowledge_client.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/client/aws_knowledge_client.py
@@ -76,14 +76,22 @@ def _parse_search_documentation_result(result: CallToolResult) -> List[Knowledge
     result_content_json = json.loads(content.text)
     raw_results = result_content_json['content']['result']
 
-    results = [
-        KnowledgeResult(
-            rank=item['rank_order'],
-            title=item['title'],
-            url=item['url'],
-            context=item['context'],
+    results = []
+    for item in raw_results:
+        if 'skill_description' in item:
+            url = item.get('url')
+            context = item['skill_description']
+        else:
+            url = item['url']
+            context = item['context']
+
+        results.append(
+            KnowledgeResult(
+                rank=item['rank_order'],
+                title=item['title'],
+                url=url,
+                context=context,
+            )
         )
-        for item in raw_results
-    ]
 
     return results

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/knowledge_models.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/knowledge_models.py
@@ -22,7 +22,7 @@ class KnowledgeResult:
 
     rank: int
     title: str
-    url: str
+    url: Optional[str]
     context: str
 
 

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py
@@ -334,14 +334,14 @@ async def search_cdk_documentation(query: str) -> str:
         - results: Array with single result containing:
             - rank: Search relevance ranking (1 = most relevant, higher is less relevant)
             - title: Document title or filename
-            - url: Source URL of the document
+            - url: Source URL of the document, if present
             - context: Full or paginated document content
     - next_step_guidance: If present, suggested next actions to take for answering user query
 
 
     Use rank to prioritize results. Check error field first - if not null, the search failed.
 
-    If a content snippet is relevant to your query but doesn't show all necessary information, use `read_iac_documentation_page` with the URL to get the complete content.
+    If a result includes a URL and the content snippet doesn't show all necessary information, use `read_iac_documentation_page` with that URL to get the complete content.
 
     Args:
         query: Search query for CDK documentation (required)
@@ -391,7 +391,7 @@ async def search_cloudformation_documentation(query: str) -> str:
       - results: Array with single result containing:
         - rank: Search relevance ranking (1 = most relevant, higher is less relevant)
         - title: Document title or filename
-        - url: Source URL of the document
+        - url: Source URL of the document, if present
         - context: Full or paginated document content
     - next_step_guidance: If present, suggested next actions to take for answering user query
 
@@ -459,7 +459,7 @@ async def search_cdk_samples_and_constructs(
       - results: Array with single result containing:
         - rank: Search relevance ranking (1 = most relevant, higher is less relevant)
         - title: Document title or filename
-        - url: Source URL of the document
+        - url: Source URL of the document, if present
         - context: Full or paginated document content
     - next_step_guidance: If present, suggested next actions to take for answering user query
 

--- a/src/aws-iac-mcp-server/tests/client/test_aws_knowledge_client.py
+++ b/src/aws-iac-mcp-server/tests/client/test_aws_knowledge_client.py
@@ -142,6 +142,42 @@ class TestParseSearchResult:
 
         assert parsed == []
 
+    def test_skill_result_without_url(self):
+        """Test parsing of skill results without document URLs."""
+        mock_result = MagicMock()
+        mock_result.is_error = False
+        mock_content = TextContent(
+            type='text',
+            text=json.dumps(
+                {
+                    'content': {
+                        'result': [
+                            {
+                                'rank_order': 1,
+                                'title': 'AWS::Lambda::Function',
+                                'url': 'https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-lambda-function.html',
+                                'context': 'CloudFormation resource documentation',
+                            },
+                            {
+                                'rank_order': 2,
+                                'title': 'AWS Lambda IaC guidance',
+                                'skill_name': 'lambda-iac-guidance',
+                                'skill_description': 'Use this skill for Lambda infrastructure guidance.',
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+        mock_result.content = [mock_content]
+
+        parsed = _parse_search_documentation_result(mock_result)
+
+        assert len(parsed) == 2
+        assert parsed[1].title == 'AWS Lambda IaC guidance'
+        assert parsed[1].url is None
+        assert parsed[1].context == 'Use this skill for Lambda infrastructure guidance.'
+
     def test_is_error_true(self):
         """Test handling of error responses from MCP client.
 


### PR DESCRIPTION
Fixes #3339.

## Summary

This fixes the AWS IaC Knowledge MCP search parser so valid skill results without document URLs do not crash the search tools.

## Changes

- handle Knowledge MCP skill results that do not include a document URL
- map skill result descriptions into the existing `context` response field
- document that search result URLs may be absent and add regression coverage

## Details

The AWS Knowledge MCP search response can contain both document results and skill results in the same `result` list. Document results include `url` and `context`, while skill results include `skill_name` and `skill_description` and may not have a `url`.

The current parser assumes every result has `url`, so `search_cdk_documentation` and `search_cloudformation_documentation` can fail with `KeyError: 'url'` before returning any useful results. This change keeps document result validation intact, but accepts skill results by using an optional URL and mapping `skill_description` to `context`.

## Verification

From `src/aws-iac-mcp-server`:

```bash
uv run --frozen pytest --cov --cov-branch --cov-report=term-missing
uv run ruff check .
uv run ruff format --check .
uv run pyright
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
