### PR TITLE
fix(ccapi-mcp-server): harden update_resource token validation

### DIFF
--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.1.0'
+__version__ = '1.0.22'

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.0.22'
+__version__ = '1.1.0'

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.0.22'
+__version__ = '1.0.9223372036854775807'

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/infrastructure_generation.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/infrastructure_generation.py
@@ -60,6 +60,10 @@ async def generate_infrastructure_code_impl_wrapper(
         'data': {
             'properties': result['properties'],
             'cloudformation_template': result.get('cloudformation_template', result['properties']),
+            'operation': result.get('operation', 'create'),
+            'patch_document': result.get('effective_patch_document'),
+            'resource_type': request.resource_type,
+            'identifier': request.identifier,
         },
         'parent_token': request.credentials_token,
         'timestamp': datetime.datetime.now().isoformat(),

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
@@ -174,7 +174,7 @@ async def update_resource_impl(request: UpdateResourceRequest, workflow_store: d
                 'run run_checkov() first and get user approval'
             )
         _validate_token_chain(request.explained_token, request.security_scan_token, workflow_store)
-    elif not security_scanning_enabled and not request.skip_security_check:
+    elif not request.skip_security_check:
         raise ClientError(
             'Security scanning is disabled. You must set skip_security_check=True '
             'to proceed without security validation.'

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
@@ -181,9 +181,45 @@ async def update_resource_impl(request: UpdateResourceRequest, workflow_store: d
         )
 
     # Always validate explained_token exists and has correct type
-    validate_workflow_token(request.explained_token, 'explained_properties', workflow_store)
+    workflow_data = validate_workflow_token(
+        request.explained_token, 'explained_properties', workflow_store
+    )
 
-    validate_patch(request.patch_document)
+    # Verify the token was generated for an update operation and matches the target resource
+    token_data = workflow_data.get('data', {})
+    stored_operation = token_data.get('operation')
+    if stored_operation and stored_operation != 'update':
+        raise ClientError(
+            f'Invalid explained_token: token was generated for {stored_operation}, not update'
+        )
+
+    stored_resource_type = token_data.get('resource_type', '')
+    if stored_resource_type and stored_resource_type != request.resource_type:
+        raise ClientError(
+            f'Resource type mismatch: token is for {stored_resource_type}, '
+            f'but update targets {request.resource_type}'
+        )
+
+    stored_identifier = token_data.get('identifier', '')
+    if stored_identifier and stored_identifier != request.identifier:
+        raise ClientError(
+            f'Identifier mismatch: token is for {stored_identifier}, '
+            f'but update targets {request.identifier}'
+        )
+
+    # Use stored patch if available; reject if caller tries to override
+    stored_patch = token_data.get('patch_document')
+    if stored_patch is not None:
+        if request.patch_document and request.patch_document != stored_patch:
+            raise ClientError(
+                'Patch document mismatch: the submitted patch differs from '
+                'what was explained and scanned. Generate and explain a new patch.'
+            )
+        patch_to_use = stored_patch
+    else:
+        patch_to_use = request.patch_document
+
+    validate_patch(patch_to_use)
     # Use MCP env region or session region, no hardcoded fallback
     env_vars = aws_session_data.get('environment_variables', {})
     region_str = env_vars.get('AWS_REGION') or aws_session_data.get('region')
@@ -192,7 +228,7 @@ async def update_resource_impl(request: UpdateResourceRequest, workflow_store: d
     cloudcontrol_client = get_aws_client('cloudcontrol', region_str)
 
     # Convert patch document to JSON string for the API
-    patch_document_str = json.dumps(request.patch_document)
+    patch_document_str = json.dumps(patch_to_use)
 
     # Update the resource
     try:

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
@@ -187,37 +187,40 @@ async def update_resource_impl(request: UpdateResourceRequest, workflow_store: d
 
     # Verify the token was generated for an update operation and matches the target resource
     token_data = workflow_data.get('data', {})
-    stored_operation = token_data.get('operation')
-    if stored_operation and stored_operation != 'update':
+    stored_operation = token_data.get('operation', '')
+    if stored_operation != 'update':
         raise ClientError(
-            f'Invalid explained_token: token was generated for {stored_operation}, not update'
+            f'Invalid explained_token: token was generated for '
+            f'{stored_operation or "unknown"}, not update'
         )
 
     stored_resource_type = token_data.get('resource_type', '')
-    if stored_resource_type and stored_resource_type != request.resource_type:
+    if stored_resource_type != request.resource_type:
         raise ClientError(
-            f'Resource type mismatch: token is for {stored_resource_type}, '
+            f'Resource type mismatch: token is for {stored_resource_type or "unknown"}, '
             f'but update targets {request.resource_type}'
         )
 
     stored_identifier = token_data.get('identifier', '')
-    if stored_identifier and stored_identifier != request.identifier:
+    if stored_identifier != request.identifier:
         raise ClientError(
-            f'Identifier mismatch: token is for {stored_identifier}, '
+            f'Identifier mismatch: token is for {stored_identifier or "unknown"}, '
             f'but update targets {request.identifier}'
         )
 
-    # Use stored patch if available; reject if caller tries to override
+    # Use the server-stored patch; reject if caller tries to override
     stored_patch = token_data.get('patch_document')
-    if stored_patch is not None:
-        if request.patch_document and request.patch_document != stored_patch:
-            raise ClientError(
-                'Patch document mismatch: the submitted patch differs from '
-                'what was explained and scanned. Generate and explain a new patch.'
-            )
-        patch_to_use = stored_patch
-    else:
-        patch_to_use = request.patch_document
+    if stored_patch is None:
+        raise ClientError(
+            'Invalid explained_token: token does not contain a patch_document. '
+            'Generate and explain the update via generate_infrastructure_code() first.'
+        )
+    if request.patch_document and request.patch_document != stored_patch:
+        raise ClientError(
+            'Patch document mismatch: the submitted patch differs from '
+            'what was explained and scanned. Generate and explain a new patch.'
+        )
+    patch_to_use = stored_patch
 
     validate_patch(patch_to_use)
     # Use MCP env region or session region, no hardcoded fallback

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
@@ -217,7 +217,7 @@ async def update_resource_impl(request: UpdateResourceRequest, workflow_store: d
             'Invalid explained_token: token does not contain a patch_document. '
             'Generate and explain the update via generate_infrastructure_code() first.'
         )
-    if request.patch_document and request.patch_document != stored_patch:
+    if request.patch_document is not None and request.patch_document != stored_patch:
         raise ClientError(
             'Patch document mismatch: the submitted patch differs from '
             'what was explained and scanned. Generate and explain a new patch.'

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
@@ -167,15 +167,21 @@ async def update_resource_impl(request: UpdateResourceRequest, workflow_store: d
     security_scanning_enabled, security_warning = check_security_scanning()
 
     # Validate security scan token if security scanning is enabled
-    if security_scanning_enabled and not request.security_scan_token:
-        raise ClientError('Security scan token required (run run_checkov() first)')
+    if security_scanning_enabled:
+        if not request.security_scan_token:
+            raise ClientError(
+                'Security scanning is enabled but no security_scan_token provided: '
+                'run run_checkov() first and get user approval'
+            )
+        _validate_token_chain(request.explained_token, request.security_scan_token, workflow_store)
+    elif not security_scanning_enabled and not request.skip_security_check:
+        raise ClientError(
+            'Security scanning is disabled. You must set skip_security_check=True '
+            'to proceed without security validation.'
+        )
 
-    # CRITICAL SECURITY: Validate explained token (already validated in token chain if security enabled)
-    if not security_scanning_enabled or request.skip_security_check:
-        validate_workflow_token(request.explained_token, 'explained_properties', workflow_store)
-    else:
-        # Token already validated in chain
-        pass
+    # Always validate explained_token exists and has correct type
+    validate_workflow_token(request.explained_token, 'explained_properties', workflow_store)
 
     validate_patch(request.patch_document)
     # Use MCP env region or session region, no hardcoded fallback

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/resource_operations.py
@@ -61,19 +61,21 @@ def _validate_token_chain(
     if not security_scan_token or security_scan_token not in workflow_store:
         raise ClientError('Invalid security_scan_token')
 
-    # Security scan token must be created after explain token in same workflow
     explained_data = workflow_store[explained_token]
     security_data = workflow_store[security_scan_token]
 
-    # For now, just ensure both tokens exist and are valid types
     if explained_data.get('type') != 'explained_properties':
         raise ClientError('Invalid explained_token type')
 
     if security_data.get('type') != 'security_scan':
         raise ClientError('Invalid security_scan_token type')
 
-    # Set the parent relationship (security scan derives from explained token)
-    workflow_store[security_scan_token]['parent_token'] = explained_token
+    stored_parent = security_data.get('parent_token')
+    if stored_parent and stored_parent != explained_token:
+        raise ClientError(
+            'Token chain mismatch: security_scan_token was not derived from '
+            'the provided explained_token'
+        )
 
 
 async def create_resource_impl(request: CreateResourceRequest, workflow_store: dict) -> dict:

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/security_scanning.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/impl/tools/security_scanning.py
@@ -151,6 +151,7 @@ async def run_checkov_impl(request: RunCheckovRequest, workflow_store: dict) -> 
                     'resource_type': resource_type,
                     'timestamp': str(datetime.datetime.now()),
                 },
+                'parent_token': request.explained_token,
                 'timestamp': datetime.datetime.now().isoformat(),
             }
 
@@ -187,6 +188,7 @@ async def run_checkov_impl(request: RunCheckovRequest, workflow_store: dict) -> 
                         'resource_type': resource_type,
                         'timestamp': str(datetime.datetime.now()),
                     },
+                    'parent_token': request.explained_token,
                     'timestamp': datetime.datetime.now().isoformat(),
                 }
 

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/infrastructure_generator.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/infrastructure_generator.py
@@ -148,6 +148,10 @@ async def generate_infrastructure_code(
         'supports_tagging': supports_tagging,
     }
 
+    if is_update:
+        result['effective_patch_document'] = patch_document
+        result['identifier'] = identifier
+
     if patch_document_with_tags:
         result['recommended_patch_document'] = patch_document_with_tags
 

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/infrastructure_generator.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/infrastructure_generator.py
@@ -149,7 +149,7 @@ async def generate_infrastructure_code(
     }
 
     if is_update:
-        result['effective_patch_document'] = patch_document
+        result['effective_patch_document'] = patch_document_with_tags or patch_document
         result['identifier'] = identifier
 
     if patch_document_with_tags:

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.1.0"
+version = "1.0.22"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.0.22"
+version = "1.1.0"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.0.22"
+version = "1.0.9223372036854775807"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/tests/test_resource_operations.py
+++ b/src/ccapi-mcp-server/tests/test_resource_operations.py
@@ -1246,3 +1246,229 @@ class TestResourceOperations:
 
         with pytest.raises(ClientError, match='skip_security_check=True'):
             await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.get_aws_client')
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_uses_stored_patch(self, mock_environ, mock_client):
+        """Verify update uses patch from token store, not caller input."""
+        mock_environ.get.return_value = 'enabled'
+        mock_client.return_value.update_resource.return_value = {
+            'ProgressEvent': {'OperationStatus': 'SUCCESS'}
+        }
+
+        stored_patch = [{'op': 'replace', 'path': '/BucketName', 'value': 'stored-name'}]
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'stored-name'},
+                    'operation': 'update',
+                    'patch_document': stored_patch,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'my-bucket',
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='my-bucket',
+            patch_document=stored_patch,
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with patch(
+            'awslabs.ccapi_mcp_server.impl.tools.resource_operations.progress_event'
+        ) as mock_progress:
+            mock_progress.return_value = {'status': 'SUCCESS'}
+            result = await update_resource_impl(request, workflow_store)
+            assert result['status'] == 'SUCCESS'
+            # Verify the stored patch was sent to CloudControl
+            call_args = mock_client.return_value.update_resource.call_args
+            import json
+
+            assert json.loads(call_args[1]['PatchDocument']) == stored_patch
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_rejects_patch_mismatch(self, mock_environ):
+        """Verify update rejects when caller patch differs from stored."""
+        mock_environ.get.return_value = 'enabled'
+
+        stored_patch = [{'op': 'replace', 'path': '/BucketName', 'value': 'stored-name'}]
+        different_patch = [{'op': 'replace', 'path': '/BucketName', 'value': 'attacker-name'}]
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'stored-name'},
+                    'operation': 'update',
+                    'patch_document': stored_patch,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'my-bucket',
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='my-bucket',
+            patch_document=different_patch,
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='Patch document mismatch'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_rejects_wrong_operation_type(self, mock_environ):
+        """Token generated for 'create' cannot be used for update."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'test'},
+                    'operation': 'create',
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': '',
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='my-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='not update'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_rejects_resource_type_mismatch(self, mock_environ):
+        """Token for AWS::S3::Bucket cannot update AWS::RDS::DBInstance."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'test'},
+                    'operation': 'update',
+                    'patch_document': [{'op': 'replace', 'path': '/test', 'value': 'x'}],
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'my-bucket',
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::RDS::DBInstance',
+            identifier='my-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'x'}],
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='Resource type mismatch'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_rejects_identifier_mismatch(self, mock_environ):
+        """Token for bucket-A cannot update bucket-B."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'bucket-a'},
+                    'operation': 'update',
+                    'patch_document': [{'op': 'replace', 'path': '/test', 'value': 'x'}],
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'bucket-a',
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='bucket-b',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'x'}],
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='Identifier mismatch'):
+            await update_resource_impl(request, workflow_store)

--- a/src/ccapi-mcp-server/tests/test_resource_operations.py
+++ b/src/ccapi-mcp-server/tests/test_resource_operations.py
@@ -65,10 +65,22 @@ class TestResourceOperations:
         """Test _validate_token_chain with valid tokens."""
         workflow_store = {
             'explained': {'type': 'explained_properties', 'data': {}},
-            'security': {'type': 'security_scan', 'data': {}},
+            'security': {'type': 'security_scan', 'data': {}, 'parent_token': 'explained'},
         }
         _validate_token_chain('explained', 'security', workflow_store)
-        assert workflow_store['security']['parent_token'] == 'explained'
+
+    def test_validate_token_chain_rejects_cross_workflow(self):
+        """Test _validate_token_chain rejects tokens from different workflows."""
+        workflow_store = {
+            'explained_b': {'type': 'explained_properties', 'data': {}},
+            'security_a': {
+                'type': 'security_scan',
+                'data': {},
+                'parent_token': 'explained_a',
+            },
+        }
+        with pytest.raises(ClientError, match='Token chain mismatch'):
+            _validate_token_chain('explained_b', 'security_a', workflow_store)
 
     def test_validate_token_chain_invalid_explained(self):
         """Test _validate_token_chain with invalid explained token."""
@@ -1558,4 +1570,50 @@ class TestResourceOperations:
         )
 
         with pytest.raises(ClientError, match='does not contain a patch_document'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_rejects_cross_workflow_tokens(self, mock_environ):
+        """Security scan from workflow A cannot be used with explained token from workflow B."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained_b': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'test'},
+                    'operation': 'update',
+                    'patch_document': [{'op': 'replace', 'path': '/test', 'value': 'x'}],
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'my-bucket',
+                },
+            },
+            'security_a': {
+                'type': 'security_scan',
+                'data': {'passed': True},
+                'parent_token': 'explained_a',
+            },
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='my-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'x'}],
+            credentials_token='creds',
+            explained_token='explained_b',
+            security_scan_token='security_a',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='Token chain mismatch'):
             await update_resource_impl(request, workflow_store)

--- a/src/ccapi-mcp-server/tests/test_resource_operations.py
+++ b/src/ccapi-mcp-server/tests/test_resource_operations.py
@@ -905,7 +905,7 @@ class TestResourceOperations:
             mock_env.get.return_value = 'enabled'
             with pytest.raises(ClientError) as exc_info:
                 await update_resource_impl(request, workflow_store)
-            assert 'Security scan token required' in str(exc_info.value)
+            assert 'no security_scan_token provided' in str(exc_info.value)
 
     def test_check_readonly_mode_with_context(self):
         """Test check_readonly_mode when Context.readonly_mode() returns True."""
@@ -1109,3 +1109,140 @@ class TestResourceOperations:
         assert result['identifier'] == 'test-bucket'
         assert 'security_analysis' in result
         assert 'error' in result['security_analysis']
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_bogus_security_token_rejected(self, mock_environ):
+        """Verify that a non-empty but non-existent security_scan_token is rejected."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {'properties': {'test': 'value'}},
+            },
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='test-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='bogus_token_not_in_store',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='Invalid security_scan_token'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_bogus_explained_token_rejected(self, mock_environ):
+        """Verify that a non-existent explained_token is rejected when scanning enabled."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='test-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            credentials_token='creds',
+            explained_token='bogus_explained_not_in_store',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='Invalid explained_token'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_wrong_token_types_rejected(self, mock_environ):
+        """Verify tokens with wrong types are rejected."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'security_scan',
+                'data': {},
+            },
+            'security': {'type': 'explained_properties', 'data': {}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='test-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_security_disabled_requires_skip(self, mock_environ):
+        """With SECURITY_SCANNING=disabled and skip_security_check=False, must reject."""
+        mock_environ.get.return_value = 'disabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {'properties': {'test': 'value'}},
+            },
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='test-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            credentials_token='creds',
+            explained_token='explained',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='skip_security_check=True'):
+            await update_resource_impl(request, workflow_store)

--- a/src/ccapi-mcp-server/tests/test_resource_operations.py
+++ b/src/ccapi-mcp-server/tests/test_resource_operations.py
@@ -203,6 +203,7 @@ class TestResourceOperations:
             'ProgressEvent': {'OperationStatus': 'SUCCESS'}
         }
 
+        patch_doc = [{'op': 'replace', 'path': '/BucketName', 'value': 'new-name'}]
         workflow_store = {
             'creds': {
                 'type': 'credentials',
@@ -214,14 +215,20 @@ class TestResourceOperations:
             },
             'explained': {
                 'type': 'explained_properties',
-                'data': {'properties': {'test': 'value'}},
+                'data': {
+                    'properties': {'test': 'value'},
+                    'operation': 'update',
+                    'patch_document': patch_doc,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'test-bucket',
+                },
             },
         }
 
         request = UpdateResourceRequest(
             resource_type='AWS::S3::Bucket',
             identifier='test-bucket',
-            patch_document=[{'op': 'replace', 'path': '/BucketName', 'value': 'new-name'}],
+            patch_document=patch_doc,
             credentials_token='creds',
             explained_token='explained',
             skip_security_check=True,
@@ -512,6 +519,7 @@ class TestResourceOperations:
             'ProgressEvent': {'OperationStatus': 'SUCCESS'}
         }
 
+        patch_doc = [{'op': 'replace', 'path': '/test', 'value': 'new'}]
         workflow_store = {
             'creds': {
                 'type': 'credentials',
@@ -523,14 +531,20 @@ class TestResourceOperations:
             },
             'explained': {
                 'type': 'explained_properties',
-                'data': {'properties': {'test': 'value'}},
+                'data': {
+                    'properties': {'test': 'value'},
+                    'operation': 'update',
+                    'patch_document': patch_doc,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'test-bucket',
+                },
             },
         }
 
         request = UpdateResourceRequest(
             resource_type='AWS::S3::Bucket',
             identifier='test-bucket',
-            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            patch_document=patch_doc,
             credentials_token='creds',
             explained_token='explained',
             skip_security_check=True,
@@ -675,6 +689,7 @@ class TestResourceOperations:
             'ProgressEvent': {'OperationStatus': 'SUCCESS'}
         }
 
+        patch_doc = [{'op': 'replace', 'path': '/test', 'value': 'new'}]
         workflow_store = {
             'creds': {
                 'type': 'credentials',
@@ -686,7 +701,13 @@ class TestResourceOperations:
             },
             'explained': {
                 'type': 'explained_properties',
-                'data': {'properties': {'test': 'value'}},
+                'data': {
+                    'properties': {'test': 'value'},
+                    'operation': 'update',
+                    'patch_document': patch_doc,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'test-bucket',
+                },
             },
             'security': {'type': 'security_scan', 'data': {'passed': True}},
         }
@@ -694,7 +715,7 @@ class TestResourceOperations:
         request = UpdateResourceRequest(
             resource_type='AWS::S3::Bucket',
             identifier='test-bucket',
-            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            patch_document=patch_doc,
             credentials_token='creds',
             explained_token='explained',
             security_scan_token='security',
@@ -750,21 +771,32 @@ class TestResourceOperations:
         """Test update_resource_impl with API error."""
         mock_client.return_value.update_resource.side_effect = Exception('API Error')
 
+        patch_doc = [{'op': 'replace', 'path': '/test', 'value': 'new'}]
         workflow_store = {
             'creds': {
                 'type': 'credentials',
-                'data': {'credentials_valid': True, 'readonly_mode': False},
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
             },
             'explained': {
                 'type': 'explained_properties',
-                'data': {'properties': {'test': 'value'}},
+                'data': {
+                    'properties': {'test': 'value'},
+                    'operation': 'update',
+                    'patch_document': patch_doc,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'test-bucket',
+                },
             },
         }
 
         request = UpdateResourceRequest(
             resource_type='AWS::S3::Bucket',
             identifier='test-bucket',
-            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            patch_document=patch_doc,
             credentials_token='creds',
             explained_token='explained',
             skip_security_check=True,
@@ -772,10 +804,9 @@ class TestResourceOperations:
         )
 
         with patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ') as mock_env:
-            with patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.validate_patch'):
-                mock_env.get.return_value = 'disabled'
-                with pytest.raises(Exception):
-                    await update_resource_impl(request, workflow_store)
+            mock_env.get.return_value = 'disabled'
+            with pytest.raises(Exception):
+                await update_resource_impl(request, workflow_store)
 
     @pytest.mark.asyncio
     @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.get_aws_client')
@@ -840,6 +871,7 @@ class TestResourceOperations:
             'ProgressEvent': {'OperationStatus': 'SUCCESS'}
         }
 
+        patch_doc = [{'op': 'replace', 'path': '/test', 'value': 'new'}]
         workflow_store = {
             'creds': {
                 'type': 'credentials',
@@ -851,14 +883,20 @@ class TestResourceOperations:
             },
             'explained': {
                 'type': 'explained_properties',
-                'data': {'properties': {'test': 'value'}},
+                'data': {
+                    'properties': {'test': 'value'},
+                    'operation': 'update',
+                    'patch_document': patch_doc,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'test-bucket',
+                },
             },
         }
 
         request = UpdateResourceRequest(
             resource_type='AWS::S3::Bucket',
             identifier='test-bucket',
-            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            patch_document=patch_doc,
             credentials_token='creds',
             explained_token='explained',
             skip_security_check=True,
@@ -1018,6 +1056,7 @@ class TestResourceOperations:
     @pytest.mark.asyncio
     async def test_update_resource_impl_no_region_configured(self):
         """Test update_resource_impl with no region configured."""
+        patch_doc = [{'op': 'replace', 'path': '/test', 'value': 'new'}]
         workflow_store = {
             'creds': {
                 'type': 'credentials',
@@ -1029,14 +1068,20 @@ class TestResourceOperations:
             },
             'explained': {
                 'type': 'explained_properties',
-                'data': {'properties': {'test': 'value'}},
+                'data': {
+                    'properties': {'test': 'value'},
+                    'operation': 'update',
+                    'patch_document': patch_doc,
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'test-bucket',
+                },
             },
         }
 
         request = UpdateResourceRequest(
             resource_type='AWS::S3::Bucket',
             identifier='test-bucket',
-            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'new'}],
+            patch_document=patch_doc,
             credentials_token='creds',
             explained_token='explained',
             skip_security_check=True,
@@ -1471,4 +1516,46 @@ class TestResourceOperations:
         )
 
         with pytest.raises(ClientError, match='Identifier mismatch'):
+            await update_resource_impl(request, workflow_store)
+
+    @pytest.mark.asyncio
+    @patch('awslabs.ccapi_mcp_server.impl.tools.resource_operations.environ')
+    async def test_update_resource_impl_rejects_missing_patch_in_token(self, mock_environ):
+        """Token without stored patch_document is rejected."""
+        mock_environ.get.return_value = 'enabled'
+
+        workflow_store = {
+            'creds': {
+                'type': 'credentials',
+                'data': {
+                    'credentials_valid': True,
+                    'readonly_mode': False,
+                    'environment_variables': {'AWS_REGION': 'us-east-1'},
+                },
+            },
+            'explained': {
+                'type': 'explained_properties',
+                'data': {
+                    'properties': {'BucketName': 'test'},
+                    'operation': 'update',
+                    'resource_type': 'AWS::S3::Bucket',
+                    'identifier': 'my-bucket',
+                    # patch_document intentionally omitted
+                },
+            },
+            'security': {'type': 'security_scan', 'data': {'passed': True}},
+        }
+
+        request = UpdateResourceRequest(
+            resource_type='AWS::S3::Bucket',
+            identifier='my-bucket',
+            patch_document=[{'op': 'replace', 'path': '/test', 'value': 'x'}],
+            credentials_token='creds',
+            explained_token='explained',
+            security_scan_token='security',
+            region='us-east-1',
+            skip_security_check=False,
+        )
+
+        with pytest.raises(ClientError, match='does not contain a patch_document'):
             await update_resource_impl(request, workflow_store)

--- a/src/ccapi-mcp-server/tests/test_server.py
+++ b/src/ccapi-mcp-server/tests/test_server.py
@@ -1321,6 +1321,9 @@ class TestTools:
         explained_token = 'valid_explained'
         security_token = 'valid_security'
         _workflow_store[explained_token] = {'type': 'explained_properties', 'data': {}}
-        _workflow_store[security_token] = {'type': 'security_scan', 'data': {}}
+        _workflow_store[security_token] = {
+            'type': 'security_scan',
+            'data': {},
+            'parent_token': explained_token,
+        }
         _validate_token_chain(explained_token, security_token, _workflow_store)
-        assert _workflow_store[security_token]['parent_token'] == explained_token

--- a/src/ccapi-mcp-server/uv.lock
+++ b/src/ccapi-mcp-server/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ccapi-mcp-server"
-version = "1.0.22"
+version = "1.0.9223372036854775807"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- **Phase 1**: Fix `update_resource_impl()` to validate token chain (explained_token + security_scan_token) using `_validate_token_chain()`, matching the existing `create_resource_impl()` pattern. Previously, bogus tokens could bypass the explain/scan safety workflow.
- **Phase 2**: Bind the patch document to the explained token so callers cannot submit a different patch than what was explained and scanned (defense-in-depth).
- **Phase 3**: Remove backward-compat fallback for pre-fix tokens.

Security issue reported by external researcher. Does not bypass AWS IAM or read-only mode — bypasses the MCP server's own pre-update safety controls.

## Test plan

- [x] Existing 49 tests pass (276 full suite, 2 pre-existing env-specific failures on main)
- [x] 4 new regression tests for Phase 1: bogus security token, bogus explained token, wrong token types, security-disabled-requires-skip
- [x] Phase 2 tests: stored patch used, mismatch rejected, wrong operation type, resource identity mismatch
- [x] CI green on all phases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)