### PR TITLE
fix(aws-pricing-mcp-server): validate and confine generate_cost_report output_file path

### DIFF
--- a/src/aws-pricing-mcp-server/README.md
+++ b/src/aws-pricing-mcp-server/README.md
@@ -150,3 +150,25 @@ The server uses two key environment variables:
   "AWS_REGION": "us-east-1"
 }
 ```
+
+### Cost report output directory
+
+The `generate_cost_report` tool can save the generated report to a file via its
+`output_file` parameter. To prevent path-traversal writes outside an intended
+location, `output_file` is confined to a base directory:
+
+- **`AWS_PRICING_MCP_OUTPUT_DIR`** (optional): The base directory reports may be
+  written to. Defaults to the current working directory of the server process.
+
+Paths are resolved and must stay within this base directory. Absolute paths that
+fall outside it, `..` traversal segments, and symlinks that escape the base are
+all rejected. To allow reports to be written elsewhere, set this variable to the
+desired directory:
+
+```json
+"env": {
+  "AWS_PROFILE": "default",
+  "AWS_REGION": "us-east-1",
+  "AWS_PRICING_MCP_OUTPUT_DIR": "/path/to/reports"
+}
+```

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/report_generator.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/report_generator.py
@@ -20,6 +20,7 @@ It supports both markdown and CSV output formats with detailed cost breakdowns.
 
 import csv
 import io
+import os
 import re
 from awslabs.aws_pricing_mcp_server.helpers import CostAnalysisHelper
 from awslabs.aws_pricing_mcp_server.static import COST_REPORT_TEMPLATE
@@ -44,6 +45,67 @@ SKIP_KEYS = {
 COST_FIELDS = {'monthly_cost', 'cost', 'price', 'one_time_cost', 'total_cost'}
 
 MONETARY_FIELDS = {'cost', 'price', 'rate', 'fee', 'charge', 'amount', 'total'}
+
+# Environment variable that overrides the base directory reports may be written to.
+# Defaults to the current working directory.
+OUTPUT_DIR_ENV_VAR = 'AWS_PRICING_MCP_OUTPUT_DIR'
+
+
+class OutputPathError(ValueError):
+    """Raised when output_file is rejected by path-confinement validation."""
+
+
+def _validate_output_path(output_file: str) -> Path:
+    """Resolve and confine output_file within the permitted output directory.
+
+    The base directory defaults to the current working directory and can be
+    overridden with the AWS_PRICING_MCP_OUTPUT_DIR environment variable. Paths
+    are canonicalized with resolve() so that '..' segments, absolute paths and
+    symlinks that escape the base directory are all rejected.
+
+    Args:
+        output_file: Caller-supplied destination path for the report.
+
+    Returns:
+        The validated, fully-resolved path contained within the base directory.
+
+    Raises:
+        OutputPathError: if output_file contains '..' segments or resolves
+            outside the permitted base directory.
+    """
+    base = Path(os.environ.get(OUTPUT_DIR_ENV_VAR) or Path.cwd()).resolve()
+
+    if '..' in Path(output_file).parts:
+        raise OutputPathError(f"output_file '{output_file}' must not contain '..' path segments")
+
+    resolved = (base / output_file).resolve()
+    if not resolved.is_relative_to(base):
+        raise OutputPathError(
+            f"output_file '{output_file}' resolves outside the permitted output directory '{base}'"
+        )
+
+    return resolved
+
+
+async def _write_report_file(
+    output_file: str, content: str, ctx: Optional[Context] = None
+) -> None:
+    """Validate the destination and write report content to a confined path.
+
+    Args:
+        output_file: Caller-supplied destination path for the report.
+        content: Report content to write.
+        ctx: Optional MCP context for logging.
+
+    Raises:
+        OutputPathError: if output_file is rejected by _validate_output_path.
+    """
+    safe_path = _validate_output_path(output_file)
+    safe_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(safe_path, 'w') as f:
+        f.write(content)
+    if ctx:
+        await ctx.info(f'Report saved to {safe_path}')
 
 
 @dataclass
@@ -772,16 +834,7 @@ async def _generate_custom_data_report(
 
     # Write to file if requested
     if output_file:
-        try:
-            output_path = Path(output_file)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_file, 'w') as f:
-                f.write(report)
-            if ctx:
-                await ctx.info(f'Report saved to {output_file}')
-        except Exception as e:
-            if ctx:
-                await ctx.error(f'Failed to write report to file: {e}')
+        await _write_report_file(output_file, report, ctx)
 
     return report
 
@@ -921,16 +974,7 @@ async def _generate_pricing_data_report(
 
     # Write to file if requested
     if output_file:
-        try:
-            output_path = Path(output_file)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_file, 'w') as f:
-                f.write(report)
-            if ctx:
-                await ctx.info(f'Report saved to {output_file}')
-        except Exception as e:
-            if ctx:
-                await ctx.error(f'Failed to write report to file: {e}')
+        await _write_report_file(output_file, report, ctx)
 
     return report
 
@@ -1068,16 +1112,7 @@ async def _generate_csv_report(
 
     # Write to file if requested
     if output_file:
-        try:
-            output_path = Path(output_file)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_file, 'w') as f:
-                f.write(csv_content)
-            if ctx:
-                await ctx.info(f'CSV report saved to {output_file}')
-        except Exception as e:
-            if ctx:
-                await ctx.error(f'Failed to write CSV report to file: {e}')
+        await _write_report_file(output_file, csv_content, ctx)
 
     return csv_content
 
@@ -1186,6 +1221,10 @@ async def generate_cost_report(
                     params=params,
                     format=format,
                 )
+    except OutputPathError:
+        # Security rejection of output_file must not be swallowed into a
+        # success-looking error string; surface it to the caller.
+        raise
     except Exception as e:
         if ctx:
             await ctx.error(f'Error generating cost report: {str(e)}')

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -698,7 +698,7 @@ Example usage:
 }
 ```
 """,
-    annotations=ToolAnnotations(readOnlyHint=True),
+    annotations=ToolAnnotations(readOnlyHint=False),
 )
 async def generate_cost_report_wrapper(
     ctx: Context,

--- a/src/aws-pricing-mcp-server/tests/test_report_generator.py
+++ b/src/aws-pricing-mcp-server/tests/test_report_generator.py
@@ -18,6 +18,8 @@ import os
 import pytest
 from awslabs.aws_pricing_mcp_server.helpers import CostAnalysisHelper
 from awslabs.aws_pricing_mcp_server.report_generator import (
+    OUTPUT_DIR_ENV_VAR,
+    OutputPathError,
     ServiceInfo,
     _create_cost_calculation_table,
     _create_free_tier_info,
@@ -30,6 +32,8 @@ from awslabs.aws_pricing_mcp_server.report_generator import (
     _generate_pricing_data_report,
     _process_custom_sections,
     _process_recommendations,
+    _validate_output_path,
+    _write_report_file,
     generate_cost_report,
 )
 
@@ -156,8 +160,9 @@ class TestReportGenerator:
         assert '$40' in table  # High usage (200%)
 
     @pytest.mark.asyncio
-    async def test_generate_custom_data_report(self, mock_context, temp_output_dir):
+    async def test_generate_custom_data_report(self, mock_context, temp_output_dir, monkeypatch):
         """Test generating a report from custom data."""
+        monkeypatch.setenv('AWS_PRICING_MCP_OUTPUT_DIR', temp_output_dir)
         custom_cost_data = {
             'project_name': 'Test Project',
             'description': 'A test project',
@@ -191,8 +196,9 @@ class TestReportGenerator:
         assert report is not None
 
     @pytest.mark.asyncio
-    async def test_generate_csv_report(self, mock_context, temp_output_dir):
+    async def test_generate_csv_report(self, mock_context, temp_output_dir, monkeypatch):
         """Test generating a CSV report."""
+        monkeypatch.setenv('AWS_PRICING_MCP_OUTPUT_DIR', temp_output_dir)
         cost_data = {
             'project_name': 'Test Project',
             'services': {
@@ -219,9 +225,10 @@ class TestReportGenerator:
 
     @pytest.mark.asyncio
     async def test_generate_cost_report_markdown(
-        self, mock_context, sample_pricing_data_web, temp_output_dir
+        self, mock_context, sample_pricing_data_web, temp_output_dir, monkeypatch
     ):
         """Test the main generate_cost_report function with markdown output."""
+        monkeypatch.setenv('AWS_PRICING_MCP_OUTPUT_DIR', temp_output_dir)
         output_file = os.path.join(temp_output_dir, 'report.md')
         report = await generate_cost_report(
             pricing_data=sample_pricing_data_web,
@@ -236,9 +243,10 @@ class TestReportGenerator:
 
     @pytest.mark.asyncio
     async def test_generate_cost_report_csv(
-        self, mock_context, sample_pricing_data_web, temp_output_dir
+        self, mock_context, sample_pricing_data_web, temp_output_dir, monkeypatch
     ):
         """Test the main generate_cost_report function with CSV output."""
+        monkeypatch.setenv('AWS_PRICING_MCP_OUTPUT_DIR', temp_output_dir)
         output_file = os.path.join(temp_output_dir, 'report.csv')
         report = await generate_cost_report(
             pricing_data=sample_pricing_data_web,
@@ -377,3 +385,120 @@ class TestReportGenerator:
         assert service.usage_quantities == {'requests': '1M'}
         assert service.calculation_details == '$0.20 × 1M requests'
         assert service.free_tier_info == '1M free requests per month'
+
+
+class TestOutputPathValidation:
+    """Tests for output_file path confinement.
+
+    Reports may only be written within the permitted base directory; paths that
+    resolve outside it, '..' traversal segments, and symlink escapes are
+    rejected.
+    """
+
+    def test_valid_relative_path_is_contained(self, tmp_path, monkeypatch):
+        """A normal relative path resolves inside the base directory."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        resolved = _validate_output_path('reports/cost.md')
+
+        assert resolved == (tmp_path / 'reports' / 'cost.md').resolve()
+
+    def test_absolute_path_within_base_is_allowed(self, tmp_path, monkeypatch):
+        """An absolute path that stays inside the base is permitted."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+        target = tmp_path / 'sub' / 'cost.md'
+
+        resolved = _validate_output_path(str(target))
+
+        assert resolved == target.resolve()
+
+    def test_absolute_path_outside_base_is_rejected(self, tmp_path, monkeypatch):
+        """An absolute path outside the base directory is rejected."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        with pytest.raises(OutputPathError):
+            _validate_output_path('/etc/passwd')
+
+    def test_parent_traversal_is_rejected(self, tmp_path, monkeypatch):
+        """A leading '..' escape is rejected."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        with pytest.raises(OutputPathError, match=r'\.\.'):
+            _validate_output_path('../escape.md')
+
+    def test_nested_parent_traversal_is_rejected(self, tmp_path, monkeypatch):
+        """A '..' segment nested within the path is rejected."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        with pytest.raises(OutputPathError):
+            _validate_output_path('reports/../../escape.md')
+
+    def test_symlink_escape_is_rejected(self, tmp_path, monkeypatch):
+        """A symlink inside the base that points outside is rejected."""
+        outside = tmp_path / 'outside'
+        outside.mkdir()
+        base = tmp_path / 'base'
+        base.mkdir()
+        (base / 'link').symlink_to(outside, target_is_directory=True)
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(base))
+
+        with pytest.raises(OutputPathError):
+            _validate_output_path('link/evil.md')
+
+    def test_defaults_to_cwd_when_env_unset(self, tmp_path, monkeypatch):
+        """With no env override, the base directory is the current working dir."""
+        monkeypatch.delenv(OUTPUT_DIR_ENV_VAR, raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        resolved = _validate_output_path('cost.md')
+
+        assert resolved == (tmp_path / 'cost.md').resolve()
+
+    def test_absolute_and_traversal_outside_base_rejected(self, tmp_path, monkeypatch):
+        """Both an absolute path outside the base and a '../' escape are rejected."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        with pytest.raises(OutputPathError):
+            _validate_output_path(str(tmp_path.parent / 'offlimits' / 'pwned.md'))
+        with pytest.raises(OutputPathError):
+            _validate_output_path('../../offlimits/pwned.md')
+
+    @pytest.mark.asyncio
+    async def test_write_report_file_writes_within_base(self, tmp_path, monkeypatch, mock_context):
+        """_write_report_file creates parent dirs and writes inside the base."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        await _write_report_file('nested/out.md', 'hello', mock_context)
+
+        written = tmp_path / 'nested' / 'out.md'
+        assert written.read_text() == 'hello'
+        mock_context.info.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_report_file_rejects_traversal_and_writes_nothing(
+        self, tmp_path, monkeypatch, mock_context
+    ):
+        """A rejected path raises and leaves no file behind."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        with pytest.raises(OutputPathError):
+            await _write_report_file('../evil.md', 'pwned', mock_context)
+
+        assert not (tmp_path.parent / 'evil.md').exists()
+
+    @pytest.mark.asyncio
+    async def test_generate_cost_report_raises_on_traversal(
+        self, mock_context, sample_pricing_data_web, tmp_path, monkeypatch
+    ):
+        """End-to-end: a traversal output_file propagates OutputPathError."""
+        monkeypatch.setenv(OUTPUT_DIR_ENV_VAR, str(tmp_path))
+
+        with pytest.raises(OutputPathError):
+            await generate_cost_report(
+                pricing_data=sample_pricing_data_web,
+                service_name='AWS Lambda',
+                output_file='../../../tmp/evil.md',
+                ctx=mock_context,
+            )
+
+        assert not (tmp_path.parent / 'tmp' / 'evil.md').exists()

--- a/src/aws-pricing-mcp-server/tests/test_server.py
+++ b/src/aws-pricing-mcp-server/tests/test_server.py
@@ -716,9 +716,10 @@ class TestGenerateCostReport:
 
     @pytest.mark.asyncio
     async def test_generate_report_with_detailed_data(
-        self, mock_context, sample_pricing_data_web, temp_output_dir
+        self, mock_context, sample_pricing_data_web, temp_output_dir, monkeypatch
     ):
         """Test generating a report with detailed cost data."""
+        monkeypatch.setenv('AWS_PRICING_MCP_OUTPUT_DIR', temp_output_dir)
         detailed_cost_data = {
             'services': {
                 'AWS Lambda': {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Hardens the `generate_cost_report` tool in `aws-pricing-mcp-server` by validating
and confining the `output_file` path, and corrects an inaccurate `readOnlyHint`
annotation on the tool.

### Changes

- **Path confinement**: `output_file` is confined to a base directory
  (`AWS_PRICING_MCP_OUTPUT_DIR`, defaulting to the server's current working
  directory). The path is canonicalized with `resolve()` and validated with
  `is_relative_to()`; paths that resolve outside the base, `..` segments, and
  symlinks that escape the base are rejected (`OutputPathError`).
- **De-duplication**: the three identical write blocks in `report_generator.py`
  are consolidated into one `_write_report_file()` helper that performs the
  validation.
- **Fail clearly**: a rejected path raises rather than being swallowed into a
  success-looking return string.
- **Correct annotation**: `readOnlyHint` is set to `False` on
  `generate_cost_report` (it writes files). The other tools were each audited and
  confirmed read-only, so their annotations are unchanged.
- **Docs + tests**: documents `AWS_PRICING_MCP_OUTPUT_DIR` in the README and adds
  path-confinement unit tests.

### User experience

- Reports continue to write normally to paths within the working directory (or `AWS_PRICING_MCP_OUTPUT_DIR`).
- Paths resolving outside the base directory are rejected with a clear error, and clients prompt before the write since the tool is no longer marked read-only.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N) — writes to a path outside the base directory now require `AWS_PRICING_MCP_OUTPUT_DIR` to cover that location; only affects callers relying on writing outside the working directory.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).