### PR TITLE
[Security Fix] SAST: The --knowledge-server CLI flag is forwarded directly into httpx.AsyncClient....

### DIFF
--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py
@@ -886,6 +886,18 @@ def main():
                 f'Example: https://xmfe3hc3pk.execute-api.us-east-2.amazonaws.com'
             )
             sys.exit(1)
+        # Restrict egress to a fixed allowlist of trusted AWS-hosted knowledge
+        # server endpoints. Without this, a malicious launcher configuration
+        # could coerce the server into POSTing JSON-RPC bodies (which include
+        # user-supplied search phrases/URLs) to an arbitrary HTTPS endpoint.
+        if parsed_url.hostname not in ALLOWED_KNOWLEDGE_SERVER_HOSTS:
+            logger.error(
+                f'Knowledge server host is not in the allowlist. Got: {parsed_url.hostname}. '
+                f'Allowed hosts: {sorted(ALLOWED_KNOWLEDGE_SERVER_HOSTS)}'
+            )
+            sys.exit(1)
+    except SystemExit:
+        raise
     except Exception as e:
         logger.error(f'Invalid knowledge server URL: {e}')
         sys.exit(1)


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** The --knowledge-server CLI flag is forwarded directly into httpx.AsyncClient.post with only an HTTPS-scheme/netloc check, allowing a malicious launcher configuration to coerce the server into POSTing JSON-RPC bodies (which may include user-supplied search phrases/URLs) to an arbitrary HTTPS endpoint.
**Rule:** claude-ssrf-dsql-knowledge-server-arg (oogway-scanner)
**File:** `src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py` (line 627)
**Severity:** MEDIUM

### Explanation
The `--knowledge-server` CLI flag was forwarded into `httpx.AsyncClient.post` after only verifying that the URL used the `https` scheme and had a non-empty netloc. Because the JSON-RPC bodies sent to that endpoint contain user-supplied data (search phrases passed to `dsql_search_documentation` and URLs passed to `dsql_read_documentation`/`dsql_recommend`), a malicious or misconfigured launcher could set `--knowledge-server` to any HTTPS endpoint and exfiltrate that content (an SSRF / arbitrary-egress vector).

The fix introduces a fixed allowlist of trusted knowledge-server hostnames (the default CloudFront distribution and the default API Gateway endpoint) and validates the parsed URL's host against it during startup, rejecting any value not on the list. The scheme/netloc checks are preserved, and a `SystemExit` re-raise guard is added so the new `sys.exit(1)` is not swallowed by the surrounding `except Exception` handler. This blocks arbitrary egress while keeping all legitimate functionality intact.

### Changes
- `src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py`: Define an allowlist of trusted knowledge server hosts (default CloudFront distribution and default API Gateway endpoint).
- `src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/server.py`: Restrict --knowledge-server to an allowlist of trusted hosts and re-raise SystemExit so the allowlist rejection is not swallowed.

### Test Suggestions
- Starting the server with --knowledge-server set to an allowed host (e.g. https://d38p8g9d7yc7ms.cloudfront.net) succeeds.
- Starting with --knowledge-server set to a disallowed HTTPS host (e.g. https://evil.example.com) exits with code 1 and logs an allowlist error.
- Starting with a non-HTTPS or malformed URL still exits with code 1 as before.
- Allowed host with a path/query (e.g. https://xmfe3hc3pk.execute-api.us-east-2.amazonaws.com/mcp) is accepted since only the hostname is matched.

### Breaking Changes
- Operators who previously pointed --knowledge-server at a custom/self-hosted endpoint will now be rejected at startup unless that host is added to ALLOWED_KNOWLEDGE_SERVER_HOSTS.