### PR TITLE
feat(cloudwatch-applicationsignals): add dynamic instrumentation tools 

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/CHANGELOG.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Dynamic instrumentation tools (preview) for interactively debugging live
+  Application Signals services without redeploying:
+  - `create_instrumentation`, `list_instrumentations`, `get_instrumentation`,
+    `delete_instrumentation`, `batch_delete_instrumentations_by_scope`,
+    `batch_delete_instrumentations_by_arns` for managing instrumentation
+    configurations.
+  - `get_instrumentation_configuration_status`, `check_instrumentation_status`,
+    `report_instrumentation_configuration_status` for status inspection and
+    reporting.
+  - `search_snapshots_for_status_event`, `get_sample_snapshot_for_breakpoint`
+    for analyzing captured snapshots from CloudWatch Logs.
+  - Ships a trimmed preview `application-signals` service model bundled under
+    `dynamic_instrumentation/aws_data/`, loaded via a session-scoped botocore
+    data loader. The bundled model is removed once the operations are generally
+    available in `botocore`.
+
 ## [0.1.0] - 2025-01-18
 
 ### Added

--- a/src/cloudwatch-applicationsignals-mcp-server/CHANGELOG.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/CHANGELOG.md
@@ -9,9 +9,8 @@
     `delete_instrumentation`, `batch_delete_instrumentations_by_scope`,
     `batch_delete_instrumentations_by_arns` for managing instrumentation
     configurations.
-  - `get_instrumentation_configuration_status`, `check_instrumentation_status`,
-    `report_instrumentation_configuration_status` for status inspection and
-    reporting.
+  - `get_instrumentation_configuration_status`, `check_instrumentation_status`
+    for status inspection.
   - `search_snapshots_for_status_event`, `get_sample_snapshot_for_breakpoint`
     for analyzing captured snapshots from CloudWatch Logs.
   - Ships a trimmed preview `application-signals` service model bundled under

--- a/src/cloudwatch-applicationsignals-mcp-server/README.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/README.md
@@ -450,7 +450,6 @@ local state, and stack traces) from CloudWatch Logs.
 - `batch_delete_instrumentations_by_arns` — Batch delete instrumentation configurations by explicit resource ARN list.
 - `get_instrumentation_configuration_status` — Get status-event history for one instrumentation configuration and one explicit status.
 - `check_instrumentation_status` — Run a consolidated READY/ACTIVE/ERROR status check over a time window.
-- `report_instrumentation_configuration_status` — Report one or more instrumentation status events to the backend.
 
 **Snapshot analysis tools**
 
@@ -1053,8 +1052,7 @@ The server requires the following AWS IAM permissions:
         "application-signals:GetInstrumentationConfiguration",
         "application-signals:DeleteInstrumentationConfiguration",
         "application-signals:BatchDeleteInstrumentationConfigurations",
-        "application-signals:GetInstrumentationConfigurationStatus",
-        "application-signals:ReportInstrumentationConfigurationStatus"
+        "application-signals:GetInstrumentationConfigurationStatus"
       ],
       "Resource": "*"
     }

--- a/src/cloudwatch-applicationsignals-mcp-server/README.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/README.md
@@ -426,6 +426,37 @@ query_rum_events(action="<action_name>", app_monitor_name="my-app", ...)
 
 **Optional parameters** (action-dependent): `resource_arn`, `page_url`, `group_by`, `platform`, `max_results`, `max_traces`, `statistic`, `period`, `session_id`, `metric`, `bucket`, `compare_previous`
 
+### 🔬 Dynamic Instrumentation Tools (Preview)
+
+Interactively debug live services without redeploying. Dynamic instrumentation
+lets you place breakpoint-style or probe-style instrumentation on running
+Application Signals services, then inspect the captured snapshots (arguments,
+local state, and stack traces) from CloudWatch Logs.
+
+> **Preview:** These tools depend on `application-signals` dynamic
+> instrumentation operations that are not yet part of the public AWS SDK. The
+> server bundles a trimmed preview service model (see
+> `awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_data/README.md`)
+> so the tools work against the preview API. The bundled model is removed once
+> the operations are generally available in `botocore`.
+
+**Configuration & status tools**
+
+- `create_instrumentation` — Create a dynamic instrumentation configuration for BREAKPOINT or PROBE.
+- `list_instrumentations` — List active instrumentation configurations for one service, environment, and type.
+- `get_instrumentation` — Get the full backend configuration for a single instrumentation target.
+- `delete_instrumentation` — Delete a single instrumentation configuration.
+- `batch_delete_instrumentations_by_scope` — Batch delete instrumentation configurations by scope.
+- `batch_delete_instrumentations_by_arns` — Batch delete instrumentation configurations by explicit resource ARN list.
+- `get_instrumentation_configuration_status` — Get status-event history for one instrumentation configuration and one explicit status.
+- `check_instrumentation_status` — Run a consolidated READY/ACTIVE/ERROR status check over a time window.
+- `report_instrumentation_configuration_status` — Report one or more instrumentation status events to the backend.
+
+**Snapshot analysis tools**
+
+- `search_snapshots_for_status_event` — Search CloudWatch Logs snapshots near a known instrumentation status timestamp.
+- `get_sample_snapshot_for_breakpoint` — Fetch one nearby snapshot to inspect the structure of captured data.
+
 ## Installation
 
 ### One-Click Installation
@@ -1016,7 +1047,14 @@ The server requires the following AWS IAM permissions:
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:GetPolicy",
-        "iam:GetPolicyVersion"
+        "iam:GetPolicyVersion",
+        "application-signals:CreateInstrumentationConfiguration",
+        "application-signals:ListInstrumentationConfigurations",
+        "application-signals:GetInstrumentationConfiguration",
+        "application-signals:DeleteInstrumentationConfiguration",
+        "application-signals:BatchDeleteInstrumentationConfigurations",
+        "application-signals:GetInstrumentationConfigurationStatus",
+        "application-signals:ReportInstrumentationConfigurationStatus"
       ],
       "Resource": "*"
     }

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/__init__.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/__init__.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dynamic instrumentation feature package for the Application Signals MCP server."""

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/application_signals_gateway.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/application_signals_gateway.py
@@ -85,11 +85,6 @@ def get_instrumentation_configuration_status(**kwargs: Any) -> Dict[str, Any]:
     return _call('get_instrumentation_configuration_status', **kwargs)
 
 
-def report_instrumentation_configuration_status(**kwargs: Any) -> Dict[str, Any]:
-    """Call ``ReportInstrumentationConfigurationStatus`` through the gateway."""
-    return _call('report_instrumentation_configuration_status', **kwargs)
-
-
 def render_error(
     err: GatewayError,
     *,

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/application_signals_gateway.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/application_signals_gateway.py
@@ -1,0 +1,125 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gateway to the AWS application-signals API.
+
+The single seam where dynamic-instrumentation tools touch botocore. Each
+operation here issues one boto3 call, wraps any raised exception in a
+``GatewayError``, and lets the caller render the failure through
+``render_error``. Tool functions never import ``botocore.exceptions`` — that
+contract belongs to this module.
+"""
+
+from .aws_clients import get_application_signals_client
+from .error_translation import render_client_error, translate_aws_error
+from botocore.exceptions import BotoCoreError, ClientError
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+
+class GatewayError(Exception):
+    """Wraps any exception raised by an application-signals call.
+
+    The original exception is preserved on ``original_exc`` so callers can
+    pass the gateway error through ``render_error`` without losing the
+    botocore-specific data ``render_client_error`` needs.
+    """
+
+    def __init__(self, original_exc: BaseException):
+        """Wrap ``original_exc``, preserving it for later rendering."""
+        super().__init__(str(original_exc))
+        self.original_exc = original_exc
+
+
+def _call(method_name: str, **kwargs: Any) -> Dict[str, Any]:
+    client = get_application_signals_client()
+    method = getattr(client, method_name)
+    try:
+        return method(**kwargs)
+    except (BotoCoreError, ClientError) as exc:
+        # Narrow on purpose: these two cover the full botocore exception
+        # surface (``ClientError`` for service-side errors, ``BotoCoreError``
+        # for credentials/connection/timeout failures). Programming errors
+        # (``AttributeError`` from a typo, ``TypeError`` from a bad kwarg)
+        # propagate unwrapped so they surface as themselves in tracebacks
+        # instead of masquerading as AWS failures.
+        raise GatewayError(exc) from exc
+
+
+def create_instrumentation_configuration(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``CreateInstrumentationConfiguration`` through the gateway."""
+    return _call('create_instrumentation_configuration', **kwargs)
+
+
+def list_instrumentation_configurations(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``ListInstrumentationConfigurations`` through the gateway."""
+    return _call('list_instrumentation_configurations', **kwargs)
+
+
+def get_instrumentation_configuration(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``GetInstrumentationConfiguration`` through the gateway."""
+    return _call('get_instrumentation_configuration', **kwargs)
+
+
+def delete_instrumentation_configuration(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``DeleteInstrumentationConfiguration`` through the gateway."""
+    return _call('delete_instrumentation_configuration', **kwargs)
+
+
+def batch_delete_instrumentation_configurations(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``BatchDeleteInstrumentationConfigurations`` through the gateway."""
+    return _call('batch_delete_instrumentation_configurations', **kwargs)
+
+
+def get_instrumentation_configuration_status(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``GetInstrumentationConfigurationStatus`` through the gateway."""
+    return _call('get_instrumentation_configuration_status', **kwargs)
+
+
+def report_instrumentation_configuration_status(**kwargs: Any) -> Dict[str, Any]:
+    """Call ``ReportInstrumentationConfigurationStatus`` through the gateway."""
+    return _call('report_instrumentation_configuration_status', **kwargs)
+
+
+def render_error(
+    err: GatewayError,
+    *,
+    action: str,
+    attempted_label: str = 'ATTEMPTED PARAMETERS:',
+    attempted: Optional[Mapping[str, object]] = None,
+    possible_causes: Optional[Sequence[str]] = None,
+    troubleshooting: Optional[Sequence[str]] = None,
+    trailer: Optional[str] = None,
+) -> str:
+    """Render a ``GatewayError`` using the appropriate error template.
+
+    Callers that want tailored prose for a ``ClientError`` pass
+    ``possible_causes`` / ``troubleshooting`` / ``trailer``; those flow
+    through ``render_client_error``. Callers that pass none of those — and
+    every non-``ClientError`` exception regardless — fall through to
+    ``translate_aws_error``, which carries its own canned bullets per
+    exception type. This preserves the per-tool rendering contract that
+    existed before tools were routed through the gateway.
+    """
+    exc = err.original_exc
+    has_tailored_prose = bool(possible_causes or troubleshooting or trailer)
+    if isinstance(exc, ClientError) and has_tailored_prose:
+        return render_client_error(
+            exc,
+            action=action,
+            attempted_label=attempted_label,
+            attempted=attempted,
+            possible_causes=possible_causes,
+            troubleshooting=troubleshooting,
+            trailer=trailer,
+        )
+    return translate_aws_error(exc, action=action, context=attempted)

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_clients.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_clients.py
@@ -1,0 +1,91 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""boto3 client factory for the dynamic instrumentation feature.
+
+Loads the bundled private ``application-signals`` service model via a
+scoped botocore data loader (no ``AWS_DATA_PATH`` env mutation), pins
+the API version to ``2024-04-15``, and lazily caches the resulting
+clients so MCP tools can reuse a single configured instance.
+"""
+
+import boto3
+import botocore.session
+import os
+from .. import __version__
+from botocore.config import Config
+from loguru import logger
+from pathlib import Path
+
+
+AWS_DATA_PATH = Path(__file__).parent / 'aws_data'
+APPLICATION_SIGNALS_API_VERSION = '2024-04-15'
+
+
+def _resolve_region() -> str:
+    """Resolve AWS region: AWS_REGION env var > profile/config > us-east-1."""
+    env_region = os.environ.get('AWS_REGION')
+    if env_region:
+        return env_region
+    profile = os.environ.get('AWS_PROFILE')
+    session = boto3.Session(profile_name=profile)
+    if session.region_name:
+        return session.region_name
+    return 'us-east-1'
+
+
+def _build_config() -> Config:
+    mcp_source = os.environ.get('MCP_RUN_FROM')
+    user_agent_suffix = f'/{mcp_source}' if mcp_source else ''
+    return Config(
+        user_agent_extra=f'awslabs.cloudwatch-applicationsignals-mcp-server/dynamic-instrumentation/{__version__}{user_agent_suffix}'
+    )
+
+
+def _build_session() -> boto3.Session:
+    """Build a boto3 Session with the bundled private model loader prepended."""
+    botocore_session = botocore.session.Session()
+    botocore_session.get_component('data_loader').search_paths.insert(0, str(AWS_DATA_PATH))
+    profile = os.environ.get('AWS_PROFILE')
+    return boto3.Session(botocore_session=botocore_session, profile_name=profile)
+
+
+_application_signals_client = None
+
+
+def get_application_signals_client():
+    """Return a lazily-built ``application-signals`` client pinned to the private model."""
+    global _application_signals_client
+    if _application_signals_client is not None:
+        return _application_signals_client
+
+    region = _resolve_region()
+
+    session = _build_session()
+    _application_signals_client = session.client(
+        'application-signals',
+        api_version=APPLICATION_SIGNALS_API_VERSION,
+        region_name=region,
+        config=_build_config(),
+    )
+    logger.debug(
+        f'application-signals client initialized (region={region}, '
+        f'api_version={APPLICATION_SIGNALS_API_VERSION})'
+    )
+    return _application_signals_client
+
+
+def _reset_clients() -> None:
+    """Drop the cached client so tests can re-initialize against a fresh stub."""
+    global _application_signals_client
+    _application_signals_client = None

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_clients.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_clients.py
@@ -33,15 +33,19 @@ APPLICATION_SIGNALS_API_VERSION = '2024-04-15'
 
 
 def _resolve_region() -> str:
-    """Resolve AWS region: AWS_REGION env var > profile/config > us-east-1."""
-    env_region = os.environ.get('AWS_REGION')
-    if env_region:
-        return env_region
-    profile = os.environ.get('AWS_PROFILE')
-    session = boto3.Session(profile_name=profile)
-    if session.region_name:
-        return session.region_name
-    return 'us-east-1'
+    """Resolve AWS region: AWS_REGION env var, else us-east-1.
+
+    Matches the parent package's ``aws_clients`` and every sibling MCP server:
+    region comes from ``AWS_REGION`` (falling back to ``us-east-1``) and a
+    configured profile's region is *not* consulted. This is deliberate — the
+    snapshot tools query CloudWatch Logs through the parent package's
+    ``logs_client``, which resolves region the same way. Honoring the profile
+    region here (but not there) would split a profile-only caller's clients
+    across two regions: instrumentations created in the profile region while
+    snapshot queries run in ``us-east-1``, surfacing as a breakpoint that shows
+    ACTIVE but whose snapshot searches always come back empty.
+    """
+    return os.environ.get('AWS_REGION', 'us-east-1')
 
 
 def _build_config() -> Config:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_data/README.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_data/README.md
@@ -1,0 +1,36 @@
+# Bundled preview service model
+
+> **Remove this entire `aws_data/` directory once the public AWS SDK ships the
+> dynamic instrumentation operations.**
+
+`application-signals/2024-04-15/service-2.json` is a bundled botocore service
+model that exposes the dynamic-instrumentation operations
+(`CreateInstrumentationConfiguration`, `ListInstrumentationConfigurations`,
+`GetInstrumentationConfiguration`, `DeleteInstrumentationConfiguration`,
+`BatchDeleteInstrumentationConfigurations`,
+`GetInstrumentationConfigurationStatus`,
+`ReportInstrumentationConfigurationStatus`) before they are available in the
+public `botocore` release. The dynamic instrumentation feature is in preview;
+these operations are not yet part of the public `application-signals` API.
+
+The model is generated from the service team's source-of-truth Smithy model and
+trimmed to only the seven dynamic-instrumentation operations the MCP tools call.
+
+It is loaded by `dynamic_instrumentation/aws_clients.py` through a *session-scoped*
+botocore data loader (no `AWS_DATA_PATH` env mutation) with the API version pinned
+to `2024-04-15`. This isolation means the bundled model is invisible to the
+existing awslabs `application-signals` client.
+
+## Removal (one-shot cleanup PR)
+
+When the public SDK ships these operations:
+
+1. Bump the `boto3` floor in `pyproject.toml` to the version that includes them.
+2. Rewrite `dynamic_instrumentation/aws_clients.py` to re-export the parent
+   `applicationsignals_client` (snapshot Logs queries already use the parent
+   `logs_client` directly).
+3. Delete this `aws_data/` directory.
+
+While the feature is in preview, this directory is shipped so the tools work
+against the preview API; it is removed in a follow-up once the operations are
+generally available in `botocore`.

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_data/application-signals/2024-04-15/service-2.json
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_data/application-signals/2024-04-15/service-2.json
@@ -1,0 +1,1565 @@
+{
+  "metadata": {
+    "apiVersion": "2024-04-15",
+    "auth": [
+      "aws.auth#sigv4"
+    ],
+    "endpointPrefix": "application-signals",
+    "protocol": "rest-json",
+    "protocols": [
+      "rest-json"
+    ],
+    "serviceFullName": "Amazon CloudWatch Application Signals",
+    "serviceId": "Application Signals",
+    "signatureVersion": "v4",
+    "signingName": "application-signals",
+    "uid": "application-signals-2024-04-15"
+  },
+  "operations": {
+    "BatchDeleteInstrumentationConfigurations": {
+      "documentation": "<p>Deletes multiple instrumentation configurations in a single request. Supports two mutually exclusive modes:</p> <ul> <li>Mode 1 (Bulk by scope): Delete all configurations matching a Service + Environment + InstrumentationType</li> <li>Mode 2 (Targeted by ARN): Delete specific configurations by providing a list of resource ARNs</li> </ul>",
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/batch-delete-instrumentation-configurations",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "BatchDeleteInstrumentationConfigurationsRequest"
+      },
+      "name": "BatchDeleteInstrumentationConfigurations",
+      "output": {
+        "shape": "BatchDeleteInstrumentationConfigurationsResponse"
+      }
+    },
+    "CreateInstrumentationConfiguration": {
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ServiceQuotaExceededException"
+        },
+        {
+          "shape": "ConflictException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/create-instrumentation-configuration",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateInstrumentationConfigurationRequest"
+      },
+      "name": "CreateInstrumentationConfiguration",
+      "output": {
+        "shape": "CreateInstrumentationConfigurationResponse"
+      }
+    },
+    "DeleteInstrumentationConfiguration": {
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/delete-instrumentation-configuration",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteInstrumentationConfigurationRequest"
+      },
+      "name": "DeleteInstrumentationConfiguration",
+      "output": {
+        "shape": "DeleteInstrumentationConfigurationResponse"
+      }
+    },
+    "GetInstrumentationConfiguration": {
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/get-instrumentation-configuration",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "GetInstrumentationConfigurationRequest"
+      },
+      "name": "GetInstrumentationConfiguration",
+      "output": {
+        "shape": "GetInstrumentationConfigurationResponse"
+      }
+    },
+    "GetInstrumentationConfigurationStatus": {
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/get-instrumentation-configuration-status",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "GetInstrumentationConfigurationStatusRequest"
+      },
+      "name": "GetInstrumentationConfigurationStatus",
+      "output": {
+        "shape": "GetInstrumentationConfigurationStatusResponse"
+      },
+      "readonly": true
+    },
+    "ListInstrumentationConfigurations": {
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/list-instrumentation-configurations",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListInstrumentationConfigurationsRequest"
+      },
+      "name": "ListInstrumentationConfigurations",
+      "output": {
+        "shape": "InstrumentationConfigurationsPage"
+      }
+    },
+    "ReportInstrumentationConfigurationStatus": {
+      "errors": [
+        {
+          "shape": "ValidationException"
+        },
+        {
+          "shape": "ThrottlingException"
+        }
+      ],
+      "http": {
+        "method": "POST",
+        "requestUri": "/report-instrumentation-configuration-status",
+        "responseCode": 200
+      },
+      "idempotent": true,
+      "input": {
+        "shape": "ReportInstrumentationConfigurationStatusRequest"
+      },
+      "name": "ReportInstrumentationConfigurationStatus",
+      "output": {
+        "shape": "ReportInstrumentationConfigurationStatusResponse"
+      }
+    }
+  },
+  "shapes": {
+    "BatchDeleteByResourceArns": {
+      "documentation": "<p>Parameters for targeted delete by ARN list (Mode 2).</p>",
+      "members": {
+        "InstrumentationType": {
+          "documentation": "<p>Instrumentation type: BREAKPOINT or PROBE.</p>",
+          "shape": "InstrumentationType"
+        },
+        "ResourceArns": {
+          "documentation": "<p>List of resource ARNs to delete.</p>",
+          "shape": "BatchDeleteByResourceArnsResourceArnsList"
+        }
+      },
+      "required": [
+        "ResourceArns",
+        "InstrumentationType"
+      ],
+      "type": "structure"
+    },
+    "BatchDeleteByResourceArnsResourceArnsList": {
+      "documentation": "<p>List of resource ARNs for batch delete operation (Mode 2). Maximum 50 ARNs per request.</p>",
+      "max": 50,
+      "member": {
+        "shape": "BatchDeleteByResourceArnsResourceArnsListMemberString"
+      },
+      "min": 1,
+      "type": "list"
+    },
+    "BatchDeleteByResourceArnsResourceArnsListMemberString": {
+      "max": 2048,
+      "min": 20,
+      "type": "string"
+    },
+    "BatchDeleteDeletionTarget": {
+      "documentation": "<p>Union type for batch delete target selection. Exactly one of the two modes must be specified.</p>",
+      "members": {
+        "ResourceArns": {
+          "documentation": "<p>Mode 2: Delete specific configurations by ARN list.</p>",
+          "shape": "BatchDeleteByResourceArns"
+        },
+        "Scope": {
+          "documentation": "<p>Mode 1: Delete all configurations matching the specified scope.</p>",
+          "shape": "BatchDeleteScope"
+        }
+      },
+      "type": "structure",
+      "union": true
+    },
+    "BatchDeleteError": {
+      "documentation": "<p>Represents an error that occurred when attempting to delete a configuration.</p>",
+      "members": {
+        "Code": {
+          "documentation": "<p>Error code indicating the type of failure.</p>",
+          "shape": "BatchDeleteErrorCode"
+        },
+        "Message": {
+          "documentation": "<p>Descriptive error message.</p>",
+          "shape": "String"
+        },
+        "ResourceArn": {
+          "documentation": "<p>ARN of the configuration that failed to delete.</p>",
+          "shape": "String"
+        }
+      },
+      "required": [
+        "ResourceArn",
+        "Code",
+        "Message"
+      ],
+      "type": "structure"
+    },
+    "BatchDeleteErrorCode": {
+      "documentation": "<p>Error codes for batch delete item-level failures.</p>",
+      "enum": [
+        "ResourceNotFoundException",
+        "AccessDeniedException",
+        "InternalServiceException"
+      ],
+      "type": "string"
+    },
+    "BatchDeleteErrorList": {
+      "documentation": "<p>List of errors in batch delete response.</p>",
+      "member": {
+        "shape": "BatchDeleteError"
+      },
+      "type": "list"
+    },
+    "BatchDeleteInstrumentationConfigurationsRequest": {
+      "members": {
+        "DeletionTarget": {
+          "documentation": "<p>The deletion target - either bulk by scope or targeted by ARN list.</p>",
+          "shape": "BatchDeleteDeletionTarget"
+        }
+      },
+      "required": [
+        "DeletionTarget"
+      ],
+      "type": "structure"
+    },
+    "BatchDeleteInstrumentationConfigurationsResponse": {
+      "members": {
+        "DeletedCount": {
+          "documentation": "<p>Number of configurations successfully deleted. For Mode 1 (scope), this is the total count of deleted items. For Mode 2 (ARN list), this equals the length of SuccessfulDeletions.</p>",
+          "shape": "Integer"
+        },
+        "Errors": {
+          "documentation": "<p>List of configurations that failed to delete.</p>",
+          "shape": "BatchDeleteErrorList"
+        },
+        "SuccessfulDeletions": {
+          "documentation": "<p>List of successfully deleted configurations. Mode 1 populates SignalType and LocationHash per item. Mode 2 populates ResourceArn per item.</p>",
+          "shape": "BatchDeleteSuccessfulDeletionList"
+        }
+      },
+      "required": [
+        "DeletedCount",
+        "SuccessfulDeletions",
+        "Errors"
+      ],
+      "type": "structure"
+    },
+    "BatchDeleteScope": {
+      "documentation": "<p>Scope parameters for bulk delete (Mode 1).</p>",
+      "members": {
+        "Environment": {
+          "documentation": "<p>Environment identifier for the instrumentation configurations.</p>",
+          "shape": "BatchDeleteScopeEnvironmentString"
+        },
+        "InstrumentationType": {
+          "documentation": "<p>Instrumentation type: BREAKPOINT or PROBE.</p>",
+          "shape": "InstrumentationType"
+        },
+        "Service": {
+          "documentation": "<p>Service name for the instrumentation configurations.</p>",
+          "shape": "BatchDeleteScopeServiceString"
+        }
+      },
+      "required": [
+        "Service",
+        "Environment",
+        "InstrumentationType"
+      ],
+      "type": "structure"
+    },
+    "BatchDeleteScopeEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9:/+=,.@_-]+",
+      "type": "string"
+    },
+    "BatchDeleteScopeServiceString": {
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9:/+=,.@_-]+",
+      "type": "string"
+    },
+    "BatchDeleteSuccessfulDeletion": {
+      "documentation": "<p>Represents a successfully deleted instrumentation configuration.</p>",
+      "members": {
+        "LocationHash": {
+          "documentation": "<p>Location hash of the deleted configuration (populated for Mode 1 only).</p>",
+          "shape": "String"
+        },
+        "ResourceArn": {
+          "documentation": "<p>ARN of the deleted configuration (populated for Mode 2 only).</p>",
+          "shape": "String"
+        },
+        "SignalType": {
+          "documentation": "<p>Signal type of the deleted configuration (populated for Mode 1 only).</p>",
+          "shape": "String"
+        }
+      },
+      "type": "structure"
+    },
+    "BatchDeleteSuccessfulDeletionList": {
+      "documentation": "<p>List of successful deletions in batch delete response.</p>",
+      "member": {
+        "shape": "BatchDeleteSuccessfulDeletion"
+      },
+      "type": "list"
+    },
+    "Boolean": {
+      "box": true,
+      "type": "boolean"
+    },
+    "CaptureConfiguration": {
+      "members": {
+        "CodeCapture": {
+          "shape": "CodeCaptureConfiguration"
+        }
+      },
+      "type": "structure",
+      "union": true
+    },
+    "CaptureLimitsConfig": {
+      "members": {
+        "MaxCollectionDepth": {
+          "shape": "CaptureLimitsConfigMaxCollectionDepthInteger"
+        },
+        "MaxCollectionWidth": {
+          "shape": "CaptureLimitsConfigMaxCollectionWidthInteger"
+        },
+        "MaxFieldsPerObject": {
+          "shape": "CaptureLimitsConfigMaxFieldsPerObjectInteger"
+        },
+        "MaxHits": {
+          "shape": "CaptureLimitsConfigMaxHitsInteger"
+        },
+        "MaxObjectDepth": {
+          "shape": "CaptureLimitsConfigMaxObjectDepthInteger"
+        },
+        "MaxStackFrames": {
+          "shape": "CaptureLimitsConfigMaxStackFramesInteger"
+        },
+        "MaxStackTraceSize": {
+          "shape": "CaptureLimitsConfigMaxStackTraceSizeInteger"
+        },
+        "MaxStringLength": {
+          "shape": "CaptureLimitsConfigMaxStringLengthInteger"
+        }
+      },
+      "type": "structure"
+    },
+    "CaptureLimitsConfigMaxCollectionDepthInteger": {
+      "box": true,
+      "max": 5,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxCollectionWidthInteger": {
+      "box": true,
+      "max": 20,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxFieldsPerObjectInteger": {
+      "box": true,
+      "max": 20,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxHitsInteger": {
+      "box": true,
+      "max": 1000,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxObjectDepthInteger": {
+      "box": true,
+      "max": 5,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxStackFramesInteger": {
+      "box": true,
+      "max": 20,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxStackTraceSizeInteger": {
+      "box": true,
+      "max": 1000,
+      "min": 1,
+      "type": "integer"
+    },
+    "CaptureLimitsConfigMaxStringLengthInteger": {
+      "box": true,
+      "max": 255,
+      "min": 1,
+      "type": "integer"
+    },
+    "CodeCaptureConfiguration": {
+      "members": {
+        "CaptureArguments": {
+          "shape": "CodeCaptureConfigurationCaptureArgumentsList"
+        },
+        "CaptureLimits": {
+          "shape": "CaptureLimitsConfig"
+        },
+        "CaptureLocals": {
+          "shape": "CodeCaptureConfigurationCaptureLocalsList"
+        },
+        "CaptureReturn": {
+          "shape": "Boolean"
+        },
+        "CaptureStackTrace": {
+          "shape": "Boolean"
+        }
+      },
+      "required": [
+        "CaptureLimits"
+      ],
+      "type": "structure"
+    },
+    "CodeCaptureConfigurationCaptureArgumentsList": {
+      "max": 10,
+      "member": {
+        "shape": "CodeCaptureConfigurationCaptureArgumentsListMemberString"
+      },
+      "min": 0,
+      "type": "list"
+    },
+    "CodeCaptureConfigurationCaptureArgumentsListMemberString": {
+      "max": 80,
+      "min": 1,
+      "type": "string"
+    },
+    "CodeCaptureConfigurationCaptureLocalsList": {
+      "max": 20,
+      "member": {
+        "shape": "CodeCaptureConfigurationCaptureLocalsListMemberString"
+      },
+      "min": 0,
+      "type": "list"
+    },
+    "CodeCaptureConfigurationCaptureLocalsListMemberString": {
+      "max": 80,
+      "min": 1,
+      "type": "string"
+    },
+    "CodeLocation": {
+      "members": {
+        "ClassName": {
+          "shape": "CodeLocationClassNameString"
+        },
+        "CodeUnit": {
+          "shape": "CodeLocationCodeUnitString"
+        },
+        "FilePath": {
+          "shape": "CodeLocationFilePathString"
+        },
+        "Language": {
+          "shape": "ProgrammingLanguage"
+        },
+        "LineNumber": {
+          "shape": "CodeLocationLineNumberInteger"
+        },
+        "MethodName": {
+          "shape": "CodeLocationMethodNameString"
+        }
+      },
+      "required": [
+        "Language",
+        "FilePath"
+      ],
+      "type": "structure"
+    },
+    "CodeLocationClassNameString": {
+      "max": 128,
+      "min": 1,
+      "type": "string"
+    },
+    "CodeLocationCodeUnitString": {
+      "max": 128,
+      "min": 1,
+      "type": "string"
+    },
+    "CodeLocationFilePathString": {
+      "max": 1024,
+      "min": 1,
+      "type": "string"
+    },
+    "CodeLocationLineNumberInteger": {
+      "box": true,
+      "min": 1,
+      "type": "integer"
+    },
+    "CodeLocationMethodNameString": {
+      "max": 80,
+      "min": 1,
+      "type": "string"
+    },
+    "ConflictException": {
+      "error": {
+        "httpStatusCode": 409,
+        "senderFault": true
+      },
+      "exception": true,
+      "members": {
+        "Message": {
+          "shape": "String"
+        }
+      },
+      "required": [
+        "Message"
+      ],
+      "type": "structure"
+    },
+    "CreateInstrumentationConfigurationRequest": {
+      "members": {
+        "AttributeFilters": {
+          "shape": "DynamicInstrumentationAttributeFilters"
+        },
+        "CaptureConfiguration": {
+          "shape": "CaptureConfiguration"
+        },
+        "Description": {
+          "shape": "CreateInstrumentationConfigurationRequestDescriptionString"
+        },
+        "Environment": {
+          "shape": "CreateInstrumentationConfigurationRequestEnvironmentString"
+        },
+        "ExpiresAt": {
+          "documentation": "<p>For BREAKPOINT: optional, defaults to 24 hours, must be between 5 min and 24 hours For PROBE: optional, can be set for auto-cleanup or left null for permanent</p>",
+          "shape": "Timestamp"
+        },
+        "InstrumentationType": {
+          "documentation": "<p>Type of instrumentation: BREAKPOINT (temporary) or PROBE (permanent)</p>",
+          "shape": "InstrumentationType"
+        },
+        "Location": {
+          "shape": "Location"
+        },
+        "Service": {
+          "shape": "CreateInstrumentationConfigurationRequestServiceString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        },
+        "Tags": {
+          "shape": "TagList"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "Service",
+        "Environment",
+        "SignalType",
+        "Location",
+        "CaptureConfiguration"
+      ],
+      "type": "structure"
+    },
+    "CreateInstrumentationConfigurationRequestDescriptionString": {
+      "max": 50,
+      "min": 1,
+      "type": "string"
+    },
+    "CreateInstrumentationConfigurationRequestEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9:/+=,.@_-]+",
+      "type": "string"
+    },
+    "CreateInstrumentationConfigurationRequestServiceString": {
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9:/+=,.@_-]+",
+      "type": "string"
+    },
+    "CreateInstrumentationConfigurationResponse": {
+      "members": {
+        "ARN": {
+          "documentation": "<p>ARN for the created instrumentation configuration</p>",
+          "shape": "InstrumentationConfigurationArn"
+        },
+        "AttributeFilters": {
+          "shape": "DynamicInstrumentationAttributeFilters"
+        },
+        "CaptureConfiguration": {
+          "shape": "CaptureConfiguration"
+        },
+        "CreatedAt": {
+          "shape": "Timestamp"
+        },
+        "Description": {
+          "shape": "String"
+        },
+        "Environment": {
+          "shape": "CreateInstrumentationConfigurationResponseEnvironmentString"
+        },
+        "ExpiresAt": {
+          "shape": "Timestamp"
+        },
+        "InstrumentationType": {
+          "shape": "InstrumentationType"
+        },
+        "Location": {
+          "shape": "Location"
+        },
+        "LocationHash": {
+          "shape": "CreateInstrumentationConfigurationResponseLocationHashString"
+        },
+        "Service": {
+          "shape": "CreateInstrumentationConfigurationResponseServiceString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "Service",
+        "Environment",
+        "SignalType",
+        "Location",
+        "LocationHash",
+        "CaptureConfiguration",
+        "CreatedAt",
+        "ARN"
+      ],
+      "type": "structure"
+    },
+    "CreateInstrumentationConfigurationResponseEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "CreateInstrumentationConfigurationResponseLocationHashString": {
+      "max": 16,
+      "min": 16,
+      "type": "string"
+    },
+    "CreateInstrumentationConfigurationResponseServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "DeleteInstrumentationConfigurationRequest": {
+      "members": {
+        "Environment": {
+          "documentation": "<p>Environment name for the instrumentation configuration.</p>",
+          "shape": "DeleteInstrumentationConfigurationRequestEnvironmentString"
+        },
+        "InstrumentationType": {
+          "documentation": "<p>Type of instrumentation configuration (BREAKPOINT or PROBE). Required to determine which table to delete from.</p>",
+          "shape": "InstrumentationType"
+        },
+        "LocationIdentifier": {
+          "documentation": "<p>Location identifier - either full code/watcher location or a pre-computed hash.</p>",
+          "shape": "LocationIdentifier"
+        },
+        "Service": {
+          "documentation": "<p>Service name for the instrumentation configuration.</p>",
+          "shape": "DeleteInstrumentationConfigurationRequestServiceString"
+        },
+        "SignalType": {
+          "documentation": "<p>Signal type for the instrumentation configuration.</p>",
+          "shape": "DynamicInstrumentationSignalType"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "Service",
+        "Environment",
+        "SignalType",
+        "LocationIdentifier"
+      ],
+      "type": "structure"
+    },
+    "DeleteInstrumentationConfigurationRequestEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "DeleteInstrumentationConfigurationRequestServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "DeleteInstrumentationConfigurationResponse": {
+      "members": {
+        "DeletionStatus": {
+          "shape": "DynamicInstrumentationDeletionStatus"
+        }
+      },
+      "required": [
+        "DeletionStatus"
+      ],
+      "type": "structure"
+    },
+    "DynamicInstrumentationAttributeFilterGroup": {
+      "key": {
+        "shape": "DynamicInstrumentationAttributeFilterGroupKeyString"
+      },
+      "type": "map",
+      "value": {
+        "shape": "DynamicInstrumentationAttributeFilterGroupValueString"
+      }
+    },
+    "DynamicInstrumentationAttributeFilterGroupKeyString": {
+      "max": 50,
+      "min": 1,
+      "type": "string"
+    },
+    "DynamicInstrumentationAttributeFilterGroupValueString": {
+      "max": 100,
+      "min": 1,
+      "type": "string"
+    },
+    "DynamicInstrumentationAttributeFilters": {
+      "max": 10,
+      "member": {
+        "shape": "DynamicInstrumentationAttributeFilterGroup"
+      },
+      "min": 1,
+      "type": "list"
+    },
+    "DynamicInstrumentationDeletionStatus": {
+      "enum": [
+        "DELETED"
+      ],
+      "type": "string"
+    },
+    "DynamicInstrumentationSignalType": {
+      "enum": [
+        "SNAPSHOT",
+        "METRIC"
+      ],
+      "type": "string"
+    },
+    "FaultDescription": {
+      "type": "string"
+    },
+    "GetInstrumentationConfigurationRequest": {
+      "members": {
+        "Environment": {
+          "documentation": "<p>Environment name for the instrumentation configuration.</p>",
+          "shape": "GetInstrumentationConfigurationRequestEnvironmentString"
+        },
+        "InstrumentationType": {
+          "documentation": "<p>Type of instrumentation configuration (BREAKPOINT or PROBE). Required to determine which table to query.</p>",
+          "shape": "InstrumentationType"
+        },
+        "LocationIdentifier": {
+          "documentation": "<p>Location identifier - either full code/watcher location or a pre-computed hash.</p>",
+          "shape": "LocationIdentifier"
+        },
+        "Service": {
+          "documentation": "<p>Service name for the instrumentation configuration.</p>",
+          "shape": "GetInstrumentationConfigurationRequestServiceString"
+        },
+        "SignalType": {
+          "documentation": "<p>Signal type for the instrumentation configuration.</p>",
+          "shape": "DynamicInstrumentationSignalType"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "Service",
+        "Environment",
+        "SignalType",
+        "LocationIdentifier"
+      ],
+      "type": "structure"
+    },
+    "GetInstrumentationConfigurationRequestEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "GetInstrumentationConfigurationRequestServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "GetInstrumentationConfigurationResponse": {
+      "members": {
+        "Configuration": {
+          "shape": "InstrumentationConfiguration"
+        }
+      },
+      "required": [
+        "Configuration"
+      ],
+      "type": "structure"
+    },
+    "GetInstrumentationConfigurationStatusRequest": {
+      "members": {
+        "EndTime": {
+          "shape": "Timestamp"
+        },
+        "Environment": {
+          "documentation": "<p>Environment name for the instrumentation configuration.</p>",
+          "shape": "GetInstrumentationConfigurationStatusRequestEnvironmentString"
+        },
+        "InstrumentationType": {
+          "documentation": "<p>Type of instrumentation configuration (BREAKPOINT or PROBE). Required to determine which table to query.</p>",
+          "shape": "InstrumentationType"
+        },
+        "LocationIdentifier": {
+          "documentation": "<p>Location identifier - either full code/watcher location or a pre-computed hash.</p>",
+          "shape": "LocationIdentifier"
+        },
+        "MaxResults": {
+          "shape": "GetInstrumentationConfigurationStatusRequestMaxResultsInteger"
+        },
+        "NextToken": {
+          "shape": "NextToken"
+        },
+        "Service": {
+          "documentation": "<p>Service name for the instrumentation configuration.</p>",
+          "shape": "GetInstrumentationConfigurationStatusRequestServiceString"
+        },
+        "SignalType": {
+          "documentation": "<p>Signal type for the instrumentation configuration.</p>",
+          "shape": "DynamicInstrumentationSignalType"
+        },
+        "StartTime": {
+          "shape": "Timestamp"
+        },
+        "Status": {
+          "shape": "InstrumentationConfigurationStatus"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "Service",
+        "Environment",
+        "SignalType",
+        "LocationIdentifier"
+      ],
+      "type": "structure"
+    },
+    "GetInstrumentationConfigurationStatusRequestEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "GetInstrumentationConfigurationStatusRequestMaxResultsInteger": {
+      "box": true,
+      "max": 100,
+      "min": 1,
+      "type": "integer"
+    },
+    "GetInstrumentationConfigurationStatusRequestServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "GetInstrumentationConfigurationStatusResponse": {
+      "members": {
+        "Environment": {
+          "shape": "GetInstrumentationConfigurationStatusResponseEnvironmentString"
+        },
+        "Events": {
+          "shape": "InstrumentationStatusEventList"
+        },
+        "Location": {
+          "shape": "Location"
+        },
+        "NextToken": {
+          "shape": "NextToken"
+        },
+        "Service": {
+          "shape": "GetInstrumentationConfigurationStatusResponseServiceString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        },
+        "Status": {
+          "shape": "InstrumentationConfigurationStatus"
+        }
+      },
+      "required": [
+        "Service",
+        "Environment",
+        "SignalType",
+        "Location",
+        "Status",
+        "Events"
+      ],
+      "type": "structure"
+    },
+    "GetInstrumentationConfigurationStatusResponseEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "GetInstrumentationConfigurationStatusResponseServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfiguration": {
+      "members": {
+        "ARN": {
+          "documentation": "<p>ARN for the instrumentation configuration</p>",
+          "shape": "InstrumentationConfigurationArn"
+        },
+        "AttributeFilters": {
+          "shape": "DynamicInstrumentationAttributeFilters"
+        },
+        "CaptureConfiguration": {
+          "shape": "CaptureConfiguration"
+        },
+        "CreatedAt": {
+          "shape": "Timestamp"
+        },
+        "Description": {
+          "shape": "InstrumentationConfigurationDescriptionString"
+        },
+        "Environment": {
+          "shape": "InstrumentationConfigurationEnvironmentString"
+        },
+        "ExpiresAt": {
+          "shape": "Timestamp"
+        },
+        "InstrumentationType": {
+          "shape": "InstrumentationType"
+        },
+        "Location": {
+          "shape": "Location"
+        },
+        "LocationHash": {
+          "shape": "InstrumentationConfigurationLocationHashString"
+        },
+        "Service": {
+          "shape": "InstrumentationConfigurationServiceString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "Service",
+        "Environment",
+        "SignalType",
+        "Location",
+        "LocationHash",
+        "CaptureConfiguration",
+        "CreatedAt",
+        "ARN"
+      ],
+      "type": "structure"
+    },
+    "InstrumentationConfigurationArn": {
+      "documentation": "<p>ARN for an instrumentation configuration Format: arn:${Partition}:application-signals:${Region}:${Account}:instrumentationConfig/${service}/${environment}/${signalType}/${locationHash} Note: service and environment can contain '/' and ':', so we use a permissive pattern that only validates the ARN prefix structure and the 16-character lowercase hex locationHash suffix (generated by LocationHashUtil &quot;%016x&quot;).</p>",
+      "pattern": "arn:[^:]+:application-signals:[^:]+:[0-9]{12}:instrumentationConfig/.+/[0-9a-f]{16}",
+      "type": "string"
+    },
+    "InstrumentationConfigurationDescriptionString": {
+      "max": 50,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfigurationEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfigurationLocationHashString": {
+      "max": 16,
+      "min": 16,
+      "type": "string"
+    },
+    "InstrumentationConfigurationServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfigurationStatus": {
+      "enum": [
+        "READY",
+        "ERROR",
+        "ACTIVE",
+        "DISABLED"
+      ],
+      "type": "string"
+    },
+    "InstrumentationConfigurationStatusReport": {
+      "members": {
+        "ErrorCause": {
+          "shape": "InstrumentationErrorCause"
+        },
+        "InstrumentationType": {
+          "shape": "InstrumentationType"
+        },
+        "LocationHash": {
+          "shape": "InstrumentationConfigurationStatusReportLocationHashString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        },
+        "Status": {
+          "shape": "InstrumentationConfigurationStatus"
+        },
+        "Time": {
+          "shape": "Timestamp"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "SignalType",
+        "LocationHash",
+        "Status",
+        "Time"
+      ],
+      "type": "structure"
+    },
+    "InstrumentationConfigurationStatusReportLocationHashString": {
+      "max": 16,
+      "min": 16,
+      "type": "string"
+    },
+    "InstrumentationConfigurationWithoutServiceEnv": {
+      "members": {
+        "ARN": {
+          "documentation": "<p>ARN for the instrumentation configuration</p>",
+          "shape": "InstrumentationConfigurationArn"
+        },
+        "AttributeFilters": {
+          "shape": "DynamicInstrumentationAttributeFilters"
+        },
+        "CaptureConfiguration": {
+          "shape": "CaptureConfiguration"
+        },
+        "CreatedAt": {
+          "shape": "Timestamp"
+        },
+        "Description": {
+          "shape": "InstrumentationConfigurationWithoutServiceEnvDescriptionString"
+        },
+        "ExpiresAt": {
+          "shape": "Timestamp"
+        },
+        "InstrumentationType": {
+          "shape": "InstrumentationType"
+        },
+        "Location": {
+          "shape": "Location"
+        },
+        "LocationHash": {
+          "shape": "InstrumentationConfigurationWithoutServiceEnvLocationHashString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "SignalType",
+        "Location",
+        "LocationHash",
+        "CaptureConfiguration",
+        "CreatedAt",
+        "ARN"
+      ],
+      "type": "structure"
+    },
+    "InstrumentationConfigurationWithoutServiceEnvDescriptionString": {
+      "max": 50,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfigurationWithoutServiceEnvLocationHashString": {
+      "max": 16,
+      "min": 16,
+      "type": "string"
+    },
+    "InstrumentationConfigurationsPage": {
+      "members": {
+        "Changed": {
+          "shape": "Boolean"
+        },
+        "Environment": {
+          "shape": "InstrumentationConfigurationsPageEnvironmentString"
+        },
+        "LatestConfigurations": {
+          "shape": "InstrumentationConfigurationsWithoutServiceEnv"
+        },
+        "NextToken": {
+          "shape": "NextToken"
+        },
+        "Service": {
+          "shape": "InstrumentationConfigurationsPageServiceString"
+        },
+        "SyncInterval": {
+          "shape": "InstrumentationConfigurationsPageSyncIntervalInteger"
+        },
+        "SyncedAt": {
+          "shape": "Timestamp"
+        }
+      },
+      "required": [
+        "Service",
+        "Environment",
+        "Changed",
+        "SyncedAt",
+        "SyncInterval"
+      ],
+      "type": "structure"
+    },
+    "InstrumentationConfigurationsPageEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfigurationsPageServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "InstrumentationConfigurationsPageSyncIntervalInteger": {
+      "box": true,
+      "min": 60,
+      "type": "integer"
+    },
+    "InstrumentationConfigurationsWithoutServiceEnv": {
+      "member": {
+        "shape": "InstrumentationConfigurationWithoutServiceEnv"
+      },
+      "type": "list"
+    },
+    "InstrumentationErrorCause": {
+      "enum": [
+        "FILE_NOT_FOUND",
+        "METHOD_NOT_FOUND",
+        "LINE_NOT_EXECUTABLE",
+        "OVERLOADED_METHODS",
+        "LANGUAGE_MISMATCH",
+        "RUNTIME_ERROR"
+      ],
+      "type": "string"
+    },
+    "InstrumentationStatusEvent": {
+      "members": {
+        "ErrorCause": {
+          "shape": "InstrumentationErrorCause"
+        },
+        "Time": {
+          "shape": "Timestamp"
+        }
+      },
+      "required": [
+        "Time"
+      ],
+      "type": "structure"
+    },
+    "InstrumentationStatusEventList": {
+      "member": {
+        "shape": "InstrumentationStatusEvent"
+      },
+      "type": "list"
+    },
+    "InstrumentationType": {
+      "documentation": "<p>Type of instrumentation configuration</p>",
+      "enum": [
+        "BREAKPOINT",
+        "PROBE"
+      ],
+      "type": "string"
+    },
+    "Integer": {
+      "box": true,
+      "type": "integer"
+    },
+    "ListInstrumentationConfigurationsRequest": {
+      "members": {
+        "Environment": {
+          "shape": "ListInstrumentationConfigurationsRequestEnvironmentString"
+        },
+        "InstrumentationType": {
+          "documentation": "<p>Type of instrumentation configuration (BREAKPOINT or PROBE). Required to determine which backing store to query.</p>",
+          "shape": "InstrumentationType"
+        },
+        "MaxResults": {
+          "shape": "ListInstrumentationConfigurationsRequestMaxResultsInteger"
+        },
+        "NextToken": {
+          "shape": "NextToken"
+        },
+        "Service": {
+          "shape": "ListInstrumentationConfigurationsRequestServiceString"
+        },
+        "SyncedAt": {
+          "shape": "Timestamp"
+        }
+      },
+      "required": [
+        "Service",
+        "Environment",
+        "InstrumentationType"
+      ],
+      "type": "structure"
+    },
+    "ListInstrumentationConfigurationsRequestEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9:/+=,.@_-]+",
+      "type": "string"
+    },
+    "ListInstrumentationConfigurationsRequestMaxResultsInteger": {
+      "box": true,
+      "max": 100,
+      "min": 1,
+      "type": "integer"
+    },
+    "ListInstrumentationConfigurationsRequestServiceString": {
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9:/+=,.@_-]+",
+      "type": "string"
+    },
+    "Location": {
+      "members": {
+        "CodeLocation": {
+          "shape": "CodeLocation"
+        }
+      },
+      "type": "structure",
+      "union": true
+    },
+    "LocationIdentifier": {
+      "documentation": "<p>Union type for identifying an instrumentation configuration by code location or locationHash. Used in Get/Delete/GetStatus operations to allow flexible identification.</p>",
+      "members": {
+        "CodeLocation": {
+          "documentation": "<p>The full code location specification (will be hashed internally)</p>",
+          "shape": "CodeLocation"
+        },
+        "LocationHash": {
+          "documentation": "<p>The pre-computed location hash (16-character hex string)</p>",
+          "shape": "LocationIdentifierLocationHashString"
+        }
+      },
+      "type": "structure",
+      "union": true
+    },
+    "LocationIdentifierLocationHashString": {
+      "max": 16,
+      "min": 16,
+      "type": "string"
+    },
+    "NextToken": {
+      "type": "string"
+    },
+    "ProgrammingLanguage": {
+      "enum": [
+        "Java",
+        "Python",
+        "Javascript"
+      ],
+      "type": "string"
+    },
+    "ReportInstrumentationConfigurationStatusRequest": {
+      "members": {
+        "Configurations": {
+          "shape": "ReportInstrumentationConfigurationStatusRequestConfigurationsList"
+        },
+        "Environment": {
+          "shape": "ReportInstrumentationConfigurationStatusRequestEnvironmentString"
+        },
+        "Service": {
+          "shape": "ReportInstrumentationConfigurationStatusRequestServiceString"
+        }
+      },
+      "required": [
+        "Service",
+        "Environment",
+        "Configurations"
+      ],
+      "type": "structure"
+    },
+    "ReportInstrumentationConfigurationStatusRequestConfigurationsList": {
+      "max": 100,
+      "member": {
+        "shape": "InstrumentationConfigurationStatusReport"
+      },
+      "min": 1,
+      "type": "list"
+    },
+    "ReportInstrumentationConfigurationStatusRequestEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "ReportInstrumentationConfigurationStatusRequestServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "ReportInstrumentationConfigurationStatusResponse": {
+      "members": {
+        "Environment": {
+          "shape": "ReportInstrumentationConfigurationStatusResponseEnvironmentString"
+        },
+        "Service": {
+          "shape": "ReportInstrumentationConfigurationStatusResponseServiceString"
+        },
+        "UnprocessedStatusEvents": {
+          "shape": "UnprocessedStatusEventList"
+        }
+      },
+      "required": [
+        "Service",
+        "Environment",
+        "UnprocessedStatusEvents"
+      ],
+      "type": "structure"
+    },
+    "ReportInstrumentationConfigurationStatusResponseEnvironmentString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "ReportInstrumentationConfigurationStatusResponseServiceString": {
+      "max": 255,
+      "min": 1,
+      "type": "string"
+    },
+    "ResourceId": {
+      "type": "string"
+    },
+    "ResourceNotFoundException": {
+      "error": {
+        "httpStatusCode": 404,
+        "senderFault": true
+      },
+      "exception": true,
+      "members": {
+        "Message": {
+          "shape": "FaultDescription"
+        },
+        "ResourceId": {
+          "shape": "ResourceId"
+        },
+        "ResourceType": {
+          "shape": "ResourceType"
+        }
+      },
+      "required": [
+        "ResourceType",
+        "ResourceId",
+        "Message"
+      ],
+      "type": "structure"
+    },
+    "ResourceType": {
+      "type": "string"
+    },
+    "ServiceQuotaExceededException": {
+      "error": {
+        "httpStatusCode": 402,
+        "senderFault": true
+      },
+      "exception": true,
+      "members": {
+        "Message": {
+          "shape": "String"
+        }
+      },
+      "required": [
+        "Message"
+      ],
+      "type": "structure"
+    },
+    "String": {
+      "type": "string"
+    },
+    "Tag": {
+      "members": {
+        "Key": {
+          "shape": "TagKey"
+        },
+        "Value": {
+          "shape": "TagValue"
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ],
+      "type": "structure"
+    },
+    "TagKey": {
+      "max": 128,
+      "min": 1,
+      "type": "string"
+    },
+    "TagList": {
+      "max": 200,
+      "member": {
+        "shape": "Tag"
+      },
+      "min": 0,
+      "type": "list"
+    },
+    "TagValue": {
+      "max": 256,
+      "min": 0,
+      "type": "string"
+    },
+    "ThrottlingException": {
+      "error": {
+        "httpStatusCode": 429,
+        "senderFault": true
+      },
+      "exception": true,
+      "members": {
+        "Message": {
+          "shape": "String"
+        }
+      },
+      "required": [
+        "Message"
+      ],
+      "type": "structure"
+    },
+    "Timestamp": {
+      "type": "timestamp"
+    },
+    "UnprocessedStatusEvent": {
+      "members": {
+        "FailedReason": {
+          "shape": "UnprocessedStatusEventFailureReason"
+        },
+        "InstrumentationType": {
+          "shape": "InstrumentationType"
+        },
+        "LocationHash": {
+          "shape": "UnprocessedStatusEventLocationHashString"
+        },
+        "SignalType": {
+          "shape": "DynamicInstrumentationSignalType"
+        },
+        "Status": {
+          "shape": "InstrumentationConfigurationStatus"
+        },
+        "Time": {
+          "shape": "Timestamp"
+        }
+      },
+      "required": [
+        "InstrumentationType",
+        "SignalType",
+        "LocationHash",
+        "Status",
+        "Time",
+        "FailedReason"
+      ],
+      "type": "structure"
+    },
+    "UnprocessedStatusEventFailureReason": {
+      "enum": [
+        "THROTTLED",
+        "INTERNAL_ERROR",
+        "VALIDATION_ERROR"
+      ],
+      "type": "string"
+    },
+    "UnprocessedStatusEventList": {
+      "member": {
+        "shape": "UnprocessedStatusEvent"
+      },
+      "type": "list"
+    },
+    "UnprocessedStatusEventLocationHashString": {
+      "max": 16,
+      "min": 16,
+      "type": "string"
+    },
+    "ValidationException": {
+      "error": {
+        "httpStatusCode": 400,
+        "senderFault": true
+      },
+      "exception": true,
+      "members": {
+        "message": {
+          "shape": "ValidationExceptionMessage"
+        }
+      },
+      "type": "structure"
+    },
+    "ValidationExceptionMessage": {
+      "type": "string"
+    }
+  },
+  "version": "2.0"
+}

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/capture.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/capture.py
@@ -1,0 +1,219 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Capture configuration ADT for dynamic instrumentation.
+
+Mirrors the ``Location`` design: a sealed sum type covers the two
+``CaptureConfiguration`` variants the ``application-signals`` API exposes,
+plus an ``UnknownCapture`` fallback so renderers stay forward-compatible.
+
+The type owns the API shape — payload assembly via ``to_api_payload`` and
+inverse parsing via ``capture_from_response``. It does *not* own prose
+rendering (renderers keep their CAPTURE SETTINGS / CAPTURE CONFIGURATION
+blocks) and it does *not* fill in tool-input defaults (defaults like
+``capture_return=True`` resolve at the tool layer where the success-message
+prose can read the resolved value).
+
+Two distinctions worth preserving across the round-trip:
+
+* ``CaptureArguments`` *omitted* means "capture all arguments"; renderers
+  show ``- Arguments: All``.
+* ``CaptureArguments`` *present-but-empty* means "capture none"; renderers
+  show ``- Arguments: (none)``.
+
+Both shapes survive parse → payload → parse round-trips.
+"""
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
+
+
+@dataclass(frozen=True)
+class CaptureLimits:
+    """Optional size caps applied to a code-capture payload."""
+
+    max_hits: Optional[int] = None
+    max_string_length: Optional[int] = None
+    max_collection_width: Optional[int] = None
+    max_collection_depth: Optional[int] = None
+    max_stack_frames: Optional[int] = None
+    max_stack_trace_size: Optional[int] = None
+    max_object_depth: Optional[int] = None
+    max_fields_per_object: Optional[int] = None
+
+    def is_empty(self) -> bool:
+        """Return True when no capture limit is set."""
+        return all(
+            v is None
+            for v in (
+                self.max_hits,
+                self.max_string_length,
+                self.max_collection_width,
+                self.max_collection_depth,
+                self.max_stack_frames,
+                self.max_stack_trace_size,
+                self.max_object_depth,
+                self.max_fields_per_object,
+            )
+        )
+
+    def to_api_payload(self) -> Dict[str, int]:
+        """Render the set capture limits as the CaptureLimits payload."""
+        payload: Dict[str, int] = {}
+        if self.max_hits is not None:
+            payload['MaxHits'] = self.max_hits
+        if self.max_string_length is not None:
+            payload['MaxStringLength'] = self.max_string_length
+        if self.max_collection_width is not None:
+            payload['MaxCollectionWidth'] = self.max_collection_width
+        if self.max_collection_depth is not None:
+            payload['MaxCollectionDepth'] = self.max_collection_depth
+        if self.max_stack_frames is not None:
+            payload['MaxStackFrames'] = self.max_stack_frames
+        if self.max_stack_trace_size is not None:
+            payload['MaxStackTraceSize'] = self.max_stack_trace_size
+        if self.max_object_depth is not None:
+            payload['MaxObjectDepth'] = self.max_object_depth
+        if self.max_fields_per_object is not None:
+            payload['MaxFieldsPerObject'] = self.max_fields_per_object
+        return payload
+
+
+@dataclass(frozen=True)
+class CodeCapture:
+    """Capture configuration for BREAKPOINT and PROBE.
+
+    ``capture_arguments`` and ``capture_locals`` are stored as tuples so the
+    ``frozen=True`` immutability contract holds against mutation through the
+    container (a caller's reference to the source list cannot mutate this
+    instance). Constructors still accept any iterable of strings — including
+    a list — and ``__post_init__`` converts to ``tuple``. This is the same
+    discipline ``Location`` applies to ``extra_fields`` via
+    ``MappingProxyType``.
+
+    The ``Optional`` distinction is meaningful and survives the round-trip:
+    ``None`` means "capture all arguments" (key omitted from the API
+    payload); an empty tuple ``()`` means "capture none" (key emitted as
+    ``[]``).
+    """
+
+    capture_return: bool
+    capture_stack_trace: bool
+    capture_arguments: Optional[Tuple[str, ...]] = None
+    capture_locals: Optional[Tuple[str, ...]] = None
+    limits: CaptureLimits = field(default_factory=CaptureLimits)
+
+    def __post_init__(self) -> None:
+        """Coerce argument/local name lists to tuples for the frozen contract."""
+        if self.capture_arguments is not None and not isinstance(self.capture_arguments, tuple):
+            object.__setattr__(self, 'capture_arguments', tuple(self.capture_arguments))
+        if self.capture_locals is not None and not isinstance(self.capture_locals, tuple):
+            object.__setattr__(self, 'capture_locals', tuple(self.capture_locals))
+
+    def to_api_payload(self) -> Dict[str, Any]:
+        """Render the CodeCapture create-request payload."""
+        config: Dict[str, Any] = {
+            'CaptureReturn': self.capture_return,
+            'CaptureStackTrace': self.capture_stack_trace,
+            'CaptureLimits': self.limits.to_api_payload(),
+        }
+        if self.capture_arguments is not None:
+            config['CaptureArguments'] = list(self.capture_arguments)
+        if self.capture_locals is not None:
+            config['CaptureLocals'] = list(self.capture_locals)
+        return {'CodeCapture': config}
+
+
+@dataclass(frozen=True)
+class UnknownCapture:
+    """A CaptureConfiguration union that did not match a known variant.
+
+    ``raw`` is wrapped in ``MappingProxyType`` to keep the ``frozen=True``
+    contract intact against mutation through the source dict — the same
+    discipline applied to ``Location.extra_fields`` and
+    ``CodeCapture.capture_arguments``.
+    """
+
+    raw: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        """Wrap ``raw`` in a read-only proxy to honor the frozen contract."""
+        if not isinstance(self.raw, MappingProxyType):
+            object.__setattr__(self, 'raw', MappingProxyType(dict(self.raw)))
+
+
+Capture = Union[CodeCapture, UnknownCapture]
+
+
+_CODE_CAPTURE_HINT_KEYS = (
+    'CaptureReturn',
+    'CaptureLimits',
+    'CaptureArguments',
+    'CaptureStackTrace',
+)
+
+
+def capture_from_response(union_dict: Optional[Dict[str, Any]]) -> Capture:
+    """Parse a ``CaptureConfiguration`` union returned by the API into the ADT.
+
+    Falls back to inferring a ``CodeCapture`` if a CodeCapture-shaped dict
+    is passed without the ``CodeCapture`` wrapper key — this matches the
+    legacy ``extract_capture_variant`` fallback that some response shapes
+    relied on.
+    """
+    if not isinstance(union_dict, dict):
+        return UnknownCapture(raw={})
+
+    code = union_dict.get('CodeCapture')
+    if isinstance(code, dict):
+        return _code_capture_from_dict(code)
+
+    if any(key in union_dict for key in _CODE_CAPTURE_HINT_KEYS):
+        return _code_capture_from_dict(union_dict)
+
+    return UnknownCapture(raw=dict(union_dict))
+
+
+def _code_capture_from_dict(payload: Dict[str, Any]) -> CodeCapture:
+    raw_limits = payload.get('CaptureLimits') or {}
+    if not isinstance(raw_limits, dict):
+        raw_limits = {}
+    limits = CaptureLimits(
+        max_hits=raw_limits.get('MaxHits'),
+        max_string_length=raw_limits.get('MaxStringLength'),
+        max_collection_width=raw_limits.get('MaxCollectionWidth'),
+        max_collection_depth=raw_limits.get('MaxCollectionDepth'),
+        max_stack_frames=raw_limits.get('MaxStackFrames'),
+        max_stack_trace_size=raw_limits.get('MaxStackTraceSize'),
+        max_object_depth=raw_limits.get('MaxObjectDepth'),
+        max_fields_per_object=raw_limits.get('MaxFieldsPerObject'),
+    )
+    return CodeCapture(
+        capture_return=bool(payload.get('CaptureReturn')),
+        capture_stack_trace=bool(payload.get('CaptureStackTrace')),
+        capture_arguments=payload.get('CaptureArguments')
+        if 'CaptureArguments' in payload
+        else None,
+        capture_locals=payload.get('CaptureLocals') if 'CaptureLocals' in payload else None,
+        limits=limits,
+    )
+
+
+__all__ = [
+    'CaptureLimits',
+    'CodeCapture',
+    'UnknownCapture',
+    'Capture',
+    'capture_from_response',
+]

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/capture.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/capture.py
@@ -36,7 +36,7 @@ Both shapes survive parse → payload → parse round-trips.
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 
 @dataclass(frozen=True)
@@ -110,8 +110,11 @@ class CodeCapture:
 
     capture_return: bool
     capture_stack_trace: bool
-    capture_arguments: Optional[Tuple[str, ...]] = None
-    capture_locals: Optional[Tuple[str, ...]] = None
+    # Declared as ``Sequence[str]`` because the constructor accepts any string
+    # sequence (commonly a list); ``__post_init__`` coerces to ``tuple`` so the
+    # stored value is always an immutable tuple despite the broader input type.
+    capture_arguments: Optional[Sequence[str]] = None
+    capture_locals: Optional[Sequence[str]] = None
     limits: CaptureLimits = field(default_factory=CaptureLimits)
 
     def __post_init__(self) -> None:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/constants.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/constants.py
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared constants for dynamic instrumentation support."""
+
+SNAPSHOT_SIGNAL_TYPE = 'SNAPSHOT'
+
+# Dynamic instrumentation snapshots are written to a per-service CloudWatch Logs
+# group. ``{service_name}`` is substituted with the target service name at query
+# time via ``resolve_snapshot_log_group``.
+SNAPSHOT_LOG_GROUP_TEMPLATE = '/aws/service-events/{service_name}'
+
+
+def resolve_snapshot_log_group(service_name: str) -> str:
+    """Resolve the per-service snapshot log group name."""
+    return SNAPSHOT_LOG_GROUP_TEMPLATE.format(service_name=service_name)

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_rendering.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_rendering.py
@@ -1,0 +1,367 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Formatting helpers for CRUD tool responses."""
+
+from .capture import CodeCapture, capture_from_response
+from .constants import SNAPSHOT_SIGNAL_TYPE
+from .formatting import format_timestamp
+from .location import Location, location_from_response, render_location_block
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+def _render_create_capture_limits(
+    max_hits: Optional[int],
+    max_string_length: Optional[int],
+    max_collection_width: Optional[int],
+    max_collection_depth: Optional[int],
+    max_stack_frames: Optional[int],
+    max_stack_trace_size: Optional[int],
+    max_object_depth: Optional[int],
+    max_fields_per_object: Optional[int],
+) -> str:
+    if not any(
+        [
+            max_hits,
+            max_string_length,
+            max_collection_width,
+            max_collection_depth,
+            max_stack_frames,
+            max_stack_trace_size,
+            max_object_depth,
+            max_fields_per_object,
+        ]
+    ):
+        return ''
+
+    output = '\nCAPTURE LIMITS:\n'
+    if max_hits:
+        output += f'- Max Hits: {max_hits}\n'
+    if max_string_length:
+        output += f'- Max String Length: {max_string_length}\n'
+    if max_collection_width:
+        output += f'- Max Collection Width: {max_collection_width}\n'
+    if max_collection_depth:
+        output += f'- Max Collection Depth: {max_collection_depth}\n'
+    if max_stack_frames:
+        output += f'- Max Stack Frames: {max_stack_frames}\n'
+    if max_stack_trace_size:
+        output += f'- Max Stack Trace Size: {max_stack_trace_size}\n'
+    if max_object_depth:
+        output += f'- Max Object Depth: {max_object_depth}\n'
+    if max_fields_per_object:
+        output += f'- Max Fields Per Object: {max_fields_per_object}\n'
+    return output
+
+
+def render_create_success_message(
+    response: Dict[str, Any],
+    normalized_type: str,
+    service: str,
+    environment: str,
+    location: Location,
+    ttl_hours: Optional[int],
+    capture_arguments: Optional[List[str]],
+    wildcard_removed: bool,
+    code_capture_locals: Optional[List[str]],
+    code_capture_return: Optional[bool],
+    code_capture_stack_trace: Optional[bool],
+    max_hits: Optional[int],
+    max_string_length: Optional[int],
+    max_collection_width: Optional[int],
+    max_collection_depth: Optional[int],
+    max_stack_frames: Optional[int],
+    max_stack_trace_size: Optional[int],
+    max_object_depth: Optional[int],
+    max_fields_per_object: Optional[int],
+    attribute_filters: Optional[List[Dict[str, str]]],
+) -> str:
+    """Render the success message for a created instrumentation configuration."""
+    location_hash = response.get('LocationHash', 'N/A')
+    arn = response.get('ARN', 'N/A')
+    created_at = format_timestamp(
+        response.get('CreatedAt'),
+        default=datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+    )
+    actual_expires_at = format_timestamp(response.get('ExpiresAt'), default='')
+
+    success_message = f"""Successfully created {normalized_type} instrumentation
+
+INSTRUMENTATION CREATED:
+- Type: {normalized_type}
+- Service: {service}
+- Environment: {environment}
+- SignalType: {SNAPSHOT_SIGNAL_TYPE}
+- ARN: {arn}
+- CreatedAt: {created_at}
+"""
+
+    if actual_expires_at:
+        suffix = (
+            f' (requested {ttl_hours} hour{"s" if ttl_hours != 1 else ""})'
+            if ttl_hours is not None
+            else ''
+        )
+        success_message += f'- Expires: {actual_expires_at}{suffix}\n'
+    else:
+        success_message += '- Expires: Never (unless deleted)\n'
+
+    success_message += '\nLOCATION:\n'
+    success_message += render_location_block(location=location, location_hash=location_hash)
+    success_message += '\nCAPTURE CONFIGURATION:\n'
+
+    if capture_arguments:
+        success_message += f'- Arguments: {", ".join(capture_arguments)}\n'
+    else:
+        success_message += '- Arguments: (none)\n'
+    if wildcard_removed:
+        success_message += '  Note: wildcard * is not supported and was ignored.\n'
+
+    if code_capture_locals:
+        success_message += f'- Local Variables: {", ".join(code_capture_locals)}\n'
+
+    success_message += f'- Return Values: {"Enabled" if code_capture_return else "Disabled"}\n'
+    success_message += f'- Stack Traces: {"Enabled" if code_capture_stack_trace else "Disabled"}\n'
+    success_message += _render_create_capture_limits(
+        max_hits=max_hits,
+        max_string_length=max_string_length,
+        max_collection_width=max_collection_width,
+        max_collection_depth=max_collection_depth,
+        max_stack_frames=max_stack_frames,
+        max_stack_trace_size=max_stack_trace_size,
+        max_object_depth=max_object_depth,
+        max_fields_per_object=max_fields_per_object,
+    )
+
+    if attribute_filters:
+        success_message += (
+            f'\nATTRIBUTE FILTERS: {len(attribute_filters)} filter group(s) applied\n'
+        )
+
+    success_message += (
+        f'\nTIP: Use this LocationHash to delete: '
+        f'delete_instrumentation(location_hash="{location_hash}")'
+    )
+    return success_message
+
+
+def render_list_instrumentations_output(
+    data: Dict[str, Any],
+    normalized_type: str,
+    service: str,
+    environment: str,
+) -> str:
+    """Render the output for a list-instrumentations result."""
+    configs = data.get('LatestConfigurations', [])
+    next_token_response = data.get('NextToken')
+
+    if not configs:
+        return f"""No active {normalized_type} instrumentations found
+
+Service: {service}
+Environment: {environment}
+
+TIP: Use create_instrumentation to add instrumentations."""
+
+    output = f"""Active {normalized_type} Instrumentations ({len(configs)} found)
+
+Service: {service}
+Environment: {environment}
+Synced At: {format_timestamp(data.get('SyncedAt'))}
+
+"""
+
+    for index, config in enumerate(configs, 1):
+        cap = capture_from_response(config.get('CaptureConfiguration', {}))
+
+        output += f"""{'=' * 60}
+INSTRUMENTATION #{index}
+{'=' * 60}
+LOCATION:
+"""
+        output += render_location_block(
+            location=location_from_response(config.get('Location', {})),
+            location_hash=config.get('LocationHash'),
+        )
+
+        output += '\nCAPTURE SETTINGS:\n'
+        if isinstance(cap, CodeCapture):
+            output += f'- Return: {"Enabled" if cap.capture_return else "Disabled"}\n'
+            output += f'- Stack Traces: {"Enabled" if cap.capture_stack_trace else "Disabled"}\n'
+
+            if cap.capture_arguments is not None:
+                if cap.capture_arguments:
+                    output += f'- Arguments: {", ".join(cap.capture_arguments)}\n'
+                else:
+                    output += '- Arguments: (none)\n'
+            else:
+                output += '- Arguments: All\n'
+
+            if cap.capture_locals:
+                output += f'- Locals: {", ".join(cap.capture_locals)}\n'
+
+            limits = cap.limits
+            if not limits.is_empty():
+                limit_strs = []
+                if limits.max_hits is not None:
+                    limit_strs.append(f'MaxHits={limits.max_hits}')
+                if limits.max_string_length is not None:
+                    limit_strs.append(f'MaxStringLen={limits.max_string_length}')
+                if limits.max_collection_width is not None:
+                    limit_strs.append(f'MaxCollWidth={limits.max_collection_width}')
+                if limit_strs:
+                    output += f'- Limits: {", ".join(limit_strs)}\n'
+        else:
+            output += '- Capture payload could not be parsed.\n'
+
+        output += f"""
+TIMING:
+- Created: {format_timestamp(config.get('CreatedAt'))}
+- Expires: {format_timestamp(config.get('ExpiresAt'), default='Never')}
+
+Description: {config.get('Description', 'N/A')}
+ARN: {config.get('ARN', 'N/A')}
+
+"""
+
+    if next_token_response:
+        output += (
+            f'\nPAGINATION: More results available. Use next_token="{next_token_response}" '
+            'to retrieve next page.'
+        )
+
+    return output
+
+
+def render_get_instrumentation_output(
+    config: Dict[str, Any],
+    service: str,
+    environment: str,
+) -> str:
+    """Render the output for a single get-instrumentation result."""
+    cap = capture_from_response(config.get('CaptureConfiguration', {}))
+
+    output = f"""INSTRUMENTATION CONFIGURATION
+
+TYPE: {config.get('InstrumentationType', 'N/A')}
+SERVICE: {service}
+ENVIRONMENT: {environment}
+SIGNAL TYPE: {config.get('SignalType', SNAPSHOT_SIGNAL_TYPE)}
+
+LOCATION:
+"""
+    output += render_location_block(
+        location=location_from_response(config.get('Location', {})),
+        location_hash=config.get('LocationHash'),
+    )
+
+    output += '\nCAPTURE CONFIGURATION:\n'
+    if isinstance(cap, CodeCapture):
+        output += f'- Return Values: {"Enabled" if cap.capture_return else "Disabled"}\n'
+        output += f'- Stack Traces: {"Enabled" if cap.capture_stack_trace else "Disabled"}\n'
+        if cap.capture_arguments is not None:
+            if cap.capture_arguments:
+                output += f'- Arguments: {", ".join(cap.capture_arguments)}\n'
+            else:
+                output += '- Arguments: (none)\n'
+        else:
+            output += '- Arguments: All\n'
+        if cap.capture_locals:
+            output += f'- Local Variables: {", ".join(cap.capture_locals)}\n'
+
+        limits = cap.limits
+        if not limits.is_empty():
+            output += '\nCAPTURE LIMITS:\n'
+            if limits.max_hits is not None:
+                output += f'- Max Hits: {limits.max_hits}\n'
+            if limits.max_string_length is not None:
+                output += f'- Max String Length: {limits.max_string_length}\n'
+            if limits.max_collection_width is not None:
+                output += f'- Max Collection Width: {limits.max_collection_width}\n'
+            if limits.max_collection_depth is not None:
+                output += f'- Max Collection Depth: {limits.max_collection_depth}\n'
+            if limits.max_stack_frames is not None:
+                output += f'- Max Stack Frames: {limits.max_stack_frames}\n'
+            if limits.max_stack_trace_size is not None:
+                output += f'- Max Stack Trace Size: {limits.max_stack_trace_size}\n'
+            if limits.max_object_depth is not None:
+                output += f'- Max Object Depth: {limits.max_object_depth}\n'
+            if limits.max_fields_per_object is not None:
+                output += f'- Max Fields Per Object: {limits.max_fields_per_object}\n'
+    else:
+        output += '- Capture payload could not be parsed.\n'
+
+    if config.get('AttributeFilters'):
+        output += f'\nATTRIBUTE FILTERS: {len(config["AttributeFilters"])} filter group(s)\n'
+        for index, filter_group in enumerate(config['AttributeFilters'], 1):
+            output += f'  Group {index}: {filter_group}\n'
+
+    output += f"""
+METADATA:
+- Description: {config.get('Description', 'N/A')}
+- Created: {format_timestamp(config.get('CreatedAt'))}
+- Expires: {format_timestamp(config.get('ExpiresAt'), default='Never')}
+- ARN: {config.get('ARN', 'N/A')}
+"""
+    return output
+
+
+def _format_batch_delete_response(
+    mode: str,
+    data: Dict[str, Any],
+    instrumentation_type: str,
+    service: Optional[str] = None,
+    environment: Optional[str] = None,
+) -> str:
+    successful = data.get('SuccessfulDeletions', [])
+    errors = data.get('Errors', [])
+    deleted_count = data.get('DeletedCount', 0)
+
+    output = f"""BATCH DELETE COMPLETED
+
+Mode: {mode}
+InstrumentationType: {instrumentation_type}
+DeletedCount: {deleted_count}
+SuccessfulDeletions: {len(successful)}
+Errors: {len(errors)}
+"""
+    if service:
+        output += f'Service: {service}\n'
+    if environment:
+        output += f'Environment: {environment}\n'
+
+    if successful:
+        output += '\nSUCCESSFUL DELETIONS:\n'
+        for index, item in enumerate(successful, 1):
+            resource_arn = item.get('ResourceArn')
+            signal_type = item.get('SignalType')
+            location_hash = item.get('LocationHash')
+            if resource_arn:
+                output += f'- Item {index}: ResourceArn={resource_arn}\n'
+            else:
+                output += (
+                    f'- Item {index}: SignalType={signal_type or "N/A"} | '
+                    f'LocationHash={location_hash or "N/A"}\n'
+                )
+
+    if errors:
+        output += '\nDELETE ERRORS:\n'
+        for index, item in enumerate(errors, 1):
+            output += (
+                f'- Item {index}: ResourceArn={item.get("ResourceArn", "N/A")} | '
+                f'Code={item.get("Code", "N/A")} | '
+                f'Message={item.get("Message", "N/A")}\n'
+            )
+
+    return output

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_tools.py
@@ -1,0 +1,626 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MCP tool entrypoints for create/list/get/delete instrumentation operations."""
+
+from . import application_signals_gateway as gateway
+from .capture import CaptureLimits, CodeCapture
+from .constants import SNAPSHOT_SIGNAL_TYPE
+from .crud_rendering import (
+    _format_batch_delete_response,
+    render_create_success_message,
+    render_get_instrumentation_output,
+    render_list_instrumentations_output,
+)
+from .location import parse_create_inputs, parse_lookup_inputs
+from .validation import (
+    _format_code_location_troubleshooting,
+    normalize_instrumentation_type,
+)
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+
+def create_instrumentation(
+    instrumentation_type: str,
+    service: str,
+    environment: str,
+    language: Optional[str] = None,
+    file_path: Optional[str] = None,
+    code_unit: Optional[str] = None,
+    class_name: Optional[str] = None,
+    method_name: Optional[str] = None,
+    line_number: Optional[int] = None,
+    capture_arguments: Optional[List[str]] = None,
+    capture_return: Optional[bool] = None,
+    capture_stack_trace: Optional[bool] = None,
+    capture_locals: Optional[List[str]] = None,
+    max_hits: Optional[int] = None,
+    max_string_length: Optional[int] = None,
+    max_collection_width: Optional[int] = None,
+    max_collection_depth: Optional[int] = None,
+    max_stack_frames: Optional[int] = None,
+    max_stack_trace_size: Optional[int] = None,
+    max_object_depth: Optional[int] = None,
+    max_fields_per_object: Optional[int] = None,
+    attribute_filters: Optional[List[Dict[str, str]]] = None,
+    description: str = 'MCP dynamic instrumentation',
+    ttl_hours: Optional[int] = None,
+) -> str:
+    """Create a dynamic instrumentation configuration for BREAKPOINT or PROBE.
+
+    This is the main creation entrypoint for the MCP server. BREAKPOINT and PROBE
+    create code-based instrumentation and require an explicit code location plus
+    explicit `capture_arguments`.
+
+    Args:
+        instrumentation_type: BREAKPOINT or PROBE.
+        service: Backend service identifier used by the AWS API.
+        environment: Backend environment identifier used by the AWS API.
+        language: Required for BREAKPOINT/PROBE code instrumentation.
+            Typically Python or Java.
+        file_path: Required for BREAKPOINT/PROBE.
+        code_unit: Module/package name for code instrumentation.
+            For Python, use the dotted runtime import path for the defining module,
+            or "__main__" only when the target file is executed directly as the
+            process entry script.
+        class_name: Optional class name for class-based targets. Java should use the simple class name only.
+        method_name: Optional function or method name for method-level instrumentation.
+        line_number: Optional 1-based line number for line-level instrumentation.
+        capture_arguments: Required for BREAKPOINT/PROBE. MCP does not infer argument names automatically.
+        capture_return: Whether to capture return values for code instrumentation. Defaults to enabled.
+        capture_stack_trace: Whether to capture stack traces for code instrumentation. Defaults to enabled.
+        capture_locals: Optional list of local variable names to capture.
+        max_hits: Optional capture limit for maximum number of hits.
+        max_string_length: Optional capture limit for string truncation.
+        max_collection_width: Optional capture limit for collection width.
+        max_collection_depth: Optional capture limit for nested collection depth.
+        max_stack_frames: Optional capture limit for stack frame count.
+        max_stack_trace_size: Optional capture limit for stack trace size.
+        max_object_depth: Optional capture limit for object traversal depth.
+        max_fields_per_object: Optional capture limit for object field count.
+        attribute_filters: Optional attribute filter groups forwarded to the AWS API.
+        description: Free-form description stored with the instrumentation. Must be 50 characters or fewer.
+        ttl_hours: Optional expiration duration in hours. Converted to an absolute UTC timestamp.
+
+    Notes:
+        - BREAKPOINT/PROBE require `language` and `file_path`.
+        - For Python, set `code_unit` to the dotted runtime import path for
+          the module that defines the target code, such as
+          `services.billing`.
+        - For Python, do not use a filename or filesystem path as `code_unit`.
+        - For Python, use `code_unit="__main__"` only when the target file
+          is executed directly as the process entry script.
+        - For Java, set `code_unit` to the package name and keep `class_name` as the simple class name only.
+        - `line_number` is only for line-level breakpoints and must be 1-based.
+        - `capture_arguments=["*"]` is not supported; "*" is ignored if present.
+        - `SignalType` is always SNAPSHOT.
+        - `description` must be 50 characters or fewer.
+        - Inspect the source file directly before calling this tool — choose `code_unit`,
+          `capture_arguments`, and method/class names explicitly.
+
+    Returns:
+        A human-readable success or failure message. Success responses include the
+        created LocationHash, resolved location details, and a delete hint.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+
+    location, location_error = parse_create_inputs(
+        normalized_type=normalized_type,
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+    )
+    if location_error:
+        return location_error
+    if location is None:
+        # Defensive: parsers return (loc, None) or (None, error_text). This
+        # branch should be unreachable, but we return a user-facing error
+        # string (not ``raise``) so the tool's "always returns a string"
+        # contract holds even if a future parser bug fires this path.
+        return 'ERROR: Internal error resolving location. Please report this issue.'
+
+    location_troubleshooting = _format_code_location_troubleshooting(
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+    )
+
+    wildcard_removed = False
+    if capture_arguments is None:
+        return (
+            'ERROR: capture_arguments is required for BREAKPOINT/PROBE code instrumentation.\n'
+            'MCP does not infer argument names automatically.\n'
+            'Inspect the source file directly and re-run with capture_arguments=[...].'
+        )
+
+    if '*' in capture_arguments:
+        wildcard_removed = True
+    capture_arguments = [arg for arg in capture_arguments if arg != '*']
+
+    code_capture_return = True if capture_return is None else capture_return
+    code_capture_stack_trace = True if capture_stack_trace is None else capture_stack_trace
+    code_capture_locals = capture_locals
+
+    capture = CodeCapture(
+        capture_return=code_capture_return,
+        capture_stack_trace=code_capture_stack_trace,
+        capture_arguments=capture_arguments,
+        capture_locals=code_capture_locals,
+        limits=CaptureLimits(
+            max_hits=max_hits,
+            max_string_length=max_string_length,
+            max_collection_width=max_collection_width,
+            max_collection_depth=max_collection_depth,
+            max_stack_frames=max_stack_frames,
+            max_stack_trace_size=max_stack_trace_size,
+            max_object_depth=max_object_depth,
+            max_fields_per_object=max_fields_per_object,
+        ),
+    )
+
+    target_desc = location.describe()
+
+    request_kwargs: Dict[str, Any] = {
+        'InstrumentationType': normalized_type,
+        'Service': service,
+        'Environment': environment,
+        'SignalType': SNAPSHOT_SIGNAL_TYPE,
+        'Location': location.to_api_payload(),
+        'CaptureConfiguration': capture.to_api_payload(),
+        'Description': description,
+    }
+    if ttl_hours is not None:
+        request_kwargs['ExpiresAt'] = datetime.now(timezone.utc) + timedelta(hours=ttl_hours)
+    if attribute_filters:
+        request_kwargs['AttributeFilters'] = attribute_filters
+
+    try:
+        response = gateway.create_instrumentation_configuration(**request_kwargs)
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action=f'create {normalized_type} instrumentation',
+            attempted_label='ATTEMPTED CONFIGURATION:',
+            attempted={
+                'Type': normalized_type,
+                'Target': target_desc,
+                'Service': service,
+                'Environment': environment,
+            },
+            possible_causes=[
+                'AWS credentials missing or scoped to a different account',
+                'Invalid service or environment identifier',
+                'Instrumentation already exists at this location',
+                'Invalid location/capture payload',
+                'AWS API endpoint not accessible',
+            ],
+            troubleshooting=[
+                'Verify AWS credentials: aws configure list',
+                'Check service name and environment match your deployment',
+                'Try listing existing instrumentations with list_instrumentations',
+            ],
+            trailer=location_troubleshooting,
+        )
+
+    return render_create_success_message(
+        response=response,
+        normalized_type=normalized_type,
+        service=service,
+        environment=environment,
+        location=location,
+        ttl_hours=ttl_hours,
+        capture_arguments=capture_arguments,
+        wildcard_removed=wildcard_removed,
+        code_capture_locals=code_capture_locals,
+        code_capture_return=code_capture_return,
+        code_capture_stack_trace=code_capture_stack_trace,
+        max_hits=max_hits,
+        max_string_length=max_string_length,
+        max_collection_width=max_collection_width,
+        max_collection_depth=max_collection_depth,
+        max_stack_frames=max_stack_frames,
+        max_stack_trace_size=max_stack_trace_size,
+        max_object_depth=max_object_depth,
+        max_fields_per_object=max_fields_per_object,
+        attribute_filters=attribute_filters,
+    )
+
+
+def list_instrumentations(
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+    synced_at: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> str:
+    """List active instrumentation configurations for one service, environment, and type.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        instrumentation_type: BREAKPOINT or PROBE.
+        synced_at: Optional AWS pagination/synchronization cursor timestamp.
+        max_results: Maximum number of configurations to request. Defaults to 100.
+        next_token: Optional AWS pagination token from a previous response.
+
+    Returns:
+        A human-readable list of configurations with location details, capture
+        settings, timing metadata, and pagination guidance when more results exist.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+
+    request_kwargs: Dict[str, Any] = {
+        'Service': service,
+        'Environment': environment,
+        'InstrumentationType': normalized_type,
+    }
+    if synced_at:
+        request_kwargs['SyncedAt'] = synced_at
+    if max_results != 100:
+        request_kwargs['MaxResults'] = max_results
+    if next_token:
+        request_kwargs['NextToken'] = next_token
+
+    try:
+        data = gateway.list_instrumentation_configurations(**request_kwargs)
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action='list instrumentations',
+            attempted={
+                'Service': service,
+                'Environment': environment,
+                'InstrumentationType': normalized_type,
+            },
+        )
+
+    return render_list_instrumentations_output(
+        data=data,
+        normalized_type=normalized_type,
+        service=service,
+        environment=environment,
+    )
+
+
+def batch_delete_instrumentations_by_scope(
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+) -> str:
+    """Batch delete instrumentation configurations by scope.
+
+    This deletes all configurations that match the provided service, environment,
+    and instrumentation type.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        instrumentation_type: BREAKPOINT or PROBE.
+
+    Returns:
+        A human-readable batch delete summary including deleted count, successful
+        deletions, and any per-item errors returned by the backend.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+
+    deletion_target = {
+        'Scope': {
+            'Service': service,
+            'Environment': environment,
+            'InstrumentationType': normalized_type,
+        }
+    }
+
+    try:
+        data = gateway.batch_delete_instrumentation_configurations(
+            DeletionTarget=deletion_target,
+        )
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action='batch delete instrumentation configurations (scope mode)',
+            attempted={
+                'Service': service,
+                'Environment': environment,
+                'InstrumentationType': normalized_type,
+            },
+        )
+
+    return _format_batch_delete_response(
+        mode='Scope',
+        data=data,
+        instrumentation_type=normalized_type,
+        service=service,
+        environment=environment,
+    )
+
+
+def batch_delete_instrumentations_by_arns(
+    resource_arns: List[str],
+    instrumentation_type: str,
+) -> str:
+    """Batch delete instrumentation configurations by explicit resource ARN list.
+
+    Args:
+        resource_arns: One to fifty instrumentation resource ARNs.
+        instrumentation_type: BREAKPOINT or PROBE.
+
+    Notes:
+        - The request is rejected when `resource_arns` is empty.
+        - The request is rejected when more than 50 ARNs are provided.
+        - All ARN values must be non-empty strings.
+
+    Returns:
+        A human-readable batch delete summary including deleted count, successful
+        deletions, and any per-item errors returned by the backend.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+    if not resource_arns:
+        return 'ERROR: resource_arns must contain at least one ARN.'
+    if len(resource_arns) > 50:
+        return 'ERROR: resource_arns can include at most 50 ARNs per request.'
+
+    invalid_arns = [arn for arn in resource_arns if not isinstance(arn, str) or not arn.strip()]
+    if invalid_arns:
+        return 'ERROR: resource_arns must contain non-empty ARN strings only.'
+
+    deletion_target = {
+        'ResourceArns': {
+            'ResourceArns': resource_arns,
+            'InstrumentationType': normalized_type,
+        }
+    }
+
+    try:
+        data = gateway.batch_delete_instrumentation_configurations(
+            DeletionTarget=deletion_target,
+        )
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action='batch delete instrumentation configurations (resource ARN mode)',
+            attempted={
+                'InstrumentationType': normalized_type,
+                'ResourceArnCount': len(resource_arns),
+            },
+        )
+
+    return _format_batch_delete_response(
+        mode='ResourceArns',
+        data=data,
+        instrumentation_type=normalized_type,
+    )
+
+
+def _render_location_identifier_help(action: str) -> str:
+    return f"""ERROR: Must provide one of:
+- location_hash
+- language + file_path (for code locations)
+
+Usage:
+1. {action} by hash:
+   {action}_instrumentation(location_hash="abc123...")
+
+2. {action} by code location:
+   {action}_instrumentation(language="Python", file_path="/app/file.py", ...)"""
+
+
+def delete_instrumentation(
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+    location_hash: Optional[str] = None,
+    language: Optional[str] = None,
+    file_path: Optional[str] = None,
+    code_unit: Optional[str] = None,
+    class_name: Optional[str] = None,
+    method_name: Optional[str] = None,
+    line_number: Optional[int] = None,
+) -> str:
+    """Delete a single instrumentation configuration.
+
+    The target can be resolved by `location_hash` or by a full location
+    description. The target can be resolved by `location_hash` or by a full code
+    location description.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        instrumentation_type: BREAKPOINT or PROBE.
+        location_hash: Preferred identifier for an existing configuration.
+        language: Code language for code-location lookup.
+        file_path: Code file path for code-location lookup.
+        code_unit: Optional module/package name for code-location lookup.
+        class_name: Optional class name for code-location lookup.
+        method_name: Optional function/method name for code-location lookup.
+        line_number: Optional 1-based line number for code-location lookup.
+
+    Returns:
+        A human-readable success or failure message describing the deletion target
+        and troubleshooting guidance when lookup or deletion fails.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+
+    location, location_error = parse_lookup_inputs(
+        normalized_type=normalized_type,
+        location_hash=location_hash,
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+        allow_code_location_lookup=True,
+    )
+    if location_error:
+        if 'missing location identifier input' in location_error:
+            return _render_location_identifier_help('delete')
+        return f'ERROR: {location_error}'
+    if location is None:
+        # Defensive: parsers return (loc, None) or (None, error_text). This
+        # branch should be unreachable, but we return a user-facing error
+        # string (not ``raise``) so the tool's "always returns a string"
+        # contract holds even if a future parser bug fires this path.
+        return 'ERROR: Internal error resolving location. Please report this issue.'
+    target_desc = location.describe()
+
+    try:
+        gateway.delete_instrumentation_configuration(
+            InstrumentationType=normalized_type,
+            Service=service,
+            Environment=environment,
+            SignalType=SNAPSHOT_SIGNAL_TYPE,
+            LocationIdentifier=location.to_identifier(),
+        )
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action=f'delete {normalized_type} instrumentation',
+            attempted_label='ATTEMPTED TO DELETE:',
+            attempted={
+                'Target': target_desc,
+                'Service': service,
+                'Environment': environment,
+            },
+            possible_causes=[
+                "Instrumentation doesn't exist at this location",
+                "Location parameters don't match exactly",
+                'Wrong service or environment identifier',
+                'Already deleted',
+            ],
+            troubleshooting=['Use list_instrumentations to see exact configuration details'],
+        )
+
+    return f"""Successfully deleted {normalized_type} instrumentation
+
+Target: {target_desc}
+Service: {service}
+Environment: {environment}
+
+TIP: Use list_instrumentations to verify removal."""
+
+
+def get_instrumentation(
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+    location_hash: Optional[str] = None,
+    language: Optional[str] = None,
+    file_path: Optional[str] = None,
+    code_unit: Optional[str] = None,
+    class_name: Optional[str] = None,
+    method_name: Optional[str] = None,
+    line_number: Optional[int] = None,
+) -> str:
+    """Get the full backend configuration for a single instrumentation target.
+
+    The target can be resolved by `location_hash` or by a full location
+    description. The target can be resolved by `location_hash` or by a full code
+    location description.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        instrumentation_type: BREAKPOINT or PROBE.
+        location_hash: Preferred identifier for an existing configuration.
+        language: Code language for code-location lookup.
+        file_path: Code file path for code-location lookup.
+        code_unit: Optional module/package name for code-location lookup.
+        class_name: Optional class name for code-location lookup.
+        method_name: Optional function/method name for code-location lookup.
+        line_number: Optional 1-based line number for code-location lookup.
+
+    Returns:
+        A human-readable configuration report including location details, capture
+        configuration, attribute filters, and backend metadata such as ARN and timestamps.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+
+    location, location_error = parse_lookup_inputs(
+        normalized_type=normalized_type,
+        location_hash=location_hash,
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+        allow_code_location_lookup=True,
+    )
+    if location_error:
+        if 'missing location identifier input' in location_error:
+            return _render_location_identifier_help('get')
+        return f'ERROR: {location_error}'
+    if location is None:
+        # Defensive: parsers return (loc, None) or (None, error_text). This
+        # branch should be unreachable, but we return a user-facing error
+        # string (not ``raise``) so the tool's "always returns a string"
+        # contract holds even if a future parser bug fires this path.
+        return 'ERROR: Internal error resolving location. Please report this issue.'
+    target_desc = location.describe()
+
+    try:
+        data = gateway.get_instrumentation_configuration(
+            InstrumentationType=normalized_type,
+            Service=service,
+            Environment=environment,
+            SignalType=SNAPSHOT_SIGNAL_TYPE,
+            LocationIdentifier=location.to_identifier(),
+        )
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action='get instrumentation',
+            attempted_label='ATTEMPTED TO RETRIEVE:',
+            attempted={
+                'Target': target_desc,
+                'Service': service,
+                'Environment': environment,
+            },
+            possible_causes=[
+                "Instrumentation doesn't exist at this location",
+                "Location parameters don't match exactly",
+                'Wrong service or environment identifier',
+            ],
+            troubleshooting=['Use list_instrumentations to see all active instrumentations'],
+        )
+
+    config = data.get('Configuration', {}) if isinstance(data, dict) else {}
+    if not config:
+        return f'No instrumentation found for {target_desc}'
+
+    return render_get_instrumentation_output(
+        config=config,
+        service=service,
+        environment=environment,
+    )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/error_translation.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/error_translation.py
@@ -1,0 +1,167 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Translate botocore exceptions into the human-readable failure text used by MCP tools.
+
+Replaces the ad-hoc ``Failed to ...`` blocks that the AWS-CLI-based code
+emitted from ``subprocess`` failure ladders. Keeps the section headers
+(``Error:``, ``ATTEMPTED PARAMETERS:``, ``POSSIBLE CAUSES:``,
+``TROUBLESHOOTING:``) so MCP clients see no contract change.
+"""
+
+from botocore.exceptions import (
+    ClientError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+    NoCredentialsError,
+    PartialCredentialsError,
+    ReadTimeoutError,
+)
+from typing import Mapping, Optional, Sequence
+
+
+def _format_block(label: str, context: Optional[Mapping[str, object]]) -> str:
+    if not context:
+        return ''
+    lines = []
+    for key, value in context.items():
+        if value is None or value == '':
+            continue
+        lines.append(f'- {key}: {value}')
+    if not lines:
+        return ''
+    return f'\n{label}\n' + '\n'.join(lines) + '\n'
+
+
+def _format_attempted_block(context: Optional[Mapping[str, object]]) -> str:
+    return _format_block('ATTEMPTED PARAMETERS:', context)
+
+
+def _format_numbered_section(label: str, items: Optional[Sequence[str]]) -> str:
+    if not items:
+        return ''
+    body = '\n'.join(f'{idx}. {item}' for idx, item in enumerate(items, 1))
+    return f'\n{label}\n{body}\n'
+
+
+def _client_error_body(exc: ClientError) -> tuple[str, str]:
+    error = exc.response.get('Error', {}) if isinstance(exc.response, dict) else {}
+    code = error.get('Code') or 'ClientError'
+    message = error.get('Message') or str(exc)
+    return code, message
+
+
+def render_client_error(
+    exc: ClientError,
+    *,
+    action: str,
+    attempted_label: str = 'ATTEMPTED PARAMETERS:',
+    attempted: Optional[Mapping[str, object]] = None,
+    possible_causes: Optional[Sequence[str]] = None,
+    troubleshooting: Optional[Sequence[str]] = None,
+    trailer: Optional[str] = None,
+) -> str:
+    """Render a tool-tailored failure block for a botocore ``ClientError``.
+
+    Tools share the same skeleton — ``Failed to {action}``, an ``Error:`` line,
+    an attempted-values block, and ``POSSIBLE CAUSES`` / ``TROUBLESHOOTING``
+    numbered sections — but each tool tunes the labels and bullet content.
+    This helper takes those bullets as parameters so each call site can keep
+    its CLI-era wording without re-implementing the skeleton.
+
+    Use ``trailer`` for any tool-specific footer (e.g. the location
+    troubleshooting block emitted after a failed create).
+    """
+    code, message = _client_error_body(exc)
+    sections = [
+        f'Failed to {action}\n',
+        f'\nError: {code} - {message}\n',
+        _format_block(attempted_label, attempted),
+        _format_numbered_section('POSSIBLE CAUSES:', possible_causes),
+        _format_numbered_section('TROUBLESHOOTING:', troubleshooting),
+    ]
+    body = ''.join(sections).rstrip()
+    if trailer:
+        return f'{body}\n\n{trailer}'
+    return body
+
+
+def translate_aws_error(
+    exc: BaseException,
+    *,
+    action: str,
+    context: Optional[Mapping[str, object]] = None,
+) -> str:
+    """Render a human-readable failure block for an AWS API exception.
+
+    Args:
+        exc: The exception raised by a boto3/botocore call.
+        action: A short verb phrase such as ``"create BREAKPOINT instrumentation"``.
+        context: Optional ordered mapping of attempted parameters.
+
+    Returns:
+        A multi-line string starting with ``Failed to {action}`` and including
+        an ``Error:`` line, an ``ATTEMPTED PARAMETERS:`` block when context
+        is provided, and standard ``POSSIBLE CAUSES``/``TROUBLESHOOTING``
+        sections tuned to the exception type.
+    """
+    attempted = _format_attempted_block(context)
+
+    if isinstance(exc, ClientError):
+        code, message = _client_error_body(exc)
+        return (
+            f'Failed to {action}\n\n'
+            f'Error: {code} - {message}\n'
+            f'{attempted}'
+            '\nPOSSIBLE CAUSES:\n'
+            '1. Invalid input parameters (validation error)\n'
+            '2. Resource not found, already exists, or scoped to a different account\n'
+            '3. Insufficient IAM permissions\n'
+            '4. Service-side throttling or transient error\n'
+            '\nTROUBLESHOOTING:\n'
+            '1. Re-read the error message above for the specific failure cause\n'
+            '2. Verify service, environment, and instrumentation_type identifiers\n'
+            '3. Verify credentials map to an account/region with access\n'
+        )
+
+    if isinstance(exc, EndpointConnectionError):
+        return (
+            f'Failed to {action}\n\n'
+            f'Error: EndpointConnectionError - {exc}\n'
+            f'{attempted}'
+            '\nTROUBLESHOOTING:\n'
+            '1. Check network connectivity to the AWS endpoint\n'
+            '2. Verify AWS region resolution (AWS_REGION env var or profile)\n'
+        )
+
+    if isinstance(exc, (ReadTimeoutError, ConnectTimeoutError)):
+        return (
+            f'Failed to {action}\n\n'
+            f'Error: TimeoutError - {exc}\n'
+            f'{attempted}'
+            '\nTROUBLESHOOTING:\n'
+            '1. Retry the request — the AWS endpoint did not respond within the socket timeout\n'
+            '2. Check network connectivity\n'
+        )
+
+    if isinstance(exc, (NoCredentialsError, PartialCredentialsError)):
+        return (
+            f'Failed to {action}\n\n'
+            f'Error: {type(exc).__name__} - {exc}\n'
+            f'{attempted}'
+            '\nTROUBLESHOOTING:\n'
+            '1. Verify AWS credentials: aws configure list\n'
+            '2. Set AWS_PROFILE or supply credentials via env vars\n'
+        )
+
+    return f'Failed to {action}\n\nUnexpected error: {exc}\n{attempted}'

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/formatting.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/formatting.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared rendering primitives used by every ``*_rendering.py`` module.
+
+These convert raw AWS API values into the human-readable shapes that MCP
+tool responses depend on.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def format_timestamp(value: Any, default: str = 'N/A') -> str:
+    """Render a boto3 ``datetime`` value in the AWS-CLI ISO format.
+
+    boto3 returns timestamp fields as native ``datetime`` objects;
+    AWS-CLI-era responses are ISO 8601 strings (``YYYY-MM-DDTHH:MM:SSZ``).
+    MCP clients depend on the latter shape, so anywhere a renderer surfaces
+    an AWS-returned timestamp, it must go through this helper.
+
+    String inputs are passed through unchanged so renderers can safely
+    accept either shape (e.g. tests that hand-roll ISO strings).
+    """
+    if value is None or value == '':
+        return default
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    return str(value)

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/location.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/location.py
@@ -229,6 +229,13 @@ class UnknownLocation:
 
 Location = Union[CodeLocation, HashLocation, UnknownLocation]
 
+# A location resolved from *caller* inputs (create/lookup). Unlike ``Location``,
+# this never includes ``UnknownLocation`` — that variant only arises when parsing
+# an API *response* (see ``location_from_response``). Narrowing the parser return
+# types to this union lets callers use ``to_identifier``/``to_api_payload``
+# without a cast, since both members implement them.
+ResolvedLocation = Union[CodeLocation, HashLocation]
+
 
 # ──────────────────────────── input parsers ────────────────────────────
 
@@ -242,7 +249,7 @@ def parse_create_inputs(
     class_name: Optional[str] = None,
     method_name: Optional[str] = None,
     line_number: Optional[int] = None,
-) -> Tuple[Optional[Location], Optional[str]]:
+) -> Tuple[Optional[ResolvedLocation], Optional[str]]:
     """Parse MCP-tool kwargs into a ``Location`` for a create-instrumentation call.
 
     HashLocation is not accepted: callers cannot create an instrumentation from
@@ -291,7 +298,7 @@ def parse_lookup_inputs(
     method_name: Optional[str] = None,
     line_number: Optional[int] = None,
     allow_code_location_lookup: bool = True,
-) -> Tuple[Optional[Location], Optional[str]]:
+) -> Tuple[Optional[ResolvedLocation], Optional[str]]:
     """Parse MCP-tool kwargs into a ``Location`` for a lookup operation.
 
     Lookup accepts a location_hash or a code location. Resolution order:
@@ -383,6 +390,7 @@ __all__: List[str] = [
     'HashLocation',
     'UnknownLocation',
     'Location',
+    'ResolvedLocation',
     'parse_create_inputs',
     'parse_lookup_inputs',
     'location_from_response',

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/location.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/location.py
@@ -1,0 +1,390 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Location ADT for dynamic instrumentation.
+
+A "location" is the central domain noun of this package: where in customer
+code (or which endpoint) an instrumentation configuration applies. The
+``application-signals`` API exposes three flavors:
+
+* ``CodeLocation``    — language + file/class/method/line, used by BREAKPOINT
+                        and PROBE.
+* ``LocationHash``    — a 16-character hex identifier referring to an
+                        already-created configuration.
+
+This module collapses the seven module-level helpers that used to build,
+identify, and render those three shapes into a single sealed ``Location``
+sum type. Two parsers cover input flow (create vs. lookup), and one parser
+covers response flow.
+
+Tools never construct API dicts directly; they call ``parse_*_inputs`` and
+then ``loc.to_api_payload()`` / ``loc.to_identifier()``. Renderers never
+inspect raw union dicts; they call ``location_from_response`` and use the
+type's instance methods.
+"""
+
+from .validation import _validate_location_inputs
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+
+
+_EMPTY_EXTRA_FIELDS: Mapping[str, Any] = MappingProxyType({})
+
+
+def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Wrap an extra-fields dict in a read-only proxy.
+
+    Prevents frozen dataclasses from being mutated through their containers.
+    Idempotent: an existing ``MappingProxyType`` is returned unchanged.
+    """
+    if isinstance(value, MappingProxyType):
+        return value
+    return MappingProxyType(dict(value))
+
+
+@dataclass(frozen=True)
+class CodeLocation:
+    """A code-based instrumentation target (BREAKPOINT or PROBE)."""
+
+    language: str
+    file_path: str
+    code_unit: Optional[str] = None
+    class_name: Optional[str] = None
+    method_name: Optional[str] = None
+    line_number: Optional[int] = None
+    extra_fields: Mapping[str, Any] = field(default_factory=lambda: _EMPTY_EXTRA_FIELDS)
+
+    def __post_init__(self) -> None:
+        """Freeze ``extra_fields`` past the dataclass frozen guard."""
+        # frozen=True only blocks reassignment; the dict itself stays
+        # mutable unless we wrap it. Use object.__setattr__ to assign past
+        # the frozen guard.
+        object.__setattr__(self, 'extra_fields', _freeze_mapping(self.extra_fields))
+
+    def describe(self) -> str:
+        """Return a one-line human description of the code target."""
+        target = self.file_path or 'N/A'
+        if self.class_name:
+            target += f' :: {self.class_name}'
+        if self.method_name:
+            target += f'.{self.method_name}'
+        if self.line_number is not None:
+            target += f':L{self.line_number}'
+        return target
+
+    def level(self) -> str:
+        """Return the breakpoint granularity (line-level or function-level)."""
+        if self.line_number is not None:
+            return f'LINE-LEVEL (L{self.line_number})'
+        return 'FUNCTION/METHOD-LEVEL'
+
+    def format_details(self, location_hash: Optional[str] = None) -> str:
+        """Render the code location as labeled detail lines."""
+        lines = ['- LocationKind: CODE']
+        if location_hash:
+            lines.append(f'- LocationHash: {location_hash}')
+        ordered = [
+            ('Language', self.language),
+            ('File Path', self.file_path),
+            ('Code Unit', self.code_unit),
+            ('Class Name', self.class_name),
+            ('Method Name', self.method_name),
+            ('Line Number', self.line_number),
+        ]
+        for label, value in ordered:
+            # Mirror legacy ``format_location_details`` semantics: present-but-empty
+            # fields (``Language=""``) still render as ``- Language: `` so missing
+            # API fields produce a visible blank instead of being silently dropped.
+            if value is not None:
+                lines.append(f'- {label}: {value}')
+        for key in sorted(self.extra_fields.keys()):
+            lines.append(f'- {key}: {self.extra_fields[key]}')
+        return '\n'.join(lines) + '\n'
+
+    def to_api_payload(self) -> Dict[str, Any]:
+        """Return the CodeLocation create-request payload."""
+        return {'CodeLocation': self._to_code_location_dict()}
+
+    def to_identifier(self) -> Dict[str, Any]:
+        """Return the CodeLocation lookup identifier payload."""
+        return {'CodeLocation': self._to_code_location_dict()}
+
+    def _to_code_location_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            'Language': self.language,
+            'FilePath': self.file_path,
+        }
+        if self.code_unit:
+            payload['CodeUnit'] = self.code_unit
+        if self.class_name:
+            payload['ClassName'] = self.class_name
+        if self.method_name:
+            payload['MethodName'] = self.method_name
+        if self.line_number is not None:
+            payload['LineNumber'] = self.line_number
+        return payload
+
+
+@dataclass(frozen=True)
+class HashLocation:
+    """An existing configuration referenced by its 16-char location hash.
+
+    Carries a deliberately narrower interface than its sibling variants:
+
+    * ``to_api_payload`` is *unsupported*: a hash cannot describe a *new*
+      configuration — ``create_instrumentation_configuration`` requires
+      a real CodeLocation.
+    * ``format_details`` is *unsupported*: a hash has no fields beyond
+      itself; ``render_location_block`` prints the hash via its
+      ``HashLocation`` special case instead.
+
+    Both methods exist as stubs that raise ``NotImplementedError`` with a
+    descriptive message rather than being absent. The asymmetry is still
+    the design — these are lookup-only — but the explicit raise turns
+    a confusing ``AttributeError`` into a clear "use ``to_identifier()``
+    instead" message when a future caller forgets the discipline.
+    """
+
+    location_hash: str
+
+    def describe(self) -> str:
+        """Return a one-line description naming the location hash."""
+        return f'LocationHash {self.location_hash}'
+
+    def level(self) -> Optional[str]:
+        """Return None — a hash carries no breakpoint granularity."""
+        return None
+
+    def to_identifier(self) -> Dict[str, Any]:
+        """Return the LocationHash lookup identifier payload."""
+        return {'LocationHash': self.location_hash}
+
+    def to_api_payload(self) -> Dict[str, Any]:
+        """Unsupported — a hash cannot describe a new configuration."""
+        raise NotImplementedError(
+            'HashLocation cannot be used in create requests — use to_identifier() instead. '
+            'create_instrumentation_configuration requires a CodeLocation.'
+        )
+
+    def format_details(self, location_hash: Optional[str] = None) -> str:
+        """Unsupported — a hash has no fields; describe() gives a one-liner."""
+        raise NotImplementedError(
+            'HashLocation has no fields to format — render_location_block handles it directly. '
+            'Use describe() for a one-line target string.'
+        )
+
+
+@dataclass(frozen=True)
+class UnknownLocation:
+    """A location union returned by the API that does not match any known variant.
+
+    A forward-compat fallback: ``location_from_response`` produces this so
+    renderers don't crash on future API additions. Input parsers never
+    produce it. Mirrors ``UnknownCapture`` in shape and naming — both are
+    public so callers doing exhaustive ``isinstance`` matching don't need
+    to reach into a private name.
+
+    ``raw`` is wrapped in ``MappingProxyType`` so the ``frozen=True``
+    contract holds against mutation through the source dict.
+    """
+
+    raw: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        """Wrap ``raw`` in a read-only proxy to honor the frozen contract."""
+        if not isinstance(self.raw, MappingProxyType):
+            object.__setattr__(self, 'raw', MappingProxyType(dict(self.raw)))
+
+    def describe(self) -> str:
+        """Return 'N/A' — an unknown location has no describable target."""
+        return 'N/A'
+
+    def level(self) -> Optional[str]:
+        """Return None — an unknown location has no granularity."""
+        return None
+
+    def format_details(self, location_hash: Optional[str] = None) -> str:
+        """Render the unknown location's raw fields as detail lines."""
+        lines = ['- LocationKind: UNKNOWN']
+        if location_hash:
+            lines.append(f'- LocationHash: {location_hash}')
+        if self.raw:
+            for key in sorted(self.raw.keys()):
+                lines.append(f'- {key}: {self.raw[key]}')
+        else:
+            lines.append('- Location payload could not be parsed.')
+        return '\n'.join(lines) + '\n'
+
+
+Location = Union[CodeLocation, HashLocation, UnknownLocation]
+
+
+# ──────────────────────────── input parsers ────────────────────────────
+
+
+def parse_create_inputs(
+    *,
+    normalized_type: str,
+    language: Optional[str] = None,
+    file_path: Optional[str] = None,
+    code_unit: Optional[str] = None,
+    class_name: Optional[str] = None,
+    method_name: Optional[str] = None,
+    line_number: Optional[int] = None,
+) -> Tuple[Optional[Location], Optional[str]]:
+    """Parse MCP-tool kwargs into a ``Location`` for a create-instrumentation call.
+
+    HashLocation is not accepted: callers cannot create an instrumentation from
+    an existing hash. Returns ``(location, None)`` on success or
+    ``(None, error_text)`` when inputs are invalid; ``error_text`` is rendered
+    verbatim back to the MCP caller.
+    """
+    if not language or not file_path:
+        return None, (
+            'ERROR: BREAKPOINT/PROBE require language and file_path.\n'
+            'Example: language="Python", file_path="/app/handler.py"'
+        )
+
+    location_validation_error = _validate_location_inputs(
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+    )
+    if location_validation_error:
+        return None, location_validation_error
+
+    return (
+        CodeLocation(
+            language=language,
+            file_path=file_path,
+            code_unit=code_unit,
+            class_name=class_name,
+            method_name=method_name,
+            line_number=line_number,
+        ),
+        None,
+    )
+
+
+def parse_lookup_inputs(
+    *,
+    normalized_type: str,
+    location_hash: Optional[str] = None,
+    language: Optional[str] = None,
+    file_path: Optional[str] = None,
+    code_unit: Optional[str] = None,
+    class_name: Optional[str] = None,
+    method_name: Optional[str] = None,
+    line_number: Optional[int] = None,
+    allow_code_location_lookup: bool = True,
+) -> Tuple[Optional[Location], Optional[str]]:
+    """Parse MCP-tool kwargs into a ``Location`` for a lookup operation.
+
+    Lookup accepts a location_hash or a code location. Resolution order:
+    hash > code location. Returns ``(location, None)`` or ``(None, error_text)``.
+    """
+    if location_hash:
+        return HashLocation(location_hash=location_hash), None
+
+    if language and file_path:
+        if not allow_code_location_lookup:
+            return None, 'code location lookup is not supported for this operation.'
+        return (
+            CodeLocation(
+                language=language,
+                file_path=file_path,
+                code_unit=code_unit,
+                class_name=class_name,
+                method_name=method_name,
+                line_number=line_number,
+            ),
+            None,
+        )
+
+    return None, (
+        'missing location identifier input. Provide location_hash '
+        'OR language+file_path (code location).'
+    )
+
+
+# ──────────────────────────── response parser ────────────────────────────
+
+
+_KNOWN_CODE_FIELDS = {'Language', 'FilePath', 'CodeUnit', 'ClassName', 'MethodName', 'LineNumber'}
+
+
+def location_from_response(union_dict: Optional[Dict[str, Any]]) -> Location:
+    """Parse a ``Location`` union returned by the API into the ADT.
+
+    Returns ``UnknownLocation`` if the dict has no recognized variant — this
+    keeps response rendering forward-compatible with future API additions.
+    """
+    if not isinstance(union_dict, dict):
+        return UnknownLocation(raw={})
+
+    code = union_dict.get('CodeLocation')
+    if isinstance(code, dict):
+        return _code_location_from_dict(code)
+
+    if 'Language' in union_dict or 'FilePath' in union_dict:
+        return _code_location_from_dict(union_dict)
+
+    return UnknownLocation(raw=dict(union_dict))
+
+
+def _code_location_from_dict(payload: Dict[str, Any]) -> CodeLocation:
+    extras = {k: v for k, v in payload.items() if k not in _KNOWN_CODE_FIELDS}
+    return CodeLocation(
+        language=payload.get('Language', ''),
+        file_path=payload.get('FilePath', ''),
+        code_unit=payload.get('CodeUnit'),
+        class_name=payload.get('ClassName'),
+        method_name=payload.get('MethodName'),
+        line_number=payload.get('LineNumber'),
+        extra_fields=extras,
+    )
+
+
+# ──────────────────────────── shared helpers ────────────────────────────
+
+
+def render_location_block(location: Location, location_hash: Optional[str] = None) -> str:
+    """Render the standard LOCATION block plus the optional INSTRUMENTATION level line."""
+    if isinstance(location, HashLocation):
+        # HashLocation has no API-side dict to format; should not normally
+        # reach a renderer, but keep the path safe.
+        block = f'- LocationKind: HASH\n- LocationHash: {location.location_hash}\n'
+        return block
+
+    output = location.format_details(location_hash=location_hash)
+    level = location.level()
+    if level:
+        output += '\nINSTRUMENTATION:\n'
+        output += f'- Level: {level}\n'
+    return output
+
+
+__all__: List[str] = [
+    'CodeLocation',
+    'HashLocation',
+    'UnknownLocation',
+    'Location',
+    'parse_create_inputs',
+    'parse_lookup_inputs',
+    'location_from_response',
+    'render_location_block',
+]

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/registration.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/registration.py
@@ -25,22 +25,95 @@ from .snapshot_tools import get_sample_snapshot_for_breakpoint, search_snapshots
 from .status_tools import (
     check_instrumentation_status,
     get_instrumentation_configuration_status,
-    report_instrumentation_configuration_status,
 )
+from mcp.types import ToolAnnotations
 
 
 def register_tools(mcp) -> None:
-    """Register all dynamic instrumentation MCP tools onto a shared server."""
-    mcp.tool()(create_instrumentation)
-    mcp.tool()(list_instrumentations)
-    mcp.tool()(get_instrumentation)
-    mcp.tool()(delete_instrumentation)
-    mcp.tool()(batch_delete_instrumentations_by_scope)
-    mcp.tool()(batch_delete_instrumentations_by_arns)
+    """Register all dynamic instrumentation MCP tools onto a shared server.
 
-    mcp.tool()(get_instrumentation_configuration_status)
-    mcp.tool()(check_instrumentation_status)
-    mcp.tool()(report_instrumentation_configuration_status)
+    Tools carry MCP annotations so clients can distinguish read-only queries
+    from state-changing operations (and warn before destructive bulk deletes).
+    Every tool sets ``openWorldHint=True`` because each one calls the AWS API.
+    """
+    # State-changing: creates a new instrumentation configuration.
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Create Instrumentation',
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=True,
+        )
+    )(create_instrumentation)
 
-    mcp.tool()(search_snapshots_for_status_event)
-    mcp.tool()(get_sample_snapshot_for_breakpoint)
+    # Read-only queries.
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='List Instrumentations', readOnlyHint=True, openWorldHint=True
+        )
+    )(list_instrumentations)
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Get Instrumentation', readOnlyHint=True, openWorldHint=True
+        )
+    )(get_instrumentation)
+
+    # Destructive: deletes are idempotent (deleting an absent config is a no-op).
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Delete Instrumentation',
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )(delete_instrumentation)
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Batch Delete Instrumentations by Scope',
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )(batch_delete_instrumentations_by_scope)
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Batch Delete Instrumentations by ARNs',
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )(batch_delete_instrumentations_by_arns)
+
+    # Read-only status queries.
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Get Instrumentation Configuration Status',
+            readOnlyHint=True,
+            openWorldHint=True,
+        )
+    )(get_instrumentation_configuration_status)
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Check Instrumentation Status', readOnlyHint=True, openWorldHint=True
+        )
+    )(check_instrumentation_status)
+
+    # Read-only snapshot analysis.
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Search Snapshots for Status Event',
+            readOnlyHint=True,
+            openWorldHint=True,
+        )
+    )(search_snapshots_for_status_event)
+    mcp.tool(
+        annotations=ToolAnnotations(
+            title='Get Sample Snapshot for Breakpoint',
+            readOnlyHint=True,
+            openWorldHint=True,
+        )
+    )(get_sample_snapshot_for_breakpoint)

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/registration.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/registration.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Register dynamic instrumentation tools on the shared Application Signals MCP server."""
+
+from .crud_tools import (
+    batch_delete_instrumentations_by_arns,
+    batch_delete_instrumentations_by_scope,
+    create_instrumentation,
+    delete_instrumentation,
+    get_instrumentation,
+    list_instrumentations,
+)
+from .snapshot_tools import get_sample_snapshot_for_breakpoint, search_snapshots_for_status_event
+from .status_tools import (
+    check_instrumentation_status,
+    get_instrumentation_configuration_status,
+    report_instrumentation_configuration_status,
+)
+
+
+def register_tools(mcp) -> None:
+    """Register all dynamic instrumentation MCP tools onto a shared server."""
+    mcp.tool()(create_instrumentation)
+    mcp.tool()(list_instrumentations)
+    mcp.tool()(get_instrumentation)
+    mcp.tool()(delete_instrumentation)
+    mcp.tool()(batch_delete_instrumentations_by_scope)
+    mcp.tool()(batch_delete_instrumentations_by_arns)
+
+    mcp.tool()(get_instrumentation_configuration_status)
+    mcp.tool()(check_instrumentation_status)
+    mcp.tool()(report_instrumentation_configuration_status)
+
+    mcp.tool()(search_snapshots_for_status_event)
+    mcp.tool()(get_sample_snapshot_for_breakpoint)

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_parsing.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_parsing.py
@@ -85,6 +85,19 @@ def _escape_logs_insights_regex(value: object) -> str:
     return re.escape(str(value)).replace('/', r'\/')
 
 
+def _escape_logs_insights_string(value: object) -> str:
+    """Escape a value for a double-quoted CloudWatch Logs Insights string literal.
+
+    Logs Insights string literals are double-quoted with backslash escaping.
+    Escape backslashes first (so the escapes added next are not themselves
+    re-escaped), then double-quotes, so an embedded quote cannot terminate the
+    literal and inject caller-controlled query syntax. This is distinct from
+    ``_escape_logs_insights_regex``, which escapes for ``/.../`` regex context,
+    not ``"..."`` literal context.
+    """
+    return str(value).replace('\\', '\\\\').replace('"', '\\"')
+
+
 def _parse_snapshot_fields(result: dict) -> dict:
     """Extract key debugging fields from a raw CloudWatch Logs snapshot result.
 
@@ -231,12 +244,26 @@ def _parse_snapshot_fields(result: dict) -> dict:
             }
         )
 
+    def _line_key(value):
+        """Order numeric line keys first (by value), non-numeric keys last (lexically).
+
+        Returns a ``(group, sort_value)`` tuple so the two kinds never compare
+        across types. A bare ``int(v) if v.isdigit() else v`` key would mix
+        ``int`` and ``str`` and raise ``TypeError`` the moment a non-digit key
+        appears alongside numeric ones (e.g. a negative line ``'-1'``, since
+        ``'-1'.isdigit()`` is ``False``), crashing snapshot parsing.
+        """
+        text = str(value)
+        if text.isdigit():
+            return (0, int(text), '')
+        return (1, 0, text)
+
     all_line_numbers = sorted(
         set(line_locals.keys())
         | set(line_arguments.keys())
         | set(line_return_values.keys())
         | set(line_throwables.keys()),
-        key=lambda v: int(v) if str(v).isdigit() else v,
+        key=_line_key,
     )
 
     return {

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_parsing.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_parsing.py
@@ -1,0 +1,292 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Snapshot payload parsing helpers for snapshot tools."""
+
+import json
+import re
+from typing import Dict
+
+
+def _preview_captured_value(captured_value: object) -> object:
+    """Return a compact preview for one snapshot CapturedValue."""
+    if not isinstance(captured_value, dict):
+        return captured_value
+
+    preview: Dict[str, object] = {}
+    value_type = captured_value.get('type')
+    if value_type not in (None, ''):
+        preview['type'] = value_type
+
+    if captured_value.get('is_null') is True:
+        preview['is_null'] = True
+        return preview
+
+    if 'not_captured_reason' in captured_value:
+        preview['not_captured_reason'] = captured_value.get('not_captured_reason')
+        return preview
+
+    if 'value' in captured_value:
+        preview['value'] = captured_value.get('value')
+        if captured_value.get('truncated') is True:
+            preview['truncated'] = True
+        if 'size' in captured_value:
+            preview['size'] = captured_value.get('size')
+        return preview
+
+    if isinstance(captured_value.get('fields'), dict):
+        fields = captured_value['fields']
+        # Expand one level: show primitive field values directly,
+        # collapse nested objects to just their type.
+        fields_preview: Dict[str, object] = {}
+        for fname, fval in fields.items():
+            if not isinstance(fval, dict):
+                fields_preview[fname] = fval
+                continue
+            if fval.get('is_null') is True:
+                fields_preview[fname] = None
+            elif 'not_captured_reason' in fval:
+                fields_preview[fname] = f'<{fval["not_captured_reason"]}>'
+            elif 'value' in fval:
+                fields_preview[fname] = fval['value']
+            else:
+                # Nested object/collection — show type only
+                fields_preview[fname] = f'<{fval.get("type", "object")}>'
+        preview['fields_preview'] = fields_preview
+        if 'size' in captured_value:
+            preview['size'] = captured_value.get('size')
+        return preview
+
+    if isinstance(captured_value.get('elements'), list):
+        preview['element_count'] = len(captured_value['elements'])
+        if captured_value['elements']:
+            preview['first_element'] = _preview_captured_value(captured_value['elements'][0])
+        return preview
+
+    if isinstance(captured_value.get('entries'), list):
+        preview['entry_count'] = len(captured_value['entries'])
+        return preview
+
+    return preview or captured_value
+
+
+def _escape_logs_insights_regex(value: object) -> str:
+    """Escape dynamic values for use inside a /.../ CloudWatch Logs Insights regex."""
+    return re.escape(str(value)).replace('/', r'\/')
+
+
+def _parse_snapshot_fields(result: dict) -> dict:
+    """Extract key debugging fields from a raw CloudWatch Logs snapshot result.
+
+    Handles the OTLP log record format where:
+    - Metadata is in top-level `attributes` (aws.di.*)
+    - Resource info is in `resource.attributes` (service.name, deployment.environment —
+      the Java agent's autoconfig path may alternatively publish deployment.environment.name)
+    - Captures and stack are nested under `body`
+    - Trace/span IDs are at root level (`traceId`, `spanId`)
+    - Stack frames use `file_path`/`line_number` (not `fileName`/`lineNumber`)
+    - Return value key is `return_value` (not `returnValue`)
+    """
+    message = result.get('@message', '')
+    try:
+        snapshot_data = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        snapshot_data = {}
+
+    if not isinstance(snapshot_data, dict):
+        snapshot_data = {}
+
+    attributes = snapshot_data.get('attributes', {})
+    if not isinstance(attributes, dict):
+        attributes = {}
+
+    resource = snapshot_data.get('resource', {})
+    if not isinstance(resource, dict):
+        resource = {}
+    resource_attributes = resource.get('attributes', {})
+    if not isinstance(resource_attributes, dict):
+        resource_attributes = {}
+
+    body = snapshot_data.get('body', {})
+    if not isinstance(body, dict):
+        body = {}
+
+    location = {
+        'class_name': attributes.get('aws.di.class_name'),
+        'method_name': attributes.get('aws.di.method_name'),
+        'file_path': attributes.get('aws.di.file_path'),
+        'code_unit': attributes.get('aws.di.code_unit'),
+        'instrumentation_level': attributes.get('aws.di.instrumentation_level'),
+        'instrumentation_type': attributes.get('aws.di.instrumentation_type'),
+    }
+
+    trace = {
+        'traceId': snapshot_data.get('traceId'),
+        'spanId': snapshot_data.get('spanId'),
+    }
+
+    stack = body.get('stack', [])
+    if not isinstance(stack, list):
+        stack = []
+
+    captures = body.get('captures', {})
+    if not isinstance(captures, dict):
+        captures = {}
+
+    entry_capture = captures.get('entry', {})
+    if not isinstance(entry_capture, dict):
+        entry_capture = {}
+
+    return_capture = captures.get('return', {})
+    if not isinstance(return_capture, dict):
+        return_capture = {}
+
+    line_captures = captures.get('lines', {})
+    if not isinstance(line_captures, dict):
+        line_captures = {}
+
+    entry_arguments = entry_capture.get('arguments', {})
+    if not isinstance(entry_arguments, dict):
+        entry_arguments = {}
+
+    entry_locals = entry_capture.get('locals', {})
+    if not isinstance(entry_locals, dict):
+        entry_locals = {}
+
+    return_arguments = return_capture.get('arguments', {})
+    if not isinstance(return_arguments, dict):
+        return_arguments = {}
+
+    return_locals = return_capture.get('locals', {})
+    if not isinstance(return_locals, dict):
+        return_locals = {}
+
+    return_value = return_capture.get('return_value')
+    throwable = return_capture.get('throwable', {})
+    if not isinstance(throwable, dict):
+        throwable = {}
+
+    line_locals: Dict[str, list[str]] = {}
+    line_local_previews: Dict[str, Dict[str, object]] = {}
+    line_arguments: Dict[str, list[str]] = {}
+    line_argument_previews: Dict[str, Dict[str, object]] = {}
+    line_return_values: Dict[str, object] = {}
+    line_throwables: Dict[str, object] = {}
+    for line_number, line_capture in line_captures.items():
+        if not isinstance(line_capture, dict):
+            continue
+        ln = str(line_number)
+
+        locals_map = line_capture.get('locals', {})
+        if isinstance(locals_map, dict) and locals_map:
+            line_locals[ln] = list(locals_map.keys())
+            line_local_previews[ln] = {
+                name: _preview_captured_value(value) for name, value in locals_map.items()
+            }
+
+        args_map = line_capture.get('arguments', {})
+        if isinstance(args_map, dict) and args_map:
+            line_arguments[ln] = list(args_map.keys())
+            line_argument_previews[ln] = {
+                name: _preview_captured_value(value) for name, value in args_map.items()
+            }
+
+        ret_val = line_capture.get('return_value')
+        if ret_val is not None:
+            line_return_values[ln] = _preview_captured_value(ret_val)
+
+        throwable_val = line_capture.get('throwable')
+        if isinstance(throwable_val, dict) and throwable_val:
+            line_throwables[ln] = {
+                'type': throwable_val.get('type'),
+                'message': throwable_val.get('message'),
+                'stacktrace_frame_count': (
+                    len(throwable_val.get('stacktrace', []))
+                    if isinstance(throwable_val.get('stacktrace'), list)
+                    else 0
+                ),
+            }
+
+    duration_ms = attributes.get('aws.di.duration_ms')
+
+    stack_preview = []
+    for frame in stack[:5]:
+        if not isinstance(frame, dict):
+            continue
+        stack_preview.append(
+            {
+                'file_path': frame.get('file_path'),
+                'function': frame.get('function'),
+                'line_number': frame.get('line_number'),
+            }
+        )
+
+    all_line_numbers = sorted(
+        set(line_locals.keys())
+        | set(line_arguments.keys())
+        | set(line_return_values.keys())
+        | set(line_throwables.keys()),
+        key=lambda v: int(v) if str(v).isdigit() else v,
+    )
+
+    return {
+        '@timestamp': result.get('@timestamp'),
+        'snapshot_id': attributes.get('aws.di.snapshot_id'),
+        'timeUnixNano': snapshot_data.get('timeUnixNano'),
+        'duration_ms': duration_ms,
+        'location_hash': attributes.get('aws.di.location_hash'),
+        'location': location,
+        'trace': trace,
+        'stack_preview': stack_preview,
+        'stack_frame_count': len(stack),
+        'entry_argument_names': list(entry_arguments.keys()),
+        'entry_arguments': {
+            name: _preview_captured_value(value) for name, value in entry_arguments.items()
+        },
+        'entry_local_names': list(entry_locals.keys()),
+        'entry_locals': {
+            name: _preview_captured_value(value) for name, value in entry_locals.items()
+        },
+        'return_argument_names': list(return_arguments.keys()),
+        'return_arguments': {
+            name: _preview_captured_value(value) for name, value in return_arguments.items()
+        },
+        'return_local_names': list(return_locals.keys()),
+        'return_locals': {
+            name: _preview_captured_value(value) for name, value in return_locals.items()
+        },
+        'return_value': _preview_captured_value(return_value)
+        if return_value is not None
+        else None,
+        'throwable': (
+            {
+                'type': throwable.get('type'),
+                'message': throwable.get('message'),
+                'stacktrace_frame_count': (
+                    len(throwable.get('stacktrace', []))
+                    if isinstance(throwable.get('stacktrace'), list)
+                    else 0
+                ),
+            }
+            if throwable
+            else None
+        ),
+        'line_numbers': all_line_numbers,
+        'line_locals': line_locals,
+        'line_local_previews': line_local_previews,
+        'line_arguments': line_arguments if line_arguments else None,
+        'line_argument_previews': line_argument_previews if line_argument_previews else None,
+        'line_return_values': line_return_values if line_return_values else None,
+        'line_throwables': line_throwables if line_throwables else None,
+        'raw_snapshot': snapshot_data,
+    }

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_queries.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_queries.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CloudWatch Logs Insights query helpers for snapshot tools."""
+
+import time
+from .. import aws_clients
+from botocore.exceptions import ClientError
+
+
+def _execute_cloudwatch_query(
+    query_string: str,
+    start_epoch: int,
+    end_epoch: int,
+    log_group_name: str,
+    max_timeout: int = 30,
+) -> dict:
+    """Execute a CloudWatch Logs Insights query and poll for results."""
+    logs = aws_clients.logs_client
+
+    try:
+        start_response = logs.start_query(
+            logGroupName=log_group_name,
+            startTime=start_epoch,
+            endTime=end_epoch,
+            queryString=query_string,
+        )
+    except ClientError as exc:
+        return {
+            'status': 'Error',
+            'error': f'Failed to start query: {exc}',
+            'results': [],
+        }
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return {'status': 'Error', 'error': str(exc), 'results': []}
+
+    query_id = start_response.get('queryId')
+    if not query_id:
+        return {
+            'status': 'Error',
+            'error': f'start_query did not return a queryId (response: {start_response})',
+            'results': [],
+        }
+
+    poll_start = time.time()
+    while poll_start + max_timeout > time.time():
+        try:
+            response = logs.get_query_results(queryId=query_id)
+        except ClientError as exc:
+            return {
+                'status': 'Error',
+                'error': f'Failed to get results: {exc}',
+                'results': [],
+                'queryId': query_id,
+            }
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            return {
+                'status': 'Error',
+                'error': str(exc),
+                'results': [],
+                'queryId': query_id,
+            }
+
+        status = response.get('status', 'Unknown')
+        if status in {'Complete', 'Failed', 'Cancelled'}:
+            results = [
+                {field.get('field', ''): field.get('value', '') for field in line}
+                for line in response.get('results', [])
+            ]
+            return {
+                'status': status,
+                'queryId': query_id,
+                'results': results,
+                'messages': response.get('messages', []),
+            }
+
+        time.sleep(1)
+
+    return {
+        'status': 'Polling Timeout',
+        'queryId': query_id,
+        'results': [],
+        'error': f'Query did not complete within {max_timeout} seconds.',
+    }

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_rendering.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_rendering.py
@@ -1,0 +1,305 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Formatting helpers for snapshot tool responses."""
+
+import json
+from .constants import resolve_snapshot_log_group
+from .snapshot_parsing import _parse_snapshot_fields
+from typing import Any, Dict, List, Optional
+
+
+_RAW_SNAPSHOT_SIZE_THRESHOLD = 10 * 1024  # 10 KB
+
+
+def render_search_snapshots_for_status_event_output(
+    service_name: str,
+    environment: str,
+    location_hash: str,
+    custom_filters: Optional[List[str]],
+    start_time_utc: str,
+    end_time_utc: str,
+    start_epoch: int,
+    end_epoch: int,
+    query_string: str,
+    query_result: Dict[str, Any],
+) -> str:
+    """Render the snapshot-search response as JSON text."""
+    log_group_name = resolve_snapshot_log_group(service_name)
+    if query_result['status'] == 'Error':
+        return json.dumps(
+            {
+                'status': 'ERROR',
+                'service_name': service_name,
+                'environment': environment,
+                'log_group_name': log_group_name,
+                'location_hash': location_hash,
+                'custom_filters': custom_filters if custom_filters else [],
+                'start_time_utc': start_time_utc,
+                'end_time_utc': end_time_utc,
+                'query_string': query_string,
+                'error': query_result.get('error', 'Unknown error'),
+            },
+            indent=2,
+        )
+
+    if query_result['status'] == 'Polling Timeout':
+        return json.dumps(
+            {
+                'queryId': query_result.get('queryId'),
+                'status': 'TIMEOUT',
+                'log_group_name': log_group_name,
+                'service_name': service_name,
+                'environment': environment,
+                'location_hash': location_hash,
+                'custom_filters': custom_filters if custom_filters else [],
+                'start_time_utc': start_time_utc,
+                'end_time_utc': end_time_utc,
+                'query_string': query_string,
+                'message': (
+                    'Query did not complete within the requested timeout. '
+                    'Use get-query-results with the returned queryId to retry.'
+                ),
+            },
+            indent=2,
+        )
+
+    results = query_result['results']
+    snapshot_summaries = []
+
+    for result in results:
+        try:
+            snapshot_data = json.loads(result.get('@message', '{}'))
+        except (json.JSONDecodeError, TypeError):
+            snapshot_data = {}
+        attributes = snapshot_data.get('attributes', {})
+        if not isinstance(attributes, dict):
+            attributes = {}
+        snapshot_summaries.append(
+            {
+                '@timestamp': result.get('@timestamp'),
+                'snapshot_id': attributes.get('aws.di.snapshot_id'),
+                'location_hash': attributes.get('aws.di.location_hash'),
+                'traceId': snapshot_data.get('traceId'),
+                'spanId': snapshot_data.get('spanId'),
+            }
+        )
+
+    output = {
+        'queryId': query_result.get('queryId'),
+        'status': query_result['status'],
+        'log_group_name': log_group_name,
+        'service_name': service_name,
+        'environment': environment,
+        'location_hash': location_hash,
+        'custom_filters': custom_filters if custom_filters else [],
+        'start_time_utc': start_time_utc,
+        'end_time_utc': end_time_utc,
+        'start_epoch': start_epoch,
+        'end_epoch': end_epoch,
+        'query_string': query_string,
+        'messages': query_result.get('messages', []),
+        'snapshot_summaries': snapshot_summaries,
+        'results': results,
+    }
+
+    return json.dumps(output, indent=2)
+
+
+def render_get_sample_snapshot_for_breakpoint_output(
+    service_name: str,
+    environment: str,
+    location_hash: str,
+    start_time_utc: str,
+    end_time_utc: str,
+    max_timeout: int,
+    query_string: str,
+    query_result: Dict[str, Any],
+    include_raw: bool = False,
+) -> str:
+    """Render the sample-snapshot response as JSON text."""
+    log_group_name = resolve_snapshot_log_group(service_name)
+    if query_result['status'] == 'Error':
+        return json.dumps(
+            {
+                'status': 'ERROR',
+                'service_name': service_name,
+                'environment': environment,
+                'log_group_name': log_group_name,
+                'location_hash': location_hash,
+                'error': query_result.get('error', 'Unknown error'),
+                'query_string': query_string,
+            },
+            indent=2,
+        )
+
+    if query_result['status'] == 'Polling Timeout':
+        return json.dumps(
+            {
+                'status': 'TIMEOUT',
+                'queryId': query_result.get('queryId'),
+                'service_name': service_name,
+                'environment': environment,
+                'log_group_name': log_group_name,
+                'location_hash': location_hash,
+                'message': f'Query did not complete within {max_timeout} seconds.',
+                'query_string': query_string,
+            },
+            indent=2,
+        )
+
+    if query_result['status'] != 'Complete':
+        return json.dumps(
+            {
+                'status': query_result['status'],
+                'queryId': query_result.get('queryId'),
+                'service_name': service_name,
+                'environment': environment,
+                'log_group_name': log_group_name,
+                'location_hash': location_hash,
+                'query_string': query_string,
+                'messages': query_result.get('messages', []),
+            },
+            indent=2,
+        )
+
+    results = query_result['results']
+    if not results:
+        return json.dumps(
+            {
+                'status': 'NO_SNAPSHOTS_FOUND',
+                'queryId': query_result.get('queryId'),
+                'service_name': service_name,
+                'environment': environment,
+                'log_group_name': log_group_name,
+                'location_hash': location_hash,
+                'time_range': {
+                    'start': start_time_utc,
+                    'end': end_time_utc,
+                },
+                'message': (
+                    'No snapshots found in this window. Suggestions: '
+                    '(1) Try an older ACTIVE event timestamp — older events have had more time '
+                    'for CloudWatch Logs ingestion. '
+                    '(2) If all timestamps fail, wait 1-2 minutes for ingestion delay. '
+                    '(3) Verify the breakpoint is still ACTIVE and not DISABLED from max_hits exhaustion.'
+                ),
+                'query_string': query_string,
+            },
+            indent=2,
+        )
+
+    raw_message = results[0].get('@message', '{}')
+    raw_size = len(raw_message.encode('utf-8'))
+    use_parsed = raw_size > _RAW_SNAPSHOT_SIZE_THRESHOLD and not include_raw
+
+    if use_parsed:
+        parsed = _parse_snapshot_fields(results[0])
+        parsed.pop('raw_snapshot', None)
+        sample_snapshot = parsed
+    else:
+        try:
+            sample_snapshot = json.loads(raw_message)
+        except (json.JSONDecodeError, TypeError):
+            sample_snapshot = {}
+
+    output = {
+        'status': 'SUCCESS',
+        'queryId': query_result.get('queryId'),
+        'service_name': service_name,
+        'environment': environment,
+        'log_group_name': log_group_name,
+        'location_hash': location_hash,
+        'time_range': {
+            'start': start_time_utc,
+            'end': end_time_utc,
+        },
+        'cloudwatch_timestamp': results[0].get('@timestamp'),
+    }
+
+    if use_parsed:
+        output['note'] = (
+            f'Raw snapshot was {raw_size:,} bytes and has been replaced with a '
+            'compact parsed summary. To get the full raw snapshot, call this tool '
+            'again with include_raw=True.'
+        )
+
+    output['sample_snapshot'] = sample_snapshot
+    output['field_documentation'] = {
+        'attributes.aws.di.snapshot_id': 'Unique snapshot identifier (UUID v4).',
+        'timeUnixNano': 'Snapshot timestamp in nanoseconds since Unix epoch.',
+        'attributes.aws.di.duration_ms': (
+            'Function execution duration in milliseconds. '
+            'Present for method-level breakpoints only; absent for line-level.'
+        ),
+        'resource.attributes.service.name': 'Service name from OTel resource.',
+        'resource.attributes.deployment.environment': (
+            'Deployment environment from OTel resource (legacy semconv key used by the Python agent '
+            "and the Java agent's fallback path). Filter on both this key and "
+            'resource.attributes.deployment.environment.name to cover every agent path.'
+        ),
+        'resource.attributes.deployment.environment.name': (
+            'Deployment environment under the modern semconv key. The Java agent emits this via '
+            'OTel autoconfiguration / OTEL_RESOURCE_ATTRIBUTES.'
+        ),
+        'attributes.aws.di.location_hash': (
+            'Breakpoint identifier. Use in filters: attributes.aws.di.location_hash = "<value>"'
+        ),
+        'attributes.aws.di.*': (
+            'Breakpoint location metadata: code_unit, class_name, method_name, file_path, '
+            'instrumentation_level, instrumentation_type.'
+        ),
+        'traceId': (
+            'OpenTelemetry trace ID (hex, 32 chars). Use to filter snapshots from the same request: '
+            'traceId = "<value>"'
+        ),
+        'spanId': 'OpenTelemetry span ID (hex, 16 chars). Use with traceId for precise span correlation.',
+        'body.stack': (
+            'Call stack frames (file_path, function, line_number), top to bottom. '
+            'First few frames are DI internals; application frames follow after.'
+        ),
+        'body.captures.entry.arguments.<name>': (
+            'Input arguments at function entry (method-level only). '
+            'Filter: @message like /"arguments"/ and @message like /"<name>"/'
+        ),
+        'body.captures.entry.locals.<name>': 'Local variables at function entry (method-level only).',
+        'body.captures.return.return_value': (
+            'Function return value (method-level only). '
+            'Filter: @message like /"return_value"/ and @message like /"<value>"/'
+        ),
+        'body.captures.return.arguments.<name>': (
+            'Arguments at function exit. Compare with entry arguments to detect mutation.'
+        ),
+        'body.captures.return.locals.<name>': 'Local variables at function exit (method-level only).',
+        'body.captures.return.throwable': 'Exception info if function threw: type, message, stacktrace.',
+        'body.captures.lines.<line>.locals.<name>': (
+            'Local variables at a specific line (line-level only). '
+            'Filter: @message like /"locals"/ and @message like /"<name>"/'
+        ),
+        'CapturedValue shapes': (
+            "Each captured value has 'type' and one of: "
+            "'value' (string representation for primitives/strings/numbers), "
+            "'fields' (map of field name to CapturedValue, for objects/structs), "
+            "'elements' (array of CapturedValue, for lists/arrays), "
+            "'entries' (array of {key: CapturedValue, value: CapturedValue}, for maps/dicts), "
+            "'is_null': true (for null values), "
+            "'not_captured_reason' — the literal is agent-specific: Python emits lowercase "
+            'camelCase (depth, fieldCount, timeout); Java emits uppercase enum names '
+            '(DEPTH, TIMEOUT). Match both forms when filtering. '
+            "Oversize collections/maps are signaled via 'truncated: true' plus 'size' (original element count), "
+            'not via a not_captured_reason.'
+        ),
+    }
+    output['messages'] = query_result.get('messages', [])
+
+    return json.dumps(output, indent=2)

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_tools.py
@@ -1,0 +1,208 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MCP tool entrypoints for CloudWatch snapshot search and sampling."""
+
+from .constants import resolve_snapshot_log_group
+from .snapshot_queries import _execute_cloudwatch_query
+from .snapshot_rendering import (
+    render_get_sample_snapshot_for_breakpoint_output,
+    render_search_snapshots_for_status_event_output,
+)
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+
+def search_snapshots_for_status_event(
+    service_name: str,
+    environment: str,
+    location_hash: str,
+    status_timestamp: str,
+    limit: int = 10,
+    max_timeout: int = 30,
+    custom_filters: Optional[List[str]] = None,
+) -> str:
+    """Search CloudWatch Logs snapshots near a known instrumentation status timestamp.
+
+    This helper builds a Logs Insights query around the supplied status event time,
+    searches for records containing the `location_hash`, and returns a JSON string
+    with query metadata, parsed snapshot summaries, and raw results.
+
+    Args:
+        service_name: Service label echoed back in the response for operator context.
+        environment: Environment label echoed back in the response for operator context.
+        location_hash: Instrumentation location hash used to filter snapshot records.
+        status_timestamp: ISO 8601 status-event timestamp used as the search anchor.
+        limit: Maximum number of matching log records to return.
+        max_timeout: Maximum polling time in seconds for the Logs Insights query.
+        custom_filters: Optional raw Logs Insights filter fragments appended with `and`.
+
+    Notes:
+        - The search window is currently `status_timestamp - 5 seconds` through
+          `status_timestamp + 1 minute`.
+        - The response is JSON text, not a human-formatted prose summary.
+        - Custom filters should already be valid Logs Insights expressions.
+
+    Returns:
+        A JSON string containing query status, query metadata, parsed snapshot
+        summaries, duration hints, and raw CloudWatch query results.
+    """
+    try:
+        event_time = datetime.fromisoformat(status_timestamp.replace('Z', '+00:00'))
+        if event_time.tzinfo is None:
+            event_time = event_time.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return 'ERROR: status_timestamp must be ISO 8601 format like "2025-02-03T18:42:00Z"'
+
+    start_time = event_time - timedelta(seconds=5)
+    end_time = event_time + timedelta(minutes=1)
+
+    start_time_utc = start_time.astimezone(timezone.utc)
+    end_time_utc = end_time.astimezone(timezone.utc)
+    start_epoch = int(start_time_utc.timestamp())
+    end_epoch = int(end_time_utc.timestamp())
+
+    # Tolerant resource matching:
+    #   - For Java snapshots `resource.attributes.*` is populated; require an exact match.
+    #   - For Python snapshots the SDK currently emits an empty resource block, so we accept
+    #     records where the field is absent (`not ispresent(...)`). location_hash by itself
+    #     uniquely identifies (service, environment, location), so this fallback does not
+    #     widen the match across services.
+    #   - Assumption: location_hash collisions across services are negligible. If a future
+    #     SDK bug ever produces records with both a colliding hash and missing resource
+    #     attributes, this filter could return cross-service results.
+    base_filters = (
+        f'attributes.aws.di.location_hash = "{location_hash}"'
+        f' and (resource.attributes.service.name = "{service_name}"'
+        f'      or not ispresent(resource.attributes.service.name))'
+        f' and (resource.attributes.deployment.environment = "{environment}"'
+        f'      or resource.attributes.deployment.environment.name = "{environment}"'
+        f'      or not ispresent(resource.attributes.deployment.environment))'
+    )
+    if custom_filters:
+        for custom_filter in custom_filters:
+            custom_filter = custom_filter.strip()
+            if custom_filter:
+                base_filters += f' and {custom_filter}'
+
+    query_string = (
+        'fields @timestamp, @message\n'
+        f'| filter {base_filters}\n'
+        '| sort @timestamp asc\n'
+        f'| limit {limit}'
+    )
+    query_result = _execute_cloudwatch_query(
+        query_string=query_string,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        log_group_name=resolve_snapshot_log_group(service_name),
+        max_timeout=max_timeout,
+    )
+
+    return render_search_snapshots_for_status_event_output(
+        service_name=service_name,
+        environment=environment,
+        location_hash=location_hash,
+        custom_filters=custom_filters,
+        start_time_utc=start_time_utc.isoformat().replace('+00:00', 'Z'),
+        end_time_utc=end_time_utc.isoformat().replace('+00:00', 'Z'),
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        query_string=query_string,
+        query_result=query_result,
+    )
+
+
+def get_sample_snapshot_for_breakpoint(
+    service_name: str,
+    environment: str,
+    location_hash: str,
+    status_timestamp: str,
+    max_timeout: int = 30,
+    include_raw: bool = False,
+) -> str:
+    """Fetch one nearby snapshot to inspect the structure of captured data.
+
+    This is a discovery helper intended to show the shape of one snapshot record
+    before building narrower CloudWatch queries or deciding which capture fields
+    matter.
+
+    Args:
+        service_name: Service label echoed back in the response for operator context.
+        environment: Environment label echoed back in the response for operator context.
+        location_hash: Instrumentation location hash used to filter snapshot records.
+        status_timestamp: ISO 8601 status-event timestamp used as the search anchor.
+        max_timeout: Maximum polling time in seconds for the Logs Insights query.
+        include_raw: When True, always include the full raw snapshot in the response.
+            When False (default), raw snapshots larger than 10 KB are replaced with a
+            compact parsed summary produced by _parse_snapshot_fields(). Small snapshots
+            are returned in full regardless of this flag.
+
+    Notes:
+        - The search window is currently `status_timestamp - 30 seconds` through
+          `status_timestamp + 90 seconds` (wider than search to accommodate
+          CloudWatch Logs ingestion delay).
+        - This helper requests only one result, sorted by most recent timestamp first.
+        - The response is JSON text, not a human-formatted prose summary.
+
+    Returns:
+        A JSON string containing query metadata plus one parsed sample snapshot,
+        or a structured timeout/error response when the query fails.
+    """
+    try:
+        event_time = datetime.fromisoformat(status_timestamp.replace('Z', '+00:00'))
+        if event_time.tzinfo is None:
+            event_time = event_time.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return 'ERROR: status_timestamp must be ISO 8601 format like "2025-02-03T18:42:00Z"'
+
+    start_time = event_time - timedelta(seconds=30)
+    end_time = event_time + timedelta(seconds=90)
+
+    start_time_utc = start_time.astimezone(timezone.utc)
+    end_time_utc = end_time.astimezone(timezone.utc)
+    start_epoch = int(start_time_utc.timestamp())
+    end_epoch = int(end_time_utc.timestamp())
+
+    # Tolerant resource matching: see search_snapshots_for_status_event for details.
+    query_string = (
+        'fields @timestamp, @message\n'
+        f'| filter attributes.aws.di.location_hash = "{location_hash}"'
+        f' and (resource.attributes.service.name = "{service_name}"'
+        f'      or not ispresent(resource.attributes.service.name))'
+        f' and (resource.attributes.deployment.environment = "{environment}"'
+        f'      or resource.attributes.deployment.environment.name = "{environment}"'
+        f'      or not ispresent(resource.attributes.deployment.environment))\n'
+        '| sort @timestamp desc\n'
+        '| limit 1'
+    )
+
+    query_result = _execute_cloudwatch_query(
+        query_string=query_string,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        log_group_name=resolve_snapshot_log_group(service_name),
+        max_timeout=max_timeout,
+    )
+
+    return render_get_sample_snapshot_for_breakpoint_output(
+        service_name=service_name,
+        environment=environment,
+        location_hash=location_hash,
+        start_time_utc=start_time_utc.isoformat().replace('+00:00', 'Z'),
+        end_time_utc=end_time_utc.isoformat().replace('+00:00', 'Z'),
+        max_timeout=max_timeout,
+        query_string=query_string,
+        query_result=query_result,
+        include_raw=include_raw,
+    )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/snapshot_tools.py
@@ -14,13 +14,47 @@
 """MCP tool entrypoints for CloudWatch snapshot search and sampling."""
 
 from .constants import resolve_snapshot_log_group
+from .snapshot_parsing import _escape_logs_insights_string
 from .snapshot_queries import _execute_cloudwatch_query
 from .snapshot_rendering import (
     render_get_sample_snapshot_for_breakpoint_output,
     render_search_snapshots_for_status_event_output,
 )
+from .validation import is_valid_location_hash
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
+
+
+def _build_base_filters(location_hash: str, service_name: str, environment: str) -> str:
+    """Build the resource-matching Logs Insights filter shared by both snapshot tools.
+
+    All three values are escaped for double-quoted string-literal context so a
+    caller-supplied quote cannot break out of the literal and inject query
+    syntax (which, for ``service_name``/``environment``, could otherwise widen
+    the match across services). ``location_hash`` is additionally validated as
+    16-char hex by the callers before reaching here.
+
+    Tolerant resource matching:
+      - For Java snapshots ``resource.attributes.*`` is populated; require an exact match.
+      - For Python snapshots the SDK currently emits an empty resource block, so we accept
+        records where the field is absent (``not ispresent(...)``). location_hash by itself
+        uniquely identifies (service, environment, location), so this fallback does not
+        widen the match across services.
+      - Assumption: location_hash collisions across services are negligible. If a future
+        SDK bug ever produces records with both a colliding hash and missing resource
+        attributes, this filter could return cross-service results.
+    """
+    location_hash_esc = _escape_logs_insights_string(location_hash)
+    service_name_esc = _escape_logs_insights_string(service_name)
+    environment_esc = _escape_logs_insights_string(environment)
+    return (
+        f'attributes.aws.di.location_hash = "{location_hash_esc}"'
+        f' and (resource.attributes.service.name = "{service_name_esc}"'
+        f'      or not ispresent(resource.attributes.service.name))'
+        f' and (resource.attributes.deployment.environment = "{environment_esc}"'
+        f'      or resource.attributes.deployment.environment.name = "{environment_esc}"'
+        f'      or not ispresent(resource.attributes.deployment.environment))'
+    )
 
 
 def search_snapshots_for_status_event(
@@ -41,7 +75,7 @@ def search_snapshots_for_status_event(
     Args:
         service_name: Service label echoed back in the response for operator context.
         environment: Environment label echoed back in the response for operator context.
-        location_hash: Instrumentation location hash used to filter snapshot records.
+        location_hash: 16-character lowercase hex instrumentation location hash used to filter snapshot records.
         status_timestamp: ISO 8601 status-event timestamp used as the search anchor.
         limit: Maximum number of matching log records to return.
         max_timeout: Maximum polling time in seconds for the Logs Insights query.
@@ -57,6 +91,14 @@ def search_snapshots_for_status_event(
         A JSON string containing query status, query metadata, parsed snapshot
         summaries, duration hints, and raw CloudWatch query results.
     """
+    if not is_valid_location_hash(location_hash):
+        return 'ERROR: location_hash must be a 16-character hex string'
+
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return 'ERROR: limit must be an integer'
+
     try:
         event_time = datetime.fromisoformat(status_timestamp.replace('Z', '+00:00'))
         if event_time.tzinfo is None:
@@ -72,28 +114,19 @@ def search_snapshots_for_status_event(
     start_epoch = int(start_time_utc.timestamp())
     end_epoch = int(end_time_utc.timestamp())
 
-    # Tolerant resource matching:
-    #   - For Java snapshots `resource.attributes.*` is populated; require an exact match.
-    #   - For Python snapshots the SDK currently emits an empty resource block, so we accept
-    #     records where the field is absent (`not ispresent(...)`). location_hash by itself
-    #     uniquely identifies (service, environment, location), so this fallback does not
-    #     widen the match across services.
-    #   - Assumption: location_hash collisions across services are negligible. If a future
-    #     SDK bug ever produces records with both a colliding hash and missing resource
-    #     attributes, this filter could return cross-service results.
-    base_filters = (
-        f'attributes.aws.di.location_hash = "{location_hash}"'
-        f' and (resource.attributes.service.name = "{service_name}"'
-        f'      or not ispresent(resource.attributes.service.name))'
-        f' and (resource.attributes.deployment.environment = "{environment}"'
-        f'      or resource.attributes.deployment.environment.name = "{environment}"'
-        f'      or not ispresent(resource.attributes.deployment.environment))'
-    )
+    base_filters = _build_base_filters(location_hash, service_name, environment)
     if custom_filters:
         for custom_filter in custom_filters:
             custom_filter = custom_filter.strip()
-            if custom_filter:
-                base_filters += f' and {custom_filter}'
+            if not custom_filter:
+                continue
+            # custom_filters are documented as raw Logs Insights fragments the
+            # caller appends on purpose, so they are passed through rather than
+            # escaped. Reject only the realistic corruption vector: an unbalanced
+            # double-quote that would leak into (or truncate) the rest of the query.
+            if (custom_filter.count('"') - custom_filter.count('\\"')) % 2 != 0:
+                return f'ERROR: custom_filters has unbalanced quotes: {custom_filter!r}'
+            base_filters += f' and {custom_filter}'
 
     query_string = (
         'fields @timestamp, @message\n'
@@ -140,7 +173,7 @@ def get_sample_snapshot_for_breakpoint(
     Args:
         service_name: Service label echoed back in the response for operator context.
         environment: Environment label echoed back in the response for operator context.
-        location_hash: Instrumentation location hash used to filter snapshot records.
+        location_hash: 16-character lowercase hex instrumentation location hash used to filter snapshot records.
         status_timestamp: ISO 8601 status-event timestamp used as the search anchor.
         max_timeout: Maximum polling time in seconds for the Logs Insights query.
         include_raw: When True, always include the full raw snapshot in the response.
@@ -159,6 +192,9 @@ def get_sample_snapshot_for_breakpoint(
         A JSON string containing query metadata plus one parsed sample snapshot,
         or a structured timeout/error response when the query fails.
     """
+    if not is_valid_location_hash(location_hash):
+        return 'ERROR: location_hash must be a 16-character hex string'
+
     try:
         event_time = datetime.fromisoformat(status_timestamp.replace('Z', '+00:00'))
         if event_time.tzinfo is None:
@@ -174,15 +210,9 @@ def get_sample_snapshot_for_breakpoint(
     start_epoch = int(start_time_utc.timestamp())
     end_epoch = int(end_time_utc.timestamp())
 
-    # Tolerant resource matching: see search_snapshots_for_status_event for details.
     query_string = (
         'fields @timestamp, @message\n'
-        f'| filter attributes.aws.di.location_hash = "{location_hash}"'
-        f' and (resource.attributes.service.name = "{service_name}"'
-        f'      or not ispresent(resource.attributes.service.name))'
-        f' and (resource.attributes.deployment.environment = "{environment}"'
-        f'      or resource.attributes.deployment.environment.name = "{environment}"'
-        f'      or not ispresent(resource.attributes.deployment.environment))\n'
+        f'| filter {_build_base_filters(location_hash, service_name, environment)}\n'
         '| sort @timestamp desc\n'
         '| limit 1'
     )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_assessment.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_assessment.py
@@ -1,0 +1,158 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Consolidated status assessment for dynamic instrumentation.
+
+The "consolidated status check" answers a single question — *what is the
+high-level state of this instrumentation right now?* — by querying three
+status signals (ACTIVE, READY, ERROR) in priority order over a time window.
+
+This module owns:
+
+* The **time-window policy.** ACTIVE events are only meaningful after the
+  instrumentation was created, so the ACTIVE query window is clamped to
+  ``max(created_at, requested_start)``. READY and ERROR are checked against
+  the full requested window.
+* The **check ordering.** ACTIVE wins; otherwise READY wins; otherwise the
+  ERROR check decides between ERROR and PENDING.
+* The **verdict shape.** Returns a sealed sum type that the renderer
+  dispatches on, instead of leaking three different argument tuples to
+  three different renderers.
+
+I/O lives in the caller. ``assess`` takes a ``check_status`` callable so
+the policy can be tested without touching boto3.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List, Optional, Tuple, Union
+
+
+# A single check call: (status_label, start, end) → (has_events, events, error_or_None).
+# Matches the existing ``_check_status_with_time_range`` shape.
+CheckStatus = Callable[[str, datetime, datetime], Tuple[bool, List[dict], Optional[str]]]
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    """The four ISO-formatted time strings every consolidated renderer needs."""
+
+    created_at: str
+    requested_start: str
+    active_query_start: str
+    query_end: str
+
+
+@dataclass(frozen=True)
+class _StatusCheckResult:
+    has_events: bool
+    events: List[dict]
+    error: Optional[str]
+
+
+@dataclass(frozen=True)
+class Active:
+    """ACTIVE events were found in the (clamped) ACTIVE window."""
+
+    active: _StatusCheckResult
+
+
+@dataclass(frozen=True)
+class Ready:
+    """ACTIVE not confirmed, but READY events were found."""
+
+    active: _StatusCheckResult
+    ready: _StatusCheckResult
+
+
+@dataclass(frozen=True)
+class ErrorOrPending:
+    """Neither ACTIVE nor READY confirmed.
+
+    The ERROR check decides between ERROR and PENDING based on whether
+    ``error.has_events`` is true.
+    """
+
+    active: _StatusCheckResult
+    ready: _StatusCheckResult
+    error: _StatusCheckResult
+
+
+Verdict = Union[Active, Ready, ErrorOrPending]
+
+
+def _check_result(
+    check: CheckStatus, status: str, start: datetime, end: datetime
+) -> _StatusCheckResult:
+    has_events, events, error = check(status, start, end)
+    return _StatusCheckResult(has_events=has_events, events=events, error=error)
+
+
+def _format_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def assess(
+    *,
+    created_at: datetime,
+    requested_start: datetime,
+    query_end: datetime,
+    check_status: CheckStatus,
+) -> Tuple[Verdict, TimeWindow]:
+    """Run the consolidated status assessment.
+
+    The caller is responsible for:
+
+    * Parsing ISO inputs into ``datetime`` objects (string parsing is an input
+      concern, not policy).
+    * Verifying ``query_end > requested_start`` before calling — that error
+      message is owned by the tool layer.
+    * Providing a ``check_status`` callable that issues the AWS query.
+
+    Returns a ``(verdict, time_window)`` pair. The renderer dispatches on
+    the verdict type; both verdict and time_window are passed to the
+    renderer.
+    """
+    requested_start_utc = requested_start.astimezone(timezone.utc)
+    query_end_utc = query_end.astimezone(timezone.utc)
+    created_at_utc = created_at.astimezone(timezone.utc)
+    active_query_start_utc = max(created_at_utc, requested_start_utc)
+
+    time_window = TimeWindow(
+        created_at=_format_iso(created_at_utc),
+        requested_start=_format_iso(requested_start_utc),
+        active_query_start=_format_iso(active_query_start_utc),
+        query_end=_format_iso(query_end_utc),
+    )
+
+    if query_end_utc > active_query_start_utc:
+        active = _check_result(check_status, 'ACTIVE', active_query_start_utc, query_end_utc)
+    else:
+        active = _StatusCheckResult(
+            has_events=False,
+            events=[],
+            error=(
+                'Skipped: ACTIVE query window is empty after applying created_at clamp '
+                f'(start={time_window.active_query_start}, end={time_window.query_end})'
+            ),
+        )
+
+    if active.has_events:
+        return Active(active=active), time_window
+
+    ready = _check_result(check_status, 'READY', requested_start_utc, query_end_utc)
+    if ready.has_events:
+        return Ready(active=active, ready=ready), time_window
+
+    error = _check_result(check_status, 'ERROR', requested_start_utc, query_end_utc)
+    return ErrorOrPending(active=active, ready=ready, error=error), time_window

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_rendering.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_rendering.py
@@ -1,0 +1,391 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Formatting helpers for status tool responses."""
+
+from .constants import SNAPSHOT_SIGNAL_TYPE, resolve_snapshot_log_group
+from .formatting import format_timestamp
+from .location import location_from_response, render_location_block
+from .status_assessment import Active, ErrorOrPending, Ready, TimeWindow, Verdict
+from typing import Any, Dict, List, Optional
+
+
+def render_get_instrumentation_configuration_status_output(
+    data: Dict[str, Any],
+    normalized_type: str,
+    service: str,
+    environment: str,
+    requested_status: str,
+) -> str:
+    """Render the explicit status-history response."""
+    events = data.get('Events', [])
+
+    output = f"""INSTRUMENTATION STATUS
+
+TYPE: {normalized_type}
+SERVICE: {data.get('Service', service)}
+ENVIRONMENT: {data.get('Environment', environment)}
+SIGNAL TYPE: {data.get('SignalType', SNAPSHOT_SIGNAL_TYPE)}
+REQUESTED STATUS FILTER: {requested_status}
+CURRENT STATUS: {data.get('Status', 'N/A')}
+
+LOCATION:
+"""
+    output += render_location_block(
+        location=location_from_response(data.get('Location', {})),
+        location_hash=data.get('LocationHash'),
+    )
+    output += f'- Events Returned: {len(events)}\n'
+
+    if events:
+        output += f'- Status Confirmation: CONFIRMED ({requested_status} events present)\n'
+    else:
+        output += f'- Status Confirmation: NOT CONFIRMED (no {requested_status} events)\n'
+
+    output += (
+        '- Interpretation Rule: Do not treat CURRENT STATUS as confirmed unless '
+        'STATUS EVENTS contain entries.\n'
+    )
+
+    if requested_status == 'ACTIVE' and not events:
+        output += (
+            '- ACTIVE Clarification: Breakpoint is not confirmed as hit yet. '
+            'If READY is not yet confirmed, check READY first. '
+            'Otherwise wait for traffic and poll ACTIVE again.\n'
+        )
+
+    output += '\nSTATUS EVENTS:\n'
+    if not events:
+        output += f'- No {requested_status} status events found\n'
+    else:
+        for index, event in enumerate(events, 1):
+            event_time = format_timestamp(event.get('Time'))
+            error_cause = event.get('ErrorCause')
+            output += f'- Event {index}: {event_time}'
+            if error_cause:
+                output += f' | ErrorCause: {error_cause}'
+            output += '\n'
+
+    next_token_response = data.get('NextToken')
+    if next_token_response:
+        output += (
+            f'\nPAGINATION: More results available. Use next_token="{next_token_response}" '
+            'to retrieve next page.'
+        )
+
+    return output
+
+
+def _render_status_section(
+    title: str,
+    start_time: str,
+    end_time: str,
+    has_events: bool,
+    events: List[dict],
+    error: Optional[str],
+    include_error_cause: bool = False,
+) -> str:
+    output = f'{title} STATUS:\n'
+    output += f'- Time Window: {start_time} to {end_time}\n'
+    if error:
+        if error.startswith('Skipped:'):
+            output += f'- Check Skipped: {error}\n'
+        else:
+            output += f'- Check Failed: {error}\n'
+        return output
+
+    if has_events:
+        output += f'- Confirmed: YES ({len(events)} event(s))\n'
+        for index, event in enumerate(events[:3], 1):
+            output += f'  - Event {index}: {format_timestamp(event.get("Time"))}'
+            if include_error_cause:
+                output += f' | ErrorCause: {event.get("ErrorCause", "Unknown")}'
+            output += '\n'
+        if len(events) > 3:
+            output += f'  - ... and {len(events) - 3} more\n'
+    else:
+        output += f'- Confirmed: NO (no {title} events found)\n'
+    return output
+
+
+def render_consolidated_active_status_output(
+    location_hash: str,
+    service: str,
+    environment: str,
+    normalized_type: str,
+    created_at: str,
+    requested_start_str: str,
+    active_query_start_str: str,
+    query_end_str: str,
+    active_has_events: bool,
+    active_events: List[dict],
+    active_error: Optional[str],
+) -> str:
+    """Render a consolidated status response when ACTIVE is confirmed or checked first."""
+    output = f"""CONSOLIDATED STATUS CHECK
+
+INSTRUMENTATION INFO:
+- LocationHash: {location_hash}
+- Service: {service}
+- Environment: {environment}
+- Type: {normalized_type}
+
+TIME RANGE:
+- Created At: {created_at}
+- Requested Start: {requested_start_str}
+- ACTIVE Query Start: {active_query_start_str}
+- Query End: {query_end_str}
+
+"""
+    output += _render_status_section(
+        title='ACTIVE',
+        start_time=active_query_start_str,
+        end_time=query_end_str,
+        has_events=active_has_events,
+        events=active_events,
+        error=active_error,
+    )
+    output += '\n'
+
+    if active_has_events:
+        output += (
+            'SNAPSHOT QUERY TIP: Try these timestamps with search_snapshots_for_status_event\n'
+            f'  (log group: "{resolve_snapshot_log_group(service)}")\n'
+            '  Oldest first — older events are more likely to have snapshots ingested:\n'
+        )
+        for idx, event in enumerate(reversed(active_events[:5])):
+            label = ' (oldest, try first)' if idx == 0 else ''
+            if idx == len(active_events[:5]) - 1 and idx > 0:
+                label = ' (most recent)'
+            output += f'  - status_timestamp="{format_timestamp(event.get("Time"), default="")}"{label}\n'
+        output += '\n'
+        output += 'OVERALL STATUS: ACTIVE ✓ (breakpoint is being hit)\n'
+        return output
+
+    output += 'OVERALL STATUS: ACTIVE not confirmed yet\n'
+    return output
+
+
+def render_consolidated_ready_status_output(
+    location_hash: str,
+    service: str,
+    environment: str,
+    normalized_type: str,
+    created_at: str,
+    requested_start_str: str,
+    active_query_start_str: str,
+    query_end_str: str,
+    active_has_events: bool,
+    active_events: List[dict],
+    active_error: Optional[str],
+    ready_has_events: bool,
+    ready_events: List[dict],
+    ready_error: Optional[str],
+) -> str:
+    """Render a consolidated status response when READY is the best confirmed state."""
+    output = render_consolidated_active_status_output(
+        location_hash=location_hash,
+        service=service,
+        environment=environment,
+        normalized_type=normalized_type,
+        created_at=created_at,
+        requested_start_str=requested_start_str,
+        active_query_start_str=active_query_start_str,
+        query_end_str=query_end_str,
+        active_has_events=active_has_events,
+        active_events=active_events,
+        active_error=active_error,
+    )
+    if output.endswith('OVERALL STATUS: ACTIVE not confirmed yet\n'):
+        output = output[: -len('OVERALL STATUS: ACTIVE not confirmed yet\n')]
+
+    output += _render_status_section(
+        title='READY',
+        start_time=requested_start_str,
+        end_time=query_end_str,
+        has_events=ready_has_events,
+        events=ready_events,
+        error=ready_error,
+    )
+    output += '\nOVERALL STATUS: READY (waiting for traffic)\n'
+    return output
+
+
+def render_consolidated_error_or_pending_status_output(
+    location_hash: str,
+    service: str,
+    environment: str,
+    normalized_type: str,
+    created_at: str,
+    requested_start_str: str,
+    active_query_start_str: str,
+    query_end_str: str,
+    active_has_events: bool,
+    active_events: List[dict],
+    active_error: Optional[str],
+    ready_has_events: bool,
+    ready_events: List[dict],
+    ready_error: Optional[str],
+    error_has_events: bool,
+    error_events: List[dict],
+    error_error: Optional[str],
+) -> str:
+    """Render a consolidated status response for ERROR or PENDING outcomes."""
+    output = render_consolidated_active_status_output(
+        location_hash=location_hash,
+        service=service,
+        environment=environment,
+        normalized_type=normalized_type,
+        created_at=created_at,
+        requested_start_str=requested_start_str,
+        active_query_start_str=active_query_start_str,
+        query_end_str=query_end_str,
+        active_has_events=active_has_events,
+        active_events=active_events,
+        active_error=active_error,
+    )
+    if output.endswith('OVERALL STATUS: ACTIVE not confirmed yet\n'):
+        output = output[: -len('OVERALL STATUS: ACTIVE not confirmed yet\n')]
+
+    output += '\n'
+    output += _render_status_section(
+        title='READY',
+        start_time=requested_start_str,
+        end_time=query_end_str,
+        has_events=ready_has_events,
+        events=ready_events,
+        error=ready_error,
+    )
+    output += '\n'
+    output += _render_status_section(
+        title='ERROR',
+        start_time=requested_start_str,
+        end_time=query_end_str,
+        has_events=error_has_events,
+        events=error_events,
+        error=error_error,
+        include_error_cause=True,
+    )
+
+    output += '\nOVERALL STATUS: '
+    if error_has_events:
+        error_cause = error_events[0].get('ErrorCause', 'Unknown') if error_events else 'Unknown'
+        output += f'ERROR ({error_cause})\n'
+        output += '\nTROUBLESHOOTING:\n'
+        if error_cause == 'FILE_NOT_FOUND':
+            output += '- Verify file_path is correct\n'
+        elif error_cause == 'METHOD_NOT_FOUND':
+            output += '- Verify method_name and code_unit are correct\n'
+            output += '- Check if the function is loaded at runtime\n'
+        elif error_cause == 'LINE_NOT_EXECUTABLE':
+            output += (
+                '- Verify line_number points to executable code (not comment/blank/declaration)\n'
+            )
+        else:
+            output += f'- Check instrumentation configuration for {error_cause}\n'
+    else:
+        output += 'PENDING (no ACTIVE, READY, or ERROR events yet - wait longer or check configuration)\n'
+        output += '\nNOTE: Status events can take 1-2 minutes to appear after creation.\n'
+
+    return output
+
+
+def render_status_assessment(
+    verdict: Verdict,
+    *,
+    location_hash: str,
+    service: str,
+    environment: str,
+    normalized_type: str,
+    time_window: TimeWindow,
+) -> str:
+    """Dispatch a ``Verdict`` to the appropriate consolidated-status renderer.
+
+    Each existing renderer keeps its own prose contract; this function only
+    routes. New renderers should be added as ``Verdict`` variants gain
+    distinct presentation.
+    """
+    common = {
+        'location_hash': location_hash,
+        'service': service,
+        'environment': environment,
+        'normalized_type': normalized_type,
+        'created_at': time_window.created_at,
+        'requested_start_str': time_window.requested_start,
+        'active_query_start_str': time_window.active_query_start,
+        'query_end_str': time_window.query_end,
+    }
+
+    if isinstance(verdict, Active):
+        return render_consolidated_active_status_output(
+            **common,
+            active_has_events=verdict.active.has_events,
+            active_events=verdict.active.events,
+            active_error=verdict.active.error,
+        )
+
+    if isinstance(verdict, Ready):
+        return render_consolidated_ready_status_output(
+            **common,
+            active_has_events=verdict.active.has_events,
+            active_events=verdict.active.events,
+            active_error=verdict.active.error,
+            ready_has_events=verdict.ready.has_events,
+            ready_events=verdict.ready.events,
+            ready_error=verdict.ready.error,
+        )
+
+    if isinstance(verdict, ErrorOrPending):
+        return render_consolidated_error_or_pending_status_output(
+            **common,
+            active_has_events=verdict.active.has_events,
+            active_events=verdict.active.events,
+            active_error=verdict.active.error,
+            ready_has_events=verdict.ready.has_events,
+            ready_events=verdict.ready.events,
+            ready_error=verdict.ready.error,
+            error_has_events=verdict.error.has_events,
+            error_events=verdict.error.events,
+            error_error=verdict.error.error,
+        )
+
+    raise TypeError(f'Unknown Verdict variant: {type(verdict).__name__}')
+
+
+def render_report_instrumentation_configuration_status_output(
+    data: Dict[str, Any],
+    normalized: List[Dict[str, str]],
+    service: str,
+    environment: str,
+) -> str:
+    """Render the status-report submission response."""
+    unprocessed = data.get('UnprocessedStatusEvents', [])
+
+    output = f"""STATUS REPORT SUBMITTED
+
+Service: {data.get('Service', service)}
+Environment: {data.get('Environment', environment)}
+Reported Events: {len(normalized)}
+Unprocessed Events: {len(unprocessed)}
+"""
+
+    if unprocessed:
+        output += '\nUNPROCESSED EVENTS:\n'
+        for index, event in enumerate(unprocessed, 1):
+            output += (
+                f'- Event {index}: {event.get("LocationHash", "N/A")} | '
+                f'{event.get("Status", "N/A")} | {format_timestamp(event.get("Time"))} | '
+                f'FailedReason: {event.get("FailedReason", "N/A")}\n'
+            )
+
+    return output

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_rendering.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_rendering.py
@@ -360,32 +360,3 @@ def render_status_assessment(
         )
 
     raise TypeError(f'Unknown Verdict variant: {type(verdict).__name__}')
-
-
-def render_report_instrumentation_configuration_status_output(
-    data: Dict[str, Any],
-    normalized: List[Dict[str, str]],
-    service: str,
-    environment: str,
-) -> str:
-    """Render the status-report submission response."""
-    unprocessed = data.get('UnprocessedStatusEvents', [])
-
-    output = f"""STATUS REPORT SUBMITTED
-
-Service: {data.get('Service', service)}
-Environment: {data.get('Environment', environment)}
-Reported Events: {len(normalized)}
-Unprocessed Events: {len(unprocessed)}
-"""
-
-    if unprocessed:
-        output += '\nUNPROCESSED EVENTS:\n'
-        for index, event in enumerate(unprocessed, 1):
-            output += (
-                f'- Event {index}: {event.get("LocationHash", "N/A")} | '
-                f'{event.get("Status", "N/A")} | {format_timestamp(event.get("Time"))} | '
-                f'FailedReason: {event.get("FailedReason", "N/A")}\n'
-            )
-
-    return output

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_tools.py
@@ -22,10 +22,11 @@ from .status_rendering import (
     render_status_assessment,
 )
 from .validation import (
+    is_valid_location_hash,
     normalize_instrumentation_type,
     validate_snapshot_signal,
 )
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -73,8 +74,18 @@ Usage:
 
 
 def _parse_iso_timestamp(value: str) -> datetime:
-    """Parse an ISO 8601 timestamp, accepting trailing 'Z' as UTC."""
-    return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    """Parse an ISO 8601 timestamp, accepting trailing 'Z' as UTC.
+
+    A naive input (no 'Z' or offset, e.g. ``2025-02-03T18:42:00``) is assumed
+    to be UTC rather than host-local. Without this, downstream ``astimezone``
+    calls in ``assess()`` would reinterpret it in the host timezone — on a
+    UTC-8 host ``18:42`` becomes ``02:42Z``, shifting the whole status query
+    window and causing ACTIVE/READY events to be missed.
+    """
+    parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def get_instrumentation_configuration_status(
@@ -247,7 +258,7 @@ def check_instrumentation_status(
         service: Backend service identifier.
         environment: Backend environment identifier.
         instrumentation_type: BREAKPOINT or PROBE.
-        location_hash: Required 16-character location hash for the target configuration.
+        location_hash: Required 16-character lowercase hex location hash for the target configuration.
         start_time: Required ISO 8601 lower bound for the overall check window.
         end_time: Required ISO 8601 upper bound for the overall check window.
         signal_type: Must be SNAPSHOT.
@@ -263,7 +274,7 @@ def check_instrumentation_status(
     if signal_error:
         return signal_error
 
-    if not location_hash or len(location_hash) != 16:
+    if not is_valid_location_hash(location_hash):
         return 'ERROR: location_hash must be a 16-character hex string'
 
     try:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_tools.py
@@ -1,0 +1,398 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MCP tool entrypoints for status queries and reporting."""
+
+from . import application_signals_gateway as gateway
+from .constants import SNAPSHOT_SIGNAL_TYPE
+from .location import parse_lookup_inputs
+from .status_assessment import assess
+from .status_rendering import (
+    render_get_instrumentation_configuration_status_output,
+    render_report_instrumentation_configuration_status_output,
+    render_status_assessment,
+)
+from .validation import (
+    normalize_instrumentation_type,
+    normalize_status_configurations,
+    validate_snapshot_signal,
+)
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _check_status_with_time_range(
+    *,
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+    location_identifier: Dict[str, Any],
+    status: str,
+    start_time: datetime,
+    end_time: datetime,
+    signal_type: str = SNAPSHOT_SIGNAL_TYPE,
+) -> Tuple[bool, List[dict], Optional[str]]:
+    """Check whether status events exist for the configuration in a time range."""
+    try:
+        data = gateway.get_instrumentation_configuration_status(
+            InstrumentationType=instrumentation_type,
+            Service=service,
+            Environment=environment,
+            SignalType=signal_type,
+            Status=status,
+            LocationIdentifier=location_identifier,
+            StartTime=start_time,
+            EndTime=end_time,
+        )
+    except gateway.GatewayError as err:
+        return False, [], f'API error: {err.original_exc}'
+
+    events = data.get('Events', []) if isinstance(data, dict) else []
+    return len(events) > 0, events, None
+
+
+def _render_status_identifier_help() -> str:
+    return """ERROR: Must provide one of:
+- location_hash
+- language + file_path (for code location identifier)
+
+Usage:
+1. Get by hash (preferred):
+   get_instrumentation_configuration_status(location_hash="abc123...")
+
+2. Get by code location:
+   get_instrumentation_configuration_status(language="Python", file_path="/app/file.py", ...)"""
+
+
+def _parse_iso_timestamp(value: str) -> datetime:
+    """Parse an ISO 8601 timestamp, accepting trailing 'Z' as UTC."""
+    return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def get_instrumentation_configuration_status(
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+    location_hash: Optional[str] = None,
+    language: Optional[str] = None,
+    file_path: Optional[str] = None,
+    code_unit: Optional[str] = None,
+    class_name: Optional[str] = None,
+    method_name: Optional[str] = None,
+    line_number: Optional[int] = None,
+    status: Optional[str] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+    signal_type: str = SNAPSHOT_SIGNAL_TYPE,
+) -> str:
+    """Get status-event history for one instrumentation configuration and one explicit status.
+
+    This API is intentionally strict: callers must provide exactly one status
+    filter because AWS defaults can be ambiguous. The response distinguishes
+    between the backend's current status field and status confirmation based on
+    returned events.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        instrumentation_type: BREAKPOINT or PROBE.
+        location_hash: Preferred identifier for an existing configuration.
+        language: Code language for code-location lookup.
+        file_path: Code file path for code-location lookup.
+        code_unit: Optional module/package name for code-location lookup.
+        class_name: Optional class name for code-location lookup.
+        method_name: Optional function/method name for code-location lookup.
+        line_number: Optional 1-based line number for code-location lookup.
+        status: Required. Must be READY, ACTIVE, ERROR, or DISABLED.
+        start_time: Optional ISO 8601 lower bound for returned events.
+        end_time: Optional ISO 8601 upper bound for returned events.
+        max_results: Maximum number of events to request. Defaults to 100.
+        next_token: Optional AWS pagination token from a previous response.
+        signal_type: Must be SNAPSHOT.
+
+    Returns:
+        A human-readable status report with location details, event count,
+        confirmation guidance, and pagination hints when additional events exist.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+    signal_error = validate_snapshot_signal(signal_type)
+    if signal_error:
+        return signal_error
+
+    location, location_error = parse_lookup_inputs(
+        normalized_type=normalized_type,
+        location_hash=location_hash,
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+        allow_code_location_lookup=True,
+    )
+    if location_error:
+        if 'missing location identifier input' in location_error:
+            return _render_status_identifier_help()
+        return f'ERROR: {location_error}'
+    if location is None:
+        # Defensive: parsers return (loc, None) or (None, error_text). This
+        # branch should be unreachable, but we return a user-facing error
+        # string (not ``raise``) so the tool's "always returns a string"
+        # contract holds even if a future parser bug fires this path.
+        return 'ERROR: Internal error resolving location. Please report this issue.'
+    target_desc = location.describe()
+
+    requested_status = (status or '').strip().upper()
+    allowed_statuses = {'READY', 'ACTIVE', 'ERROR', 'DISABLED'}
+    if not requested_status:
+        return """ERROR: status is required
+
+This API cannot return all statuses in one call.
+If status is omitted, AWS defaults to ACTIVE, which is ambiguous.
+
+Use explicit status checks in this order:
+1. status="READY"
+2. status="ACTIVE" (only after READY is confirmed by events)
+3. status="ERROR" (if READY not confirmed)
+4. status="DISABLED" (when checking max-hits scenarios)"""
+
+    if requested_status not in allowed_statuses:
+        return (
+            'ERROR: invalid status. Must be one of: READY, ACTIVE, ERROR, DISABLED '
+            f'(received: {status})'
+        )
+
+    request_kwargs: Dict[str, Any] = {
+        'InstrumentationType': normalized_type,
+        'Service': service,
+        'Environment': environment,
+        'SignalType': SNAPSHOT_SIGNAL_TYPE,
+        'Status': requested_status,
+        'LocationIdentifier': location.to_identifier(),
+    }
+
+    if start_time:
+        try:
+            request_kwargs['StartTime'] = _parse_iso_timestamp(start_time)
+        except ValueError as exc:
+            return f'ERROR: Invalid start_time format. Expected ISO 8601. Error: {exc}'
+    if end_time:
+        try:
+            request_kwargs['EndTime'] = _parse_iso_timestamp(end_time)
+        except ValueError as exc:
+            return f'ERROR: Invalid end_time format. Expected ISO 8601. Error: {exc}'
+    if max_results != 100:
+        request_kwargs['MaxResults'] = max_results
+    if next_token:
+        request_kwargs['NextToken'] = next_token
+
+    try:
+        data = gateway.get_instrumentation_configuration_status(**request_kwargs)
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action='get instrumentation status',
+            attempted_label='ATTEMPTED TO RETRIEVE:',
+            attempted={
+                'Target': target_desc,
+                'Service': service,
+                'Environment': environment,
+            },
+            possible_causes=[
+                "Instrumentation doesn't exist at this location",
+                "Location parameters don't match exactly",
+                'Wrong service or environment identifier',
+            ],
+            troubleshooting=['Use get_instrumentation to verify the configuration exists'],
+        )
+
+    return render_get_instrumentation_configuration_status_output(
+        data=data,
+        normalized_type=normalized_type,
+        service=service,
+        environment=environment,
+        requested_status=requested_status,
+    )
+
+
+def check_instrumentation_status(
+    service: str,
+    environment: str,
+    instrumentation_type: str,
+    location_hash: str,
+    start_time: str,
+    end_time: str,
+    signal_type: str = SNAPSHOT_SIGNAL_TYPE,
+) -> str:
+    """Run a consolidated READY/ACTIVE/ERROR status check over a time window.
+
+    This helper is opinionated: it first fetches the instrumentation creation
+    time, clamps the ACTIVE search window so it does not start before creation,
+    and then checks ACTIVE, READY, and ERROR in order to produce a single
+    high-level interpretation.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        instrumentation_type: BREAKPOINT or PROBE.
+        location_hash: Required 16-character location hash for the target configuration.
+        start_time: Required ISO 8601 lower bound for the overall check window.
+        end_time: Required ISO 8601 upper bound for the overall check window.
+        signal_type: Must be SNAPSHOT.
+
+    Returns:
+        A human-readable consolidated assessment such as ACTIVE, READY, ERROR, or
+        PENDING, plus troubleshooting guidance and snapshot-query hints when applicable.
+    """
+    normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
+    if type_error:
+        return type_error
+    signal_error = validate_snapshot_signal(signal_type)
+    if signal_error:
+        return signal_error
+
+    if not location_hash or len(location_hash) != 16:
+        return 'ERROR: location_hash must be a 16-character hex string'
+
+    try:
+        created_at_response = gateway.get_instrumentation_configuration(
+            InstrumentationType=normalized_type,
+            Service=service,
+            Environment=environment,
+            SignalType=SNAPSHOT_SIGNAL_TYPE,
+            LocationIdentifier={'LocationHash': location_hash},
+        )
+    except gateway.GatewayError as err:
+        return f'ERROR: Failed to fetch created_at: Exception: {err.original_exc}'
+
+    config = (
+        created_at_response.get('Configuration', {})
+        if isinstance(created_at_response, dict)
+        else {}
+    )
+    if not config:
+        return f'ERROR: Failed to fetch created_at: No instrumentation found for LocationHash {location_hash}'
+    created_dt = config.get('CreatedAt')
+    if created_dt is None:
+        return 'ERROR: Failed to fetch created_at: CreatedAt not found in instrumentation configuration'
+
+    try:
+        start_dt = _parse_iso_timestamp(start_time)
+    except ValueError as exc:
+        return f'ERROR: Invalid start_time format. Expected ISO 8601. Error: {exc}'
+
+    try:
+        query_end_dt = _parse_iso_timestamp(end_time)
+    except ValueError as exc:
+        return f'ERROR: Invalid end_time format. Expected ISO 8601. Error: {exc}'
+
+    if query_end_dt <= start_dt:
+        return 'ERROR: end_time must be later than start_time'
+
+    location_identifier = {'LocationHash': location_hash}
+
+    def check_status(
+        status: str, start: datetime, end: datetime
+    ) -> Tuple[bool, List[dict], Optional[str]]:
+        return _check_status_with_time_range(
+            service=service,
+            environment=environment,
+            instrumentation_type=normalized_type,
+            location_identifier=location_identifier,
+            status=status,
+            start_time=start,
+            end_time=end,
+            signal_type=SNAPSHOT_SIGNAL_TYPE,
+        )
+
+    verdict, time_window = assess(
+        created_at=created_dt,
+        requested_start=start_dt,
+        query_end=query_end_dt,
+        check_status=check_status,
+    )
+
+    return render_status_assessment(
+        verdict,
+        location_hash=location_hash,
+        service=service,
+        environment=environment,
+        normalized_type=normalized_type,
+        time_window=time_window,
+    )
+
+
+def report_instrumentation_configuration_status(
+    service: str,
+    environment: str,
+    configurations: List[Dict[str, str]],
+) -> str:
+    """Report one or more instrumentation status events to the backend.
+
+    Args:
+        service: Backend service identifier.
+        environment: Backend environment identifier.
+        configurations: List of status-event objects. Each item must normalize to:
+            InstrumentationType, SignalType, LocationHash, Status, and Time.
+            Optional ErrorCause is allowed for ERROR events.
+
+    Notes:
+        - Only BREAKPOINT and PROBE status events are accepted.
+        - SignalType must be SNAPSHOT.
+        - LocationHash must be a 16-character string.
+
+    Returns:
+        A human-readable submission summary including any unprocessed events
+        returned by the backend.
+    """
+    if not configurations:
+        return 'ERROR: configurations must contain at least one status report'
+
+    normalized, error = normalize_status_configurations(configurations)
+    if error:
+        return error
+
+    try:
+        data = gateway.report_instrumentation_configuration_status(
+            Service=service,
+            Environment=environment,
+            Configurations=normalized,
+        )
+    except gateway.GatewayError as err:
+        return gateway.render_error(
+            err,
+            action='report instrumentation status',
+            attempted_label='ATTEMPTED TO REPORT:',
+            attempted={
+                'Service': service,
+                'Environment': environment,
+                'Events': len(normalized),
+            },
+            possible_causes=[
+                'Validation error in configurations list',
+                'Invalid service or environment identifier',
+                'Throttling or service error',
+            ],
+            troubleshooting=['Verify configuration fields and retry'],
+        )
+
+    return render_report_instrumentation_configuration_status_output(
+        data=data,
+        normalized=normalized,
+        service=service,
+        environment=environment,
+    )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/status_tools.py
@@ -19,12 +19,10 @@ from .location import parse_lookup_inputs
 from .status_assessment import assess
 from .status_rendering import (
     render_get_instrumentation_configuration_status_output,
-    render_report_instrumentation_configuration_status_output,
     render_status_assessment,
 )
 from .validation import (
     normalize_instrumentation_type,
-    normalize_status_configurations,
     validate_snapshot_signal,
 )
 from datetime import datetime
@@ -333,66 +331,4 @@ def check_instrumentation_status(
         environment=environment,
         normalized_type=normalized_type,
         time_window=time_window,
-    )
-
-
-def report_instrumentation_configuration_status(
-    service: str,
-    environment: str,
-    configurations: List[Dict[str, str]],
-) -> str:
-    """Report one or more instrumentation status events to the backend.
-
-    Args:
-        service: Backend service identifier.
-        environment: Backend environment identifier.
-        configurations: List of status-event objects. Each item must normalize to:
-            InstrumentationType, SignalType, LocationHash, Status, and Time.
-            Optional ErrorCause is allowed for ERROR events.
-
-    Notes:
-        - Only BREAKPOINT and PROBE status events are accepted.
-        - SignalType must be SNAPSHOT.
-        - LocationHash must be a 16-character string.
-
-    Returns:
-        A human-readable submission summary including any unprocessed events
-        returned by the backend.
-    """
-    if not configurations:
-        return 'ERROR: configurations must contain at least one status report'
-
-    normalized, error = normalize_status_configurations(configurations)
-    if error:
-        return error
-
-    try:
-        data = gateway.report_instrumentation_configuration_status(
-            Service=service,
-            Environment=environment,
-            Configurations=normalized,
-        )
-    except gateway.GatewayError as err:
-        return gateway.render_error(
-            err,
-            action='report instrumentation status',
-            attempted_label='ATTEMPTED TO REPORT:',
-            attempted={
-                'Service': service,
-                'Environment': environment,
-                'Events': len(normalized),
-            },
-            possible_causes=[
-                'Validation error in configurations list',
-                'Invalid service or environment identifier',
-                'Throttling or service error',
-            ],
-            troubleshooting=['Verify configuration fields and retry'],
-        )
-
-    return render_report_instrumentation_configuration_status_output(
-        data=data,
-        normalized=normalized,
-        service=service,
-        environment=environment,
     )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
@@ -14,7 +14,7 @@
 """Validation and normalization helpers for instrumentation inputs."""
 
 from .constants import SNAPSHOT_SIGNAL_TYPE
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 
 def normalize_instrumentation_type(
@@ -167,85 +167,3 @@ def _validate_location_inputs(
     )
 
     return message
-
-
-def normalize_status_configurations(
-    configurations: List[Dict[str, str]],
-) -> Tuple[Optional[List[Dict[str, str]]], Optional[str]]:
-    """Normalize and validate status report configurations."""
-    key_map = {
-        'instrumentation_type': 'InstrumentationType',
-        'signal_type': 'SignalType',
-        'location_hash': 'LocationHash',
-        'status': 'Status',
-        'time': 'Time',
-        'error_cause': 'ErrorCause',
-    }
-
-    required_keys = ['InstrumentationType', 'SignalType', 'LocationHash', 'Status', 'Time']
-    allowed_instrumentation = {'BREAKPOINT', 'PROBE'}
-    allowed_signal = {SNAPSHOT_SIGNAL_TYPE}
-    allowed_status = {'READY', 'ERROR', 'ACTIVE', 'DISABLED'}
-    allowed_error_cause = {
-        'FILE_NOT_FOUND',
-        'METHOD_NOT_FOUND',
-        'LINE_NOT_EXECUTABLE',
-        'OVERLOADED_METHODS',
-        'LANGUAGE_MISMATCH',
-        'RUNTIME_ERROR',
-    }
-
-    normalized_list: List[Dict[str, str]] = []
-
-    for idx, item in enumerate(configurations, 1):
-        if not isinstance(item, dict):
-            return None, f'ERROR: configurations[{idx}] must be an object'
-
-        normalized: Dict[str, str] = {}
-        for key, value in item.items():
-            canonical_key = key_map.get(key, key)
-            if canonical_key in normalized and normalized[canonical_key] != value:
-                return (
-                    None,
-                    f'ERROR: configurations[{idx}] has conflicting values for {canonical_key}',
-                )
-            normalized[canonical_key] = value
-
-        if not normalized.get('SignalType'):
-            normalized['SignalType'] = SNAPSHOT_SIGNAL_TYPE
-
-        missing = [key for key in required_keys if not normalized.get(key)]
-        if missing:
-            return (
-                None,
-                f'ERROR: configurations[{idx}] missing required fields: {", ".join(missing)}',
-            )
-
-        if normalized['InstrumentationType'] not in allowed_instrumentation:
-            return (
-                None,
-                f'ERROR: configurations[{idx}] invalid InstrumentationType: {normalized["InstrumentationType"]}',
-            )
-
-        if normalized['SignalType'] not in allowed_signal:
-            return (
-                None,
-                f'ERROR: configurations[{idx}] invalid SignalType: {normalized["SignalType"]}',
-            )
-
-        if normalized['Status'] not in allowed_status:
-            return None, f'ERROR: configurations[{idx}] invalid Status: {normalized["Status"]}'
-
-        if 'ErrorCause' in normalized and normalized['ErrorCause'] not in allowed_error_cause:
-            return (
-                None,
-                f'ERROR: configurations[{idx}] invalid ErrorCause: {normalized["ErrorCause"]}',
-            )
-
-        location_hash = normalized.get('LocationHash')
-        if not isinstance(location_hash, str) or len(location_hash) != 16:
-            return None, f'ERROR: configurations[{idx}] LocationHash must be a 16-character string'
-
-        normalized_list.append(normalized)
-
-    return normalized_list, None

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
@@ -1,0 +1,251 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation and normalization helpers for instrumentation inputs."""
+
+from .constants import SNAPSHOT_SIGNAL_TYPE
+from typing import Dict, List, Optional, Tuple
+
+
+def normalize_instrumentation_type(
+    instrumentation_type: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Normalize the type to upper-case; return ``(normalized, error)``."""
+    normalized = (instrumentation_type or '').strip().upper()
+    allowed = {'BREAKPOINT', 'PROBE'}
+    if normalized not in allowed:
+        return None, (
+            'ERROR: instrumentation_type must be one of BREAKPOINT, PROBE '
+            f'(received: {instrumentation_type})'
+        )
+    return normalized, None
+
+
+def validate_snapshot_signal(signal_type: str) -> Optional[str]:
+    """Return an error message unless ``signal_type`` is SNAPSHOT, else None."""
+    normalized = (signal_type or '').strip().upper()
+    if normalized != SNAPSHOT_SIGNAL_TYPE:
+        return f'ERROR: signal_type must be SNAPSHOT for this API (received: {signal_type})'
+    return None
+
+
+def _format_code_location_troubleshooting(
+    language: str,
+    file_path: str,
+    code_unit: Optional[str],
+    class_name: Optional[str],
+    method_name: Optional[str],
+    line_number: Optional[int],
+) -> str:
+    """Build troubleshooting guidance for code-location create failures."""
+    lang = (language or '').strip().lower()
+
+    lines = [
+        'CODE LOCATION TROUBLESHOOTING:',
+        '- file_path: source file path for the target code.',
+        '- code_unit: Python runtime module path OR Java package name.',
+        '- class_name: use for class methods (Java: simple class name only).',
+        '- method_name: function/method name.',
+        '- line_number: set only for line-level breakpoints (1-based).',
+    ]
+
+    if line_number is None:
+        lines.append('- Breakpoint level: FUNCTION/METHOD-level (line_number omitted).')
+    else:
+        lines.append(f'- Breakpoint level: LINE-LEVEL (L{line_number}).')
+
+    if lang == 'python':
+        lines.extend(
+            [
+                '- Python rules:',
+                '  * Set code_unit to the dotted runtime import path for the module that defines the target code.',
+                '  * Example: services.billing, not billing.py or /app/services/billing.py.',
+                '  * Use code_unit="__main__" only when the target file is executed',
+                '    directly as the process entry script.',
+                '  * If call site uses direct import aliasing, target importing module and alias name.',
+                '  * If you cannot determine the runtime module path confidently, inspect first instead of guessing.',
+            ]
+        )
+    elif lang == 'java':
+        lines.extend(
+            [
+                '- Java rules:',
+                '  * Set code_unit to the Java package name (e.g., com.amazon.sampleapp).',
+                '  * class_name must be simple name (e.g., OrderContext), not fully qualified.',
+            ]
+        )
+
+    lines.extend(
+        [
+            'LOCATION INPUTS RECEIVED:',
+            f'- language={language}',
+            f'- file_path={file_path}',
+            f'- code_unit={code_unit}',
+            f'- class_name={class_name}',
+            f'- method_name={method_name}',
+            f'- line_number={line_number}',
+        ]
+    )
+
+    return '\n'.join(lines)
+
+
+def _validate_location_inputs(
+    language: str,
+    file_path: str,
+    code_unit: Optional[str],
+    class_name: Optional[str],
+    method_name: Optional[str],
+    line_number: Optional[int],
+) -> Optional[str]:
+    """Validate high-risk location fields and return actionable error text if invalid."""
+    lang = (language or '').strip().lower()
+
+    errors: List[str] = []
+    suggestions: List[str] = []
+
+    if not file_path or not str(file_path).strip():
+        errors.append('file_path is required and must be non-empty.')
+
+    if line_number is not None and line_number < 1:
+        errors.append(f'line_number must be >= 1 (received: {line_number}).')
+
+    if lang not in {'python', 'java'}:
+        errors.append(f'language must be Python or Java (received: {language}).')
+
+    if lang == 'java':
+        if class_name and '.' in class_name:
+            errors.append(
+                'For Java, class_name must be simple (e.g., "OrderContext"), '
+                'not fully qualified (e.g., "com.example.OrderContext").'
+            )
+            if not code_unit:
+                parts = class_name.split('.')
+                if len(parts) > 1:
+                    suggestions.append(
+                        f'Use code_unit="{".".join(parts[:-1])}" and class_name="{parts[-1]}".'
+                    )
+        if code_unit and '/' in code_unit:
+            suggestions.append(
+                'Java code_unit should be a package name with dots, not a path with slashes.'
+            )
+
+    if lang == 'python' and code_unit and code_unit.endswith('.py'):
+        suggestions.append(
+            'Python code_unit should be a module path (e.g., services.billing), not a .py filename.'
+        )
+
+    if not errors:
+        return None
+
+    message = 'Invalid breakpoint location inputs:\n'
+    for idx, err in enumerate(errors, 1):
+        message += f'{idx}. {err}\n'
+
+    if suggestions:
+        message += '\nSuggestions:\n'
+        for idx, item in enumerate(suggestions, 1):
+            message += f'{idx}. {item}\n'
+
+    message += '\n' + _format_code_location_troubleshooting(
+        language=language,
+        file_path=file_path,
+        code_unit=code_unit,
+        class_name=class_name,
+        method_name=method_name,
+        line_number=line_number,
+    )
+
+    return message
+
+
+def normalize_status_configurations(
+    configurations: List[Dict[str, str]],
+) -> Tuple[Optional[List[Dict[str, str]]], Optional[str]]:
+    """Normalize and validate status report configurations."""
+    key_map = {
+        'instrumentation_type': 'InstrumentationType',
+        'signal_type': 'SignalType',
+        'location_hash': 'LocationHash',
+        'status': 'Status',
+        'time': 'Time',
+        'error_cause': 'ErrorCause',
+    }
+
+    required_keys = ['InstrumentationType', 'SignalType', 'LocationHash', 'Status', 'Time']
+    allowed_instrumentation = {'BREAKPOINT', 'PROBE'}
+    allowed_signal = {SNAPSHOT_SIGNAL_TYPE}
+    allowed_status = {'READY', 'ERROR', 'ACTIVE', 'DISABLED'}
+    allowed_error_cause = {
+        'FILE_NOT_FOUND',
+        'METHOD_NOT_FOUND',
+        'LINE_NOT_EXECUTABLE',
+        'OVERLOADED_METHODS',
+        'LANGUAGE_MISMATCH',
+        'RUNTIME_ERROR',
+    }
+
+    normalized_list: List[Dict[str, str]] = []
+
+    for idx, item in enumerate(configurations, 1):
+        if not isinstance(item, dict):
+            return None, f'ERROR: configurations[{idx}] must be an object'
+
+        normalized: Dict[str, str] = {}
+        for key, value in item.items():
+            canonical_key = key_map.get(key, key)
+            if canonical_key in normalized and normalized[canonical_key] != value:
+                return (
+                    None,
+                    f'ERROR: configurations[{idx}] has conflicting values for {canonical_key}',
+                )
+            normalized[canonical_key] = value
+
+        if not normalized.get('SignalType'):
+            normalized['SignalType'] = SNAPSHOT_SIGNAL_TYPE
+
+        missing = [key for key in required_keys if not normalized.get(key)]
+        if missing:
+            return (
+                None,
+                f'ERROR: configurations[{idx}] missing required fields: {", ".join(missing)}',
+            )
+
+        if normalized['InstrumentationType'] not in allowed_instrumentation:
+            return (
+                None,
+                f'ERROR: configurations[{idx}] invalid InstrumentationType: {normalized["InstrumentationType"]}',
+            )
+
+        if normalized['SignalType'] not in allowed_signal:
+            return (
+                None,
+                f'ERROR: configurations[{idx}] invalid SignalType: {normalized["SignalType"]}',
+            )
+
+        if normalized['Status'] not in allowed_status:
+            return None, f'ERROR: configurations[{idx}] invalid Status: {normalized["Status"]}'
+
+        if 'ErrorCause' in normalized and normalized['ErrorCause'] not in allowed_error_cause:
+            return (
+                None,
+                f'ERROR: configurations[{idx}] invalid ErrorCause: {normalized["ErrorCause"]}',
+            )
+
+        location_hash = normalized.get('LocationHash')
+        if not isinstance(location_hash, str) or len(location_hash) != 16:
+            return None, f'ERROR: configurations[{idx}] LocationHash must be a 16-character string'
+
+        normalized_list.append(normalized)
+
+    return normalized_list, None

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
@@ -19,12 +19,18 @@ from typing import List, Optional, Tuple
 
 def normalize_instrumentation_type(
     instrumentation_type: str,
-) -> Tuple[Optional[str], Optional[str]]:
-    """Normalize the type to upper-case; return ``(normalized, error)``."""
+) -> Tuple[str, Optional[str]]:
+    """Normalize the type to upper-case; return ``(normalized, error)``.
+
+    The normalized value is always a ``str`` (the upper-cased received value
+    even on the error path) so callers get a non-optional type once they
+    return early on ``error``. Callers must check ``error`` before using
+    ``normalized``.
+    """
     normalized = (instrumentation_type or '').strip().upper()
     allowed = {'BREAKPOINT', 'PROBE'}
     if normalized not in allowed:
-        return None, (
+        return normalized, (
             'ERROR: instrumentation_type must be one of BREAKPOINT, PROBE '
             f'(received: {instrumentation_type})'
         )
@@ -40,14 +46,19 @@ def validate_snapshot_signal(signal_type: str) -> Optional[str]:
 
 
 def _format_code_location_troubleshooting(
-    language: str,
-    file_path: str,
+    language: Optional[str],
+    file_path: Optional[str],
     code_unit: Optional[str],
     class_name: Optional[str],
     method_name: Optional[str],
     line_number: Optional[int],
 ) -> str:
-    """Build troubleshooting guidance for code-location create failures."""
+    """Build troubleshooting guidance for code-location create failures.
+
+    ``language``/``file_path`` are ``Optional`` because callers pass raw,
+    unvalidated MCP inputs (which may be ``None``); the body renders them
+    verbatim and guards with ``(language or '')`` where it matters.
+    """
     lang = (language or '').strip().lower()
 
     lines = [

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 """Validation and normalization helpers for instrumentation inputs."""
 
+import re
 from .constants import SNAPSHOT_SIGNAL_TYPE
 from typing import List, Optional, Tuple
+
+
+_LOCATION_HASH_RE = re.compile(r'[0-9a-f]{16}')
 
 
 def normalize_instrumentation_type(
@@ -35,6 +39,18 @@ def normalize_instrumentation_type(
             f'(received: {instrumentation_type})'
         )
     return normalized, None
+
+
+def is_valid_location_hash(location_hash: Optional[str]) -> bool:
+    """Return True for a 16-character lowercase hexadecimal location hash.
+
+    Location hashes are 16 lowercase hex characters by API design. Validating
+    against this shape (rather than only checking length) lets snapshot/status
+    tools reject malformed input before it is interpolated into a CloudWatch
+    Logs Insights query — hex can never contain the double-quote that would
+    otherwise break out of a query string literal.
+    """
+    return bool(location_hash and _LOCATION_HASH_RE.fullmatch(location_hash))
 
 
 def validate_snapshot_signal(signal_type: str) -> Optional[str]:

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/server.py
@@ -50,6 +50,9 @@ from .canary_utils import (
     get_canary_metrics_and_service_insights,
 )
 from .change_tools import list_change_events
+from .dynamic_instrumentation.registration import (
+    register_tools as register_dynamic_instrumentation_tools,
+)
 from .enablement_tools import get_enablement_guide
 from .group_tools import (
     audit_group_health,
@@ -1708,6 +1711,9 @@ mcp.tool()(list_grouping_attribute_definitions)
 
 # RUM tools
 mcp.tool()(query_rum_events)
+
+# Dynamic instrumentation tools (preview - see dynamic_instrumentation/aws_data/README.md)
+register_dynamic_instrumentation_tools(mcp)
 
 
 def main():

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_capture.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_capture.py
@@ -1,0 +1,131 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct tests for the Capture ADT (capture.py).
+
+The ADT owns the CaptureConfiguration API shape contract — payload
+assembly via ``to_api_payload`` and inverse parsing via
+``capture_from_response``. These tests pin the contract that:
+
+* ``CaptureArguments`` distinguishes "omitted" (capture all) from
+  "present-but-empty" (capture none) across the round-trip.
+* The legacy fallback (CodeCapture-shaped dict without the wrapper key)
+  still parses to ``CodeCapture``.
+* Unknown payloads parse to ``UnknownCapture`` rather than raising.
+"""
+
+import pytest
+from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.capture import (
+    CaptureLimits,
+    CodeCapture,
+    UnknownCapture,
+    capture_from_response,
+)
+
+
+class TestCaptureFromResponse:
+    """capture_from_response on every shape the API can return."""
+
+    def test_parses_code_capture_with_full_payload(self):
+        """Parses code capture with full payload."""
+        cap = capture_from_response(
+            {
+                'CodeCapture': {
+                    'CaptureReturn': True,
+                    'CaptureStackTrace': False,
+                    'CaptureArguments': ['order_id'],
+                    'CaptureLocals': ['x', 'y'],
+                    'CaptureLimits': {'MaxHits': 3, 'MaxStringLength': 128},
+                }
+            }
+        )
+        assert isinstance(cap, CodeCapture)
+        assert cap.capture_return is True
+        assert cap.capture_stack_trace is False
+        assert cap.capture_arguments == ('order_id',)
+        assert cap.capture_locals == ('x', 'y')
+        assert cap.limits.max_hits == 3
+        assert cap.limits.max_string_length == 128
+        assert cap.limits.max_collection_width is None
+
+    def test_unknown_payload_returns_unknown_capture(self):
+        """Unknown payload returns unknown capture."""
+        cap = capture_from_response({'FuturisticCapture': {'Foo': 1}})
+        assert isinstance(cap, UnknownCapture)
+        assert cap.raw == {'FuturisticCapture': {'Foo': 1}}
+
+    def test_non_dict_input_returns_empty_unknown_capture(self):
+        """Non dict input returns empty unknown capture."""
+        cap = capture_from_response(None)
+        assert isinstance(cap, UnknownCapture)
+        assert cap.raw == {}
+
+    def test_legacy_fallback_infers_code_capture_without_wrapper_key(self):
+        """Legacy fallback infers code capture without wrapper key."""
+        # Some response shapes return CodeCapture-style dicts directly without
+        # the CodeCapture wrapper. The legacy extract_capture_variant accepted
+        # this; the ADT's ``capture_from_response`` must too.
+        cap = capture_from_response(
+            {'CaptureReturn': True, 'CaptureStackTrace': True, 'CaptureLimits': {'MaxHits': 5}}
+        )
+        assert isinstance(cap, CodeCapture)
+        assert cap.capture_return is True
+        assert cap.limits.max_hits == 5
+
+
+class TestCaptureArgumentsRoundTrip:
+    """Omitted-vs-empty CaptureArguments survives parse → payload → parse."""
+
+    def test_omitted_arguments_round_trip_to_omitted(self):
+        """Omitted arguments round trip to omitted."""
+        cap = CodeCapture(capture_return=True, capture_stack_trace=True, capture_arguments=None)
+        payload = cap.to_api_payload()
+        assert 'CaptureArguments' not in payload['CodeCapture']
+        round_tripped = capture_from_response(payload)
+        assert isinstance(round_tripped, CodeCapture)
+        assert round_tripped.capture_arguments is None
+
+    def test_empty_arguments_round_trip_to_empty(self):
+        """Empty arguments round trip to empty."""
+        cap = CodeCapture(capture_return=True, capture_stack_trace=True, capture_arguments=[])
+        # The dataclass stores capture_arguments as a tuple regardless of how
+        # the caller spelled the empty sequence; the API payload still emits
+        # a JSON list so the wire contract is unchanged.
+        assert cap.capture_arguments == ()
+        payload = cap.to_api_payload()
+        assert payload['CodeCapture']['CaptureArguments'] == []
+        round_tripped = capture_from_response(payload)
+        assert isinstance(round_tripped, CodeCapture)
+        assert round_tripped.capture_arguments == ()
+
+
+class TestCaptureLimits:
+    """CaptureLimits emit only the keys that were set."""
+
+    def test_empty_limits_emit_empty_payload(self):
+        """Empty limits emit empty payload."""
+        assert CaptureLimits().is_empty()
+        assert CaptureLimits().to_api_payload() == {}
+
+    def test_partial_limits_emit_only_set_keys(self):
+        """Partial limits emit only set keys."""
+        payload = CaptureLimits(max_hits=3, max_object_depth=5).to_api_payload()
+        assert payload == {'MaxHits': 3, 'MaxObjectDepth': 5}
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_snapshot_queries.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_snapshot_queries.py
@@ -1,0 +1,201 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dynamic_instrumentation/snapshot_queries.py."""
+
+import boto3
+from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_queries import (
+    _execute_cloudwatch_query,
+)
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+from unittest.mock import MagicMock, patch
+
+
+TIME = 'awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_queries.time'
+LOGS_CLIENT = 'awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_queries.aws_clients.logs_client'
+
+
+def _stub_logs():
+    """Patch the shared parent logs_client with a stubbed client for the test."""
+    client = boto3.client('logs', region_name='us-east-1')
+    stubber = Stubber(client)
+    stubber.activate()
+    patcher = patch(LOGS_CLIENT, client)
+    patcher.start()
+    return stubber, patcher
+
+
+class TestExecuteCloudwatchQuery:
+    """Cover the start/poll lifecycle of _execute_cloudwatch_query."""
+
+    @patch(TIME)
+    def test_success_complete(self, mock_time):
+        """Successful query returns parsed results."""
+        mock_time.time.side_effect = [0, 1]
+        mock_time.sleep = MagicMock()
+        stubber, patcher = _stub_logs()
+        try:
+            stubber.add_response('start_query', {'queryId': 'q-1'})
+            stubber.add_response(
+                'get_query_results',
+                {
+                    'status': 'Complete',
+                    'results': [[{'field': '@timestamp', 'value': '2024-01-01'}]],
+                    'statistics': {
+                        'recordsMatched': 1.0,
+                        'recordsScanned': 1.0,
+                        'bytesScanned': 100.0,
+                    },
+                },
+            )
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group'
+            )
+            stubber.assert_no_pending_responses()
+        finally:
+            patcher.stop()
+        assert result['status'] == 'Complete'
+        assert result['queryId'] == 'q-1'
+        assert len(result['results']) == 1
+        assert result['results'][0]['@timestamp'] == '2024-01-01'
+
+    def test_start_failure(self):
+        """A start_query client error is reported as an error result."""
+        stubber, patcher = _stub_logs()
+        try:
+            stubber.add_client_error(
+                'start_query',
+                service_error_code='AccessDenied',
+                service_message='access denied',
+            )
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group'
+            )
+        finally:
+            patcher.stop()
+        assert result['status'] == 'Error'
+        assert 'Failed to start query' in result['error']
+
+    @patch(TIME)
+    def test_poll_failure(self, mock_time):
+        """A get_query_results client error is reported as an error result."""
+        mock_time.time.side_effect = [0, 1]
+        mock_time.sleep = MagicMock()
+        stubber, patcher = _stub_logs()
+        try:
+            stubber.add_response('start_query', {'queryId': 'q-1'})
+            stubber.add_client_error(
+                'get_query_results',
+                service_error_code='ThrottlingException',
+                service_message='slow down',
+            )
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group'
+            )
+        finally:
+            patcher.stop()
+        assert result['status'] == 'Error'
+        assert 'Failed to get results' in result['error']
+        assert result['queryId'] == 'q-1'
+
+    @patch(TIME)
+    def test_failed_status(self, mock_time):
+        """A Failed query status is surfaced verbatim."""
+        mock_time.time.side_effect = [0, 1]
+        mock_time.sleep = MagicMock()
+        stubber, patcher = _stub_logs()
+        try:
+            stubber.add_response('start_query', {'queryId': 'q-1'})
+            stubber.add_response(
+                'get_query_results',
+                {
+                    'status': 'Failed',
+                    'results': [],
+                    'statistics': {
+                        'recordsMatched': 0.0,
+                        'recordsScanned': 0.0,
+                        'bytesScanned': 0.0,
+                    },
+                },
+            )
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group'
+            )
+        finally:
+            patcher.stop()
+        assert result['status'] == 'Failed'
+
+    @patch(TIME)
+    def test_poll_timeout(self, mock_time):
+        """Polling past max_timeout returns a timeout result."""
+        # First time.time() is poll_start, next call is past max_timeout — loop exits.
+        mock_time.time.side_effect = [0, 100]
+        mock_time.sleep = MagicMock()
+        stubber, patcher = _stub_logs()
+        try:
+            stubber.add_response('start_query', {'queryId': 'q-1'})
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group', max_timeout=30
+            )
+        finally:
+            patcher.stop()
+        assert result['status'] == 'Polling Timeout'
+
+    def test_start_query_unexpected_exception(self):
+        """An unexpected (non-ClientError) start exception is captured."""
+        with patch(LOGS_CLIENT, _RaisingClient(start_exc=RuntimeError('unexpected'))):
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group'
+            )
+        assert result['status'] == 'Error'
+        assert 'unexpected' in result['error']
+
+    def test_start_query_missing_query_id(self):
+        """A start response without a queryId is reported as an error."""
+        with patch(LOGS_CLIENT, _FakeClient(start_response={})):
+            result = _execute_cloudwatch_query(
+                'fields @timestamp', 1000, 2000, log_group_name='/test/log-group'
+            )
+        assert result['status'] == 'Error'
+        assert 'did not return a queryId' in result['error']
+
+
+class _FakeClient:
+    """Minimal duck-typed CloudWatch Logs client for tests that bypass Stubber."""
+
+    def __init__(self, start_response=None):
+        """Store the canned start_query response."""
+        self._start_response = start_response or {}
+
+    def start_query(self, **_kwargs):
+        """Return the canned start_query response."""
+        return self._start_response
+
+
+class _RaisingClient:
+    """A client whose start_query raises a configured exception."""
+
+    def __init__(self, start_exc=None):
+        """Store the exception start_query should raise."""
+        self._start_exc = start_exc
+
+    def start_query(self, **_kwargs):
+        """Raise the configured start exception."""
+        if self._start_exc is not None:
+            raise self._start_exc
+
+    def get_query_results(self, **_kwargs):
+        """Raise a ClientError for completeness."""
+        raise ClientError({'Error': {'Code': 'x', 'Message': 'x'}}, 'GetQueryResults')

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_status_assessment.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_status_assessment.py
@@ -1,0 +1,193 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-function tests for the consolidated status assessment policy.
+
+The assessment owns the priority order (ACTIVE → READY → ERROR/PENDING) and
+the ACTIVE-window clamp. These tests exercise that policy with a fake
+``check_status`` callable so no AWS stub is required.
+"""
+
+import pytest
+from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.status_assessment import (
+    Active,
+    ErrorOrPending,
+    Ready,
+    TimeWindow,
+    assess,
+)
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple
+
+
+def _fake_check(
+    events_per_status: Dict[str, List[dict]], errors_per_status: Optional[Dict[str, str]] = None
+):
+    """Build a ``check_status`` callable backed by an in-memory script."""
+    errors_per_status = errors_per_status or {}
+    calls: List[Tuple[str, datetime, datetime]] = []
+
+    def check(
+        status: str, start: datetime, end: datetime
+    ) -> Tuple[bool, List[dict], Optional[str]]:
+        calls.append((status, start, end))
+        if status in errors_per_status:
+            return False, [], errors_per_status[status]
+        events = events_per_status.get(status, [])
+        return bool(events), events, None
+
+    check.calls = calls  # type: ignore[attr-defined]
+    return check
+
+
+CREATED = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+START = datetime(2026, 5, 1, 12, 30, 0, tzinfo=timezone.utc)
+END = datetime(2026, 5, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+
+class TestAssessmentPriority:
+    """Verdict picks the highest-priority confirmed status."""
+
+    def test_active_wins_when_active_has_events(self):
+        """Active wins when active has events."""
+        check = _fake_check({'ACTIVE': [{'Time': 'now'}], 'READY': [{'Time': 'ignored'}]})
+        verdict, _ = assess(
+            created_at=CREATED, requested_start=START, query_end=END, check_status=check
+        )
+        assert isinstance(verdict, Active)
+        assert verdict.active.has_events is True
+        # Should short-circuit before checking READY/ERROR.
+        statuses_called = [s for s, _, _ in check.calls]  # type: ignore[attr-defined]
+        assert statuses_called == ['ACTIVE']
+
+    def test_ready_wins_when_active_empty_and_ready_has_events(self):
+        """Ready wins when active empty and ready has events."""
+        check = _fake_check({'READY': [{'Time': 'ready-event'}]})
+        verdict, _ = assess(
+            created_at=CREATED, requested_start=START, query_end=END, check_status=check
+        )
+        assert isinstance(verdict, Ready)
+        assert verdict.ready.has_events is True
+        assert verdict.active.has_events is False
+        statuses_called = [s for s, _, _ in check.calls]  # type: ignore[attr-defined]
+        assert statuses_called == ['ACTIVE', 'READY']
+
+    def test_error_or_pending_when_active_and_ready_empty(self):
+        """Error or pending when active and ready empty."""
+        check = _fake_check({'ERROR': [{'Time': 'boom', 'ErrorCause': 'FILE_NOT_FOUND'}]})
+        verdict, _ = assess(
+            created_at=CREATED, requested_start=START, query_end=END, check_status=check
+        )
+        assert isinstance(verdict, ErrorOrPending)
+        assert verdict.error.has_events is True
+        assert verdict.error.events[0]['ErrorCause'] == 'FILE_NOT_FOUND'
+
+    def test_pending_when_all_three_checks_empty(self):
+        """Pending when all three checks empty."""
+        check = _fake_check({})
+        verdict, _ = assess(
+            created_at=CREATED, requested_start=START, query_end=END, check_status=check
+        )
+        assert isinstance(verdict, ErrorOrPending)
+        assert verdict.active.has_events is False
+        assert verdict.ready.has_events is False
+        assert verdict.error.has_events is False
+
+
+class TestActiveWindowClamp:
+    """ACTIVE is searched only after the resource was created."""
+
+    def test_active_start_is_clamped_to_created_at_when_request_predates_creation(self):
+        """Active start is clamped to created at when request predates creation."""
+        # requested_start is *before* created_at — clamp must push ACTIVE start forward.
+        requested_start = CREATED - timedelta(hours=1)
+        end = CREATED + timedelta(minutes=30)
+        check = _fake_check({})
+        verdict, time_window = assess(
+            created_at=CREATED, requested_start=requested_start, query_end=end, check_status=check
+        )
+
+        active_call = next(call for call in check.calls if call[0] == 'ACTIVE')  # type: ignore[attr-defined]
+        _, active_start, active_end = active_call
+        assert active_start == CREATED
+        assert active_end == end
+        assert time_window.active_query_start == '2026-05-01T12:00:00Z'
+        assert time_window.requested_start == '2026-05-01T11:00:00Z'
+        # And we keep going through READY/ERROR since ACTIVE was empty.
+        assert isinstance(verdict, ErrorOrPending)
+
+    def test_active_skipped_when_clamped_window_is_empty(self):
+        """Active skipped when clamped window is empty."""
+        # query_end is before created_at, so the clamped ACTIVE window collapses.
+        requested_start = CREATED - timedelta(hours=2)
+        end = CREATED - timedelta(minutes=30)
+        check = _fake_check({'READY': [{'Time': 'ready'}]})
+        verdict, time_window = assess(
+            created_at=CREATED, requested_start=requested_start, query_end=end, check_status=check
+        )
+
+        # ACTIVE was *not* called at all — the policy short-circuits the empty window.
+        statuses_called = [s for s, _, _ in check.calls]  # type: ignore[attr-defined]
+        assert 'ACTIVE' not in statuses_called
+        assert isinstance(verdict, Ready)
+        assert verdict.active.has_events is False
+        assert verdict.active.error is not None
+        assert 'Skipped' in verdict.active.error
+        # The skip-reason carries the clamped window for the renderer.
+        assert time_window.active_query_start in verdict.active.error
+        assert time_window.query_end in verdict.active.error
+
+
+class TestCheckErrorsPropagate:
+    """Errors from a check call are surfaced on the verdict, not raised."""
+
+    def test_active_check_error_does_not_short_circuit(self):
+        """Active check error does not short circuit."""
+        check = _fake_check(
+            events_per_status={'READY': [{'Time': 'ready'}]},
+            errors_per_status={'ACTIVE': 'API error: boom'},
+        )
+        verdict, _ = assess(
+            created_at=CREATED, requested_start=START, query_end=END, check_status=check
+        )
+        # ACTIVE failed → has_events False → fall through. READY then wins.
+        assert isinstance(verdict, Ready)
+        assert verdict.active.error == 'API error: boom'
+
+
+class TestTimeWindowFormatting:
+    """The TimeWindow view-model holds ISO strings the renderer needs."""
+
+    def test_time_window_iso_strings_use_utc_z_suffix(self):
+        """Time window iso strings use utc z suffix."""
+        # Pass a non-UTC datetime; assessment should convert.
+        non_utc = datetime(2026, 5, 1, 9, 0, 0, tzinfo=timezone(timedelta(hours=-3)))
+        end = non_utc + timedelta(hours=2)
+        check = _fake_check({})
+        _, time_window = assess(
+            created_at=non_utc, requested_start=non_utc, query_end=end, check_status=check
+        )
+
+        assert isinstance(time_window, TimeWindow)
+        # 09:00 UTC-3 == 12:00 UTC.
+        assert time_window.created_at == '2026-05-01T12:00:00Z'
+        assert time_window.requested_start == '2026-05-01T12:00:00Z'
+        assert time_window.query_end == '2026-05-01T14:00:00Z'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -1,0 +1,926 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dynamic instrumentation helper modules."""
+
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.aws_clients as aws_clients
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.capture as capture
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.constants as constants
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.crud_rendering as crud_rendering
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.crud_tools as crud_tools
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.error_translation as error_translation
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.location as location
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.registration as registration
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_parsing as snapshot_parsing
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_rendering as snapshot_rendering
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.status_rendering as status_rendering
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.validation as validation
+import json
+import os
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError, NoCredentialsError
+from botocore.stub import Stubber
+from datetime import datetime, timezone
+
+
+class RecorderMCP:
+    """Capture tool registration without depending on a live MCP server."""
+
+    def __init__(self):
+        """Initialize the recorder."""
+        self.registered = []
+
+    def tool(self):
+        """Return a decorator that records the registered tool's name."""
+
+        def _decorator(func):
+            self.registered.append(func.__name__)
+            return func
+
+        return _decorator
+
+
+@pytest.fixture(autouse=True)
+def _reset_dynamic_instrumentation_clients():
+    """Drop cached boto3 clients between tests so Stubber can target a fresh client."""
+    aws_clients._reset_clients()
+    yield
+    aws_clients._reset_clients()
+
+
+class TestBoto3ClientFactory:
+    """Test the lazy boto3 client factory for dynamic instrumentation."""
+
+    def test_application_signals_client_loads_private_model(self):
+        """Application signals client loads private model."""
+        client = aws_clients.get_application_signals_client()
+        assert 'CreateInstrumentationConfiguration' in client.meta.service_model.operation_names
+        assert client.meta.service_model.api_version == aws_clients.APPLICATION_SIGNALS_API_VERSION
+
+    def test_application_signals_client_is_singleton(self):
+        """Application signals client is singleton."""
+        first = aws_clients.get_application_signals_client()
+        second = aws_clients.get_application_signals_client()
+        assert first is second
+
+    def test_default_endpoint_resolution(self):
+        """The client uses normal AWS endpoint resolution."""
+        aws_clients._reset_clients()
+        client = aws_clients.get_application_signals_client()
+        assert client.meta.endpoint_url.startswith('https://')
+        assert 'application-signals' in client.meta.endpoint_url
+
+
+class TestErrorTranslator:
+    """Test the boto3 exception → human message helper."""
+
+    def _make_client_error(self, code: str, message: str) -> ClientError:
+        return ClientError(
+            error_response={'Error': {'Code': code, 'Message': message}},
+            operation_name='CreateInstrumentationConfiguration',
+        )
+
+    def test_client_error_includes_code_and_message(self):
+        """Client error includes code and message."""
+        rendered = error_translation.translate_aws_error(
+            self._make_client_error('ValidationException', 'bad input'),
+            action='create instrumentation',
+            context={'Service': 'svc', 'Environment': 'env'},
+        )
+        assert 'ValidationException' in rendered
+        assert 'bad input' in rendered
+        assert 'ATTEMPTED PARAMETERS:' in rendered
+        assert '- Service: svc' in rendered
+
+    def test_endpoint_connection_error_renders_endpoint_guidance(self):
+        """Endpoint connection error renders endpoint guidance."""
+        rendered = error_translation.translate_aws_error(
+            EndpointConnectionError(endpoint_url='http://x'),
+            action='list instrumentations',
+        )
+        assert 'EndpointConnectionError' in rendered
+        assert 'network connectivity' in rendered
+
+    def test_no_credentials_error_renders_credential_guidance(self):
+        """No credentials error renders credential guidance."""
+        rendered = error_translation.translate_aws_error(
+            NoCredentialsError(),
+            action='get instrumentation',
+        )
+        assert 'NoCredentialsError' in rendered
+        assert 'aws configure list' in rendered
+
+    def test_generic_exception_falls_back_to_unexpected_error(self):
+        """Generic exception falls back to unexpected error."""
+        rendered = error_translation.translate_aws_error(
+            RuntimeError('boom'),
+            action='probe',
+        )
+        assert 'Unexpected error: boom' in rendered
+
+    def test_context_with_blank_values_renders_without_placeholders(self):
+        """Context with blank values renders without placeholders."""
+        rendered = error_translation.translate_aws_error(
+            self._make_client_error('InternalFailure', 'whoops'),
+            action='x',
+            context={'Service': 'svc', 'Environment': ''},
+        )
+        assert '- Service: svc' in rendered
+        assert 'Environment: ' not in rendered
+
+    def test_render_client_error_emits_all_sections_in_order(self):
+        """Render client error emits all sections in order."""
+        rendered = error_translation.render_client_error(
+            self._make_client_error('ValidationException', 'bad input'),
+            action='create instrumentation',
+            attempted_label='ATTEMPTED CONFIGURATION:',
+            attempted={'Service': 'svc', 'Environment': 'env'},
+            possible_causes=['First cause', 'Second cause'],
+            troubleshooting=['Step one'],
+            trailer='LOCATION TROUBLESHOOTING:\n- something',
+        )
+        assert 'Failed to create instrumentation' in rendered
+        assert 'Error: ValidationException - bad input' in rendered
+        assert 'ATTEMPTED CONFIGURATION:\n- Service: svc' in rendered
+        assert 'POSSIBLE CAUSES:\n1. First cause\n2. Second cause' in rendered
+        assert 'TROUBLESHOOTING:\n1. Step one' in rendered
+        assert rendered.endswith('LOCATION TROUBLESHOOTING:\n- something')
+
+
+class TestCrudToolsBoto3Integration:
+    """Stubber-driven coverage for the boto3 CRUD path."""
+
+    def _stub_application_signals(self) -> Stubber:
+        client = aws_clients.get_application_signals_client()
+        stubber = Stubber(client)
+        stubber.activate()
+        return stubber
+
+    def test_list_instrumentations_renders_empty_list(self):
+        """List instrumentations renders empty list."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'list_instrumentation_configurations',
+            {
+                'Service': 'svc',
+                'Environment': 'env',
+                'Changed': False,
+                'LatestConfigurations': [],
+                'SyncedAt': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'SyncInterval': 60,
+            },
+            expected_params={
+                'Service': 'svc',
+                'Environment': 'env',
+                'InstrumentationType': 'BREAKPOINT',
+            },
+        )
+        rendered = crud_tools.list_instrumentations(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'No active BREAKPOINT instrumentations found' in rendered
+
+    def test_list_instrumentations_translates_client_error(self):
+        """List instrumentations translates client error."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'list_instrumentation_configurations',
+            service_error_code='ValidationException',
+            service_message='bad scope',
+        )
+        rendered = crud_tools.list_instrumentations(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'Failed to list instrumentations' in rendered
+        assert 'ValidationException' in rendered
+        assert 'bad scope' in rendered
+
+    def test_create_instrumentation_strips_wildcard_capture_argument(self):
+        """Create instrumentation strips wildcard capture argument."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'create_instrumentation_configuration',
+            {
+                'InstrumentationType': 'BREAKPOINT',
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Location': {
+                    'CodeLocation': {
+                        'Language': 'Python',
+                        'FilePath': '/app/handler.py',
+                        'MethodName': 'run',
+                    }
+                },
+                'LocationHash': 'aaaabbbbccccdddd',
+                'Description': 'MCP dynamic instrumentation',
+                'ExpiresAt': datetime(2026, 3, 10, 12, 0, 0, tzinfo=timezone.utc),
+                'CaptureConfiguration': {
+                    'CodeCapture': {
+                        'CaptureArguments': ['order_id'],
+                        'CaptureReturn': True,
+                        'CaptureStackTrace': True,
+                        'CaptureLimits': {},
+                    }
+                },
+                'CreatedAt': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'ARN': 'arn:demo',
+            },
+        )
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/handler.py',
+            code_unit='services.handler',
+            method_name='run',
+            capture_arguments=['order_id', '*'],
+        )
+        stubber.assert_no_pending_responses()
+        assert 'Successfully created BREAKPOINT instrumentation' in rendered
+        assert 'wildcard * is not supported and was ignored' in rendered
+        assert 'aaaabbbbccccdddd' in rendered
+
+    def test_create_instrumentation_renders_client_error_with_attempted_block(self):
+        """Create instrumentation renders client error with attempted block."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'create_instrumentation_configuration',
+            service_error_code='ResourceAlreadyExistsException',
+            service_message='duplicate location',
+        )
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/handler.py',
+            code_unit='services.handler',
+            method_name='run',
+            capture_arguments=['order_id'],
+        )
+        assert 'Failed to create BREAKPOINT instrumentation' in rendered
+        assert 'ResourceAlreadyExistsException' in rendered
+        assert 'ATTEMPTED CONFIGURATION:' in rendered
+        assert '/app/handler.py.run' in rendered
+
+    def test_delete_instrumentation_uses_dict_location_identifier(self):
+        """Delete instrumentation uses dict location identifier."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'delete_instrumentation_configuration',
+            {'DeletionStatus': 'DELETED'},
+            expected_params={
+                'InstrumentationType': 'BREAKPOINT',
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'LocationIdentifier': {'LocationHash': 'aaaabbbbccccdddd'},
+            },
+        )
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'Successfully deleted BREAKPOINT instrumentation' in rendered
+
+    def test_get_instrumentation_unwraps_configuration(self):
+        """Get instrumentation unwraps configuration."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration',
+            {
+                'Configuration': {
+                    'InstrumentationType': 'BREAKPOINT',
+                    'Service': 'svc',
+                    'Environment': 'env',
+                    'SignalType': 'SNAPSHOT',
+                    'LocationHash': 'aaaabbbbccccdddd',
+                    'Location': {
+                        'CodeLocation': {
+                            'Language': 'Python',
+                            'FilePath': '/app/handler.py',
+                            'MethodName': 'run',
+                        }
+                    },
+                    'CaptureConfiguration': {
+                        'CodeCapture': {
+                            'CaptureArguments': ['order_id'],
+                            'CaptureReturn': True,
+                            'CaptureStackTrace': True,
+                            'CaptureLimits': {},
+                        }
+                    },
+                    'CreatedAt': datetime(2026, 3, 9, 11, 0, 0, tzinfo=timezone.utc),
+                    'Description': 'demo',
+                    'ARN': 'arn:demo',
+                }
+            },
+        )
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'INSTRUMENTATION CONFIGURATION' in rendered
+        assert 'aaaabbbbccccdddd' in rendered
+
+    def test_batch_delete_by_scope_renders_summary(self):
+        """Batch delete by scope renders summary."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'batch_delete_instrumentation_configurations',
+            {
+                'DeletedCount': 2,
+                'SuccessfulDeletions': [
+                    {'SignalType': 'SNAPSHOT', 'LocationHash': 'aaaabbbbccccdddd'},
+                    {'SignalType': 'SNAPSHOT', 'LocationHash': '1111111111111111'},
+                ],
+                'Errors': [],
+            },
+            expected_params={
+                'DeletionTarget': {
+                    'Scope': {
+                        'Service': 'svc',
+                        'Environment': 'env',
+                        'InstrumentationType': 'BREAKPOINT',
+                    }
+                }
+            },
+        )
+        rendered = crud_tools.batch_delete_instrumentations_by_scope(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'DeletedCount: 2' in rendered
+        assert 'SuccessfulDeletions: 2' in rendered
+
+
+class TestLocationLookupParser:
+    """Test parse_lookup_inputs across supported input shapes."""
+
+    def test_resolves_hash(self):
+        """Resolves hash."""
+        loc, error = location.parse_lookup_inputs(
+            normalized_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert error is None
+        assert loc is not None
+        assert loc.describe() == 'LocationHash aaaabbbbccccdddd'
+        assert loc.to_identifier() == {'LocationHash': 'aaaabbbbccccdddd'}
+
+    def test_resolves_code_location(self):
+        """Resolves code location."""
+        loc, error = location.parse_lookup_inputs(
+            normalized_type='PROBE',
+            language='Python',
+            file_path='/app/handler.py',
+            method_name='run',
+        )
+        assert error is None
+        assert loc is not None
+        assert loc.to_identifier() == {
+            'CodeLocation': {
+                'Language': 'Python',
+                'FilePath': '/app/handler.py',
+                'MethodName': 'run',
+            }
+        }
+        assert loc.describe() == '/app/handler.py.run'
+
+
+class TestLocationVariantContracts:
+    """Pin the asymmetric-by-design interface on HashLocation and UnknownLocation.
+
+    The asymmetric-by-design interface on HashLocation and the
+    forward-compat behavior on UnknownLocation, so a future refactor
+    that calls these methods generically fails loudly instead of
+    silently producing malformed output.
+    """
+
+    def test_hash_location_to_api_payload_raises_with_teaching_message(self):
+        """Hash location to api payload raises with teaching message."""
+        loc = location.HashLocation(location_hash='aaaabbbbccccdddd')
+        with pytest.raises(NotImplementedError) as exc_info:
+            loc.to_api_payload()
+        message = str(exc_info.value)
+        assert 'HashLocation cannot be used in create requests' in message
+        assert 'to_identifier()' in message
+
+    def test_hash_location_format_details_raises_with_teaching_message(self):
+        """Hash location format details raises with teaching message."""
+        loc = location.HashLocation(location_hash='aaaabbbbccccdddd')
+        with pytest.raises(NotImplementedError) as exc_info:
+            loc.format_details()
+        message = str(exc_info.value)
+        assert 'HashLocation has no fields to format' in message
+        assert 'describe()' in message
+
+    def test_hash_location_describe_and_identifier_still_work(self):
+        """Hash location describe and identifier still work."""
+        loc = location.HashLocation(location_hash='aaaabbbbccccdddd')
+        assert loc.describe() == 'LocationHash aaaabbbbccccdddd'
+        assert loc.to_identifier() == {'LocationHash': 'aaaabbbbccccdddd'}
+        assert loc.level() is None
+
+    def test_unknown_location_describe_returns_placeholder(self):
+        """Unknown location describe returns placeholder."""
+        loc = location.location_from_response({'FuturisticLocation': {'Foo': 1}})
+        assert isinstance(loc, location.UnknownLocation)
+        assert loc.describe() == 'N/A'
+        assert loc.level() is None
+
+    def test_unknown_location_format_details_renders_unknown_kind(self):
+        """Unknown location format details renders unknown kind."""
+        loc = location.location_from_response({'FuturisticLocation': {'Foo': 1}})
+        rendered = loc.format_details(location_hash='aaaabbbbccccdddd')
+        assert '- LocationKind: UNKNOWN' in rendered
+        assert '- LocationHash: aaaabbbbccccdddd' in rendered
+        assert '- FuturisticLocation: ' in rendered
+
+    def test_unknown_location_format_details_handles_empty_payload(self):
+        """Unknown location format details handles empty payload."""
+        loc = location.location_from_response(None)
+        assert isinstance(loc, location.UnknownLocation)
+        rendered = loc.format_details()
+        assert '- LocationKind: UNKNOWN' in rendered
+        assert 'Location payload could not be parsed.' in rendered
+
+
+class TestSignalValidationAndNormalization:
+    """Test signal validation and status normalization helpers."""
+
+    def test_validate_snapshot_signal_accepts_snapshot(self):
+        """Validate snapshot signal accepts snapshot."""
+        assert validation.validate_snapshot_signal('SNAPSHOT') is None
+
+    def test_validate_snapshot_signal_rejects_span(self):
+        """Validate snapshot signal rejects span."""
+        error = validation.validate_snapshot_signal('SPAN')
+        assert error is not None
+        assert 'must be SNAPSHOT' in error
+
+    def test_normalize_status_defaults_signal_to_snapshot(self):
+        """Normalize status defaults signal to snapshot."""
+        normalized, error = validation.normalize_status_configurations(
+            [
+                {
+                    'InstrumentationType': 'BREAKPOINT',
+                    'LocationHash': 'aaaabbbbccccdddd',
+                    'Status': 'READY',
+                    'Time': '2026-03-06T00:00:00Z',
+                }
+            ]
+        )
+        assert error is None
+        assert normalized is not None
+        assert normalized[0]['SignalType'] == 'SNAPSHOT'
+
+    def test_normalize_status_rejects_watcher(self):
+        """Normalize status rejects watcher."""
+        normalized, error = validation.normalize_status_configurations(
+            [
+                {
+                    'InstrumentationType': 'WATCHER',
+                    'SignalType': 'SNAPSHOT',
+                    'LocationHash': 'aaaabbbbccccdddd',
+                    'Status': 'READY',
+                    'Time': '2026-03-06T00:00:00Z',
+                }
+            ]
+        )
+        assert normalized is None
+        assert error is not None
+        assert 'invalid InstrumentationType' in error
+
+
+class TestBatchDeleteFormatting:
+    """Test batch-delete response rendering."""
+
+    def test_batch_delete_response_includes_success_and_errors(self):
+        """Batch delete response includes success and errors."""
+        rendered = crud_rendering._format_batch_delete_response(
+            mode='ResourceArns',
+            instrumentation_type='BREAKPOINT',
+            data={
+                'DeletedCount': 1,
+                'SuccessfulDeletions': [
+                    {
+                        'ResourceArn': (
+                            'arn:aws:application-signals:us-west-1:123456789012:'
+                            'instrumentationConfig/svc/env/SNAPSHOT/aaaabbbbccccdddd'
+                        )
+                    }
+                ],
+                'Errors': [
+                    {
+                        'ResourceArn': (
+                            'arn:aws:application-signals:us-west-1:123456789012:'
+                            'instrumentationConfig/svc/env/SNAPSHOT/1111111111111111'
+                        ),
+                        'Code': 'ResourceNotFoundException',
+                        'Message': 'not found',
+                    }
+                ],
+            },
+        )
+        assert 'DeletedCount: 1' in rendered
+        assert 'SuccessfulDeletions: 1' in rendered
+        assert 'Errors: 1' in rendered
+        assert 'ResourceNotFoundException' in rendered
+
+
+class TestCrudRenderingHelpers:
+    """Test CRUD response renderers."""
+
+    def test_render_list_output_formats_boto3_datetimes_in_iso_format(self):
+        """Datetime timestamps render in the original CLI shape.
+
+        boto3 returns timestamps as ``datetime`` objects; the renderer must
+        emit them in the original CLI's ``YYYY-MM-DDTHH:MM:SSZ`` shape so MCP
+        clients see no contract change.
+        """
+        rendered = crud_rendering.render_list_instrumentations_output(
+            data={
+                'SyncedAt': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'LatestConfigurations': [
+                    {
+                        'LocationHash': 'aaaabbbbccccdddd',
+                        'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/x.py'}},
+                        'CaptureConfiguration': {'CodeCapture': {'CaptureLimits': {}}},
+                        'CreatedAt': datetime(2026, 3, 9, 11, 0, 0, tzinfo=timezone.utc),
+                        'ExpiresAt': datetime(2026, 3, 10, 11, 0, 0, tzinfo=timezone.utc),
+                        'ARN': 'arn:demo',
+                    }
+                ],
+            },
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+        )
+        assert 'Synced At: 2026-03-09T12:00:00Z' in rendered
+        assert '- Created: 2026-03-09T11:00:00Z' in rendered
+        assert '- Expires: 2026-03-10T11:00:00Z' in rendered
+
+    def test_render_list_output_includes_location_and_limits(self):
+        """Render list output includes location and limits."""
+        rendered = crud_rendering.render_list_instrumentations_output(
+            data={
+                'SyncedAt': '2026-03-09T12:00:00Z',
+                'LatestConfigurations': [
+                    {
+                        'LocationHash': 'aaaabbbbccccdddd',
+                        'Location': {
+                            'CodeLocation': {
+                                'Language': 'Python',
+                                'FilePath': '/app/handler.py',
+                                'MethodName': 'run',
+                            }
+                        },
+                        'CaptureConfiguration': {
+                            'CodeCapture': {
+                                'CaptureArguments': ['order_id'],
+                                'CaptureReturn': True,
+                                'CaptureStackTrace': False,
+                                'CaptureLocals': ['result'],
+                                'CaptureLimits': {
+                                    'MaxHits': 3,
+                                    'MaxStringLength': 128,
+                                    'MaxCollectionWidth': 10,
+                                },
+                            }
+                        },
+                        'CreatedAt': '2026-03-09T11:00:00Z',
+                        'ExpiresAt': '2026-03-10T11:00:00Z',
+                        'Description': 'demo',
+                        'ARN': 'arn:demo',
+                    }
+                ],
+            },
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+        )
+        assert 'Active BREAKPOINT Instrumentations (1 found)' in rendered
+        assert 'LocationHash: aaaabbbbccccdddd' in rendered
+        assert '- Level: FUNCTION/METHOD-LEVEL' in rendered
+        assert '- Limits: MaxHits=3, MaxStringLen=128, MaxCollWidth=10' in rendered
+
+    def test_render_get_output_includes_attribute_filters_and_metadata(self):
+        """Render get output includes attribute filters and metadata."""
+        rendered = crud_rendering.render_get_instrumentation_output(
+            config={
+                'InstrumentationType': 'BREAKPOINT',
+                'SignalType': 'SNAPSHOT',
+                'LocationHash': 'aaaabbbbccccdddd',
+                'Location': {
+                    'CodeLocation': {
+                        'Language': 'Python',
+                        'FilePath': '/app/handler.py',
+                        'MethodName': 'run',
+                    }
+                },
+                'CaptureConfiguration': {
+                    'CodeCapture': {
+                        'CaptureArguments': [],
+                        'CaptureReturn': True,
+                        'CaptureStackTrace': True,
+                        'CaptureLimits': {
+                            'MaxCollectionDepth': 4,
+                            'MaxObjectDepth': 2,
+                        },
+                    }
+                },
+                'AttributeFilters': [{'Key': 'stage', 'Value': 'prod'}],
+                'Description': 'demo',
+                'CreatedAt': '2026-03-09T11:00:00Z',
+                'ExpiresAt': 'Never',
+                'ARN': 'arn:demo',
+            },
+            service='svc',
+            environment='env',
+        )
+        assert 'INSTRUMENTATION CONFIGURATION' in rendered
+        assert '- Arguments: (none)' in rendered
+        assert '- Max Collection Depth: 4' in rendered
+        assert '- Max Object Depth: 2' in rendered
+        assert 'ATTRIBUTE FILTERS: 1 filter group(s)' in rendered
+        assert '- ARN: arn:demo' in rendered
+
+
+class TestStatusRenderingHelpers:
+    """Test status response renderers."""
+
+    def test_render_get_status_output_includes_confirmation_and_pagination(self):
+        """Render get status output includes confirmation and pagination."""
+        rendered = status_rendering.render_get_instrumentation_configuration_status_output(
+            data={
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Status': 'READY',
+                'LocationHash': 'aaaabbbbccccdddd',
+                'Location': {
+                    'CodeLocation': {
+                        'Language': 'Python',
+                        'FilePath': '/app/handler.py',
+                        'MethodName': 'run',
+                    }
+                },
+                'Events': [{'Time': '2026-03-09T12:00:00Z'}],
+                'NextToken': 'next-page',
+            },
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            requested_status='READY',
+        )
+        assert 'REQUESTED STATUS FILTER: READY' in rendered
+        assert 'Status Confirmation: CONFIRMED' in rendered
+        assert '- Level: FUNCTION/METHOD-LEVEL' in rendered
+        assert 'next_token="next-page"' in rendered
+
+    def test_render_consolidated_error_output_includes_troubleshooting(self):
+        """Render consolidated error output includes troubleshooting."""
+        rendered = status_rendering.render_consolidated_error_or_pending_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+            ready_has_events=False,
+            ready_events=[],
+            ready_error=None,
+            error_has_events=True,
+            error_events=[{'Time': '2026-03-09T11:06:00Z', 'ErrorCause': 'METHOD_NOT_FOUND'}],
+            error_error=None,
+        )
+        assert 'ERROR STATUS:' in rendered
+        assert 'OVERALL STATUS: ERROR (METHOD_NOT_FOUND)' in rendered
+        assert 'Verify method_name and code_unit are correct' in rendered
+
+
+class TestSnapshotHelpers:
+    """Test snapshot parsing and rendering helpers."""
+
+    def test_parse_snapshot_fields_extracts_core_fields(self):
+        """Parse snapshot fields extracts core fields."""
+        rendered = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@timestamp': '2026-03-09T12:00:00Z',
+                '@message': json.dumps(
+                    {
+                        'timeUnixNano': 1762689600000000000,
+                        'traceId': 'trace-123',
+                        'attributes': {
+                            'event.name': 'aws.dynamic_instrumentation.snapshot',
+                            'aws.di.snapshot_id': 'snap-1',
+                            'aws.di.location_hash': 'aaaabbbbccccdddd',
+                            'aws.di.instrumentation_level': 'method',
+                            'aws.di.method_name': 'run',
+                            'aws.di.duration_ms': 42,
+                        },
+                        'body': {
+                            'captures': {
+                                'entry': {
+                                    'arguments': {'order_id': {'type': 'str', 'value': 'A-1'}}
+                                },
+                                'return': {'return_value': {'type': 'int', 'value': '1'}},
+                            },
+                        },
+                    }
+                ),
+            }
+        )
+        assert rendered['snapshot_id'] == 'snap-1'
+        assert rendered['duration_ms'] == 42
+        assert rendered['entry_argument_names'] == ['order_id']
+        assert rendered['return_value']['value'] == '1'
+
+    def test_parse_snapshot_fields_handles_absent_body(self):
+        """Missing snapshot body degrades gracefully.
+
+        Per spec, `body` is absent when the agent produced no stack/captures.
+        The parser must degrade gracefully without raising.
+        """
+        rendered = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@timestamp': '2026-03-09T12:00:00Z',
+                '@message': json.dumps(
+                    {
+                        'timeUnixNano': 1762689600000000000,
+                        'attributes': {
+                            'event.name': 'aws.dynamic_instrumentation.snapshot',
+                            'aws.di.snapshot_id': 'snap-nobody',
+                            'aws.di.location_hash': 'aaaabbbbccccdddd',
+                            'aws.di.instrumentation_level': 'method',
+                            'aws.di.method_name': 'run',
+                        },
+                    }
+                ),
+            }
+        )
+        assert rendered['snapshot_id'] == 'snap-nobody'
+        assert rendered['stack_preview'] == []
+        assert rendered['stack_frame_count'] == 0
+        assert rendered['entry_argument_names'] == []
+        assert rendered['entry_local_names'] == []
+        assert rendered['return_value'] is None
+        assert rendered['line_numbers'] == []
+
+    def test_render_sample_snapshot_output_includes_suggested_filters(self):
+        """Render sample snapshot output includes suggested filters."""
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='2026-03-09T11:59:55Z',
+            end_time_utc='2026-03-09T12:01:00Z',
+            max_timeout=30,
+            query_string='fields @timestamp, @message | limit 1',
+            query_result={
+                'status': 'Complete',
+                'queryId': 'query-123',
+                'results': [
+                    {
+                        '@timestamp': '2026-03-09T12:00:00Z',
+                        '@message': json.dumps(
+                            {
+                                'timeUnixNano': 1762689600000000000,
+                                'traceId': 'trace-123',
+                                'attributes': {
+                                    'event.name': 'aws.dynamic_instrumentation.snapshot',
+                                    'aws.di.snapshot_id': 'snap-1',
+                                    'aws.di.location_hash': 'aaaabbbbccccdddd',
+                                    'aws.di.instrumentation_level': 'method',
+                                    'aws.di.method_name': 'run',
+                                },
+                                'body': {
+                                    'captures': {
+                                        'entry': {
+                                            'arguments': {
+                                                'order_id': {'type': 'str', 'value': 'A-1'}
+                                            }
+                                        },
+                                    },
+                                },
+                            }
+                        ),
+                    }
+                ],
+                'messages': [],
+            },
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'SUCCESS'
+        assert parsed['sample_snapshot']['attributes']['aws.di.snapshot_id'] == 'snap-1'
+        assert parsed['field_documentation']
+        assert 'attributes.aws.di.location_hash' in parsed['field_documentation']
+
+
+class TestCodeInstrumentationArgumentContract:
+    """Test code-instrumentation-specific guardrails."""
+
+    def test_create_requires_capture_arguments_for_code_instrumentation(self):
+        """Create requires capture arguments for code instrumentation."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/demo_app.py',
+            code_unit='__main__',
+            method_name='process_payment',
+        )
+        assert 'capture_arguments is required' in rendered
+        assert 'Inspect the source file' in rendered
+
+    def test_code_capture_preserves_explicit_empty_argument_list(self):
+        """Code capture preserves explicit empty argument list."""
+        cap = capture.CodeCapture(
+            capture_return=True,
+            capture_stack_trace=True,
+            capture_arguments=[],
+        )
+        payload = cap.to_api_payload()
+        assert 'CodeCapture' in payload
+        assert 'CaptureArguments' in payload['CodeCapture']
+        assert payload['CodeCapture']['CaptureArguments'] == []
+
+
+class TestToolRegistration:
+    """Test MCP registration for the dynamic instrumentation surface."""
+
+    def test_register_tools_registers_dynamic_instrumentation_surface(self):
+        """Register tools registers dynamic instrumentation surface."""
+        recorder = RecorderMCP()
+
+        registration.register_tools(recorder)
+
+        assert recorder.registered == [
+            'create_instrumentation',
+            'list_instrumentations',
+            'get_instrumentation',
+            'delete_instrumentation',
+            'batch_delete_instrumentations_by_scope',
+            'batch_delete_instrumentations_by_arns',
+            'get_instrumentation_configuration_status',
+            'check_instrumentation_status',
+            'report_instrumentation_configuration_status',
+            'search_snapshots_for_status_event',
+            'get_sample_snapshot_for_breakpoint',
+        ]
+
+
+class TestSnapshotLogGroupResolution:
+    """Test per-service snapshot log group resolution."""
+
+    def test_substitutes_service_name(self):
+        """The template is filled with the target service name."""
+        assert (
+            constants.resolve_snapshot_log_group('checkout-service')
+            == '/aws/service-events/checkout-service'
+        )
+
+
+# Ensure tests don't depend on any pre-existing AWS credentials in the env.
+# Stubber injects responses without making real API calls, but boto3 still
+# requires *some* credentials when constructing the client. Set placeholders
+# so the factory succeeds in CI environments without configured credentials.
+os.environ.setdefault('AWS_ACCESS_KEY_ID', 'test')
+os.environ.setdefault('AWS_SECRET_ACCESS_KEY', 'test')
+os.environ.setdefault('AWS_DEFAULT_REGION', 'us-west-2')

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -27,6 +27,7 @@ import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.location as location
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.registration as registration
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_parsing as snapshot_parsing
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_queries as snapshot_queries
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_rendering as snapshot_rendering
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_tools as snapshot_tools
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.status_rendering as status_rendering
@@ -2733,3 +2734,965 @@ class TestCrudToolsMoreEntrypoints:
 os.environ.setdefault('AWS_ACCESS_KEY_ID', 'test')
 os.environ.setdefault('AWS_SECRET_ACCESS_KEY', 'test')
 os.environ.setdefault('AWS_DEFAULT_REGION', 'us-west-2')
+
+
+class TestResolveRegion:
+    """Cover the region-resolution ladder in dynamic_instrumentation.aws_clients."""
+
+    def test_env_region_wins(self, monkeypatch):
+        """AWS_REGION env var takes precedence over profile/config."""
+        monkeypatch.setenv('AWS_REGION', 'eu-central-1')
+        assert aws_clients._resolve_region() == 'eu-central-1'
+
+    def test_session_region_used_when_no_env(self, monkeypatch):
+        """With no AWS_REGION, the boto3 session's region_name is returned."""
+        monkeypatch.delenv('AWS_REGION', raising=False)
+
+        class _FakeSession:
+            region_name = 'ap-southeast-2'
+
+        monkeypatch.setattr(aws_clients.boto3, 'Session', lambda **kwargs: _FakeSession())
+        assert aws_clients._resolve_region() == 'ap-southeast-2'
+
+    def test_falls_back_to_us_east_1(self, monkeypatch):
+        """With neither env var nor session region, us-east-1 is the fallback."""
+        monkeypatch.delenv('AWS_REGION', raising=False)
+
+        class _FakeSession:
+            region_name = None
+
+        monkeypatch.setattr(aws_clients.boto3, 'Session', lambda **kwargs: _FakeSession())
+        assert aws_clients._resolve_region() == 'us-east-1'
+
+
+class TestCaptureLimitsPayload:
+    """Cover each CaptureLimits field being emitted into the API payload."""
+
+    def test_each_limit_field_emitted(self):
+        """Every set CaptureLimits field is rendered into to_api_payload."""
+        limits = capture.CaptureLimits(
+            max_hits=1,
+            max_string_length=2,
+            max_collection_width=3,
+            max_collection_depth=4,
+            max_stack_frames=5,
+            max_stack_trace_size=6,
+            max_object_depth=7,
+            max_fields_per_object=8,
+        )
+        payload = limits.to_api_payload()
+        assert payload == {
+            'MaxHits': 1,
+            'MaxStringLength': 2,
+            'MaxCollectionWidth': 3,
+            'MaxCollectionDepth': 4,
+            'MaxStackFrames': 5,
+            'MaxStackTraceSize': 6,
+            'MaxObjectDepth': 7,
+            'MaxFieldsPerObject': 8,
+        }
+
+
+class TestCodeCapturePayloadAndParsing:
+    """Cover CodeCapture payload locals emission and capture_from_response branches."""
+
+    def test_capture_locals_emitted_in_payload(self):
+        """A non-None capture_locals is emitted as CaptureLocals in the payload."""
+        cap = capture.CodeCapture(
+            capture_return=True,
+            capture_stack_trace=False,
+            capture_arguments=['a'],
+            capture_locals=['x', 'y'],
+        )
+        payload = cap.to_api_payload()
+        assert payload['CodeCapture']['CaptureLocals'] == ['x', 'y']
+
+    def test_non_dict_input_yields_unknown_capture(self):
+        """A non-dict union value parses to UnknownCapture with empty raw."""
+        result = capture.capture_from_response(None)
+        assert isinstance(result, capture.UnknownCapture)
+        assert dict(result.raw) == {}
+
+    def test_inferred_code_capture_without_wrapper_key(self):
+        """A CodeCapture-shaped dict without the wrapper key infers a CodeCapture."""
+        result = capture.capture_from_response({'CaptureReturn': True, 'CaptureStackTrace': True})
+        assert isinstance(result, capture.CodeCapture)
+        assert result.capture_return is True
+
+    def test_capture_limits_present_but_not_a_dict_coerced(self):
+        """A non-dict CaptureLimits is coerced to an empty CaptureLimits."""
+        result = capture.capture_from_response(
+            {'CodeCapture': {'CaptureReturn': True, 'CaptureLimits': 'oops'}}
+        )
+        assert isinstance(result, capture.CodeCapture)
+        assert result.limits.is_empty()
+
+
+class TestCrudRenderingBranches:
+    """Cover the empty-arguments and locals rendering branches in crud_rendering."""
+
+    def test_create_success_renders_empty_arguments_as_none(self):
+        """An empty capture_arguments tuple renders '- Arguments: (none)'."""
+        loc = location.CodeLocation(language='Python', file_path='/app/h.py')
+        rendered = crud_rendering.render_create_success_message(
+            response={'LocationHash': 'h', 'ARN': 'arn', 'CreatedAt': None},
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            location=loc,
+            ttl_hours=None,
+            capture_arguments=[],
+            wildcard_removed=False,
+            code_capture_locals=None,
+            code_capture_return=True,
+            code_capture_stack_trace=True,
+            max_hits=None,
+            max_string_length=None,
+            max_collection_width=None,
+            max_collection_depth=None,
+            max_stack_frames=None,
+            max_stack_trace_size=None,
+            max_object_depth=None,
+            max_fields_per_object=None,
+            attribute_filters=None,
+        )
+        assert '- Arguments: (none)' in rendered
+
+    def test_list_output_renders_empty_arguments_as_none(self):
+        """A listed config with present-but-empty CaptureArguments renders '(none)'."""
+        data = {
+            'LatestConfigurations': [
+                {
+                    'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/app/h.py'}},
+                    'LocationHash': 'h',
+                    'CaptureConfiguration': {
+                        'CodeCapture': {
+                            'CaptureReturn': True,
+                            'CaptureStackTrace': True,
+                            'CaptureArguments': [],
+                        }
+                    },
+                }
+            ]
+        }
+        rendered = crud_rendering.render_list_instrumentations_output(
+            data=data,
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+        )
+        assert '- Arguments: (none)' in rendered
+
+    def test_get_instrumentation_output_renders_local_variables(self):
+        """A CodeCapture with capture_locals renders the Local Variables line."""
+        config = {
+            'InstrumentationType': 'BREAKPOINT',
+            'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/app/h.py'}},
+            'CaptureConfiguration': {
+                'CodeCapture': {
+                    'CaptureReturn': True,
+                    'CaptureStackTrace': True,
+                    'CaptureLocals': ['counter', 'total'],
+                }
+            },
+        }
+        rendered = crud_rendering.render_get_instrumentation_output(
+            config=config, service='svc', environment='env'
+        )
+        assert '- Local Variables: counter, total' in rendered
+
+
+class TestErrorTranslationEmptyHelpers:
+    """Cover the empty-input early returns in error_translation helpers."""
+
+    def test_format_block_with_all_blank_values_returns_empty(self):
+        """A context whose values are all blank yields an empty block."""
+        assert error_translation._format_block('LABEL:', {'a': None, 'b': ''}) == ''
+
+    def test_numbered_section_with_empty_items_returns_empty(self):
+        """An empty items sequence yields an empty numbered section."""
+        assert error_translation._format_numbered_section('LABEL:', []) == ''
+
+    def test_read_timeout_renders_timeout_guidance(self):
+        """A ReadTimeoutError renders the timeout troubleshooting block."""
+        from botocore.exceptions import ReadTimeoutError
+
+        rendered = error_translation.translate_aws_error(
+            ReadTimeoutError(endpoint_url='http://x'),
+            action='create instrumentation',
+        )
+        assert 'TimeoutError' in rendered
+        assert 'did not respond within the socket timeout' in rendered
+
+
+class TestLocationBranches:
+    """Cover the describe/format/payload/parse branches in location."""
+
+    def test_describe_with_class_method_and_line(self):
+        """Describe renders class_name, method_name, and line_number segments."""
+        loc = location.CodeLocation(
+            language='Java',
+            file_path='/app/Order.java',
+            class_name='Order',
+            method_name='submit',
+            line_number=42,
+        )
+        assert loc.describe() == '/app/Order.java :: Order.submit:L42'
+
+    def test_level_line_level_when_line_number_set(self):
+        """Level reports LINE-LEVEL when a line_number is present."""
+        loc = location.CodeLocation(language='Python', file_path='/app/h.py', line_number=7)
+        assert loc.level() == 'LINE-LEVEL (L7)'
+
+    def test_format_details_with_extra_fields(self):
+        """format_details renders extra_fields after the known fields."""
+        loc = location.CodeLocation(
+            language='Python',
+            file_path='/app/h.py',
+            extra_fields={'CustomKey': 'CustomVal'},
+        )
+        rendered = loc.format_details()
+        assert '- CustomKey: CustomVal' in rendered
+
+    def test_to_api_payload_with_class_and_line(self):
+        """to_api_payload includes ClassName and LineNumber when set."""
+        loc = location.CodeLocation(
+            language='Java',
+            file_path='/app/Order.java',
+            class_name='Order',
+            line_number=42,
+        )
+        payload = loc.to_api_payload()['CodeLocation']
+        assert payload['ClassName'] == 'Order'
+        assert payload['LineNumber'] == 42
+
+    def test_parse_create_inputs_validation_error(self):
+        """An invalid line_number surfaces a validation error from parse_create_inputs."""
+        loc, err = location.parse_create_inputs(
+            normalized_type='BREAKPOINT',
+            language='Python',
+            file_path='/app/h.py',
+            line_number=0,
+        )
+        assert loc is None
+        assert err
+
+    def test_parse_lookup_inputs_disallows_code_location(self):
+        """allow_code_location_lookup=False rejects a code-location lookup."""
+        loc, err = location.parse_lookup_inputs(
+            normalized_type='BREAKPOINT',
+            language='Python',
+            file_path='/app/h.py',
+            allow_code_location_lookup=False,
+        )
+        assert loc is None
+        assert err is not None
+        assert 'not supported' in err
+
+    def test_location_from_response_bare_code_fields(self):
+        """A bare Language/FilePath dict (no wrapper) parses to a CodeLocation."""
+        result = location.location_from_response({'Language': 'Python', 'FilePath': '/app/h.py'})
+        assert isinstance(result, location.CodeLocation)
+        assert result.file_path == '/app/h.py'
+
+    def test_render_location_block_hash_location(self):
+        """A HashLocation renders the HASH location block."""
+        rendered = location.render_location_block(
+            location.HashLocation(location_hash='aaaabbbbccccdddd')
+        )
+        assert '- LocationKind: HASH' in rendered
+        assert '- LocationHash: aaaabbbbccccdddd' in rendered
+
+
+class TestSnapshotParsingCoercion:
+    """Cover the non-dict coercion branches and the regex escape helper."""
+
+    def test_escape_regex_with_slash(self):
+        """A value containing '/' is escaped for a Logs Insights /.../ regex."""
+        escaped = snapshot_parsing._escape_logs_insights_regex('a/b')
+        assert escaped == r'a\/b'
+
+    def test_non_dict_subfields_coerced_to_empty(self):
+        """Non-dict resource/captures/throwable subfields are coerced to {}."""
+        message = json.dumps(
+            {
+                'resource': {'attributes': 'not-a-dict'},
+                'body': {
+                    'captures': {
+                        'entry': {'arguments': 'x', 'locals': 1},
+                        'return': {'arguments': [], 'locals': 2, 'throwable': 'oops'},
+                    }
+                },
+            }
+        )
+        parsed = snapshot_parsing._parse_snapshot_fields({'@message': message})
+        assert parsed['entry_argument_names'] == []
+        assert parsed['entry_local_names'] == []
+        assert parsed['return_argument_names'] == []
+        assert parsed['return_local_names'] == []
+        assert parsed['throwable'] is None
+
+    def test_non_dict_captures_coerced_to_empty(self):
+        """A non-dict body.captures is coerced to {} before sub-extraction."""
+        message = json.dumps({'body': {'captures': 'not-a-dict'}})
+        parsed = snapshot_parsing._parse_snapshot_fields({'@message': message})
+        assert parsed['entry_argument_names'] == []
+        assert parsed['return_value'] is None
+
+
+class TestSnapshotRenderingCoercion:
+    """Cover the non-dict attributes coercion in snapshot search rendering."""
+
+    def test_non_dict_attributes_coerced(self):
+        """A snapshot whose attributes are not a dict is coerced to {}."""
+        query_result = {
+            'status': 'Complete',
+            'queryId': 'q-1',
+            'results': [{'@message': json.dumps({'attributes': 'nope'})}],
+            'messages': [],
+        }
+        rendered = snapshot_rendering.render_search_snapshots_for_status_event_output(
+            service_name='svc',
+            environment='env',
+            location_hash='h',
+            custom_filters=None,
+            start_time_utc='s',
+            end_time_utc='e',
+            start_epoch=0,
+            end_epoch=1,
+            query_string='q',
+            query_result=query_result,
+        )
+        parsed = json.loads(rendered)
+        assert parsed['snapshot_summaries'][0]['snapshot_id'] is None
+
+
+class TestSnapshotQueriesPolling:
+    """Cover the polling loop, terminal status, timeout, and exception paths."""
+
+    def test_terminal_status_returns_results(self, monkeypatch):
+        """A Complete status returns parsed results immediately."""
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                return {'queryId': 'q-1'}
+
+            def get_query_results(self, **kwargs):
+                return {
+                    'status': 'Complete',
+                    'results': [[{'field': '@message', 'value': '{}'}]],
+                    'messages': [],
+                }
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+        )
+        assert result['status'] == 'Complete'
+        assert result['results'] == [{'@message': '{}'}]
+
+    def test_sleep_then_complete(self, monkeypatch):
+        """A Running poll triggers time.sleep(1), then the next poll completes."""
+        sleeps = []
+        monkeypatch.setattr(snapshot_queries.time, 'sleep', lambda s: sleeps.append(s))
+
+        statuses = iter(['Running', 'Complete'])
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                return {'queryId': 'q-1'}
+
+            def get_query_results(self, **kwargs):
+                return {'status': next(statuses), 'results': [], 'messages': []}
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+        )
+        assert result['status'] == 'Complete'
+        assert sleeps == [1]
+
+    def test_missing_query_id_returns_error(self, monkeypatch):
+        """A start_query response without a queryId returns an error dict."""
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                return {}
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+        )
+        assert result['status'] == 'Error'
+        assert 'did not return a queryId' in result['error']
+
+    def test_start_query_generic_exception_handled(self, monkeypatch):
+        """A non-ClientError from start_query yields an error dict."""
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                raise RuntimeError('start-boom')
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+        )
+        assert result['status'] == 'Error'
+        assert result['error'] == 'start-boom'
+
+    def test_get_results_client_error_handled(self, monkeypatch):
+        """A ClientError from get_query_results yields a structured error dict."""
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                return {'queryId': 'q-1'}
+
+            def get_query_results(self, **kwargs):
+                raise ClientError(
+                    error_response={'Error': {'Code': 'X', 'Message': 'nope'}},
+                    operation_name='GetQueryResults',
+                )
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+        )
+        assert result['status'] == 'Error'
+        assert 'Failed to get results' in result['error']
+        assert result['queryId'] == 'q-1'
+
+    def test_polling_timeout_returns_timeout(self, monkeypatch):
+        """When the deadline passes without a terminal status, a timeout dict results."""
+        monkeypatch.setattr(snapshot_queries.time, 'sleep', lambda s: None)
+        # First time() call (poll_start) is small; subsequent calls exceed the deadline.
+        times = iter([1000.0, 1000.0, 2000.0, 2000.0])
+        monkeypatch.setattr(snapshot_queries.time, 'time', lambda: next(times))
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                return {'queryId': 'q-1'}
+
+            def get_query_results(self, **kwargs):
+                return {'status': 'Running', 'results': [], 'messages': []}
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+            max_timeout=5,
+        )
+        assert result['status'] == 'Polling Timeout'
+        assert result['queryId'] == 'q-1'
+
+    def test_get_results_generic_exception_handled(self, monkeypatch):
+        """A non-ClientError from get_query_results yields an error dict."""
+
+        class _Logs:
+            def start_query(self, **kwargs):
+                return {'queryId': 'q-1'}
+
+            def get_query_results(self, **kwargs):
+                raise RuntimeError('boom')
+
+        monkeypatch.setattr(snapshot_queries.aws_clients, 'logs_client', _Logs())
+        result = snapshot_queries._execute_cloudwatch_query(
+            query_string='q',
+            start_epoch=0,
+            end_epoch=1,
+            log_group_name='lg',
+        )
+        assert result['status'] == 'Error'
+        assert result['error'] == 'boom'
+        assert result['queryId'] == 'q-1'
+
+
+class TestSnapshotToolsNaiveTimeAndFilters:
+    """Cover naive-timestamp tz handling and custom_filters appending."""
+
+    def test_search_appends_custom_filters_with_naive_timestamp(self, monkeypatch):
+        """A naive timestamp gets UTC tzinfo and custom filters are appended."""
+        captured = {}
+
+        def _fake_query(*, query_string, **kwargs):
+            captured['query_string'] = query_string
+            return {'status': 'Complete', 'queryId': 'q', 'results': [], 'messages': []}
+
+        monkeypatch.setattr(snapshot_tools, '_execute_cloudwatch_query', _fake_query)
+        rendered = snapshot_tools.search_snapshots_for_status_event(
+            service_name='svc',
+            environment='env',
+            location_hash='h',
+            status_timestamp='2026-03-09T12:00:00',
+            custom_filters=['@message like /boom/', '   ', ''],
+        )
+        assert '@message like /boom/' in captured['query_string']
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'Complete'
+
+    def test_sample_handles_naive_timestamp(self, monkeypatch):
+        """get_sample_snapshot_for_breakpoint accepts a naive timestamp."""
+
+        def _fake_query(**kwargs):
+            return {'status': 'Complete', 'queryId': 'q', 'results': [], 'messages': []}
+
+        monkeypatch.setattr(snapshot_tools, '_execute_cloudwatch_query', _fake_query)
+        rendered = snapshot_tools.get_sample_snapshot_for_breakpoint(
+            service_name='svc',
+            environment='env',
+            location_hash='h',
+            status_timestamp='2026-03-09T12:00:00',
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'NO_SNAPSHOTS_FOUND'
+
+
+class TestStatusRenderingBranches:
+    """Cover error-cause, ACTIVE-not-confirmed, and verdict dispatch branches."""
+
+    def _result(self, has_events=False, events=None, error=None):
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        return status_assessment._StatusCheckResult(
+            has_events=has_events, events=events or [], error=error
+        )
+
+    def _time_window(self):
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        return status_assessment.TimeWindow(
+            created_at='2026-03-09T11:00:00Z',
+            requested_start='2026-03-09T12:00:00Z',
+            active_query_start='2026-03-09T12:00:00Z',
+            query_end='2026-03-09T12:05:00Z',
+        )
+
+    def test_explicit_status_renders_error_cause(self):
+        """An event with an ErrorCause appends the ErrorCause segment."""
+        data = {
+            'Status': 'ERROR',
+            'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/app/h.py'}},
+            'Events': [
+                {
+                    'Time': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                    'ErrorCause': 'FILE_NOT_FOUND',
+                }
+            ],
+        }
+        rendered = status_rendering.render_get_instrumentation_configuration_status_output(
+            data=data,
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            requested_status='ERROR',
+        )
+        assert 'ErrorCause: FILE_NOT_FOUND' in rendered
+
+    def test_ready_dispatch_includes_active_not_confirmed_strip(self):
+        """A Ready verdict dispatches to the ready renderer (ACTIVE strip path)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        verdict = status_assessment.Ready(
+            active=self._result(has_events=False),
+            ready=self._result(has_events=True, events=[{'Time': None}]),
+        )
+        rendered = status_rendering.render_status_assessment(
+            verdict,
+            location_hash='h',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            time_window=self._time_window(),
+        )
+        assert 'OVERALL STATUS: READY (waiting for traffic)' in rendered
+        assert 'ACTIVE not confirmed yet' not in rendered
+
+    def test_active_dispatch_renders_active_output(self):
+        """An Active verdict dispatches to the active renderer."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        verdict = status_assessment.Active(
+            active=self._result(
+                has_events=True,
+                events=[{'Time': datetime(2026, 3, 9, 12, 1, 0, tzinfo=timezone.utc)}],
+            )
+        )
+        rendered = status_rendering.render_status_assessment(
+            verdict,
+            location_hash='h',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            time_window=self._time_window(),
+        )
+        assert 'OVERALL STATUS: ACTIVE' in rendered
+
+    def test_error_or_pending_dispatch_renders_pending(self):
+        """An ErrorOrPending verdict with no events renders PENDING."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        verdict = status_assessment.ErrorOrPending(
+            active=self._result(),
+            ready=self._result(),
+            error=self._result(),
+        )
+        rendered = status_rendering.render_status_assessment(
+            verdict,
+            location_hash='h',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            time_window=self._time_window(),
+        )
+        assert 'OVERALL STATUS: PENDING' in rendered
+
+    def test_unknown_verdict_raises_type_error(self):
+        """An unknown verdict type raises a TypeError from the dispatcher."""
+        with pytest.raises(TypeError):
+            status_rendering.render_status_assessment(
+                object(),  # type: ignore[arg-type]
+                location_hash='h',
+                service='svc',
+                environment='env',
+                normalized_type='BREAKPOINT',
+                time_window=self._time_window(),
+            )
+
+
+class TestStatusAssessmentBranches:
+    """Cover the empty-ACTIVE-window skip and READY/ERROR fall-through branches."""
+
+    def test_empty_active_window_skips_active_check(self):
+        """When the ACTIVE window is empty after clamping, ACTIVE is skipped."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        created = datetime(2026, 3, 9, 13, 0, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 9, 12, 30, 0, tzinfo=timezone.utc)
+
+        calls = []
+
+        def check(status, s, e):
+            calls.append(status)
+            return False, [], None
+
+        verdict, _window = status_assessment.assess(
+            created_at=created,
+            requested_start=start,
+            query_end=end,
+            check_status=check,
+        )
+        assert isinstance(verdict, status_assessment.ErrorOrPending)
+        assert 'ACTIVE' not in calls
+        assert verdict.active.error is not None
+        assert verdict.active.error.startswith('Skipped:')
+
+    def test_ready_has_events_returns_ready(self):
+        """When ACTIVE is empty but READY has events, a Ready verdict results."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation import (
+            status_assessment,
+        )
+
+        created = datetime(2026, 3, 9, 11, 0, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 9, 12, 30, 0, tzinfo=timezone.utc)
+
+        def check(status, s, e):
+            return (status == 'READY'), ([{'Time': start}] if status == 'READY' else []), None
+
+        verdict, _window = status_assessment.assess(
+            created_at=created,
+            requested_start=start,
+            query_end=end,
+            check_status=check,
+        )
+        assert isinstance(verdict, status_assessment.Ready)
+
+
+class TestStatusToolsBranches:
+    """Cover gateway-error, empty-config, and missing-CreatedAt branches."""
+
+    def _stub_application_signals(self) -> Stubber:
+        client = aws_clients.get_application_signals_client()
+        stubber = Stubber(client)
+        stubber.activate()
+        return stubber
+
+    def test_check_status_with_time_range_gateway_error(self, monkeypatch):
+        """_check_status_with_time_range maps a GatewayError to an API error string."""
+
+        def _raise(**kwargs):
+            raise status_tools.gateway.GatewayError(RuntimeError('boom'))
+
+        monkeypatch.setattr(
+            status_tools.gateway, 'get_instrumentation_configuration_status', _raise
+        )
+        has_events, events, error = status_tools._check_status_with_time_range(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_identifier={'LocationHash': 'h'},
+            status='ACTIVE',
+            start_time=datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+            end_time=datetime(2026, 3, 9, 12, 5, 0, tzinfo=timezone.utc),
+        )
+        assert has_events is False
+        assert events == []
+        assert error is not None
+        assert 'API error: boom' in error
+
+    def test_get_status_renders_error_for_lookup_error(self, monkeypatch):
+        """A non-'missing' lookup error surfaces as an ERROR string."""
+        monkeypatch.setattr(
+            status_tools, 'parse_lookup_inputs', lambda **kwargs: (None, 'bad location')
+        )
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+        )
+        assert rendered == 'ERROR: bad location'
+
+    def test_get_status_defensive_location_none(self, monkeypatch):
+        """A lookup parser returning (None, None) trips the defensive internal-error path."""
+        monkeypatch.setattr(status_tools, 'parse_lookup_inputs', lambda **kwargs: (None, None))
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+        )
+        assert 'Internal error resolving location' in rendered
+
+    def test_check_status_empty_config_reports_not_found(self, monkeypatch):
+        """An empty Configuration block surfaces a no-instrumentation error."""
+        monkeypatch.setattr(
+            status_tools.gateway,
+            'get_instrumentation_configuration',
+            lambda **kwargs: {'Configuration': {}},
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        assert 'No instrumentation found for LocationHash' in rendered
+
+    def test_check_status_missing_created_at(self, monkeypatch):
+        """A configuration lacking CreatedAt surfaces a created_at error."""
+        config = _full_instrumentation_configuration()
+        config.pop('CreatedAt')
+        monkeypatch.setattr(
+            status_tools.gateway,
+            'get_instrumentation_configuration',
+            lambda **kwargs: {'Configuration': config},
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        assert 'CreatedAt not found' in rendered
+
+
+class TestCrudToolsTtlAndFilters:
+    """Cover ExpiresAt/AttributeFilters emission and code-location lookup errors."""
+
+    def _stub_application_signals(self) -> Stubber:
+        client = aws_clients.get_application_signals_client()
+        stubber = Stubber(client)
+        stubber.activate()
+        return stubber
+
+    def test_create_with_ttl_and_attribute_filters(self):
+        """ttl_hours adds ExpiresAt and attribute_filters adds AttributeFilters."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'create_instrumentation_configuration',
+            {
+                'InstrumentationType': 'BREAKPOINT',
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Location': {
+                    'CodeLocation': {'Language': 'Python', 'FilePath': '/app/handler.py'}
+                },
+                'LocationHash': 'aaaabbbbccccdddd',
+                'Description': 'MCP dynamic instrumentation',
+                'ExpiresAt': datetime(2026, 3, 10, 12, 0, 0, tzinfo=timezone.utc),
+                'CaptureConfiguration': {
+                    'CodeCapture': {
+                        'CaptureArguments': ['order_id'],
+                        'CaptureReturn': True,
+                        'CaptureStackTrace': True,
+                        'CaptureLimits': {},
+                    }
+                },
+                'CreatedAt': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'ARN': 'arn:demo',
+            },
+        )
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/handler.py',
+            capture_arguments=['order_id'],
+            ttl_hours=3,
+            attribute_filters=[{'Key': 'stage', 'Value': 'prod'}],
+        )
+        stubber.assert_no_pending_responses()
+        assert 'Successfully created BREAKPOINT instrumentation' in rendered
+        assert 'ATTRIBUTE FILTERS: 1 filter group(s) applied' in rendered
+
+    def test_delete_renders_error_for_lookup_error(self, monkeypatch):
+        """delete_instrumentation surfaces a non-'missing' lookup error as ERROR."""
+        monkeypatch.setattr(
+            crud_tools, 'parse_lookup_inputs', lambda **kwargs: (None, 'bad location')
+        )
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert rendered == 'ERROR: bad location'
+
+    def test_get_renders_error_for_lookup_error(self, monkeypatch):
+        """get_instrumentation surfaces a non-'missing' lookup error as ERROR."""
+        monkeypatch.setattr(
+            crud_tools, 'parse_lookup_inputs', lambda **kwargs: (None, 'bad location')
+        )
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert rendered == 'ERROR: bad location'
+
+    def test_get_reports_no_instrumentation_for_empty_config(self, monkeypatch):
+        """get_instrumentation reports no-instrumentation when Configuration is empty."""
+        monkeypatch.setattr(
+            crud_tools.gateway,
+            'get_instrumentation_configuration',
+            lambda **kwargs: {'Configuration': {}},
+        )
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'No instrumentation found for' in rendered
+
+
+class TestCrudToolsTypeAndDefensiveBranches:
+    """Cover the invalid-type early returns and defensive location-None branches."""
+
+    def test_list_rejects_invalid_type(self):
+        """list_instrumentations short-circuits on an invalid instrumentation_type."""
+        rendered = crud_tools.list_instrumentations(
+            service='svc', environment='env', instrumentation_type='NOPE'
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_by_arns_rejects_invalid_type(self):
+        """batch_delete_instrumentations_by_arns short-circuits on an invalid type."""
+        rendered = crud_tools.batch_delete_instrumentations_by_arns(
+            resource_arns=['arn:demo'], instrumentation_type='NOPE'
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_delete_rejects_invalid_type(self):
+        """delete_instrumentation short-circuits on an invalid instrumentation_type."""
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='NOPE',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_get_rejects_invalid_type(self):
+        """get_instrumentation short-circuits on an invalid instrumentation_type."""
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='NOPE',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_create_defensive_location_none(self, monkeypatch):
+        """A parser returning (None, None) trips the defensive internal-error path."""
+        monkeypatch.setattr(crud_tools, 'parse_create_inputs', lambda **kwargs: (None, None))
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/h.py',
+            capture_arguments=['a'],
+        )
+        assert 'Internal error resolving location' in rendered
+
+    def test_delete_defensive_location_none(self, monkeypatch):
+        """A lookup parser returning (None, None) trips delete's defensive path."""
+        monkeypatch.setattr(crud_tools, 'parse_lookup_inputs', lambda **kwargs: (None, None))
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'Internal error resolving location' in rendered
+
+    def test_get_defensive_location_none(self, monkeypatch):
+        """A lookup parser returning (None, None) trips get's defensive path."""
+        monkeypatch.setattr(crud_tools, 'parse_lookup_inputs', lambda **kwargs: (None, None))
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'Internal error resolving location' in rendered

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -922,6 +922,99 @@ class TestGetInstrumentationConfigurationStatusTool:
         assert 'ATTEMPTED TO RETRIEVE:' in rendered
         assert 'ResourceNotFoundException' in rendered
 
+    def test_rejects_invalid_instrumentation_type(self):
+        """An invalid instrumentation_type is rejected before any API call."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='WATCHER',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_rejects_invalid_signal_type(self):
+        """A non-SNAPSHOT signal_type is rejected before any API call."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+            signal_type='METRIC',
+        )
+        assert 'must be SNAPSHOT' in rendered
+
+    def test_rejects_invalid_start_time(self):
+        """A malformed start_time is rejected before any API call."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+            start_time='nope',
+        )
+        assert 'Invalid start_time format' in rendered
+
+    def test_rejects_invalid_end_time(self):
+        """A malformed end_time is rejected before any API call."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='nope',
+        )
+        assert 'Invalid end_time format' in rendered
+
+    def test_forwards_optional_params_and_renders_pagination(self):
+        """Optional time/paging params are forwarded; a NextToken yields pagination hint."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration_status',
+            {
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Location': {
+                    'CodeLocation': {'Language': 'Python', 'FilePath': '/app/handler.py'}
+                },
+                'Status': 'ACTIVE',
+                'Events': [],
+                'NextToken': 'next-page-token',
+            },
+            expected_params={
+                'InstrumentationType': 'BREAKPOINT',
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Status': 'ACTIVE',
+                'LocationIdentifier': {'LocationHash': 'aaaabbbbccccdddd'},
+                'StartTime': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'EndTime': datetime(2026, 3, 9, 12, 5, 0, tzinfo=timezone.utc),
+                'MaxResults': 5,
+                'NextToken': 'prev-token',
+            },
+        )
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='ACTIVE',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+            max_results=5,
+            next_token='prev-token',
+        )
+        stubber.assert_no_pending_responses()
+        # ACTIVE with no events triggers the clarification block and pagination hint.
+        assert 'ACTIVE Clarification' in rendered
+        assert 'next-page-token' in rendered
+
 
 def _full_instrumentation_configuration() -> dict:
     """A Configuration block with every field the bundled model marks required."""
@@ -1036,6 +1129,65 @@ class TestCheckInstrumentationStatusTool:
         )
         stubber.assert_no_pending_responses()
         assert 'ACTIVE' in rendered
+
+    def test_rejects_invalid_instrumentation_type(self):
+        """An invalid instrumentation_type is rejected before any API call."""
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='WATCHER',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_rejects_invalid_signal_type(self):
+        """A non-SNAPSHOT signal_type is rejected before any API call."""
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+            signal_type='METRIC',
+        )
+        assert 'must be SNAPSHOT' in rendered
+
+    def test_rejects_invalid_start_time(self):
+        """A malformed start_time is rejected after the config fetch succeeds."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration',
+            {'Configuration': _full_instrumentation_configuration()},
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='nope',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        assert 'Invalid start_time format' in rendered
+
+    def test_rejects_invalid_end_time(self):
+        """A malformed end_time is rejected after the config fetch succeeds."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration',
+            {'Configuration': _full_instrumentation_configuration()},
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='nope',
+        )
+        assert 'Invalid end_time format' in rendered
 
 
 class TestSnapshotToolsCloudWatchPath:
@@ -1277,6 +1429,1301 @@ class TestSnapshotLogGroupResolution:
             constants.resolve_snapshot_log_group('checkout-service')
             == '/aws/service-events/checkout-service'
         )
+
+
+class TestSnapshotParsingPreviewHelper:
+    """Direct coverage for snapshot_parsing._preview_captured_value."""
+
+    def test_non_dict_returns_input_unchanged(self):
+        """A non-dict captured value is returned verbatim."""
+        assert snapshot_parsing._preview_captured_value('plain') == 'plain'
+        assert snapshot_parsing._preview_captured_value(7) == 7
+
+    def test_is_null_short_circuits(self):
+        """is_null=True yields just type and is_null."""
+        preview = snapshot_parsing._preview_captured_value(
+            {'type': 'str', 'is_null': True, 'value': 'ignored'}
+        )
+        assert preview == {'type': 'str', 'is_null': True}
+
+    def test_not_captured_reason_short_circuits(self):
+        """not_captured_reason short-circuits with its reason."""
+        preview = snapshot_parsing._preview_captured_value(
+            {'type': 'obj', 'not_captured_reason': 'depth'}
+        )
+        assert preview == {'type': 'obj', 'not_captured_reason': 'depth'}
+
+    def test_value_with_truncated_and_size(self):
+        """A primitive value carries truncated and size flags."""
+        preview = snapshot_parsing._preview_captured_value(
+            {'type': 'str', 'value': 'abc', 'truncated': True, 'size': 99}
+        )
+        assert preview == {'type': 'str', 'value': 'abc', 'truncated': True, 'size': 99}
+
+    def test_fields_preview_expands_one_level(self):
+        """Fields preview expands primitives and collapses nested objects."""
+        preview = snapshot_parsing._preview_captured_value(
+            {
+                'type': 'Order',
+                'size': 4,
+                'fields': {
+                    'id': {'type': 'str', 'value': 'A-1'},
+                    'missing': {'type': 'str', 'is_null': True},
+                    'skipped': {'type': 'obj', 'not_captured_reason': 'timeout'},
+                    'nested': {'type': 'Address'},
+                    'raw': 'literal',
+                },
+            }
+        )
+        assert isinstance(preview, dict)
+        assert preview['type'] == 'Order'
+        assert preview['size'] == 4
+        fp = preview['fields_preview']
+        assert isinstance(fp, dict)
+        assert fp['id'] == 'A-1'
+        assert fp['missing'] is None
+        assert fp['skipped'] == '<timeout>'
+        assert fp['nested'] == '<Address>'
+        assert fp['raw'] == 'literal'
+
+    def test_elements_preview_summarizes_first_element(self):
+        """Elements preview reports count and previews the first element."""
+        preview = snapshot_parsing._preview_captured_value(
+            {
+                'type': 'list',
+                'elements': [
+                    {'type': 'int', 'value': '1'},
+                    {'type': 'int', 'value': '2'},
+                ],
+            }
+        )
+        assert isinstance(preview, dict)
+        assert preview['element_count'] == 2
+        assert preview['first_element'] == {'type': 'int', 'value': '1'}
+
+    def test_empty_elements_omits_first_element(self):
+        """An empty elements list reports count zero and no first_element."""
+        preview = snapshot_parsing._preview_captured_value({'type': 'list', 'elements': []})
+        assert isinstance(preview, dict)
+        assert preview['element_count'] == 0
+        assert 'first_element' not in preview
+
+    def test_entries_preview_reports_count(self):
+        """Entries preview reports the entry count."""
+        preview = snapshot_parsing._preview_captured_value(
+            {'type': 'dict', 'entries': [{'key': 1}, {'key': 2}]}
+        )
+        assert isinstance(preview, dict)
+        assert preview['entry_count'] == 2
+
+    def test_bare_type_only_returns_preview(self):
+        """A captured value with only a type returns the type preview."""
+        preview = snapshot_parsing._preview_captured_value({'type': 'CustomObject'})
+        assert preview == {'type': 'CustomObject'}
+
+    def test_empty_dict_returns_original(self):
+        """An empty dict (no type, no value) returns the original dict."""
+        assert snapshot_parsing._preview_captured_value({}) == {}
+
+
+class TestSnapshotParsingFields:
+    """Direct coverage for snapshot_parsing._parse_snapshot_fields edge cases."""
+
+    def test_invalid_json_message_degrades_to_empty(self):
+        """Non-JSON @message degrades to empty parsed output."""
+        parsed = snapshot_parsing._parse_snapshot_fields({'@message': 'not-json{'})
+        assert parsed['snapshot_id'] is None
+        assert parsed['raw_snapshot'] == {}
+        assert parsed['stack_frame_count'] == 0
+
+    def test_non_dict_json_message_degrades_to_empty(self):
+        """A JSON array @message degrades to empty parsed output."""
+        parsed = snapshot_parsing._parse_snapshot_fields({'@message': json.dumps([1, 2, 3])})
+        assert parsed['raw_snapshot'] == {}
+
+    def test_non_dict_attributes_resource_body_are_coerced(self):
+        """Non-dict attributes/resource/body fields coerce to empty dicts."""
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'attributes': ['not', 'a', 'dict'],
+                        'resource': 'nope',
+                        'body': 42,
+                        'traceId': 't',
+                        'spanId': 's',
+                    }
+                )
+            }
+        )
+        assert parsed['snapshot_id'] is None
+        assert parsed['trace'] == {'traceId': 't', 'spanId': 's'}
+        assert parsed['stack_preview'] == []
+
+    def test_non_list_stack_and_non_dict_captures_coerced(self):
+        """Non-list stack and non-dict capture sub-objects coerce safely."""
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'body': {
+                            'stack': 'not-a-list',
+                            'captures': {
+                                'entry': 'nope',
+                                'return': 5,
+                                'lines': [],
+                            },
+                        },
+                    }
+                )
+            }
+        )
+        assert parsed['stack_frame_count'] == 0
+        assert parsed['entry_argument_names'] == []
+        assert parsed['return_value'] is None
+
+    def test_stack_preview_skips_non_dict_frames_and_caps_at_five(self):
+        """Stack preview skips non-dict frames and previews at most five."""
+        stack: list = [
+            {'file_path': f'/f{i}.py', 'function': 'fn', 'line_number': i} for i in range(7)
+        ]
+        stack.insert(0, 'garbage')
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {'@message': json.dumps({'body': {'stack': stack}})}
+        )
+        assert parsed['stack_frame_count'] == 8
+        # stack[:5] is ['garbage', f0, f1, f2, f3]; the string frame is skipped.
+        assert len(parsed['stack_preview']) == 4
+
+    def test_entry_locals_and_return_arguments_locals(self):
+        """Entry locals and return arguments/locals are previewed."""
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'body': {
+                            'captures': {
+                                'entry': {
+                                    'arguments': {'a': {'type': 'int', 'value': '1'}},
+                                    'locals': {'tmp': {'type': 'int', 'value': '2'}},
+                                },
+                                'return': {
+                                    'arguments': {'a': {'type': 'int', 'value': '1'}},
+                                    'locals': {'r': {'type': 'int', 'value': '3'}},
+                                    'return_value': {'type': 'int', 'value': '9'},
+                                    'throwable': {
+                                        'type': 'ValueError',
+                                        'message': 'boom',
+                                        'stacktrace': [{}, {}],
+                                    },
+                                },
+                            },
+                        },
+                    }
+                )
+            }
+        )
+        assert parsed['entry_local_names'] == ['tmp']
+        assert parsed['return_argument_names'] == ['a']
+        assert parsed['return_local_names'] == ['r']
+        assert parsed['return_value']['value'] == '9'
+        assert parsed['throwable']['type'] == 'ValueError'
+        assert parsed['throwable']['stacktrace_frame_count'] == 2
+
+    def test_throwable_with_non_list_stacktrace_counts_zero(self):
+        """A throwable whose stacktrace is not a list reports zero frames."""
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'body': {
+                            'captures': {
+                                'return': {
+                                    'throwable': {'type': 'E', 'message': 'm', 'stacktrace': 'x'}
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        )
+        assert parsed['throwable']['stacktrace_frame_count'] == 0
+
+    def test_line_captures_with_locals_args_return_and_throwable(self):
+        """Line captures aggregate locals, arguments, return values, and throwables."""
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'body': {
+                            'captures': {
+                                'lines': {
+                                    'not-a-dict-line': 'skip-me',
+                                    '10': {
+                                        'locals': {'x': {'type': 'int', 'value': '1'}},
+                                        'arguments': {'y': {'type': 'int', 'value': '2'}},
+                                        'return_value': {'type': 'int', 'value': '5'},
+                                        'throwable': {
+                                            'type': 'IOError',
+                                            'message': 'bad',
+                                            'stacktrace': [{}],
+                                        },
+                                    },
+                                    '2': {
+                                        'locals': {},
+                                        'arguments': {},
+                                    },
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        )
+        assert parsed['line_numbers'] == ['10']
+        assert parsed['line_locals']['10'] == ['x']
+        assert parsed['line_arguments']['10'] == ['y']
+        assert parsed['line_return_values']['10']['value'] == '5'
+        assert parsed['line_throwables']['10']['type'] == 'IOError'
+        assert parsed['line_throwables']['10']['stacktrace_frame_count'] == 1
+
+    def test_line_throwable_non_list_stacktrace_counts_zero(self):
+        """A line throwable with non-list stacktrace reports zero frames."""
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'body': {
+                            'captures': {
+                                'lines': {
+                                    '5': {
+                                        'throwable': {
+                                            'type': 'E',
+                                            'message': 'm',
+                                            'stacktrace': 'notlist',
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        )
+        assert parsed['line_throwables']['5']['stacktrace_frame_count'] == 0
+
+
+class TestValidationLocationInputs:
+    """Direct coverage for validation._validate_location_inputs and troubleshooting."""
+
+    def test_valid_python_location_returns_none(self):
+        """A valid Python location passes validation."""
+        assert (
+            validation._validate_location_inputs(
+                language='Python',
+                file_path='/app/h.py',
+                code_unit='services.billing',
+                class_name=None,
+                method_name='run',
+                line_number=None,
+            )
+            is None
+        )
+
+    def test_missing_file_path_reports_error(self):
+        """A missing file_path produces a required-field error."""
+        message = validation._validate_location_inputs(
+            language='Python',
+            file_path='',
+            code_unit='services.billing',
+            class_name=None,
+            method_name='run',
+            line_number=None,
+        )
+        assert message is not None
+        assert 'file_path is required' in message
+
+    def test_line_number_below_one_reports_error(self):
+        """A line_number below 1 produces a range error."""
+        message = validation._validate_location_inputs(
+            language='Python',
+            file_path='/app/h.py',
+            code_unit='services.billing',
+            class_name=None,
+            method_name='run',
+            line_number=0,
+        )
+        assert message is not None
+        assert 'line_number must be >= 1' in message
+
+    def test_unsupported_language_reports_error(self):
+        """An unsupported language produces a language error."""
+        message = validation._validate_location_inputs(
+            language='Ruby',
+            file_path='/app/h.rb',
+            code_unit=None,
+            class_name=None,
+            method_name='run',
+            line_number=None,
+        )
+        assert message is not None
+        assert 'language must be Python or Java' in message
+
+    def test_java_fully_qualified_class_name_errors_with_suggestion(self):
+        """A fully qualified Java class_name errors and suggests a split."""
+        message = validation._validate_location_inputs(
+            language='Java',
+            file_path='/app/Order.java',
+            code_unit=None,
+            class_name='com.example.OrderContext',
+            method_name='run',
+            line_number=None,
+        )
+        assert message is not None
+        assert 'class_name must be simple' in message
+        assert 'code_unit="com.example"' in message
+        assert 'class_name="OrderContext"' in message
+
+    def test_java_code_unit_with_slashes_adds_suggestion(self):
+        """A Java code_unit with slashes adds a package-name suggestion."""
+        message = validation._validate_location_inputs(
+            language='Java',
+            file_path='',
+            code_unit='com/example/app',
+            class_name='com.example.Order',
+            method_name='run',
+            line_number=None,
+        )
+        assert message is not None
+        assert 'package name with dots, not a path with slashes' in message
+
+    def test_python_code_unit_with_py_extension_adds_suggestion(self):
+        """A Python code_unit ending in .py adds a module-path suggestion."""
+        message = validation._validate_location_inputs(
+            language='Python',
+            file_path='',
+            code_unit='billing.py',
+            class_name=None,
+            method_name='run',
+            line_number=None,
+        )
+        assert message is not None
+        assert 'module path (e.g., services.billing), not a .py filename' in message
+
+    def test_troubleshooting_python_branch_renders_python_rules(self):
+        """The Python troubleshooting branch renders Python-specific rules."""
+        rendered = validation._format_code_location_troubleshooting(
+            language='Python',
+            file_path='/app/h.py',
+            code_unit='services.billing',
+            class_name=None,
+            method_name='run',
+            line_number=12,
+        )
+        assert 'Python rules:' in rendered
+        assert 'LINE-LEVEL (L12)' in rendered
+        assert 'language=Python' in rendered
+
+    def test_troubleshooting_java_branch_renders_java_rules(self):
+        """The Java troubleshooting branch renders Java-specific rules."""
+        rendered = validation._format_code_location_troubleshooting(
+            language='Java',
+            file_path='/app/Order.java',
+            code_unit='com.example',
+            class_name='OrderContext',
+            method_name='run',
+            line_number=None,
+        )
+        assert 'Java rules:' in rendered
+        assert 'FUNCTION/METHOD-level' in rendered
+
+
+class TestCrudRenderingMoreHelpers:
+    """Additional coverage for crud_rendering renderers."""
+
+    def test_create_capture_limits_empty_returns_blank(self):
+        """No limits produce an empty capture-limits block."""
+        assert (
+            crud_rendering._render_create_capture_limits(
+                max_hits=None,
+                max_string_length=None,
+                max_collection_width=None,
+                max_collection_depth=None,
+                max_stack_frames=None,
+                max_stack_trace_size=None,
+                max_object_depth=None,
+                max_fields_per_object=None,
+            )
+            == ''
+        )
+
+    def test_create_capture_limits_renders_all_set_limits(self):
+        """Every populated limit renders its labeled line."""
+        rendered = crud_rendering._render_create_capture_limits(
+            max_hits=1,
+            max_string_length=2,
+            max_collection_width=3,
+            max_collection_depth=4,
+            max_stack_frames=5,
+            max_stack_trace_size=6,
+            max_object_depth=7,
+            max_fields_per_object=8,
+        )
+        assert '- Max Hits: 1' in rendered
+        assert '- Max String Length: 2' in rendered
+        assert '- Max Collection Width: 3' in rendered
+        assert '- Max Collection Depth: 4' in rendered
+        assert '- Max Stack Frames: 5' in rendered
+        assert '- Max Stack Trace Size: 6' in rendered
+        assert '- Max Object Depth: 7' in rendered
+        assert '- Max Fields Per Object: 8' in rendered
+
+    def test_render_create_success_message_full(self):
+        """A full create-success message renders expiry, locals, limits, and filters."""
+        loc = location.CodeLocation(language='Python', file_path='/app/h.py', method_name='run')
+        rendered = crud_rendering.render_create_success_message(
+            response={
+                'LocationHash': 'aaaabbbbccccdddd',
+                'ARN': 'arn:demo',
+                'CreatedAt': datetime(2026, 3, 9, 11, 0, 0, tzinfo=timezone.utc),
+                'ExpiresAt': datetime(2026, 3, 10, 11, 0, 0, tzinfo=timezone.utc),
+            },
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            location=loc,
+            ttl_hours=24,
+            capture_arguments=['order_id'],
+            wildcard_removed=True,
+            code_capture_locals=['result'],
+            code_capture_return=True,
+            code_capture_stack_trace=False,
+            max_hits=3,
+            max_string_length=None,
+            max_collection_width=None,
+            max_collection_depth=None,
+            max_stack_frames=None,
+            max_stack_trace_size=None,
+            max_object_depth=None,
+            max_fields_per_object=None,
+            attribute_filters=[{'Key': 'stage', 'Value': 'prod'}],
+        )
+        assert 'Successfully created BREAKPOINT instrumentation' in rendered
+        assert '- Expires: 2026-03-10T11:00:00Z (requested 24 hours)' in rendered
+        assert '- Arguments: order_id' in rendered
+        assert 'wildcard * is not supported and was ignored' in rendered
+        assert '- Local Variables: result' in rendered
+        assert '- Return Values: Enabled' in rendered
+        assert '- Stack Traces: Disabled' in rendered
+        assert '- Max Hits: 3' in rendered
+        assert 'ATTRIBUTE FILTERS: 1 filter group(s) applied' in rendered
+
+    def test_render_create_success_message_never_expires_no_args(self):
+        """No ExpiresAt and empty arguments render the never-expires/none paths."""
+        loc = location.CodeLocation(language='Python', file_path='/app/h.py', method_name='run')
+        rendered = crud_rendering.render_create_success_message(
+            response={'LocationHash': 'aaaabbbbccccdddd'},
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            location=loc,
+            ttl_hours=None,
+            capture_arguments=[],
+            wildcard_removed=False,
+            code_capture_locals=None,
+            code_capture_return=False,
+            code_capture_stack_trace=True,
+            max_hits=None,
+            max_string_length=None,
+            max_collection_width=None,
+            max_collection_depth=None,
+            max_stack_frames=None,
+            max_stack_trace_size=None,
+            max_object_depth=None,
+            max_fields_per_object=None,
+            attribute_filters=None,
+        )
+        assert '- Expires: Never (unless deleted)' in rendered
+        assert '- Arguments: (none)' in rendered
+        assert '- Return Values: Disabled' in rendered
+
+    def test_render_list_output_capture_payload_unparseable(self):
+        """A non-code capture payload renders the could-not-parse note."""
+        rendered = crud_rendering.render_list_instrumentations_output(
+            data={
+                'SyncedAt': '2026-03-09T12:00:00Z',
+                'NextToken': 'more',
+                'LatestConfigurations': [
+                    {
+                        'LocationHash': 'aaaabbbbccccdddd',
+                        'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/x.py'}},
+                        'CaptureConfiguration': {},
+                        'CreatedAt': '2026-03-09T11:00:00Z',
+                    }
+                ],
+            },
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+        )
+        assert 'Capture payload could not be parsed.' in rendered
+        assert 'next_token="more"' in rendered
+
+    def test_render_get_output_capture_payload_unparseable(self):
+        """A get-instrumentation render with no code capture notes the parse failure."""
+        rendered = crud_rendering.render_get_instrumentation_output(
+            config={
+                'InstrumentationType': 'BREAKPOINT',
+                'SignalType': 'SNAPSHOT',
+                'LocationHash': 'aaaabbbbccccdddd',
+                'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/x.py'}},
+                'CaptureConfiguration': {},
+            },
+            service='svc',
+            environment='env',
+        )
+        assert 'Capture payload could not be parsed.' in rendered
+
+    def test_render_get_output_arguments_all_and_full_limits(self):
+        """Arguments=None renders 'All' and every populated limit renders."""
+        rendered = crud_rendering.render_get_instrumentation_output(
+            config={
+                'InstrumentationType': 'BREAKPOINT',
+                'SignalType': 'SNAPSHOT',
+                'LocationHash': 'aaaabbbbccccdddd',
+                'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/x.py'}},
+                'CaptureConfiguration': {
+                    'CodeCapture': {
+                        'CaptureReturn': True,
+                        'CaptureStackTrace': True,
+                        'CaptureLimits': {
+                            'MaxHits': 1,
+                            'MaxStringLength': 2,
+                            'MaxCollectionWidth': 3,
+                            'MaxCollectionDepth': 4,
+                            'MaxStackFrames': 5,
+                            'MaxStackTraceSize': 6,
+                            'MaxObjectDepth': 7,
+                            'MaxFieldsPerObject': 8,
+                        },
+                    }
+                },
+            },
+            service='svc',
+            environment='env',
+        )
+        assert '- Arguments: All' in rendered
+        assert '- Max Hits: 1' in rendered
+        assert '- Max Stack Frames: 5' in rendered
+        assert '- Max Fields Per Object: 8' in rendered
+
+    def test_batch_delete_response_minimal_no_sections(self):
+        """An empty batch-delete response renders counts without item sections."""
+        rendered = crud_rendering._format_batch_delete_response(
+            mode='Scope',
+            instrumentation_type='BREAKPOINT',
+            data={},
+        )
+        assert 'DeletedCount: 0' in rendered
+        assert 'SUCCESSFUL DELETIONS:' not in rendered
+        assert 'DELETE ERRORS:' not in rendered
+
+
+class TestStatusRenderingMoreHelpers:
+    """Additional coverage for status_rendering renderers."""
+
+    def test_render_status_section_skipped_branch(self):
+        """A 'Skipped:' error renders the check-skipped line."""
+        rendered = status_rendering._render_status_section(
+            title='READY',
+            start_time='s',
+            end_time='e',
+            has_events=False,
+            events=[],
+            error='Skipped: not needed',
+        )
+        assert '- Check Skipped: Skipped: not needed' in rendered
+
+    def test_render_status_section_failed_branch(self):
+        """A non-skipped error renders the check-failed line."""
+        rendered = status_rendering._render_status_section(
+            title='READY',
+            start_time='s',
+            end_time='e',
+            has_events=False,
+            events=[],
+            error='boom',
+        )
+        assert '- Check Failed: boom' in rendered
+
+    def test_render_status_section_truncates_after_three_events(self):
+        """More than three events render a truncation note."""
+        events = [{'Time': f'2026-03-09T12:0{i}:00Z'} for i in range(5)]
+        rendered = status_rendering._render_status_section(
+            title='ERROR',
+            start_time='s',
+            end_time='e',
+            has_events=True,
+            events=events,
+            error=None,
+            include_error_cause=True,
+        )
+        assert '- Confirmed: YES (5 event(s))' in rendered
+        assert '... and 2 more' in rendered
+        assert 'ErrorCause: Unknown' in rendered
+
+    def test_render_active_status_with_events_renders_snapshot_tips(self):
+        """A confirmed ACTIVE status renders snapshot timestamp tips."""
+        rendered = status_rendering.render_consolidated_active_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=True,
+            active_events=[
+                {'Time': '2026-03-09T11:06:00Z'},
+                {'Time': '2026-03-09T11:07:00Z'},
+            ],
+            active_error=None,
+        )
+        assert 'SNAPSHOT QUERY TIP' in rendered
+        assert 'OVERALL STATUS: ACTIVE' in rendered
+        assert '(oldest, try first)' in rendered
+        assert '(most recent)' in rendered
+
+    def test_render_active_status_without_events_not_confirmed(self):
+        """An ACTIVE status with no events renders the not-confirmed verdict."""
+        rendered = status_rendering.render_consolidated_active_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+        )
+        assert 'OVERALL STATUS: ACTIVE not confirmed yet' in rendered
+
+    def test_render_ready_status_output(self):
+        """A READY consolidated render appends the READY section and verdict."""
+        rendered = status_rendering.render_consolidated_ready_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+            ready_has_events=True,
+            ready_events=[{'Time': '2026-03-09T11:06:00Z'}],
+            ready_error=None,
+        )
+        assert 'READY STATUS:' in rendered
+        assert 'OVERALL STATUS: READY (waiting for traffic)' in rendered
+
+    def test_error_output_file_not_found_branch(self):
+        """An ERROR cause FILE_NOT_FOUND renders the file_path troubleshooting."""
+        rendered = status_rendering.render_consolidated_error_or_pending_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+            ready_has_events=False,
+            ready_events=[],
+            ready_error=None,
+            error_has_events=True,
+            error_events=[{'Time': '2026-03-09T11:06:00Z', 'ErrorCause': 'FILE_NOT_FOUND'}],
+            error_error=None,
+        )
+        assert 'OVERALL STATUS: ERROR (FILE_NOT_FOUND)' in rendered
+        assert 'Verify file_path is correct' in rendered
+
+    def test_error_output_line_not_executable_branch(self):
+        """An ERROR cause LINE_NOT_EXECUTABLE renders the line troubleshooting."""
+        rendered = status_rendering.render_consolidated_error_or_pending_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+            ready_has_events=False,
+            ready_events=[],
+            ready_error=None,
+            error_has_events=True,
+            error_events=[{'Time': '2026-03-09T11:06:00Z', 'ErrorCause': 'LINE_NOT_EXECUTABLE'}],
+            error_error=None,
+        )
+        assert 'OVERALL STATUS: ERROR (LINE_NOT_EXECUTABLE)' in rendered
+        assert 'executable code' in rendered
+
+    def test_error_output_other_cause_branch(self):
+        """An unrecognized ERROR cause renders the generic troubleshooting."""
+        rendered = status_rendering.render_consolidated_error_or_pending_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+            ready_has_events=False,
+            ready_events=[],
+            ready_error=None,
+            error_has_events=True,
+            error_events=[{'Time': '2026-03-09T11:06:00Z', 'ErrorCause': 'WEIRD_CAUSE'}],
+            error_error=None,
+        )
+        assert 'OVERALL STATUS: ERROR (WEIRD_CAUSE)' in rendered
+        assert 'Check instrumentation configuration for WEIRD_CAUSE' in rendered
+
+    def test_error_output_pending_branch(self):
+        """No ACTIVE/READY/ERROR events renders the PENDING verdict."""
+        rendered = status_rendering.render_consolidated_error_or_pending_status_output(
+            location_hash='aaaabbbbccccdddd',
+            service='svc',
+            environment='env',
+            normalized_type='BREAKPOINT',
+            created_at='2026-03-09T11:00:00Z',
+            requested_start_str='2026-03-09T11:05:00Z',
+            active_query_start_str='2026-03-09T11:05:00Z',
+            query_end_str='2026-03-09T11:10:00Z',
+            active_has_events=False,
+            active_events=[],
+            active_error=None,
+            ready_has_events=False,
+            ready_events=[],
+            ready_error=None,
+            error_has_events=False,
+            error_events=[],
+            error_error=None,
+        )
+        assert 'OVERALL STATUS: PENDING' in rendered
+        assert 'can take 1-2 minutes' in rendered
+
+    def test_get_status_output_active_clarification_when_no_events(self):
+        """An ACTIVE filter with no events renders the ACTIVE clarification."""
+        rendered = status_rendering.render_get_instrumentation_configuration_status_output(
+            data={'Status': 'ACTIVE', 'Events': []},
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            requested_status='ACTIVE',
+        )
+        assert 'ACTIVE Clarification' in rendered
+        assert 'NOT CONFIRMED' in rendered
+        assert 'No ACTIVE status events found' in rendered
+
+
+class TestSnapshotRenderingMoreHelpers:
+    """Additional coverage for snapshot_rendering branches."""
+
+    def test_search_output_error_branch(self):
+        """An Error query_result renders the ERROR JSON envelope."""
+        rendered = snapshot_rendering.render_search_snapshots_for_status_event_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            custom_filters=None,
+            start_time_utc='2026-03-09T11:59:55Z',
+            end_time_utc='2026-03-09T12:01:00Z',
+            start_epoch=1,
+            end_epoch=2,
+            query_string='fields @timestamp',
+            query_result={'status': 'Error', 'error': 'kaboom'},
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'ERROR'
+        assert parsed['error'] == 'kaboom'
+
+    def test_search_output_timeout_branch(self):
+        """A Polling Timeout query_result renders the TIMEOUT envelope."""
+        rendered = snapshot_rendering.render_search_snapshots_for_status_event_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            custom_filters=['x'],
+            start_time_utc='2026-03-09T11:59:55Z',
+            end_time_utc='2026-03-09T12:01:00Z',
+            start_epoch=1,
+            end_epoch=2,
+            query_string='fields @timestamp',
+            query_result={'status': 'Polling Timeout', 'queryId': 'q-9'},
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'TIMEOUT'
+        assert parsed['queryId'] == 'q-9'
+        assert parsed['custom_filters'] == ['x']
+
+    def test_search_output_handles_invalid_message_json(self):
+        """A result with non-JSON @message yields a summary with null fields."""
+        rendered = snapshot_rendering.render_search_snapshots_for_status_event_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            custom_filters=None,
+            start_time_utc='2026-03-09T11:59:55Z',
+            end_time_utc='2026-03-09T12:01:00Z',
+            start_epoch=1,
+            end_epoch=2,
+            query_string='fields @timestamp',
+            query_result={
+                'status': 'Complete',
+                'queryId': 'q-1',
+                'results': [{'@timestamp': 't', '@message': 'not-json{'}],
+            },
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'Complete'
+        assert parsed['snapshot_summaries'][0]['snapshot_id'] is None
+
+    def test_sample_output_error_branch(self):
+        """An Error sample query renders the ERROR envelope."""
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='s',
+            end_time_utc='e',
+            max_timeout=30,
+            query_string='q',
+            query_result={'status': 'Error', 'error': 'kaboom'},
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'ERROR'
+        assert parsed['error'] == 'kaboom'
+
+    def test_sample_output_timeout_branch(self):
+        """A Polling Timeout sample query renders the TIMEOUT envelope."""
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='s',
+            end_time_utc='e',
+            max_timeout=30,
+            query_string='q',
+            query_result={'status': 'Polling Timeout', 'queryId': 'q-7'},
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'TIMEOUT'
+        assert '30 seconds' in parsed['message']
+
+    def test_sample_output_non_complete_status_branch(self):
+        """A non-Complete, non-error status renders a passthrough envelope."""
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='s',
+            end_time_utc='e',
+            max_timeout=30,
+            query_string='q',
+            query_result={'status': 'Running', 'queryId': 'q-3'},
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'Running'
+
+    def test_sample_output_no_results_branch(self):
+        """A Complete status with no results renders NO_SNAPSHOTS_FOUND."""
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='s',
+            end_time_utc='e',
+            max_timeout=30,
+            query_string='q',
+            query_result={'status': 'Complete', 'queryId': 'q-4', 'results': []},
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'NO_SNAPSHOTS_FOUND'
+
+    def test_sample_output_large_snapshot_uses_parsed_summary(self):
+        """A >10KB snapshot with include_raw=False is replaced by a parsed summary."""
+        big_value = 'x' * 11000
+        message = json.dumps(
+            {
+                'timeUnixNano': 1762689600000000000,
+                'traceId': 'trace-1',
+                'attributes': {
+                    'aws.di.snapshot_id': 'snap-big',
+                    'aws.di.location_hash': 'aaaabbbbccccdddd',
+                },
+                'body': {
+                    'captures': {
+                        'entry': {'arguments': {'blob': {'type': 'str', 'value': big_value}}}
+                    }
+                },
+            }
+        )
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='s',
+            end_time_utc='e',
+            max_timeout=30,
+            query_string='q',
+            query_result={
+                'status': 'Complete',
+                'queryId': 'q-5',
+                'results': [{'@timestamp': 't', '@message': message}],
+            },
+            include_raw=False,
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'SUCCESS'
+        assert 'note' in parsed
+        assert 'compact parsed summary' in parsed['note']
+        assert parsed['sample_snapshot']['snapshot_id'] == 'snap-big'
+        assert 'raw_snapshot' not in parsed['sample_snapshot']
+
+    def test_sample_output_invalid_message_json_yields_empty_snapshot(self):
+        """A small result with invalid JSON @message yields an empty sample snapshot."""
+        rendered = snapshot_rendering.render_get_sample_snapshot_for_breakpoint_output(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            start_time_utc='s',
+            end_time_utc='e',
+            max_timeout=30,
+            query_string='q',
+            query_result={
+                'status': 'Complete',
+                'queryId': 'q-6',
+                'results': [{'@timestamp': 't', '@message': 'not-json{'}],
+            },
+            include_raw=False,
+        )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'SUCCESS'
+        assert parsed['sample_snapshot'] == {}
+
+
+class TestCrudToolsMoreEntrypoints:
+    """Additional Stubber-driven and validation coverage for crud_tools."""
+
+    def _stub_application_signals(self) -> Stubber:
+        client = aws_clients.get_application_signals_client()
+        stubber = Stubber(client)
+        stubber.activate()
+        return stubber
+
+    def test_create_rejects_invalid_instrumentation_type(self):
+        """An invalid instrumentation_type short-circuits create."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BOGUS',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/h.py',
+            method_name='run',
+            capture_arguments=['x'],
+        )
+        assert 'instrumentation_type must be one of' in rendered
+
+    def test_create_rejects_missing_file_path(self):
+        """A missing file_path returns the location validation error."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path=None,
+            method_name='run',
+            capture_arguments=['x'],
+        )
+        assert 'file_path' in rendered
+
+    def test_list_instrumentations_renders_populated_results(self):
+        """A populated list response renders configuration details."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'list_instrumentation_configurations',
+            {
+                'Service': 'svc',
+                'Environment': 'env',
+                'Changed': True,
+                'LatestConfigurations': [
+                    {
+                        'InstrumentationType': 'BREAKPOINT',
+                        'SignalType': 'SNAPSHOT',
+                        'LocationHash': 'aaaabbbbccccdddd',
+                        'Location': {
+                            'CodeLocation': {
+                                'Language': 'Python',
+                                'FilePath': '/app/handler.py',
+                                'MethodName': 'run',
+                            }
+                        },
+                        'CaptureConfiguration': {
+                            'CodeCapture': {
+                                'CaptureArguments': ['order_id'],
+                                'CaptureReturn': True,
+                                'CaptureStackTrace': True,
+                                'CaptureLimits': {},
+                            }
+                        },
+                        'CreatedAt': datetime(2026, 3, 9, 11, 0, 0, tzinfo=timezone.utc),
+                        'ARN': 'arn:demo',
+                    }
+                ],
+                'SyncedAt': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'SyncInterval': 60,
+            },
+        )
+        rendered = crud_tools.list_instrumentations(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'Active BREAKPOINT Instrumentations (1 found)' in rendered
+        assert 'aaaabbbbccccdddd' in rendered
+
+    def test_list_instrumentations_forwards_optional_params(self):
+        """Optional synced_at/max_results/next_token are forwarded to the API."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'list_instrumentation_configurations',
+            {
+                'Service': 'svc',
+                'Environment': 'env',
+                'Changed': False,
+                'LatestConfigurations': [],
+                'SyncedAt': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+                'SyncInterval': 60,
+            },
+            expected_params={
+                'Service': 'svc',
+                'Environment': 'env',
+                'InstrumentationType': 'BREAKPOINT',
+                'SyncedAt': '2026-03-09T11:00:00Z',
+                'MaxResults': 5,
+                'NextToken': 'tok',
+            },
+        )
+        rendered = crud_tools.list_instrumentations(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            synced_at='2026-03-09T11:00:00Z',
+            max_results=5,
+            next_token='tok',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'No active BREAKPOINT instrumentations found' in rendered
+
+    def test_get_instrumentation_error_path(self):
+        """A backend error on get renders the attempted-retrieve block."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'get_instrumentation_configuration',
+            service_error_code='ResourceNotFoundException',
+            service_message='no such config',
+        )
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'ATTEMPTED TO RETRIEVE:' in rendered
+        assert 'ResourceNotFoundException' in rendered
+
+    def test_get_instrumentation_requires_location_identifier(self):
+        """Get without any location identifier returns usage help."""
+        rendered = crud_tools.get_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'Must provide one of' in rendered
+
+    def test_delete_instrumentation_by_code_location(self):
+        """Delete resolves a code location into a CodeLocation identifier."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'delete_instrumentation_configuration',
+            {'DeletionStatus': 'DELETED'},
+            expected_params={
+                'InstrumentationType': 'BREAKPOINT',
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'LocationIdentifier': {
+                    'CodeLocation': {
+                        'Language': 'Python',
+                        'FilePath': '/app/handler.py',
+                        'MethodName': 'run',
+                    }
+                },
+            },
+        )
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            language='Python',
+            file_path='/app/handler.py',
+            method_name='run',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'Successfully deleted BREAKPOINT instrumentation' in rendered
+
+    def test_delete_instrumentation_requires_location_identifier(self):
+        """Delete without any location identifier returns usage help."""
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'Must provide one of' in rendered
+
+    def test_delete_instrumentation_error_path(self):
+        """A backend error on delete renders the attempted-delete block."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'delete_instrumentation_configuration',
+            service_error_code='ResourceNotFoundException',
+            service_message='gone',
+        )
+        rendered = crud_tools.delete_instrumentation(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'ATTEMPTED TO DELETE:' in rendered
+        assert 'ResourceNotFoundException' in rendered
+
+    def test_batch_delete_by_arns_success(self):
+        """Batch delete by ARNs renders a successful summary."""
+        stubber = self._stub_application_signals()
+        arn = (
+            'arn:aws:application-signals:us-west-1:123456789012:'
+            'instrumentationConfig/svc/env/SNAPSHOT/aaaabbbbccccdddd'
+        )
+        stubber.add_response(
+            'batch_delete_instrumentation_configurations',
+            {
+                'DeletedCount': 1,
+                'SuccessfulDeletions': [{'ResourceArn': arn}],
+                'Errors': [],
+            },
+            expected_params={
+                'DeletionTarget': {
+                    'ResourceArns': {
+                        'ResourceArns': [arn],
+                        'InstrumentationType': 'BREAKPOINT',
+                    }
+                }
+            },
+        )
+        rendered = crud_tools.batch_delete_instrumentations_by_arns(
+            resource_arns=[arn],
+            instrumentation_type='BREAKPOINT',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'DeletedCount: 1' in rendered
+        assert 'Mode: ResourceArns' in rendered
+
+    def test_batch_delete_by_arns_error_path(self):
+        """A backend error on ARN batch delete renders the attempted block."""
+        stubber = self._stub_application_signals()
+        arn = (
+            'arn:aws:application-signals:us-west-1:123456789012:'
+            'instrumentationConfig/svc/env/SNAPSHOT/aaaabbbbccccdddd'
+        )
+        stubber.add_client_error(
+            'batch_delete_instrumentation_configurations',
+            service_error_code='ValidationException',
+            service_message='bad arns',
+        )
+        rendered = crud_tools.batch_delete_instrumentations_by_arns(
+            resource_arns=[arn],
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'ValidationException' in rendered
+        assert 'bad arns' in rendered
+
+    def test_batch_delete_by_arns_rejects_empty_list(self):
+        """An empty ARN list is rejected before any API call."""
+        rendered = crud_tools.batch_delete_instrumentations_by_arns(
+            resource_arns=[],
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'at least one ARN' in rendered
+
+    def test_batch_delete_by_arns_rejects_too_many(self):
+        """More than 50 ARNs are rejected before any API call."""
+        rendered = crud_tools.batch_delete_instrumentations_by_arns(
+            resource_arns=['arn'] * 51,
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'at most 50 ARNs' in rendered
+
+    def test_batch_delete_by_arns_rejects_blank_arn(self):
+        """A blank ARN entry is rejected before any API call."""
+        rendered = crud_tools.batch_delete_instrumentations_by_arns(
+            resource_arns=['  '],
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'non-empty ARN strings only' in rendered
+
+    def test_batch_delete_by_scope_error_path(self):
+        """A backend error on scope batch delete renders the failure block."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'batch_delete_instrumentation_configurations',
+            service_error_code='ValidationException',
+            service_message='bad scope',
+        )
+        rendered = crud_tools.batch_delete_instrumentations_by_scope(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+        )
+        assert 'ValidationException' in rendered
+        assert 'bad scope' in rendered
+
+    def test_batch_delete_by_scope_rejects_invalid_type(self):
+        """An invalid instrumentation_type short-circuits scope batch delete."""
+        rendered = crud_tools.batch_delete_instrumentations_by_scope(
+            service='svc',
+            environment='env',
+            instrumentation_type='NOPE',
+        )
+        assert 'instrumentation_type must be one of' in rendered
 
 
 # Ensure tests don't depend on any pre-existing AWS credentials in the env.

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -43,12 +43,14 @@ class RecorderMCP:
     def __init__(self):
         """Initialize the recorder."""
         self.registered = []
+        self.annotations = {}
 
-    def tool(self):
-        """Return a decorator that records the registered tool's name."""
+    def tool(self, *, annotations=None):
+        """Return a decorator that records the registered tool's name and annotations."""
 
         def _decorator(func):
             self.registered.append(func.__name__)
+            self.annotations[func.__name__] = annotations
             return func
 
         return _decorator
@@ -488,39 +490,6 @@ class TestSignalValidationAndNormalization:
         assert error is not None
         assert 'must be SNAPSHOT' in error
 
-    def test_normalize_status_defaults_signal_to_snapshot(self):
-        """Normalize status defaults signal to snapshot."""
-        normalized, error = validation.normalize_status_configurations(
-            [
-                {
-                    'InstrumentationType': 'BREAKPOINT',
-                    'LocationHash': 'aaaabbbbccccdddd',
-                    'Status': 'READY',
-                    'Time': '2026-03-06T00:00:00Z',
-                }
-            ]
-        )
-        assert error is None
-        assert normalized is not None
-        assert normalized[0]['SignalType'] == 'SNAPSHOT'
-
-    def test_normalize_status_rejects_watcher(self):
-        """Normalize status rejects watcher."""
-        normalized, error = validation.normalize_status_configurations(
-            [
-                {
-                    'InstrumentationType': 'WATCHER',
-                    'SignalType': 'SNAPSHOT',
-                    'LocationHash': 'aaaabbbbccccdddd',
-                    'Status': 'READY',
-                    'Time': '2026-03-06T00:00:00Z',
-                }
-            ]
-        )
-        assert normalized is None
-        assert error is not None
-        assert 'invalid InstrumentationType' in error
-
 
 class TestBatchDeleteFormatting:
     """Test batch-delete response rendering."""
@@ -900,10 +869,61 @@ class TestToolRegistration:
             'batch_delete_instrumentations_by_arns',
             'get_instrumentation_configuration_status',
             'check_instrumentation_status',
-            'report_instrumentation_configuration_status',
             'search_snapshots_for_status_event',
             'get_sample_snapshot_for_breakpoint',
         ]
+
+    def test_read_only_tools_are_annotated_read_only(self):
+        """Read-only tools carry ``readOnlyHint=True`` for MCP clients."""
+        recorder = RecorderMCP()
+
+        registration.register_tools(recorder)
+
+        for name in (
+            'list_instrumentations',
+            'get_instrumentation',
+            'get_instrumentation_configuration_status',
+            'check_instrumentation_status',
+            'search_snapshots_for_status_event',
+            'get_sample_snapshot_for_breakpoint',
+        ):
+            assert recorder.annotations[name].readOnlyHint is True
+
+    def test_destructive_tools_are_annotated_destructive(self):
+        """Delete tools carry ``destructiveHint=True`` so clients can warn first."""
+        recorder = RecorderMCP()
+
+        registration.register_tools(recorder)
+
+        for name in (
+            'delete_instrumentation',
+            'batch_delete_instrumentations_by_scope',
+            'batch_delete_instrumentations_by_arns',
+        ):
+            annotations = recorder.annotations[name]
+            assert annotations.readOnlyHint is False
+            assert annotations.destructiveHint is True
+            assert annotations.idempotentHint is True
+
+    def test_create_tool_is_state_changing_but_not_destructive(self):
+        """create_instrumentation is a write, not a read and not destructive."""
+        recorder = RecorderMCP()
+
+        registration.register_tools(recorder)
+
+        annotations = recorder.annotations['create_instrumentation']
+        assert annotations.readOnlyHint is False
+        assert annotations.destructiveHint is False
+        assert annotations.idempotentHint is False
+
+    def test_every_tool_is_annotated_open_world(self):
+        """Every tool calls the AWS API, so all carry ``openWorldHint=True``."""
+        recorder = RecorderMCP()
+
+        registration.register_tools(recorder)
+
+        for name in recorder.registered:
+            assert recorder.annotations[name].openWorldHint is True
 
 
 class TestSnapshotLogGroupResolution:

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -17,6 +17,7 @@
 
 """Unit tests for dynamic instrumentation helper modules."""
 
+import awslabs.cloudwatch_applicationsignals_mcp_server.aws_clients as parent_aws_clients
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.aws_clients as aws_clients
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.capture as capture
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.constants as constants
@@ -27,7 +28,9 @@ import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.registration as registration
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_parsing as snapshot_parsing
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_rendering as snapshot_rendering
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.snapshot_tools as snapshot_tools
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.status_rendering as status_rendering
+import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.status_tools as status_tools
 import awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.validation as validation
 import json
 import os
@@ -819,6 +822,345 @@ class TestSnapshotHelpers:
         assert parsed['sample_snapshot']['attributes']['aws.di.snapshot_id'] == 'snap-1'
         assert parsed['field_documentation']
         assert 'attributes.aws.di.location_hash' in parsed['field_documentation']
+
+
+class TestGetInstrumentationConfigurationStatusTool:
+    """Stubber-driven coverage for the get-status tool entrypoint."""
+
+    def _stub_application_signals(self) -> Stubber:
+        client = aws_clients.get_application_signals_client()
+        stubber = Stubber(client)
+        stubber.activate()
+        return stubber
+
+    def test_requires_status_argument(self):
+        """Omitting status returns the explicit-status guidance, not an API call."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+        )
+        assert 'status is required' in rendered
+
+    def test_rejects_invalid_status(self):
+        """An out-of-enum status is rejected before any API call."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='WAT',
+        )
+        assert 'invalid status' in rendered
+
+    def test_requires_location_identifier(self):
+        """Without a location identifier, the tool returns usage help."""
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            status='READY',
+        )
+        assert 'Must provide one of' in rendered
+
+    def test_renders_confirmed_status_with_events(self):
+        """A READY response with events renders a CONFIRMED report."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration_status',
+            {
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Location': {
+                    'CodeLocation': {
+                        'Language': 'Python',
+                        'FilePath': '/app/handler.py',
+                        'MethodName': 'run',
+                    }
+                },
+                'Status': 'READY',
+                'Events': [{'Time': datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc)}],
+            },
+            expected_params={
+                'InstrumentationType': 'BREAKPOINT',
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Status': 'READY',
+                'LocationIdentifier': {'LocationHash': 'aaaabbbbccccdddd'},
+            },
+        )
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'INSTRUMENTATION STATUS' in rendered
+        assert 'CONFIRMED' in rendered
+        assert 'Events Returned: 1' in rendered
+
+    def test_translates_client_error_with_attempted_block(self):
+        """A backend error renders the attempted-retrieval block."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'get_instrumentation_configuration_status',
+            service_error_code='ResourceNotFoundException',
+            service_message='no such config',
+        )
+        rendered = status_tools.get_instrumentation_configuration_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            status='READY',
+        )
+        assert 'ATTEMPTED TO RETRIEVE:' in rendered
+        assert 'ResourceNotFoundException' in rendered
+
+
+def _full_instrumentation_configuration() -> dict:
+    """A Configuration block with every field the bundled model marks required."""
+    return {
+        'InstrumentationType': 'BREAKPOINT',
+        'Service': 'svc',
+        'Environment': 'env',
+        'SignalType': 'SNAPSHOT',
+        'Location': {
+            'CodeLocation': {
+                'Language': 'Python',
+                'FilePath': '/app/handler.py',
+                'MethodName': 'run',
+            }
+        },
+        'LocationHash': 'aaaabbbbccccdddd',
+        'CaptureConfiguration': {
+            'CodeCapture': {
+                'CaptureArguments': ['order_id'],
+                'CaptureReturn': True,
+                'CaptureStackTrace': True,
+                'CaptureLimits': {},
+            }
+        },
+        'CreatedAt': datetime(2026, 3, 9, 11, 0, 0, tzinfo=timezone.utc),
+        'ARN': 'arn:demo',
+    }
+
+
+class TestCheckInstrumentationStatusTool:
+    """Stubber-driven coverage for the consolidated status-check tool."""
+
+    def _stub_application_signals(self) -> Stubber:
+        client = aws_clients.get_application_signals_client()
+        stubber = Stubber(client)
+        stubber.activate()
+        return stubber
+
+    def test_rejects_bad_location_hash_length(self):
+        """A non-16-character location hash is rejected before any API call."""
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='short',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        assert 'location_hash must be a 16-character' in rendered
+
+    def test_rejects_end_before_start(self):
+        """end_time must be later than start_time; this is caught after config fetch."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration',
+            {'Configuration': _full_instrumentation_configuration()},
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:05:00Z',
+            end_time='2026-03-09T12:00:00Z',
+        )
+        assert 'end_time must be later than start_time' in rendered
+
+    def test_config_fetch_error_reports_failure(self):
+        """A backend error fetching the configuration surfaces a created_at failure."""
+        stubber = self._stub_application_signals()
+        stubber.add_client_error(
+            'get_instrumentation_configuration',
+            service_error_code='ResourceNotFoundException',
+            service_message='no such config',
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        assert 'Failed to fetch created_at' in rendered
+
+    def test_active_verdict_renders_when_active_events_present(self):
+        """A populated ACTIVE check yields an ACTIVE consolidated assessment."""
+        stubber = self._stub_application_signals()
+        stubber.add_response(
+            'get_instrumentation_configuration',
+            {'Configuration': _full_instrumentation_configuration()},
+        )
+        # The consolidated check queries ACTIVE first; one event short-circuits to ACTIVE.
+        stubber.add_response(
+            'get_instrumentation_configuration_status',
+            {
+                'Service': 'svc',
+                'Environment': 'env',
+                'SignalType': 'SNAPSHOT',
+                'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/app/h.py'}},
+                'Status': 'ACTIVE',
+                'Events': [{'Time': datetime(2026, 3, 9, 12, 1, 0, tzinfo=timezone.utc)}],
+            },
+        )
+        rendered = status_tools.check_instrumentation_status(
+            service='svc',
+            environment='env',
+            instrumentation_type='BREAKPOINT',
+            location_hash='aaaabbbbccccdddd',
+            start_time='2026-03-09T12:00:00Z',
+            end_time='2026-03-09T12:05:00Z',
+        )
+        stubber.assert_no_pending_responses()
+        assert 'ACTIVE' in rendered
+
+
+class TestSnapshotToolsCloudWatchPath:
+    """Cover the snapshot tool entrypoints by stubbing the parent logs client.
+
+    The parent ``logs_client`` is a module-level singleton, so each test uses
+    ``Stubber`` as a context manager to guarantee it deactivates before the next
+    test stubs the same client.
+    """
+
+    def test_search_rejects_bad_timestamp(self):
+        """A non-ISO status_timestamp returns a usage error before querying."""
+        rendered = snapshot_tools.search_snapshots_for_status_event(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            status_timestamp='not-a-timestamp',
+        )
+        assert 'ISO 8601 format' in rendered
+
+    def test_search_renders_results_from_logs_insights(self):
+        """A completed Logs Insights query renders snapshot summaries as JSON."""
+        with Stubber(parent_aws_clients.logs_client) as stubber:
+            stubber.add_response('start_query', {'queryId': 'q-1'})
+            stubber.add_response(
+                'get_query_results',
+                {
+                    'status': 'Complete',
+                    'results': [
+                        [
+                            {'field': '@timestamp', 'value': '2026-03-09 12:00:00.000'},
+                            {
+                                'field': '@message',
+                                'value': json.dumps(
+                                    {
+                                        'traceId': 'trace-1',
+                                        'attributes': {
+                                            'aws.di.snapshot_id': 'snap-1',
+                                            'aws.di.location_hash': 'aaaabbbbccccdddd',
+                                        },
+                                    }
+                                ),
+                            },
+                        ]
+                    ],
+                },
+            )
+            rendered = snapshot_tools.search_snapshots_for_status_event(
+                service_name='svc',
+                environment='env',
+                location_hash='aaaabbbbccccdddd',
+                status_timestamp='2026-03-09T12:00:00Z',
+            )
+            stubber.assert_no_pending_responses()
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'Complete'
+        assert parsed['snapshot_summaries'][0]['snapshot_id'] == 'snap-1'
+
+    def test_search_renders_error_when_start_query_fails(self):
+        """A start_query ClientError surfaces as a structured ERROR response."""
+        with Stubber(parent_aws_clients.logs_client) as stubber:
+            stubber.add_client_error(
+                'start_query',
+                service_error_code='ResourceNotFoundException',
+                service_message='no log group',
+            )
+            rendered = snapshot_tools.search_snapshots_for_status_event(
+                service_name='svc',
+                environment='env',
+                location_hash='aaaabbbbccccdddd',
+                status_timestamp='2026-03-09T12:00:00Z',
+            )
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'ERROR'
+        assert 'Failed to start query' in parsed['error']
+
+    def test_sample_rejects_bad_timestamp(self):
+        """get_sample_snapshot_for_breakpoint validates the timestamp too."""
+        rendered = snapshot_tools.get_sample_snapshot_for_breakpoint(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            status_timestamp='nope',
+        )
+        assert 'ISO 8601 format' in rendered
+
+    def test_sample_renders_single_snapshot(self):
+        """A single completed result renders a SUCCESS sample-snapshot response."""
+        with Stubber(parent_aws_clients.logs_client) as stubber:
+            stubber.add_response('start_query', {'queryId': 'q-2'})
+            stubber.add_response(
+                'get_query_results',
+                {
+                    'status': 'Complete',
+                    'results': [
+                        [
+                            {'field': '@timestamp', 'value': '2026-03-09 12:00:00.000'},
+                            {
+                                'field': '@message',
+                                'value': json.dumps(
+                                    {
+                                        'traceId': 'trace-1',
+                                        'attributes': {
+                                            'event.name': 'aws.dynamic_instrumentation.snapshot',
+                                            'aws.di.snapshot_id': 'snap-1',
+                                            'aws.di.location_hash': 'aaaabbbbccccdddd',
+                                        },
+                                    }
+                                ),
+                            },
+                        ]
+                    ],
+                },
+            )
+            rendered = snapshot_tools.get_sample_snapshot_for_breakpoint(
+                service_name='svc',
+                environment='env',
+                location_hash='aaaabbbbccccdddd',
+                status_timestamp='2026-03-09T12:00:00Z',
+                include_raw=True,
+            )
+            stubber.assert_no_pending_responses()
+        parsed = json.loads(rendered)
+        assert parsed['status'] == 'SUCCESS'
+        assert parsed['sample_snapshot']['attributes']['aws.di.snapshot_id'] == 'snap-1'
 
 
 class TestCodeInstrumentationArgumentContract:

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -38,7 +38,7 @@ import os
 import pytest
 from botocore.exceptions import ClientError, EndpointConnectionError, NoCredentialsError
 from botocore.stub import Stubber
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 
 class RecorderMCP:
@@ -1713,6 +1713,34 @@ class TestSnapshotParsingFields:
         )
         assert parsed['line_throwables']['5']['stacktrace_frame_count'] == 0
 
+    def test_mixed_numeric_and_non_numeric_line_keys_sort_without_crash(self):
+        """Numeric and non-numeric line keys sort with a total order, no TypeError.
+
+        A bare ``int(v) if v.isdigit() else v`` sort key would raise TypeError
+        comparing int vs str. ``'-1'.isdigit()`` is False, so a negative line
+        number is the realistic trigger. Numeric keys sort first by value
+        (so ``'9'`` before ``'10'``), non-numeric keys sort last lexically.
+        """
+        parsed = snapshot_parsing._parse_snapshot_fields(
+            {
+                '@message': json.dumps(
+                    {
+                        'body': {
+                            'captures': {
+                                'lines': {
+                                    '10': {'locals': {'a': {'type': 'int', 'value': '1'}}},
+                                    '9': {'locals': {'b': {'type': 'int', 'value': '2'}}},
+                                    '-1': {'locals': {'c': {'type': 'int', 'value': '3'}}},
+                                    'entry': {'locals': {'d': {'type': 'int', 'value': '4'}}},
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        )
+        assert parsed['line_numbers'] == ['9', '10', '-1', 'entry']
+
 
 class TestValidationLocationInputs:
     """Direct coverage for validation._validate_location_inputs and troubleshooting."""
@@ -2737,31 +2765,22 @@ os.environ.setdefault('AWS_DEFAULT_REGION', 'us-west-2')
 
 
 class TestResolveRegion:
-    """Cover the region-resolution ladder in dynamic_instrumentation.aws_clients."""
+    """Cover region resolution in dynamic_instrumentation.aws_clients.
+
+    DI deliberately matches the parent package (and every sibling MCP server):
+    AWS_REGION env var, else us-east-1. The profile region is intentionally not
+    consulted, so the DI app-signals client and the parent's logs_client always
+    resolve to the same region for a given caller.
+    """
 
     def test_env_region_wins(self, monkeypatch):
-        """AWS_REGION env var takes precedence over profile/config."""
+        """AWS_REGION env var is used when set."""
         monkeypatch.setenv('AWS_REGION', 'eu-central-1')
         assert aws_clients._resolve_region() == 'eu-central-1'
 
-    def test_session_region_used_when_no_env(self, monkeypatch):
-        """With no AWS_REGION, the boto3 session's region_name is returned."""
-        monkeypatch.delenv('AWS_REGION', raising=False)
-
-        class _FakeSession:
-            region_name = 'ap-southeast-2'
-
-        monkeypatch.setattr(aws_clients.boto3, 'Session', lambda **kwargs: _FakeSession())
-        assert aws_clients._resolve_region() == 'ap-southeast-2'
-
     def test_falls_back_to_us_east_1(self, monkeypatch):
-        """With neither env var nor session region, us-east-1 is the fallback."""
+        """With no AWS_REGION, us-east-1 is the fallback (profile region ignored)."""
         monkeypatch.delenv('AWS_REGION', raising=False)
-
-        class _FakeSession:
-            region_name = None
-
-        monkeypatch.setattr(aws_clients.boto3, 'Session', lambda **kwargs: _FakeSession())
         assert aws_clients._resolve_region() == 'us-east-1'
 
 
@@ -3238,7 +3257,7 @@ class TestSnapshotToolsNaiveTimeAndFilters:
         rendered = snapshot_tools.search_snapshots_for_status_event(
             service_name='svc',
             environment='env',
-            location_hash='h',
+            location_hash='aaaabbbbccccdddd',
             status_timestamp='2026-03-09T12:00:00',
             custom_filters=['@message like /boom/', '   ', ''],
         )
@@ -3256,11 +3275,115 @@ class TestSnapshotToolsNaiveTimeAndFilters:
         rendered = snapshot_tools.get_sample_snapshot_for_breakpoint(
             service_name='svc',
             environment='env',
-            location_hash='h',
+            location_hash='aaaabbbbccccdddd',
             status_timestamp='2026-03-09T12:00:00',
         )
         parsed = json.loads(rendered)
         assert parsed['status'] == 'NO_SNAPSHOTS_FOUND'
+
+
+class TestIsValidLocationHash:
+    """Cover the shared 16-char lowercase-hex location-hash validator."""
+
+    def test_valid_lowercase_hex(self):
+        """A 16-char lowercase hex string is valid."""
+        assert validation.is_valid_location_hash('0123456789abcdef') is True
+
+    def test_uppercase_hex_rejected(self):
+        """Uppercase hex is rejected (hashes are lowercase by API design)."""
+        assert validation.is_valid_location_hash('0123456789ABCDEF') is False
+
+    def test_wrong_length_rejected(self):
+        """A hash that is not exactly 16 characters is rejected."""
+        assert validation.is_valid_location_hash('abc') is False
+        assert validation.is_valid_location_hash('a' * 17) is False
+
+    def test_non_hex_characters_rejected(self):
+        """A 16-char string with a non-hex character is rejected."""
+        assert validation.is_valid_location_hash('zzzzzzzzzzzzzzzz') is False
+
+    def test_none_and_empty_rejected(self):
+        """None and empty input are rejected."""
+        assert validation.is_valid_location_hash(None) is False
+        assert validation.is_valid_location_hash('') is False
+
+
+class TestSnapshotToolsQueryHardening:
+    """Cover injection-hardening guards on the snapshot query tools."""
+
+    def test_search_rejects_invalid_location_hash(self):
+        """search_snapshots rejects a non-hex location_hash before querying."""
+        rendered = snapshot_tools.search_snapshots_for_status_event(
+            service_name='svc',
+            environment='env',
+            location_hash='not-a-hash',
+            status_timestamp='2026-03-09T12:00:00Z',
+        )
+        assert rendered == 'ERROR: location_hash must be a 16-character hex string'
+
+    def test_sample_rejects_invalid_location_hash(self):
+        """get_sample_snapshot rejects a non-hex location_hash before querying."""
+        rendered = snapshot_tools.get_sample_snapshot_for_breakpoint(
+            service_name='svc',
+            environment='env',
+            location_hash='not-a-hash',
+            status_timestamp='2026-03-09T12:00:00Z',
+        )
+        assert rendered == 'ERROR: location_hash must be a 16-character hex string'
+
+    def test_search_rejects_non_integer_limit(self, monkeypatch):
+        """A non-integer limit is rejected before the query runs."""
+        monkeypatch.setattr(
+            snapshot_tools,
+            '_execute_cloudwatch_query',
+            lambda **kwargs: pytest.fail('query should not run'),
+        )
+        rendered = snapshot_tools.search_snapshots_for_status_event(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            status_timestamp='2026-03-09T12:00:00Z',
+            limit='ten',  # type: ignore[arg-type]
+        )
+        assert rendered == 'ERROR: limit must be an integer'
+
+    def test_search_rejects_unbalanced_quote_in_custom_filter(self, monkeypatch):
+        """A custom filter with an unbalanced double-quote is rejected."""
+        monkeypatch.setattr(
+            snapshot_tools,
+            '_execute_cloudwatch_query',
+            lambda **kwargs: pytest.fail('query should not run'),
+        )
+        rendered = snapshot_tools.search_snapshots_for_status_event(
+            service_name='svc',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            status_timestamp='2026-03-09T12:00:00Z',
+            custom_filters=['service.name = "leak'],
+        )
+        assert 'unbalanced quotes' in rendered
+
+    def test_search_escapes_quotes_in_service_and_environment(self, monkeypatch):
+        """A double-quote in service_name/environment is escaped, not left raw.
+
+        Without escaping, the quote would terminate the Logs Insights string
+        literal and the rest would become caller-controlled query syntax.
+        """
+        captured = {}
+
+        def _fake_query(*, query_string, **kwargs):
+            captured['query_string'] = query_string
+            return {'status': 'Complete', 'queryId': 'q', 'results': [], 'messages': []}
+
+        monkeypatch.setattr(snapshot_tools, '_execute_cloudwatch_query', _fake_query)
+        snapshot_tools.search_snapshots_for_status_event(
+            service_name='svc" or "1"="1',
+            environment='env',
+            location_hash='aaaabbbbccccdddd',
+            status_timestamp='2026-03-09T12:00:00Z',
+        )
+        # The injected quote is backslash-escaped, so the literal is not broken.
+        assert 'service.name = "svc\\" or \\"1\\"=\\"1"' in captured['query_string']
 
 
 class TestStatusRenderingBranches:
@@ -3435,6 +3558,26 @@ class TestStatusAssessmentBranches:
             check_status=check,
         )
         assert isinstance(verdict, status_assessment.Ready)
+
+
+class TestParseIsoTimestamp:
+    """Cover naive vs tz-aware handling in status_tools._parse_iso_timestamp."""
+
+    def test_naive_input_assumed_utc(self):
+        """A naive timestamp (no Z/offset) is tagged UTC without shifting digits."""
+        parsed = status_tools._parse_iso_timestamp('2025-02-03T18:42:00')
+        assert parsed.tzinfo is timezone.utc
+        assert parsed.hour == 18  # not shifted into host-local time
+
+    def test_z_suffix_parsed_as_utc(self):
+        """A trailing Z is parsed as a UTC offset."""
+        parsed = status_tools._parse_iso_timestamp('2025-02-03T18:42:00Z')
+        assert parsed.utcoffset() == timedelta(0)
+
+    def test_explicit_offset_preserved(self):
+        """An explicit offset is preserved rather than overwritten with UTC."""
+        parsed = status_tools._parse_iso_timestamp('2025-02-03T18:42:00+05:00')
+        assert parsed.utcoffset() == timedelta(hours=5)
 
 
 class TestStatusToolsBranches:


### PR DESCRIPTION
## Description

This PR adds **dynamic instrumentation** tools to the CloudWatch Application Signals MCP server. Dynamic instrumentation lets users interactively debug live Application Signals services without redeploying — placing breakpoint- or probe-style instrumentation on running services and inspecting the captured snapshots (arguments, local state, stack traces) from CloudWatch Logs.

### Intent of this change

The goal is to **land the dynamic instrumentation tools now, bundled with a trimmed service model**, so that:

1. **The tools are usable immediately** against the preview dynamic instrumentation API.
2. **Once the public AWS SDK ships the new dynamic instrumentation APIs**, a follow-up PR will:
   - bump the `boto3`/`botocore` floor to the version that includes the operations,
   - rewire the client factory to use the public model instead of the bundled one,
   - and delete the bundled `aws_data/` model directory.

In other words: bundle the preview model today so the feature works, then cut over to the published Python SDK as soon as the APIs are generally available.

### Tools added (11)

**Configuration & status**
- `create_instrumentation`, `list_instrumentations`, `get_instrumentation`, `delete_instrumentation`, `batch_delete_instrumentations_by_scope`, `batch_delete_instrumentations_by_arns`
- `get_instrumentation_configuration_status`, `check_instrumentation_status`

**Snapshot analysis**
- `search_snapshots_for_status_event`, `get_sample_snapshot_for_breakpoint`

### Preview API note

These tools depend on `application-signals` dynamic instrumentation operations that are **not yet in the public AWS SDK**. The server bundles a trimmed preview service model (only the seven `*InstrumentationConfiguration*` operations the tools call, generated from the service team's source-of-truth Smithy model) loaded via a **session-scoped** botocore data loader — it does not mutate `AWS_DATA_PATH` and is invisible to the existing application-signals client. The bundled model is removed in the follow-up once the operations are generally available in `botocore` (see `dynamic_instrumentation/aws_data/README.md`).

The feature requires no special configuration: snapshots are read from a per-service CloudWatch Logs group (`/aws/service-events/<service-name>`) and the client uses normal AWS endpoint resolution.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `uv run --frozen pytest tests/` — 945 passed (66 dynamic-instrumentation tests)
- [x] `ruff check` / `ruff format` clean
- [x] pre-commit hooks pass (detect-secrets, license headers, json formatting, AST/credential checks)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (server README, CHANGELOG, package docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## By submitting this pull request

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

