### PR TITLE
feat(eks-mcp-server): Add runtime AWS context switching

### DIFF
--- a/src/eks-mcp-server/README.md
+++ b/src/eks-mcp-server/README.md
@@ -613,6 +613,49 @@ Parameters:
 
 * cluster_name, insight_id (optional), category (optional), next_token (optional)
 
+### AWS Context Management
+
+#### `get_aws_context`
+
+Returns the currently configured AWS profile and region used for all AWS API calls.
+
+Features:
+
+* Returns the current AWS profile and region from environment variables.
+* Returns `None` for values that are not explicitly set (falling back to AWS SDK defaults).
+
+Parameters:
+
+* None
+
+#### `set_aws_context`
+
+Changes the AWS profile and/or region at runtime without restarting the MCP server.
+
+Features:
+
+* Sets the AWS profile and/or region used for all subsequent AWS API calls.
+* Clears all cached AWS and Kubernetes clients to ensure new connections use the updated credentials.
+* Pass an empty string (`""`) to clear a value and revert to AWS SDK defaults.
+* Useful for switching between AWS accounts or regions, or querying clusters in different regions.
+
+Parameters:
+
+* profile (optional): AWS profile name from `~/.aws/credentials` or `~/.aws/config`. Pass `None` to keep current value, empty string to clear.
+* region (optional): AWS region code (e.g., `us-east-1`, `ap-south-1`). Pass `None` to keep current value, empty string to clear.
+
+Example usage:
+
+```
+# Switch to a production account in us-west-2
+set_aws_context(profile="prod-account", region="us-west-2")
+
+# Change only the region, keep the current profile
+set_aws_context(region="eu-west-1")
+
+# Clear the profile to use default credentials
+set_aws_context(profile="")
+```
 
 ## Security & permissions
 

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/aws_context_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/aws_context_handler.py
@@ -1,0 +1,168 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS context handler for runtime profile/region switching."""
+
+from awslabs.eks_mcp_server.aws_helper import AwsHelper
+from awslabs.eks_mcp_server.k8s_client_cache import K8sClientCache
+from awslabs.eks_mcp_server.logging_helper import LogLevel, log_with_request_id
+from loguru import logger
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel, Field
+from typing import Annotated, Optional
+
+
+class AwsContextData(BaseModel):
+    """Data model for AWS context operations."""
+
+    success: bool = Field(description='Whether the operation succeeded')
+    profile: Optional[str] = Field(description='Current AWS profile (None if using default)')
+    region: Optional[str] = Field(description='Current AWS region (None if using default)')
+    message: str = Field(description='Human-readable status message')
+
+
+class AwsContextHandler:
+    """Handler for AWS context management tools.
+
+    Provides tools to get and set AWS profile/region at runtime without
+    restarting the MCP server.
+    """
+
+    def __init__(self, mcp: FastMCP):
+        """Initialize the AWS context handler and register tools.
+
+        Args:
+            mcp: The FastMCP server instance
+        """
+        self.mcp = mcp
+
+        # Register tools using the same pattern as other handlers
+        self.mcp.tool(name='get_aws_context')(self.get_aws_context)
+        self.mcp.tool(name='set_aws_context')(self.set_aws_context)
+
+    async def get_aws_context(self, ctx: Context) -> CallToolResult:
+        """Get the current AWS profile and region.
+
+        Returns the currently configured AWS profile and region used for
+        all AWS API calls. Returns None for values that are not explicitly
+        set (falling back to AWS SDK defaults).
+
+        This tool is useful for verifying which AWS credentials are currently
+        in use before making API calls.
+
+        Args:
+            ctx: The MCP context
+
+        Returns:
+            CallToolResult with current profile and region
+        """
+        log_with_request_id(ctx, LogLevel.INFO, 'Getting AWS context')
+
+        profile = AwsHelper.get_aws_profile()
+        region = AwsHelper.get_aws_region()
+
+        data = AwsContextData(
+            success=True,
+            profile=profile,
+            region=region,
+            message=f'AWS context: profile={profile or "(default)"}, region={region or "(default)"}',
+        )
+
+        return CallToolResult(
+            content=[TextContent(type='text', text=data.model_dump_json(indent=2))]
+        )
+
+    async def set_aws_context(
+        self,
+        ctx: Context,
+        profile: Annotated[
+            Optional[str],
+            Field(description='AWS profile name to use. Pass empty string "" to clear and use default credentials.'),
+        ] = None,
+        region: Annotated[
+            Optional[str],
+            Field(description='AWS region to use (e.g., "us-east-1", "ap-south-1"). Pass empty string "" to clear.'),
+        ] = None,
+    ) -> CallToolResult:
+        """Set the AWS profile and/or region at runtime.
+
+        Changes the AWS profile and/or region used for all subsequent AWS API calls.
+        This clears all cached AWS and Kubernetes clients to ensure new connections
+        use the updated credentials.
+
+        Use this tool to switch between AWS accounts or regions without restarting
+        the MCP server. For example, to switch from a dev account to prod, or to
+        query clusters in different regions.
+
+        IMPORTANT: After switching context, any subsequent tool calls will use the
+        new credentials. This affects all AWS API operations including EKS cluster
+        access.
+
+        ## Usage Tips
+        - Use get_aws_context first to see current settings
+        - Pass None (or omit) to keep a value unchanged
+        - Pass empty string "" to clear a value and use SDK defaults
+        - Both profile and region can be changed in a single call
+
+        Args:
+            ctx: The MCP context
+            profile: AWS profile name from ~/.aws/credentials or ~/.aws/config.
+                    Pass None to keep current value, empty string to clear.
+            region: AWS region code (e.g., "us-east-1").
+                    Pass None to keep current value, empty string to clear.
+
+        Returns:
+            CallToolResult with the new profile and region values
+        """
+        try:
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Setting AWS context: profile={profile}, region={region}',
+            )
+
+            # Update AWS context and clear boto3 client cache
+            result = AwsHelper.set_aws_context(profile=profile, region=region)
+
+            # Also clear Kubernetes client cache since it uses AWS credentials
+            k8s_cache = K8sClientCache()
+            k8s_cache.clear_cache()
+
+            new_profile = result['profile']
+            new_region = result['region']
+
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'AWS context updated: profile={new_profile}, region={new_region}',
+            )
+
+            data = AwsContextData(
+                success=True,
+                profile=new_profile,
+                region=new_region,
+                message=f'AWS context updated: profile={new_profile or "(default)"}, region={new_region or "(default)"}',
+            )
+
+            return CallToolResult(
+                content=[TextContent(type='text', text=data.model_dump_json(indent=2))]
+            )
+        except Exception as e:
+            error_msg = f'Failed to set AWS context: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            return CallToolResult(
+                isError=True,
+                content=[TextContent(type='text', text=error_msg)],
+            )

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/aws_helper.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/aws_helper.py
@@ -38,6 +38,47 @@ class AwsHelper:
     # Client cache with AWS service name as key
     _client_cache: Dict[str, Any] = {}
 
+    @classmethod
+    def set_aws_context(cls, profile: Optional[str] = None, region: Optional[str] = None) -> Dict[str, Optional[str]]:
+        """Set AWS profile and/or region at runtime and clear cached clients.
+
+        Args:
+            profile: AWS profile name to use. Pass empty string to unset.
+            region: AWS region to use. Pass empty string to unset.
+
+        Returns:
+            Dict with the new profile and region values
+        """
+        if profile is not None:
+            if profile == '':
+                os.environ.pop('AWS_PROFILE', None)
+                logger.info('Cleared AWS_PROFILE')
+            else:
+                os.environ['AWS_PROFILE'] = profile
+                logger.info(f'Set AWS_PROFILE to {profile}')
+
+        if region is not None:
+            if region == '':
+                os.environ.pop('AWS_REGION', None)
+                logger.info('Cleared AWS_REGION')
+            else:
+                os.environ['AWS_REGION'] = region
+                logger.info(f'Set AWS_REGION to {region}')
+
+        # Clear the client cache so new clients use updated credentials
+        cls.clear_client_cache()
+
+        return {
+            'profile': cls.get_aws_profile(),
+            'region': cls.get_aws_region(),
+        }
+
+    @classmethod
+    def clear_client_cache(cls) -> None:
+        """Clear all cached boto3 clients."""
+        cls._client_cache.clear()
+        logger.info('Cleared AWS client cache')
+
     @staticmethod
     def get_aws_region() -> Optional[str]:
         """Get the AWS region from the environment if set."""

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_client_cache.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_client_cache.py
@@ -87,6 +87,16 @@ class K8sClientCache:
         """Return the current authentication mode."""
         return self._auth_mode
 
+    def clear_cache(self) -> None:
+        """Clear all cached Kubernetes clients.
+
+        This should be called when AWS credentials change to ensure
+        new clients are created with the updated credentials.
+        """
+        self._client_cache.clear()
+        self._sts_event_handlers_registered = False
+        logger.info('Cleared Kubernetes client cache')
+
     def _get_sts_client(self):
         """Get the STS client with event handlers registered."""
         sts_client = AwsHelper.create_boto3_client('sts')

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/server.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/server.py
@@ -27,6 +27,7 @@ Environment Variables:
 
 import argparse
 import os
+from awslabs.eks_mcp_server.aws_context_handler import AwsContextHandler
 from awslabs.eks_mcp_server.cloudwatch_handler import CloudWatchHandler
 from awslabs.eks_mcp_server.cloudwatch_metrics_guidance_handler import CloudWatchMetricsHandler
 from awslabs.eks_mcp_server.eks_kb_handler import EKSKnowledgeBaseHandler
@@ -178,6 +179,9 @@ def main():
 
     # Initialize handlers - all tools are always registered, access control is handled within tools
     K8sHandler(mcp, allow_write, allow_sensitive_data_access)
+
+    # AWS context handler for runtime profile/region switching (available in all modes)
+    AwsContextHandler(mcp)
 
     # AWS-dependent handlers require AWS credentials and are skipped in kubeconfig mode
     if auth_mode != 'kubeconfig':

--- a/src/eks-mcp-server/tests/test_aws_context_handler.py
+++ b/src/eks-mcp-server/tests/test_aws_context_handler.py
@@ -1,0 +1,185 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ruff: noqa: D101, D102, D103
+"""Tests for the AWS Context Handler."""
+
+import json
+import os
+import pytest
+from awslabs.eks_mcp_server.aws_context_handler import AwsContextHandler, AwsContextData
+from awslabs.eks_mcp_server.aws_helper import AwsHelper
+from awslabs.eks_mcp_server.k8s_client_cache import K8sClientCache
+from mcp.server.fastmcp import FastMCP
+from unittest.mock import MagicMock, patch
+
+
+class TestAwsContextHandler:
+    """Tests for the AwsContextHandler class."""
+
+    def setup_method(self):
+        """Set up the test environment."""
+        # Clear caches before each test
+        AwsHelper._client_cache = {}
+
+        # Reset K8sClientCache singleton for clean tests
+        K8sClientCache._instance = None
+
+    @pytest.fixture
+    def mcp_server(self):
+        """Create a mock MCP server."""
+        return FastMCP('test-server')
+
+    @pytest.fixture
+    def handler(self, mcp_server):
+        """Create an AwsContextHandler instance."""
+        return AwsContextHandler(mcp_server)
+
+    @pytest.fixture
+    def mock_ctx(self):
+        """Create a mock MCP context."""
+        ctx = MagicMock()
+        ctx.request_id = 'test-request-id'
+        return ctx
+
+    def test_handler_registers_tools(self, mcp_server, handler):
+        """Test that the handler registers the expected tools."""
+        # Get registered tools
+        tools = mcp_server._tool_manager._tools
+
+        # Verify both tools are registered
+        assert 'get_aws_context' in tools
+        assert 'set_aws_context' in tools
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {'AWS_PROFILE': 'test-profile', 'AWS_REGION': 'us-west-2'}, clear=True)
+    async def test_get_aws_context(self, handler, mock_ctx):
+        """Test get_aws_context returns current profile and region."""
+        result = await handler.get_aws_context(mock_ctx)
+
+        assert result.isError is not True
+        assert len(result.content) == 1
+
+        data = json.loads(result.content[0].text)
+        assert data['success'] is True
+        assert data['profile'] == 'test-profile'
+        assert data['region'] == 'us-west-2'
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {}, clear=True)
+    async def test_get_aws_context_no_values_set(self, handler, mock_ctx):
+        """Test get_aws_context when no profile/region is set."""
+        result = await handler.get_aws_context(mock_ctx)
+
+        data = json.loads(result.content[0].text)
+        assert data['success'] is True
+        assert data['profile'] is None
+        assert data['region'] is None
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {}, clear=True)
+    async def test_set_aws_context_sets_values(self, handler, mock_ctx):
+        """Test set_aws_context sets profile and region."""
+        result = await handler.set_aws_context(
+            mock_ctx, profile='new-profile', region='ap-south-1'
+        )
+
+        assert result.isError is not True
+        data = json.loads(result.content[0].text)
+        assert data['success'] is True
+        assert data['profile'] == 'new-profile'
+        assert data['region'] == 'ap-south-1'
+        assert os.environ.get('AWS_PROFILE') == 'new-profile'
+        assert os.environ.get('AWS_REGION') == 'ap-south-1'
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {'AWS_PROFILE': 'old-profile', 'AWS_REGION': 'old-region'}, clear=True)
+    async def test_set_aws_context_clears_values(self, handler, mock_ctx):
+        """Test set_aws_context clears values when empty string is passed."""
+        result = await handler.set_aws_context(mock_ctx, profile='', region='')
+
+        data = json.loads(result.content[0].text)
+        assert data['success'] is True
+        assert data['profile'] is None
+        assert data['region'] is None
+        assert 'AWS_PROFILE' not in os.environ
+        assert 'AWS_REGION' not in os.environ
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {'AWS_PROFILE': 'existing-profile'}, clear=True)
+    async def test_set_aws_context_partial_update(self, handler, mock_ctx):
+        """Test set_aws_context only updates specified values."""
+        # Only update region
+        result = await handler.set_aws_context(mock_ctx, region='eu-west-1')
+
+        data = json.loads(result.content[0].text)
+        assert data['success'] is True
+        assert data['profile'] == 'existing-profile'
+        assert data['region'] == 'eu-west-1'
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {}, clear=True)
+    async def test_set_aws_context_clears_aws_client_cache(self, handler, mock_ctx):
+        """Test that set_aws_context clears the AWS client cache."""
+        # Add a mock client to the cache
+        AwsHelper._client_cache['eks'] = MagicMock()
+
+        # Set new context
+        await handler.set_aws_context(mock_ctx, profile='new-profile')
+
+        # Verify cache was cleared
+        assert len(AwsHelper._client_cache) == 0
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {'EKS_AUTH_MODE': 'iam'}, clear=True)
+    async def test_set_aws_context_clears_k8s_client_cache(self, handler, mock_ctx):
+        """Test that set_aws_context clears the Kubernetes client cache."""
+        # Initialize the K8sClientCache singleton
+        k8s_cache = K8sClientCache()
+        k8s_cache._client_cache['test-cluster'] = MagicMock()
+
+        # Set new context
+        await handler.set_aws_context(mock_ctx, profile='new-profile')
+
+        # Verify K8s cache was cleared
+        assert len(k8s_cache._client_cache) == 0
+
+
+class TestAwsContextData:
+    """Tests for the AwsContextData model."""
+
+    def test_data_model_fields(self):
+        """Test that AwsContextData has expected fields."""
+        data = AwsContextData(
+            success=True,
+            profile='test-profile',
+            region='us-west-2',
+            message='Test message',
+        )
+
+        assert data.success is True
+        assert data.profile == 'test-profile'
+        assert data.region == 'us-west-2'
+        assert data.message == 'Test message'
+
+    def test_data_model_nullable_fields(self):
+        """Test that profile and region can be None."""
+        data = AwsContextData(
+            success=True,
+            profile=None,
+            region=None,
+            message='No profile or region set',
+        )
+
+        assert data.profile is None
+        assert data.region is None

--- a/src/eks-mcp-server/tests/test_aws_helper.py
+++ b/src/eks-mcp-server/tests/test_aws_helper.py
@@ -260,3 +260,59 @@ class TestAwsHelper:
 
         # Verify that the same client instance was returned both times
         assert client1 is client2
+
+    def test_clear_client_cache(self):
+        """Test that clear_client_cache clears all cached clients."""
+        # Add some clients to the cache
+        AwsHelper._client_cache['service1'] = MagicMock()
+        AwsHelper._client_cache['service2'] = MagicMock()
+
+        # Verify cache is not empty
+        assert len(AwsHelper._client_cache) == 2
+
+        # Clear the cache
+        AwsHelper.clear_client_cache()
+
+        # Verify cache is empty
+        assert len(AwsHelper._client_cache) == 0
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_set_aws_context_set_profile_and_region(self):
+        """Test that set_aws_context sets profile and region in environment."""
+        result = AwsHelper.set_aws_context(profile='test-profile', region='us-west-2')
+
+        assert result['profile'] == 'test-profile'
+        assert result['region'] == 'us-west-2'
+        assert os.environ.get('AWS_PROFILE') == 'test-profile'
+        assert os.environ.get('AWS_REGION') == 'us-west-2'
+
+    @patch.dict(os.environ, {'AWS_PROFILE': 'old-profile', 'AWS_REGION': 'old-region'}, clear=True)
+    def test_set_aws_context_clear_profile_and_region(self):
+        """Test that set_aws_context clears profile and region when empty string is passed."""
+        result = AwsHelper.set_aws_context(profile='', region='')
+
+        assert result['profile'] is None
+        assert result['region'] is None
+        assert 'AWS_PROFILE' not in os.environ
+        assert 'AWS_REGION' not in os.environ
+
+    @patch.dict(os.environ, {'AWS_PROFILE': 'existing-profile'}, clear=True)
+    def test_set_aws_context_partial_update(self):
+        """Test that set_aws_context only updates specified values."""
+        # Only set region, keep existing profile
+        result = AwsHelper.set_aws_context(region='eu-west-1')
+
+        assert result['profile'] == 'existing-profile'
+        assert result['region'] == 'eu-west-1'
+
+    @patch('boto3.client')
+    def test_set_aws_context_clears_cache(self, mock_boto3_client):
+        """Test that set_aws_context clears the client cache."""
+        # Add a client to the cache
+        AwsHelper._client_cache['eks'] = MagicMock()
+
+        # Set AWS context
+        AwsHelper.set_aws_context(profile='new-profile')
+
+        # Verify cache was cleared
+        assert len(AwsHelper._client_cache) == 0


### PR DESCRIPTION
## Summary

Add tools to change AWS profile and region at runtime without restarting the MCP server. This enables switching between AWS accounts or regions dynamically when working with multiple EKS clusters.

### New Tools

- **`get_aws_context`**: Returns the currently configured AWS profile and region
- **`set_aws_context`**: Changes the AWS profile and/or region at runtime, clearing all cached clients to ensure new connections use updated credentials

### Use Cases

- Switch between dev/staging/prod AWS accounts without restarting the MCP server
- Query EKS clusters in different regions within the same session
- Dynamically change credentials when working across multiple AWS accounts

### Changes

- Add `AwsContextHandler` with `get_aws_context` and `set_aws_context` tools
- Add `set_aws_context()` and `clear_client_cache()` methods to `AwsHelper`
- Add `clear_cache()` method to `K8sClientCache`
- Register `AwsContextHandler` in server startup
- Add comprehensive tests for new functionality
- Document new tools in README

## Test plan

- [x] All existing tests pass
- [x] New tests for `AwsContextHandler` pass (10 tests)
- [x] New tests for `AwsHelper.set_aws_context()` pass (4 tests)
- [x] Verified tools register correctly on server startup

## Example Usage

```python
# Get current context
get_aws_context()
# Returns: {"profile": "dev", "region": "us-east-1"}

# Switch to production account in us-west-2
set_aws_context(profile="prod-account", region="us-west-2")

# Change only region, keep current profile
set_aws_context(region="eu-west-1")

# Clear profile to use default credentials
set_aws_context(profile="")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).