### PR TITLE
chore: add path validation for params_file to block sensitive file reads

### DIFF
--- a/src/sagemaker-ai-mcp-server/awslabs/sagemaker_ai_mcp_server/path_validation.py
+++ b/src/sagemaker-ai-mcp-server/awslabs/sagemaker_ai_mcp_server/path_validation.py
@@ -1,0 +1,103 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Path validation to prevent reading sensitive files."""
+
+import os
+from loguru import logger
+
+
+# File basenames that must never be read.
+BLOCKED_FILENAMES: frozenset[str] = frozenset(
+    {
+        '.env',
+        '.netrc',
+        '.pgpass',
+        '.bashrc',
+        '.bash_profile',
+        '.zshrc',
+        '.profile',
+        '.npmrc',
+        '.pypirc',
+        '.gitconfig',
+        '.git-credentials',
+        'authorized_keys',
+        'known_hosts',
+        'id_rsa',
+        'id_rsa.pub',
+        'id_ed25519',
+        'id_ed25519.pub',
+        'id_ecdsa',
+        'id_ecdsa.pub',
+        'credentials',
+        'config.json',
+    }
+)
+
+# Directory prefixes (resolved) that must never be read from.
+_HOME = os.path.realpath(os.path.expanduser('~'))
+BLOCKED_READ_DIRS: tuple[str, ...] = (
+    os.path.join(_HOME, '.aws'),
+    os.path.join(_HOME, '.ssh'),
+    os.path.join(_HOME, '.gnupg'),
+    os.path.join(_HOME, '.docker'),
+    '/proc',
+)
+
+# Exact file paths that must never be read.
+BLOCKED_READ_FILES: tuple[str, ...] = (
+    os.path.realpath('/etc/shadow'),
+    os.path.realpath('/etc/passwd'),
+)
+
+
+def validate_file_read_path(file_path: str) -> str:
+    """Validate a file path before reading.
+
+    Ensures the path is absolute, resolves symlinks and traversals,
+    and blocks access to sensitive directories and filenames.
+
+    Args:
+        file_path: The path to validate.
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        ValueError: If the path violates any security policy.
+    """
+    if not os.path.isabs(file_path):
+        raise ValueError(f'Path must be absolute, got relative path: {file_path}')
+
+    resolved = os.path.realpath(os.path.expanduser(file_path))
+
+    # Check blocked directories
+    for blocked_dir in BLOCKED_READ_DIRS:
+        if resolved == blocked_dir or resolved.startswith(blocked_dir + os.sep):
+            logger.warning('[security] Blocked read from sensitive directory: {}', file_path)
+            raise ValueError(f'Reading from sensitive directory is not allowed: {file_path}')
+
+    # Check blocked exact file paths
+    for blocked_file in BLOCKED_READ_FILES:
+        if resolved == blocked_file:
+            logger.warning('[security] Blocked read of sensitive system file: {}', file_path)
+            raise ValueError(f'Reading sensitive system file is not allowed: {file_path}')
+
+    # Check blocked filenames
+    basename = os.path.basename(resolved).lower()
+    if basename in BLOCKED_FILENAMES:
+        logger.warning('[security] Blocked read of sensitive file: {}', basename)
+        raise ValueError(f'Reading sensitive file is not allowed: {basename}')
+
+    return resolved

--- a/src/sagemaker-ai-mcp-server/awslabs/sagemaker_ai_mcp_server/sagemaker_hyperpod/hyperpod_stack_handler.py
+++ b/src/sagemaker-ai-mcp-server/awslabs/sagemaker_ai_mcp_server/sagemaker_hyperpod/hyperpod_stack_handler.py
@@ -35,6 +35,7 @@ from awslabs.sagemaker_ai_mcp_server.consts import (
     SUPPORTED_REGIONS,
 )
 from awslabs.sagemaker_ai_mcp_server.logging_helper import LogLevel, log_with_request_id
+from awslabs.sagemaker_ai_mcp_server.path_validation import validate_file_read_path
 from awslabs.sagemaker_ai_mcp_server.sagemaker_hyperpod.models import (
     DeleteStackResponse,
     DeployStackResponse,
@@ -355,7 +356,8 @@ class HyperPodStackHandler:
                 if params_file is None:
                     raise ValueError('params_file is required for deploy operation')
 
-                with open(params_file, 'r') as f:
+                validated_path = validate_file_read_path(params_file)
+                with open(validated_path, 'r') as f:
                     template_params = json.load(f)
 
                 return await self._deploy_stack(

--- a/src/sagemaker-ai-mcp-server/tests/test_path_validation.py
+++ b/src/sagemaker-ai-mcp-server/tests/test_path_validation.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ruff: noqa: D101, D102, D103
+"""Tests for path validation."""
+
+import os
+import pytest
+from awslabs.sagemaker_ai_mcp_server.path_validation import validate_file_read_path
+
+
+class TestValidateFileReadPath:
+    """Tests for validate_file_read_path."""
+
+    def test_valid_absolute_path(self):
+        """Test that a valid absolute path is accepted and resolved."""
+        result = validate_file_read_path('/tmp/test-params.json')
+        assert os.path.isabs(result)
+
+    def test_relative_path_rejected(self):
+        """Test that relative paths are rejected."""
+        with pytest.raises(ValueError, match='Path must be absolute'):
+            validate_file_read_path('../test.json')
+
+    def test_relative_path_with_traversal_rejected(self):
+        """Test that relative paths with traversal are rejected."""
+        with pytest.raises(ValueError, match='Path must be absolute'):
+            validate_file_read_path('../../.aws/credentials')
+
+    def test_dot_relative_path_rejected(self):
+        """Test that dot-relative paths are rejected."""
+        with pytest.raises(ValueError, match='Path must be absolute'):
+            validate_file_read_path('./params.json')
+
+    def test_aws_credentials_blocked(self):
+        """Test that ~/.aws/credentials is blocked."""
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_file_read_path(os.path.join(home, '.aws', 'credentials'))
+
+    def test_aws_config_blocked(self):
+        """Test that ~/.aws/config is blocked."""
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_file_read_path(os.path.join(home, '.aws', 'config'))
+
+    def test_ssh_directory_blocked(self):
+        """Test that ~/.ssh/ files are blocked."""
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_file_read_path(os.path.join(home, '.ssh', 'id_rsa'))
+
+    def test_gnupg_directory_blocked(self):
+        """Test that ~/.gnupg/ files are blocked."""
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_file_read_path(os.path.join(home, '.gnupg', 'private-keys-v1.d'))
+
+    def test_docker_directory_blocked(self):
+        """Test that ~/.docker/ files are blocked."""
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_file_read_path(os.path.join(home, '.docker', 'config.json'))
+
+    def test_etc_shadow_blocked(self):
+        """Test that /etc/shadow is blocked."""
+        with pytest.raises(ValueError, match='sensitive'):
+            validate_file_read_path('/etc/shadow')
+
+    def test_etc_passwd_blocked(self):
+        """Test that /etc/passwd is blocked."""
+        with pytest.raises(ValueError, match='sensitive'):
+            validate_file_read_path('/etc/passwd')
+
+    def test_proc_blocked(self):
+        """Test that /proc/ files are blocked."""
+        with pytest.raises(ValueError, match='sensitive directory'):
+            validate_file_read_path('/proc/self/environ')
+
+    def test_sensitive_filename_id_rsa_blocked(self):
+        """Test that id_rsa filename is blocked regardless of directory."""
+        with pytest.raises(ValueError, match='sensitive file'):
+            validate_file_read_path('/tmp/id_rsa')
+
+    def test_sensitive_filename_credentials_blocked(self):
+        """Test that 'credentials' filename is blocked regardless of directory."""
+        with pytest.raises(ValueError, match='sensitive file'):
+            validate_file_read_path('/tmp/credentials')
+
+    def test_sensitive_filename_env_blocked(self):
+        """Test that .env filename is blocked regardless of directory."""
+        with pytest.raises(ValueError, match='sensitive file'):
+            validate_file_read_path('/tmp/.env')
+
+    def test_sensitive_filename_netrc_blocked(self):
+        """Test that .netrc filename is blocked regardless of directory."""
+        with pytest.raises(ValueError, match='sensitive file'):
+            validate_file_read_path('/tmp/.netrc')
+
+    def test_valid_json_filename_allowed(self):
+        """Test that a normal JSON file in a safe directory is allowed."""
+        result = validate_file_read_path('/tmp/my-cluster-params.json')
+        assert result.endswith('my-cluster-params.json')
+
+    def test_valid_path_in_home_allowed(self):
+        """Test that a normal file in home directory is allowed."""
+        home = os.path.expanduser('~')
+        result = validate_file_read_path(os.path.join(home, 'workspace', 'params.json'))
+        assert 'workspace' in result
+
+    def test_symlink_traversal_to_sensitive_dir_blocked(self, tmp_path):
+        """Test that symlinks resolving to sensitive directories are blocked."""
+        home = os.path.expanduser('~')
+        aws_dir = os.path.join(home, '.aws')
+        if os.path.exists(aws_dir):
+            link = tmp_path / 'sneaky-link'
+            link.symlink_to(aws_dir)
+            with pytest.raises(ValueError, match='sensitive directory'):
+                validate_file_read_path(str(link / 'credentials'))
+
+    def test_path_with_dot_dot_in_absolute_resolves_and_validates(self):
+        """Test that /tmp/../etc/passwd is resolved and blocked."""
+        with pytest.raises(ValueError, match='sensitive'):
+            validate_file_read_path('/tmp/../etc/passwd')
+
+    def test_tilde_expansion(self):
+        """Test that ~ paths are rejected as non-absolute."""
+        with pytest.raises(ValueError, match='Path must be absolute'):
+            validate_file_read_path('~/.aws/credentials')


### PR DESCRIPTION
## Summary

### Changes

Adds server-side path validation for the `params_file` parameter in `manage_hyperpod_stacks` to prevent reading sensitive files. Introduces `validate_file_read_path()` which rejects relative paths, blocks sensitive directories (`~/.aws`, `~/.ssh`, `~/.gnupg`, `~/.docker`, `/etc/passwd`, `/etc/shadow`, `/proc`), and blocks known sensitive filenames (`credentials`, `id_rsa`, `.env`, etc.). Pattern is consistent with `aws-transform-mcp-server`'s `file_validation.py`.

### User experience

**Before:** `params_file` was passed directly to `open()` with no validation. Any absolute or relative path would be accepted.

**After:** Relative paths, paths to sensitive directories, and sensitive filenames are rejected with a clear `ValueError`. Normal usage (absolute path to a user-created JSON params file) is unaffected.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? **N**

**RFC issue number**: N/A

Checklist:
- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
