### PR TITLE
chore(sagemaker-unified-studio-mcp): remove preview from the smus-mcp documentation

### DIFF
--- a/src/sagemaker-unified-studio-spark-troubleshooting-mcp-server/README.md
+++ b/src/sagemaker-unified-studio-spark-troubleshooting-mcp-server/README.md
@@ -2,7 +2,7 @@
 
 A fully managed remote MCP server that provides specialized tools for troubleshooting Apache Spark applications on Amazon EMR, AWS Glue, and Amazon SageMaker Notebooks. This server simplifies the troubleshooting process through conversational AI capabilities, automated workload analysis, and intelligent code recommendations.
 
-**Important Note**: Not all MCP clients today support remote servers. Please make sure that your client supports remote MCP servers or that you have a suitable proxy setup to use this server. The Amazon SageMaker Unified Studio MCP server is in preview and is subject to change.
+**Important Note**: Not all MCP clients today support remote servers. Please make sure that your client supports remote MCP servers or that you have a suitable proxy setup to use this server.
 
 ## Key Features & Capabilities
 
@@ -15,7 +15,7 @@ A fully managed remote MCP server that provides specialized tools for troublesho
 
 ## Architecture
 
-The troubleshooting agent has three main components: an MCP-compatible AI Assistant in your development environment for interaction, the [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) that handles secure communication and authentication between your client and AWS services, and the Amazon SageMaker Unified Studio Remote MCP Server (preview) that provides specialized Spark troubleshooting tools for Amazon EMR, AWS Glue and Amazon SageMaker Notebooks. This diagram illustrates how you interact with the Amazon SageMaker Unified Studio Remote MCP Server through your AI Assistant.
+The troubleshooting agent has three main components: an MCP-compatible AI Assistant in your development environment for interaction, the [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) that handles secure communication and authentication between your client and AWS services, and the Amazon SageMaker Unified Studio Remote MCP Server that provides specialized Spark troubleshooting tools for Amazon EMR, AWS Glue and Amazon SageMaker Notebooks. This diagram illustrates how you interact with the Amazon SageMaker Unified Studio Remote MCP Server through your AI Assistant.
 
 ![img](https://docs.aws.amazon.com/images/emr/latest/ReleaseGuide/images/spark-troubleshooting-agent-architecture.png)
 

--- a/src/sagemaker-unified-studio-spark-upgrade-mcp-server/README.md
+++ b/src/sagemaker-unified-studio-spark-upgrade-mcp-server/README.md
@@ -16,7 +16,7 @@ A fully managed remote MCP server that provides specialized tools and guidance f
 
 
 ## Architecture
-The upgrade agent has three main components: any MCP-compatible AI Assistant in your development environment for interaction, the [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) that handles secure communication between your client and the MCP server, and the Amazon SageMaker Unified Studio Managed MCP Server (in preview) that provides specialized Spark upgrade tools for Amazon EMR. This diagram illustrates how you interact with the Amazon SageMaker Unified Studio Managed MCP Server through your AI Assistant.
+The upgrade agent has three main components: any MCP-compatible AI Assistant in your development environment for interaction, the [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) that handles secure communication between your client and the MCP server, and the Amazon SageMaker Unified Studio Managed MCP Server that provides specialized Spark upgrade tools for Amazon EMR. This diagram illustrates how you interact with the Amazon SageMaker Unified Studio Managed MCP Server through your AI Assistant.
 
 ![img](https://docs.aws.amazon.com/images/emr/latest/ReleaseGuide/images/SparkUpgradeIntroduction.png)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Removed "in preview" language from the README documentation for two MCP servers:
- `sagemaker-unified-studio-spark-upgrade-mcp-server/README.md`: Removed `(in preview)` from the Architecture section description of the Amazon SageMaker Unified Studio Managed MCP Server.
- `sagemaker-unified-studio-spark-troubleshooting-mcp-server/README.md`: Removed the sentence `The Amazon SageMaker Unified Studio MCP server is in preview and is subject to change.` from the Important Note, and removed `(preview)` from the Architecture section description of the Amazon SageMaker Unified Studio Remote MCP Server.

### User experience

**Before**: The README docs contained "in preview" qualifiers that indicated the MCP servers were not yet generally available (e.g., `(in preview)`, `(preview)`, and `is in preview and is subject to change`).

**After**: The README docs no longer contain any "in preview" language, reflecting that the servers are now generally available.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).