### PR TITLE
fix(cloudwatch-applicationsignals): address DI post-merge review feedback

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/CHANGELOG.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Dynamic instrumentation tools (preview) for interactively debugging live
+- Dynamic instrumentation tools for interactively debugging live
   Application Signals services without redeploying:
   - `create_instrumentation`, `list_instrumentations`, `get_instrumentation`,
     `delete_instrumentation`, `batch_delete_instrumentations_by_scope`,
@@ -13,7 +13,7 @@
     for status inspection.
   - `search_snapshots_for_status_event`, `get_sample_snapshot_for_breakpoint`
     for analyzing captured snapshots from CloudWatch Logs.
-  - Ships a trimmed preview `application-signals` service model bundled under
+  - Ships a trimmed `application-signals` service model bundled under
     `dynamic_instrumentation/aws_data/`, loaded via a session-scoped botocore
     data loader. The bundled model is removed once the operations are generally
     available in `botocore`.

--- a/src/cloudwatch-applicationsignals-mcp-server/README.md
+++ b/src/cloudwatch-applicationsignals-mcp-server/README.md
@@ -426,18 +426,18 @@ query_rum_events(action="<action_name>", app_monitor_name="my-app", ...)
 
 **Optional parameters** (action-dependent): `resource_arn`, `page_url`, `group_by`, `platform`, `max_results`, `max_traces`, `statistic`, `period`, `session_id`, `metric`, `bucket`, `compare_previous`
 
-### 🔬 Dynamic Instrumentation Tools (Preview)
+### 🔬 Dynamic Instrumentation Tools
 
 Interactively debug live services without redeploying. Dynamic instrumentation
 lets you place breakpoint-style or probe-style instrumentation on running
 Application Signals services, then inspect the captured snapshots (arguments,
 local state, and stack traces) from CloudWatch Logs.
 
-> **Preview:** These tools depend on `application-signals` dynamic
+> **Note:** These tools depend on `application-signals` dynamic
 > instrumentation operations that are not yet part of the public AWS SDK. The
-> server bundles a trimmed preview service model (see
+> server bundles a trimmed service model (see
 > `awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/aws_data/README.md`)
-> so the tools work against the preview API. The bundled model is removed once
+> so the tools work against these operations. The bundled model is removed once
 > the operations are generally available in `botocore`.
 
 **Configuration & status tools**

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/capture.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/capture.py
@@ -24,14 +24,14 @@ blocks) and it does *not* fill in tool-input defaults (defaults like
 ``capture_return=True`` resolve at the tool layer where the success-message
 prose can read the resolved value).
 
-Two distinctions worth preserving across the round-trip:
-
-* ``CaptureArguments`` *omitted* means "capture all arguments"; renderers
-  show ``- Arguments: All``.
-* ``CaptureArguments`` *present-but-empty* means "capture none"; renderers
-  show ``- Arguments: (none)``.
-
-Both shapes survive parse → payload → parse round-trips.
+The ADT preserves the distinction between an *omitted* list (``None`` — key
+absent from the API payload) and a *present-but-empty* list (``()`` — key
+emitted as ``[]``) so an API response round-trips parse → payload → parse
+without losing information. It does *not* assert what the backend means by
+either shape. The MCP *create* tool deliberately does not expose both shapes:
+it rejects empty lists and the ``*`` wildcard and treats an omitted list as
+"capture nothing for that field" (see ``create_instrumentation``). Renderers
+report the raw shape rather than labeling it "all" or "none".
 """
 
 from dataclasses import dataclass, field
@@ -102,10 +102,11 @@ class CodeCapture:
     discipline ``Location`` applies to ``extra_fields`` via
     ``MappingProxyType``.
 
-    The ``Optional`` distinction is meaningful and survives the round-trip:
-    ``None`` means "capture all arguments" (key omitted from the API
-    payload); an empty tuple ``()`` means "capture none" (key emitted as
-    ``[]``).
+    The ``Optional`` distinction is preserved across the round-trip: ``None``
+    omits the key from the API payload, while an empty tuple ``()`` emits the
+    key as ``[]``. This ADT does not assign semantics to either shape; the
+    create tool restricts which shapes it will send (see
+    ``create_instrumentation``).
     """
 
     capture_return: bool

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_rendering.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_rendering.py
@@ -73,8 +73,8 @@ def render_create_success_message(
     location: Location,
     ttl_hours: Optional[int],
     capture_arguments: Optional[List[str]],
-    wildcard_removed: bool,
     code_capture_locals: Optional[List[str]],
+    is_line_level: bool,
     code_capture_return: Optional[bool],
     code_capture_stack_trace: Optional[bool],
     max_hits: Optional[int],
@@ -121,17 +121,17 @@ INSTRUMENTATION CREATED:
     success_message += render_location_block(location=location, location_hash=location_hash)
     success_message += '\nCAPTURE CONFIGURATION:\n'
 
-    if capture_arguments:
-        success_message += f'- Arguments: {", ".join(capture_arguments)}\n'
-    else:
-        success_message += '- Arguments: (none)\n'
-    if wildcard_removed:
-        success_message += '  Note: wildcard * is not supported and was ignored.\n'
+    if not is_line_level:
+        if capture_arguments:
+            success_message += f'- Arguments: {", ".join(capture_arguments)}\n'
+        else:
+            success_message += '- Arguments: (none)\n'
 
     if code_capture_locals:
         success_message += f'- Local Variables: {", ".join(code_capture_locals)}\n'
 
-    success_message += f'- Return Values: {"Enabled" if code_capture_return else "Disabled"}\n'
+    if not is_line_level:
+        success_message += f'- Return Values: {"Enabled" if code_capture_return else "Disabled"}\n'
     success_message += f'- Stack Traces: {"Enabled" if code_capture_stack_trace else "Disabled"}\n'
     success_message += _render_create_capture_limits(
         max_hits=max_hits,
@@ -148,6 +148,16 @@ INSTRUMENTATION CREATED:
         success_message += (
             f'\nATTRIBUTE FILTERS: {len(attribute_filters)} filter group(s) applied\n'
         )
+
+    if normalized_type == 'PROBE':
+        expected_ready = '~10-12 min'
+    else:
+        expected_ready = '~1-2 min'
+    success_message += (
+        f'\nNOTE: Allow {expected_ready} before this configuration reports READY. '
+        'Status checks immediately after creation may return no events yet — '
+        'wait and re-check rather than recreating.\n'
+    )
 
     success_message += (
         f'\nTIP: Use this LocationHash to delete: '
@@ -200,16 +210,19 @@ LOCATION:
             output += f'- Return: {"Enabled" if cap.capture_return else "Disabled"}\n'
             output += f'- Stack Traces: {"Enabled" if cap.capture_stack_trace else "Disabled"}\n'
 
-            if cap.capture_arguments is not None:
-                if cap.capture_arguments:
-                    output += f'- Arguments: {", ".join(cap.capture_arguments)}\n'
-                else:
-                    output += '- Arguments: (none)\n'
+            if cap.capture_arguments is None:
+                output += '- Arguments: (not set)\n'
+            elif cap.capture_arguments:
+                output += f'- Arguments: {", ".join(cap.capture_arguments)}\n'
             else:
-                output += '- Arguments: All\n'
+                output += '- Arguments: (empty list)\n'
 
-            if cap.capture_locals:
+            if cap.capture_locals is None:
+                output += '- Locals: (not set)\n'
+            elif cap.capture_locals:
                 output += f'- Locals: {", ".join(cap.capture_locals)}\n'
+            else:
+                output += '- Locals: (empty list)\n'
 
             limits = cap.limits
             if not limits.is_empty():
@@ -270,15 +283,18 @@ LOCATION:
     if isinstance(cap, CodeCapture):
         output += f'- Return Values: {"Enabled" if cap.capture_return else "Disabled"}\n'
         output += f'- Stack Traces: {"Enabled" if cap.capture_stack_trace else "Disabled"}\n'
-        if cap.capture_arguments is not None:
-            if cap.capture_arguments:
-                output += f'- Arguments: {", ".join(cap.capture_arguments)}\n'
-            else:
-                output += '- Arguments: (none)\n'
+        if cap.capture_arguments is None:
+            output += '- Arguments: (not set)\n'
+        elif cap.capture_arguments:
+            output += f'- Arguments: {", ".join(cap.capture_arguments)}\n'
         else:
-            output += '- Arguments: All\n'
-        if cap.capture_locals:
+            output += '- Arguments: (empty list)\n'
+        if cap.capture_locals is None:
+            output += '- Local Variables: (not set)\n'
+        elif cap.capture_locals:
             output += f'- Local Variables: {", ".join(cap.capture_locals)}\n'
+        else:
+            output += '- Local Variables: (empty list)\n'
 
         limits = cap.limits
         if not limits.is_empty():

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/crud_tools.py
@@ -26,6 +26,8 @@ from .location import parse_create_inputs, parse_lookup_inputs
 from .validation import (
     _format_code_location_troubleshooting,
     normalize_instrumentation_type,
+    validate_capture_names,
+    validate_probe_constraints,
 )
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -60,11 +62,17 @@ def create_instrumentation(
     """Create a dynamic instrumentation configuration for BREAKPOINT or PROBE.
 
     This is the main creation entrypoint for the MCP server. BREAKPOINT and PROBE
-    create code-based instrumentation and require an explicit code location plus
-    explicit `capture_arguments`.
+    create code-based instrumentation and require an explicit code location. Set
+    capture_arguments for method/function-level targets and capture_locals for
+    line-level targets.
 
     Args:
-        instrumentation_type: BREAKPOINT or PROBE.
+        instrumentation_type: BREAKPOINT or PROBE. PROBE is method/function-level only
+            (no line_number) and is not supported for JavaScript. Unlike BREAKPOINT,
+            PROBE has no max_hits cap — it fires on every hit, which makes it suited to
+            long-running observation/monitoring without worrying about hitting a limit.
+            The trade-off: a PROBE never expires on its own, so you must delete it
+            explicitly when done.
         service: Backend service identifier used by the AWS API.
         environment: Backend environment identifier used by the AWS API.
         language: Required for BREAKPOINT/PROBE code instrumentation.
@@ -77,11 +85,18 @@ def create_instrumentation(
         class_name: Optional class name for class-based targets. Java should use the simple class name only.
         method_name: Optional function or method name for method-level instrumentation.
         line_number: Optional 1-based line number for line-level instrumentation.
-        capture_arguments: Required for BREAKPOINT/PROBE. MCP does not infer argument names automatically.
+        capture_arguments: A list of argument names to capture, for method/function-level
+            instrumentation (when line_number is not set). MCP does not infer argument names
+            automatically. Provide explicit names; an empty list and the wildcard "*" are
+            rejected. Omit to capture no arguments.
         capture_return: Whether to capture return values for code instrumentation. Defaults to enabled.
         capture_stack_trace: Whether to capture stack traces for code instrumentation. Defaults to enabled.
-        capture_locals: Optional list of local variable names to capture.
-        max_hits: Optional capture limit for maximum number of hits.
+        capture_locals: A list of local variable names to capture, for line-level
+            instrumentation (when line_number is set). MCP does not infer variable names
+            automatically. Provide explicit names; an empty list and the wildcard "*" are
+            rejected. Omit to capture no locals.
+        max_hits: Optional capture limit for maximum number of hits. Applies to BREAKPOINT
+            only; PROBE has no max_hits (it fires on every hit) and the value is ignored.
         max_string_length: Optional capture limit for string truncation.
         max_collection_width: Optional capture limit for collection width.
         max_collection_depth: Optional capture limit for nested collection depth.
@@ -89,9 +104,17 @@ def create_instrumentation(
         max_stack_trace_size: Optional capture limit for stack trace size.
         max_object_depth: Optional capture limit for object traversal depth.
         max_fields_per_object: Optional capture limit for object field count.
-        attribute_filters: Optional attribute filter groups forwarded to the AWS API.
+        attribute_filters: Optional list of resource-attribute filter groups that scope
+            which service instances the instrumentation applies to. Each group is a
+            dict of OpenTelemetry resource-attribute names to exact-match values
+            (e.g. {"service.version": "1.2.0", "deployment.environment": "prod"}).
+            Matching is exact (no wildcards/patterns); conditions are AND-ed within a
+            group and groups are OR-ed together. Up to 10 groups; keys and values must
+            be 1-50 and 1-100 characters respectively. Omit to apply to all instances.
         description: Free-form description stored with the instrumentation. Must be 50 characters or fewer.
-        ttl_hours: Optional expiration duration in hours. Converted to an absolute UTC timestamp.
+        ttl_hours: Optional expiration duration in hours. Converted to an absolute UTC
+            timestamp. Ignored for PROBE — a PROBE does not expire on its own and must be
+            deleted explicitly, so set up cleanup accordingly.
 
     Notes:
         - BREAKPOINT/PROBE require `language` and `file_path`.
@@ -103,7 +126,17 @@ def create_instrumentation(
           is executed directly as the process entry script.
         - For Java, set `code_unit` to the package name and keep `class_name` as the simple class name only.
         - `line_number` is only for line-level breakpoints and must be 1-based.
-        - `capture_arguments=["*"]` is not supported; "*" is ignored if present.
+        - Target an executable statement when setting `line_number`. Python/Java ignore a
+          non-executable line (blank/comment/decorator/signature) and the breakpoint never
+          fires; JavaScript slides the breakpoint to the next parseable line. Choose the
+          line deliberately.
+        - PROBE is method/function-level only: not supported for JavaScript, and
+          `line_number` is ignored.
+        - PROBE has no `max_hits` and fires on every hit (unlike BREAKPOINT). This makes
+          it suited to long-running observation/monitoring without worrying about a hit
+          limit — but a PROBE does not expire on its own (`ttl_hours` is ignored), so you
+          must delete it explicitly when you are done.
+        - `capture_arguments` and `capture_locals` reject `["*"]` and empty lists; omit to capture none.
         - `SignalType` is always SNAPSHOT.
         - `description` must be 50 characters or fewer.
         - Inspect the source file directly before calling this tool — choose `code_unit`,
@@ -116,6 +149,10 @@ def create_instrumentation(
     normalized_type, type_error = normalize_instrumentation_type(instrumentation_type)
     if type_error:
         return type_error
+
+    probe_error = validate_probe_constraints(normalized_type, language, line_number)
+    if probe_error:
+        return probe_error
 
     location, location_error = parse_create_inputs(
         normalized_type=normalized_type,
@@ -144,17 +181,26 @@ def create_instrumentation(
         line_number=line_number,
     )
 
-    wildcard_removed = False
-    if capture_arguments is None:
-        return (
-            'ERROR: capture_arguments is required for BREAKPOINT/PROBE code instrumentation.\n'
-            'MCP does not infer argument names automatically.\n'
-            'Inspect the source file directly and re-run with capture_arguments=[...].'
-        )
+    capture_arguments_error = validate_capture_names('capture_arguments', capture_arguments)
+    if capture_arguments_error:
+        return capture_arguments_error
+    capture_locals_error = validate_capture_names('capture_locals', capture_locals)
+    if capture_locals_error:
+        return capture_locals_error
 
-    if '*' in capture_arguments:
-        wildcard_removed = True
-    capture_arguments = [arg for arg in capture_arguments if arg != '*']
+    # Line-level instrumentation (line_number set) fires mid-function, where only
+    # locals carry data — arguments/return values are call-boundary concepts that
+    # do not apply. A line-level config without capture_locals would capture
+    # nothing useful, so require it. (JavaScript is always line-level per its
+    # location rules, so this requirement always applies to JavaScript.)
+    is_line_level = line_number is not None
+    if is_line_level and not capture_locals:
+        return (
+            'ERROR: line-level instrumentation (line_number set) requires capture_locals.\n'
+            'At a specific line, only local variables carry data — arguments and return '
+            'values apply to method/function-level targets (no line_number).\n'
+            'Provide capture_locals=[...] with the local variable names to capture.'
+        )
 
     code_capture_return = True if capture_return is None else capture_return
     code_capture_stack_trace = True if capture_stack_trace is None else capture_stack_trace
@@ -229,8 +275,8 @@ def create_instrumentation(
         location=location,
         ttl_hours=ttl_hours,
         capture_arguments=capture_arguments,
-        wildcard_removed=wildcard_removed,
         code_capture_locals=code_capture_locals,
+        is_line_level=is_line_level,
         code_capture_return=code_capture_return,
         code_capture_stack_trace=code_capture_stack_trace,
         max_hits=max_hits,

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/location.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/location.py
@@ -33,7 +33,7 @@ inspect raw union dicts; they call ``location_from_response`` and use the
 type's instance methods.
 """
 
-from .validation import _validate_location_inputs
+from .validation import _validate_location_inputs, canonical_language
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
@@ -55,7 +55,21 @@ def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
 
 @dataclass(frozen=True)
 class CodeLocation:
-    """A code-based instrumentation target (BREAKPOINT or PROBE)."""
+    """A code-based instrumentation target (BREAKPOINT or PROBE).
+
+    Which fields identify the target vs. which are metadata depends on language:
+
+    * Java       — ``code_unit`` (package), ``class_name`` (simple name), and
+                   ``method_name`` together identify the target; all required.
+    * Python     — ``code_unit`` (dotted module path) and ``method_name``
+                   identify the target; ``class_name`` is optional (qualifies a
+                   method defined in a class).
+    * JavaScript — ``file_path`` + ``line_number`` identify the target;
+                   ``code_unit``/``class_name``/``method_name`` are not used.
+
+    ``line_number`` makes any target line-level (fires at that line rather than
+    on method entry/exit).
+    """
 
     language: str
     file_path: str
@@ -276,7 +290,7 @@ def parse_create_inputs(
 
     return (
         CodeLocation(
-            language=language,
+            language=canonical_language(language) or language,
             file_path=file_path,
             code_unit=code_unit,
             class_name=class_name,

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/dynamic_instrumentation/validation.py
@@ -20,6 +20,19 @@ from typing import List, Optional, Tuple
 
 _LOCATION_HASH_RE = re.compile(r'[0-9a-f]{16}')
 
+_CANONICAL_LANGUAGES = {'python': 'Python', 'java': 'Java', 'javascript': 'Javascript'}
+
+
+def canonical_language(language: Optional[str]) -> Optional[str]:
+    """Return the API's canonical ``ProgrammingLanguage`` casing, or None if unknown.
+
+    The bundled service model's enum is case-sensitive (``Java``, ``Python``,
+    ``Javascript``). Callers accept any casing (e.g. ``"javascript"``,
+    ``"JavaScript"``) and map to the canonical form before sending to the API,
+    so a validated language is not rejected by the backend on a casing mismatch.
+    """
+    return _CANONICAL_LANGUAGES.get((language or '').strip().lower())
+
 
 def normalize_instrumentation_type(
     instrumentation_type: str,
@@ -39,6 +52,59 @@ def normalize_instrumentation_type(
             f'(received: {instrumentation_type})'
         )
     return normalized, None
+
+
+def validate_capture_names(field_name: str, names: Optional[List[str]]) -> Optional[str]:
+    """Validate a capture-name list (``capture_arguments`` / ``capture_locals``).
+
+    Returns an error string if invalid, else ``None``. An omitted list
+    (``None``) is valid and means "capture nothing for that field". A provided
+    list must be non-empty and may not contain the ``*`` wildcard — both the
+    empty list and ``*`` are rejected so the ambiguous "capture all" shapes
+    never reach the API.
+    """
+    if names is None:
+        return None
+    if not names:
+        return (
+            f'ERROR: {field_name} must contain at least one name if provided. '
+            'Omit it to capture none.'
+        )
+    if '*' in names:
+        return (
+            f'ERROR: {field_name} does not support the wildcard "*". '
+            'List explicit names, or omit it to capture none.'
+        )
+    return None
+
+
+def validate_probe_constraints(
+    normalized_type: str,
+    language: Optional[str],
+    line_number: Optional[int],
+) -> Optional[str]:
+    """Validate PROBE-only constraints; return error text if invalid, else None.
+
+    PROBE differs from BREAKPOINT in two ways the SDKs enforce:
+
+    * PROBE is not supported for JavaScript.
+    * PROBE is method/function-level only — the SDKs ignore line_number, so a
+      PROBE with line_number set would silently not behave as written.
+    """
+    if normalized_type != 'PROBE':
+        return None
+    lang = (language or '').strip().lower()
+    if lang == 'javascript':
+        return (
+            'ERROR: PROBE is not supported for JavaScript. '
+            'Use instrumentation_type=BREAKPOINT for JavaScript targets.'
+        )
+    if line_number is not None:
+        return (
+            'ERROR: PROBE does not support line_number (the SDKs ignore it). '
+            'Omit line_number for PROBE — it is method/function-level only.'
+        )
+    return None
 
 
 def is_valid_location_hash(location_hash: Optional[str]) -> bool:
@@ -90,6 +156,17 @@ def _format_code_location_troubleshooting(
         lines.append('- Breakpoint level: FUNCTION/METHOD-level (line_number omitted).')
     else:
         lines.append(f'- Breakpoint level: LINE-LEVEL (L{line_number}).')
+        if lang in ('python', 'java'):
+            lines.append(
+                '  * NOTE: target an executable statement. In Python/Java a non-executable '
+                'line (blank, comment, decorator, signature) is ignored and the breakpoint '
+                'never fires.'
+            )
+        elif lang == 'javascript':
+            lines.append(
+                '  * NOTE: in JavaScript a breakpoint on a non-executable line slides to the '
+                'next parseable line and fires there — verify it lands where you intend.'
+            )
 
     if lang == 'python':
         lines.extend(
@@ -109,6 +186,15 @@ def _format_code_location_troubleshooting(
                 '- Java rules:',
                 '  * Set code_unit to the Java package name (e.g., com.amazon.sampleapp).',
                 '  * class_name must be simple name (e.g., OrderContext), not fully qualified.',
+            ]
+        )
+    elif lang == 'javascript':
+        lines.extend(
+            [
+                '- JavaScript rules:',
+                '  * JavaScript binds by file_path + line_number; line_number is required (>= 1).',
+                '  * code_unit, class_name, and method_name are not used for JavaScript.',
+                '  * Point line_number at the executable statement you want to observe.',
             ]
         )
 
@@ -135,7 +221,15 @@ def _validate_location_inputs(
     method_name: Optional[str],
     line_number: Optional[int],
 ) -> Optional[str]:
-    """Validate high-risk location fields and return actionable error text if invalid."""
+    """Validate location fields and return actionable error text if invalid.
+
+    Enforces the per-language fields the SDK needs to bind the instrumentation;
+    without them the SDK silently drops the configuration and nothing fires:
+
+    * Java       — requires code_unit, class_name, and method_name.
+    * Python     — requires code_unit and method_name (class_name optional).
+    * JavaScript — requires line_number (>= 1); binds by file + line.
+    """
     lang = (language or '').strip().lower()
 
     errors: List[str] = []
@@ -147,10 +241,16 @@ def _validate_location_inputs(
     if line_number is not None and line_number < 1:
         errors.append(f'line_number must be >= 1 (received: {line_number}).')
 
-    if lang not in {'python', 'java'}:
-        errors.append(f'language must be Python or Java (received: {language}).')
+    if lang not in {'python', 'java', 'javascript'}:
+        errors.append(f'language must be Python, Java, or JavaScript (received: {language}).')
 
     if lang == 'java':
+        if not code_unit:
+            errors.append('Java requires code_unit (the package name, e.g. com.amazon.sampleapp).')
+        if not class_name:
+            errors.append('Java requires class_name (the simple class name, e.g. OrderContext).')
+        if not method_name:
+            errors.append('Java requires method_name.')
         if class_name and '.' in class_name:
             errors.append(
                 'For Java, class_name must be simple (e.g., "OrderContext"), '
@@ -167,10 +267,21 @@ def _validate_location_inputs(
                 'Java code_unit should be a package name with dots, not a path with slashes.'
             )
 
-    if lang == 'python' and code_unit and code_unit.endswith('.py'):
-        suggestions.append(
-            'Python code_unit should be a module path (e.g., services.billing), not a .py filename.'
-        )
+    elif lang == 'python':
+        if not code_unit:
+            errors.append(
+                'Python requires code_unit (the dotted runtime module path, e.g. services.billing).'
+            )
+        if not method_name:
+            errors.append('Python requires method_name.')
+        if code_unit and code_unit.endswith('.py'):
+            suggestions.append(
+                'Python code_unit should be a module path (e.g., services.billing), not a .py filename.'
+            )
+
+    elif lang == 'javascript':
+        if line_number is None:
+            errors.append('JavaScript requires line_number (>= 1); it binds by file and line.')
 
     if not errors:
         return None

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_tools.py
@@ -220,8 +220,25 @@ class TestCrudToolsBoto3Integration:
         assert 'ValidationException' in rendered
         assert 'bad scope' in rendered
 
-    def test_create_instrumentation_strips_wildcard_capture_argument(self):
-        """Create instrumentation strips wildcard capture argument."""
+    def test_create_instrumentation_rejects_wildcard_capture_argument(self):
+        """Create instrumentation rejects a wildcard in capture_arguments before any API call."""
+        stubber = self._stub_application_signals()
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/handler.py',
+            code_unit='services.handler',
+            method_name='run',
+            capture_arguments=['order_id', '*'],
+        )
+        # No API call should have been made — the wildcard is rejected up front.
+        stubber.assert_no_pending_responses()
+        assert 'capture_arguments does not support the wildcard' in rendered
+
+    def test_create_line_level_success_suppresses_arguments_and_return(self):
+        """A line-level create success message shows locals/stack traces, not arguments/return."""
         stubber = self._stub_application_signals()
         stubber.add_response(
             'create_instrumentation_configuration',
@@ -234,15 +251,14 @@ class TestCrudToolsBoto3Integration:
                     'CodeLocation': {
                         'Language': 'Python',
                         'FilePath': '/app/handler.py',
-                        'MethodName': 'run',
+                        'LineNumber': 42,
                     }
                 },
                 'LocationHash': 'aaaabbbbccccdddd',
                 'Description': 'MCP dynamic instrumentation',
-                'ExpiresAt': datetime(2026, 3, 10, 12, 0, 0, tzinfo=timezone.utc),
                 'CaptureConfiguration': {
                     'CodeCapture': {
-                        'CaptureArguments': ['order_id'],
+                        'CaptureLocals': ['total'],
                         'CaptureReturn': True,
                         'CaptureStackTrace': True,
                         'CaptureLimits': {},
@@ -260,12 +276,15 @@ class TestCrudToolsBoto3Integration:
             file_path='/app/handler.py',
             code_unit='services.handler',
             method_name='run',
-            capture_arguments=['order_id', '*'],
+            line_number=42,
+            capture_locals=['total'],
         )
         stubber.assert_no_pending_responses()
         assert 'Successfully created BREAKPOINT instrumentation' in rendered
-        assert 'wildcard * is not supported and was ignored' in rendered
-        assert 'aaaabbbbccccdddd' in rendered
+        assert '- Local Variables: total' in rendered
+        assert '- Stack Traces: Enabled' in rendered
+        assert '- Arguments:' not in rendered
+        assert '- Return Values:' not in rendered
 
     def test_create_instrumentation_renders_client_error_with_attempted_block(self):
         """Create instrumentation renders client error with attempted block."""
@@ -495,6 +514,58 @@ class TestSignalValidationAndNormalization:
         assert 'must be SNAPSHOT' in error
 
 
+class TestProbeConstraints:
+    """Test PROBE-only constraint validation."""
+
+    def test_breakpoint_is_unconstrained(self):
+        """A BREAKPOINT type returns None regardless of language/line_number."""
+        assert validation.validate_probe_constraints('BREAKPOINT', 'JavaScript', 5) is None
+
+    def test_probe_rejects_javascript(self):
+        """PROBE on JavaScript is rejected."""
+        error = validation.validate_probe_constraints('PROBE', 'JavaScript', None)
+        assert error is not None
+        assert 'PROBE is not supported for JavaScript' in error
+
+    def test_probe_rejects_line_number(self):
+        """PROBE with a line_number is rejected (the SDKs ignore it)."""
+        error = validation.validate_probe_constraints('PROBE', 'Python', 42)
+        assert error is not None
+        assert 'PROBE does not support line_number' in error
+
+    def test_valid_probe_passes(self):
+        """A method-level PROBE on a supported language passes."""
+        assert validation.validate_probe_constraints('PROBE', 'Python', None) is None
+
+    def test_create_probe_javascript_rejected_end_to_end(self):
+        """create_instrumentation rejects a PROBE on JavaScript before any API call."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='PROBE',
+            service='svc',
+            environment='env',
+            language='JavaScript',
+            file_path='/app/handler.js',
+            line_number=10,
+            capture_locals=['total'],
+        )
+        assert 'PROBE is not supported for JavaScript' in rendered
+
+    def test_create_probe_with_line_number_rejected_end_to_end(self):
+        """create_instrumentation rejects a PROBE with line_number before any API call."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='PROBE',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/handler.py',
+            code_unit='services.handler',
+            method_name='run',
+            line_number=42,
+            capture_arguments=['order_id'],
+        )
+        assert 'PROBE does not support line_number' in rendered
+
+
 class TestBatchDeleteFormatting:
     """Test batch-delete response rendering."""
 
@@ -642,7 +713,7 @@ class TestCrudRenderingHelpers:
             environment='env',
         )
         assert 'INSTRUMENTATION CONFIGURATION' in rendered
-        assert '- Arguments: (none)' in rendered
+        assert '- Arguments: (empty list)' in rendered
         assert '- Max Collection Depth: 4' in rendered
         assert '- Max Object Depth: 2' in rendered
         assert 'ATTRIBUTE FILTERS: 1 filter group(s)' in rendered
@@ -1319,8 +1390,8 @@ class TestSnapshotToolsCloudWatchPath:
 class TestCodeInstrumentationArgumentContract:
     """Test code-instrumentation-specific guardrails."""
 
-    def test_create_requires_capture_arguments_for_code_instrumentation(self):
-        """Create requires capture arguments for code instrumentation."""
+    def test_create_rejects_empty_capture_arguments_list(self):
+        """An explicit empty capture_arguments list is rejected (omit to capture none)."""
         rendered = crud_tools.create_instrumentation(
             instrumentation_type='BREAKPOINT',
             service='svc',
@@ -1329,9 +1400,39 @@ class TestCodeInstrumentationArgumentContract:
             file_path='/app/demo_app.py',
             code_unit='__main__',
             method_name='process_payment',
+            capture_arguments=[],
         )
-        assert 'capture_arguments is required' in rendered
-        assert 'Inspect the source file' in rendered
+        assert 'capture_arguments must contain at least one name' in rendered
+
+    def test_create_rejects_empty_capture_locals_list(self):
+        """An explicit empty capture_locals list is rejected (omit to capture none)."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/demo_app.py',
+            code_unit='__main__',
+            method_name='process_payment',
+            capture_arguments=['order_id'],
+            capture_locals=[],
+        )
+        assert 'capture_locals must contain at least one name' in rendered
+
+    def test_create_line_level_requires_capture_locals(self):
+        """A line-level config (line_number set) without capture_locals is rejected."""
+        rendered = crud_tools.create_instrumentation(
+            instrumentation_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+            language='Python',
+            file_path='/app/demo_app.py',
+            code_unit='services.demo',
+            method_name='process_payment',
+            line_number=42,
+            capture_arguments=['order_id'],
+        )
+        assert 'line-level instrumentation (line_number set) requires capture_locals' in rendered
 
     def test_code_capture_preserves_explicit_empty_argument_list(self):
         """Code capture preserves explicit empty argument list."""
@@ -1796,7 +1897,7 @@ class TestValidationLocationInputs:
             line_number=None,
         )
         assert message is not None
-        assert 'language must be Python or Java' in message
+        assert 'language must be Python, Java, or JavaScript' in message
 
     def test_java_fully_qualified_class_name_errors_with_suggestion(self):
         """A fully qualified Java class_name errors and suggests a split."""
@@ -1839,6 +1940,71 @@ class TestValidationLocationInputs:
         assert message is not None
         assert 'module path (e.g., services.billing), not a .py filename' in message
 
+    def test_java_missing_required_fields_reports_errors(self):
+        """Java without code_unit/class_name/method_name reports each as required."""
+        message = validation._validate_location_inputs(
+            language='Java',
+            file_path='/app/Order.java',
+            code_unit=None,
+            class_name=None,
+            method_name=None,
+            line_number=None,
+        )
+        assert message is not None
+        assert 'Java requires code_unit' in message
+        assert 'Java requires class_name' in message
+        assert 'Java requires method_name' in message
+
+    def test_python_missing_required_fields_reports_errors(self):
+        """Python without code_unit/method_name reports each as required."""
+        message = validation._validate_location_inputs(
+            language='Python',
+            file_path='/app/h.py',
+            code_unit=None,
+            class_name=None,
+            method_name=None,
+            line_number=None,
+        )
+        assert message is not None
+        assert 'Python requires code_unit' in message
+        assert 'Python requires method_name' in message
+
+    def test_valid_javascript_line_location_returns_none(self):
+        """A valid JavaScript line location (line_number set) passes validation."""
+        assert (
+            validation._validate_location_inputs(
+                language='JavaScript',
+                file_path='/app/handler.js',
+                code_unit=None,
+                class_name=None,
+                method_name=None,
+                line_number=42,
+            )
+            is None
+        )
+
+    def test_javascript_without_line_number_reports_error(self):
+        """JavaScript without a line_number reports the line-binding requirement."""
+        message = validation._validate_location_inputs(
+            language='JavaScript',
+            file_path='/app/handler.js',
+            code_unit=None,
+            class_name=None,
+            method_name=None,
+            line_number=None,
+        )
+        assert message is not None
+        assert 'JavaScript requires line_number' in message
+
+    def test_canonical_language_maps_casing(self):
+        """canonical_language maps any casing to the API's enum casing, else None."""
+        assert validation.canonical_language('javascript') == 'Javascript'
+        assert validation.canonical_language('JavaScript') == 'Javascript'
+        assert validation.canonical_language('PYTHON') == 'Python'
+        assert validation.canonical_language('java') == 'Java'
+        assert validation.canonical_language('ruby') is None
+        assert validation.canonical_language(None) is None
+
     def test_troubleshooting_python_branch_renders_python_rules(self):
         """The Python troubleshooting branch renders Python-specific rules."""
         rendered = validation._format_code_location_troubleshooting(
@@ -1865,6 +2031,34 @@ class TestValidationLocationInputs:
         )
         assert 'Java rules:' in rendered
         assert 'FUNCTION/METHOD-level' in rendered
+
+    def test_troubleshooting_javascript_branch_renders_js_rules_and_slide_note(self):
+        """The JavaScript branch renders JS rules and the line-slide note for line-level."""
+        rendered = validation._format_code_location_troubleshooting(
+            language='JavaScript',
+            file_path='/app/handler.js',
+            code_unit=None,
+            class_name=None,
+            method_name=None,
+            line_number=42,
+        )
+        assert 'JavaScript rules:' in rendered
+        assert 'binds by file_path + line_number' in rendered
+        assert 'slides to the next parseable line' in rendered
+        assert 'LINE-LEVEL (L42)' in rendered
+
+    def test_troubleshooting_python_line_level_notes_non_executable(self):
+        """The Python branch warns that a non-executable line never fires."""
+        rendered = validation._format_code_location_troubleshooting(
+            language='Python',
+            file_path='/app/h.py',
+            code_unit='services.billing',
+            class_name=None,
+            method_name='run',
+            line_number=12,
+        )
+        assert 'non-executable' in rendered
+        assert 'never fires' in rendered
 
 
 class TestCrudRenderingMoreHelpers:
@@ -1923,8 +2117,8 @@ class TestCrudRenderingMoreHelpers:
             location=loc,
             ttl_hours=24,
             capture_arguments=['order_id'],
-            wildcard_removed=True,
             code_capture_locals=['result'],
+            is_line_level=False,
             code_capture_return=True,
             code_capture_stack_trace=False,
             max_hits=3,
@@ -1940,7 +2134,6 @@ class TestCrudRenderingMoreHelpers:
         assert 'Successfully created BREAKPOINT instrumentation' in rendered
         assert '- Expires: 2026-03-10T11:00:00Z (requested 24 hours)' in rendered
         assert '- Arguments: order_id' in rendered
-        assert 'wildcard * is not supported and was ignored' in rendered
         assert '- Local Variables: result' in rendered
         assert '- Return Values: Enabled' in rendered
         assert '- Stack Traces: Disabled' in rendered
@@ -1958,8 +2151,8 @@ class TestCrudRenderingMoreHelpers:
             location=loc,
             ttl_hours=None,
             capture_arguments=[],
-            wildcard_removed=False,
             code_capture_locals=None,
+            is_line_level=False,
             code_capture_return=False,
             code_capture_stack_trace=True,
             max_hits=None,
@@ -2013,8 +2206,8 @@ class TestCrudRenderingMoreHelpers:
         )
         assert 'Capture payload could not be parsed.' in rendered
 
-    def test_render_get_output_arguments_all_and_full_limits(self):
-        """Arguments=None renders 'All' and every populated limit renders."""
+    def test_render_get_output_arguments_not_set_and_full_limits(self):
+        """Omitted CaptureArguments renders '(not set)' and every populated limit renders."""
         rendered = crud_rendering.render_get_instrumentation_output(
             config={
                 'InstrumentationType': 'BREAKPOINT',
@@ -2041,7 +2234,7 @@ class TestCrudRenderingMoreHelpers:
             service='svc',
             environment='env',
         )
-        assert '- Arguments: All' in rendered
+        assert '- Arguments: (not set)' in rendered
         assert '- Max Hits: 1' in rendered
         assert '- Max Stack Frames: 5' in rendered
         assert '- Max Fields Per Object: 8' in rendered
@@ -2861,8 +3054,8 @@ class TestCrudRenderingBranches:
             location=loc,
             ttl_hours=None,
             capture_arguments=[],
-            wildcard_removed=False,
             code_capture_locals=None,
+            is_line_level=False,
             code_capture_return=True,
             code_capture_stack_trace=True,
             max_hits=None,
@@ -2877,8 +3070,8 @@ class TestCrudRenderingBranches:
         )
         assert '- Arguments: (none)' in rendered
 
-    def test_list_output_renders_empty_arguments_as_none(self):
-        """A listed config with present-but-empty CaptureArguments renders '(none)'."""
+    def test_list_output_renders_empty_arguments_as_empty_list(self):
+        """A listed config with present-but-empty CaptureArguments renders '(empty list)'."""
         data = {
             'LatestConfigurations': [
                 {
@@ -2900,7 +3093,7 @@ class TestCrudRenderingBranches:
             service='svc',
             environment='env',
         )
-        assert '- Arguments: (none)' in rendered
+        assert '- Arguments: (empty list)' in rendered
 
     def test_get_instrumentation_output_renders_local_variables(self):
         """A CodeCapture with capture_locals renders the Local Variables line."""
@@ -2919,6 +3112,78 @@ class TestCrudRenderingBranches:
             config=config, service='svc', environment='env'
         )
         assert '- Local Variables: counter, total' in rendered
+
+    def test_list_output_renders_empty_locals_as_empty_list(self):
+        """A listed config with present-but-empty CaptureLocals renders '(empty list)'."""
+        data = {
+            'LatestConfigurations': [
+                {
+                    'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/app/h.py'}},
+                    'LocationHash': 'h',
+                    'CaptureConfiguration': {
+                        'CodeCapture': {
+                            'CaptureReturn': True,
+                            'CaptureStackTrace': True,
+                            'CaptureArguments': ['order_id'],
+                            'CaptureLocals': [],
+                        }
+                    },
+                }
+            ]
+        }
+        rendered = crud_rendering.render_list_instrumentations_output(
+            data=data,
+            normalized_type='BREAKPOINT',
+            service='svc',
+            environment='env',
+        )
+        assert '- Locals: (empty list)' in rendered
+
+    def test_get_output_renders_empty_locals_as_empty_list(self):
+        """A get config with present-but-empty CaptureLocals renders '(empty list)'."""
+        config = {
+            'InstrumentationType': 'BREAKPOINT',
+            'Location': {'CodeLocation': {'Language': 'Python', 'FilePath': '/app/h.py'}},
+            'CaptureConfiguration': {
+                'CodeCapture': {
+                    'CaptureReturn': True,
+                    'CaptureStackTrace': True,
+                    'CaptureArguments': ['order_id'],
+                    'CaptureLocals': [],
+                }
+            },
+        }
+        rendered = crud_rendering.render_get_instrumentation_output(
+            config=config, service='svc', environment='env'
+        )
+        assert '- Local Variables: (empty list)' in rendered
+
+    def test_create_success_message_probe_shows_longer_ready_window(self):
+        """A PROBE create-success message shows the ~10-12 min READY window."""
+        loc = location.CodeLocation(language='Python', file_path='/app/h.py', method_name='run')
+        rendered = crud_rendering.render_create_success_message(
+            response={'LocationHash': 'aaaabbbbccccdddd', 'ARN': 'arn', 'CreatedAt': None},
+            normalized_type='PROBE',
+            service='svc',
+            environment='env',
+            location=loc,
+            ttl_hours=None,
+            capture_arguments=['order_id'],
+            code_capture_locals=None,
+            is_line_level=False,
+            code_capture_return=True,
+            code_capture_stack_trace=True,
+            max_hits=None,
+            max_string_length=None,
+            max_collection_width=None,
+            max_collection_depth=None,
+            max_stack_frames=None,
+            max_stack_trace_size=None,
+            max_object_depth=None,
+            max_fields_per_object=None,
+            attribute_filters=None,
+        )
+        assert 'Allow ~10-12 min before this configuration reports READY' in rendered
 
 
 class TestErrorTranslationEmptyHelpers:
@@ -2991,10 +3256,24 @@ class TestLocationBranches:
             normalized_type='BREAKPOINT',
             language='Python',
             file_path='/app/h.py',
+            code_unit='services.h',
+            method_name='run',
             line_number=0,
         )
         assert loc is None
         assert err
+
+    def test_parse_create_inputs_canonicalizes_language_casing(self):
+        """parse_create_inputs maps language casing to the API enum (javascript -> Javascript)."""
+        loc, err = location.parse_create_inputs(
+            normalized_type='BREAKPOINT',
+            language='javascript',
+            file_path='/app/handler.js',
+            line_number=42,
+        )
+        assert err is None
+        assert loc is not None
+        assert loc.to_api_payload()['CodeLocation']['Language'] == 'Javascript'
 
     def test_parse_lookup_inputs_disallows_code_location(self):
         """allow_code_location_lookup=False rejects a code-location lookup."""
@@ -3718,6 +3997,8 @@ class TestCrudToolsTtlAndFilters:
             environment='env',
             language='Python',
             file_path='/app/handler.py',
+            code_unit='services.handler',
+            method_name='run',
             capture_arguments=['order_id'],
             ttl_hours=3,
             attribute_filters=[{'Key': 'stage', 'Value': 'prod'}],


### PR DESCRIPTION
## Summary

Follow-up to #3801 addressing @srprash's post-merge review of the dynamic instrumentation tools. Refines input validation, per-language behavior, and documentation for the `cloudwatch-applicationsignals-mcp-server` DI tools. Behavior changes are MCP-side only (no service-model changes).

## Changes

**Capture inputs**
- `capture_arguments` and `capture_locals` now reject both an empty list `[]` and the `*` wildcard; an omitted list means "capture none". Removes the previous mandatory-`capture_arguments` error and the silent wildcard strip, eliminating the ambiguous "empty = all" shape.
- Read-path renderers (list/get) report the raw shape (`(not set)` / `(empty list)` / names) instead of asserting "All"/"None".

**Line-level vs. method-level**
- Line-level configs (`line_number` set) require `capture_locals` (hard error) — arguments/return don't apply mid-function. The create success message suppresses the Arguments/Return lines for line-level targets (Stack Traces stays).

**JavaScript support**
- `JavaScript` is now a first-class language: accepted by validation, casing normalized to the API's `ProgrammingLanguage` enum so it reaches the backend, with a JS-specific troubleshooting block.

**Per-language required fields (hard errors, up front)**
- Java: `code_unit` + `class_name` + `method_name`; Python: `code_unit` + `method_name`; JavaScript: `line_number >= 1`. Rejects unbindable configs before the API silently drops them. Target-vs-metadata guidance added to the `CodeLocation` docstring.

**PROBE constraints**
- Reject PROBE on JavaScript and PROBE with `line_number`. Docstrings emphasize PROBE has no `max_hits` (fires on every hit — good for long-running monitoring) but never expires on its own (`ttl_hours` ignored), so it must be deleted explicitly.

**Documentation**
- Non-executable `line_number` behavior (Java/Python ignore it and never fire; JavaScript slides to the next parseable line).
- `attribute_filters` semantics (OTel resource attribute names, exact match, AND within a group, OR across groups).
- Create success message includes a READY-timing hint (~1-2 min BREAKPOINT / ~10-12 min PROBE) so agents don't poll-and-recreate in a loop.
- Dropped "preview" labeling from the README and CHANGELOG now that the feature has shipped.


## Testing
- DI subpackage at 100% line coverage.
- 1133 package tests pass; `ruff check`, `ruff format --check`, and `pyright` all clean.



---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
