### PR TITLE
fix(bedrock-kb-retrieval): preserve non-ASCII text in tool results

### DIFF
--- a/src/bedrock-kb-retrieval-mcp-server/CHANGELOG.md
+++ b/src/bedrock-kb-retrieval-mcp-server/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Preserve non-ASCII (e.g. CJK, accented, emoji) text in `QueryKnowledgeBases` and `ListKnowledgeBases` tool results by serializing with `json.dumps(..., ensure_ascii=False)`, so Knowledge Base content reaches the model and user as readable characters instead of `\uXXXX` escape sequences.
+
 ## [1.0.0] - 2025-05-26
 
 ### Removed

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
@@ -110,4 +110,4 @@ async def query_knowledge_base(
                 }
             )
 
-    return '\n\n'.join([json.dumps(document) for document in documents])
+    return '\n\n'.join([json.dumps(document, ensure_ascii=False) for document in documents])

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -125,7 +125,7 @@ async def list_knowledge_bases_tool() -> str:
     3. Use the names to determine which knowledge base and data source(s) are most relevant to the user's query
     """
     knowledge_bases = await discover_knowledge_bases(kb_agent_mgmt_client, kb_inclusion_tag_key)
-    return json.dumps(knowledge_bases)
+    return json.dumps(knowledge_bases, ensure_ascii=False)
 
 
 @mcp.tool(name='QueryKnowledgeBases')

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
@@ -161,6 +161,39 @@ class TestQueryKnowledgeBase:
         mock_bedrock_agent_runtime_client.retrieve.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_query_knowledge_base_preserves_non_ascii(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that non-ASCII (e.g. CJK) content is preserved and not unicode-escaped."""
+        # Modify the mock to return non-ASCII content
+        mock_bedrock_agent_runtime_client.retrieve.return_value = {
+            'retrievalResults': [
+                {
+                    'content': {'text': '東京は日本の首都です。', 'type': 'TEXT'},
+                    'location': {'s3Location': {'uri': 's3://test-bucket/도쿄.txt'}},
+                    'score': 0.95,
+                },
+            ]
+        }
+
+        # Call the function
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+        )
+
+        # The raw serialized result must contain the literal characters, not \\uXXXX escapes
+        assert '東京は日本の首都です。' in result
+        assert '도쿄.txt' in result
+        assert '\\u' not in result
+
+        # And it must still round-trip as valid JSON
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+        assert documents[0]['content']['text'] == '東京は日本の首都です。'
+        assert documents[0]['location']['s3Location']['uri'] == 's3://test-bucket/도쿄.txt'
+
+    @pytest.mark.asyncio
     async def test_query_knowledge_base_with_image_content(
         self, mock_bedrock_agent_runtime_client
     ):

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
@@ -93,6 +93,34 @@ class TestListKnowledgeBasesTool:
         # Check that discover_knowledge_bases was called with the correct arguments
         mock_discover_knowledge_bases.assert_called_once()
 
+    @pytest.mark.asyncio
+    @patch('awslabs.bedrock_kb_retrieval_mcp_server.server.discover_knowledge_bases')
+    async def test_list_knowledge_bases_tool_preserves_non_ascii(
+        self, mock_discover_knowledge_bases
+    ):
+        """Test that non-ASCII knowledge base names are preserved and not unicode-escaped."""
+        mock_discover_knowledge_bases.return_value = {
+            'kb-12345': {
+                'name': '東京ナレッジベース',
+                'description': '日本語のテスト用ナレッジベース',
+                'data_sources': [
+                    {'id': 'ds-12345', 'name': '한국어 데이터 소스'},
+                ],
+            },
+        }
+
+        result = await list_knowledge_bases_tool()
+
+        # The raw serialized result must contain the literal characters, not \\uXXXX escapes
+        assert '東京ナレッジベース' in result
+        assert '한국어 데이터 소스' in result
+        assert '\\u' not in result
+
+        # And it must still round-trip as valid JSON
+        kb_mapping = json.loads(result)
+        assert kb_mapping['kb-12345']['name'] == '東京ナレッジベース'
+        assert kb_mapping['kb-12345']['data_sources'][0]['name'] == '한국어 데이터 소스'
+
 
 class TestQueryKnowledgeBasesTool:
     """Tests for the query_knowledge_bases_tool function."""


### PR DESCRIPTION
Thank you for maintaining the AWS MCP servers.

Fixes #3820

## Summary

`QueryKnowledgeBases` and `ListKnowledgeBases` serialized results with `json.dumps(...)` (default `ensure_ascii=True`), so non-ASCII KB content (CJK, accented, emoji) was returned as `\uXXXX` escapes — token bloat + unreadable payloads. This adds `ensure_ascii=False` to the two user/model-visible serialization points (the MCP transport is already UTF-8).

## Changes

- `knowledgebases/retrieval.py:113`, `server.py:128` — add `ensure_ascii=False`
- regression tests in `test_retrieval.py` + `test_server.py`
- `## [Unreleased]` / `### Fixed` CHANGELOG entry

## Before / After

| Item | Before | After |
|------|--------|-------|
| KB text `東京は日本の首都です。` in tool output | ❌ `東京...` (escaped) | ✅ `東京は日本の首都です。` |
| KB name `한국어 데이터 소스` | ❌ `한국...` | ✅ `한국어 데이터 소스` |
| Output is valid JSON / round-trips via `json.loads` | ✅ | ✅ (unchanged) |
| Public API / tool signatures / result ordering | — | ✅ Unchanged |
| ASCII-only content | ✅ identical bytes | ✅ identical bytes |

## Tests

`40 passed`, `ruff check` clean. Reverting the source change (keeping the tests) makes the 2 new tests FAIL with `assert '東京...' in '...\\u6771\\u4eac...'`, proving they catch the bug; restoring it → all pass.

---

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
