### PR TITLE
fix(redshift-mcp-server): empty result set

### DIFF
--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -333,7 +333,13 @@ async def _execute_protected_statement(
     # Get results from user query
     data_client = client_manager.redshift_data_client()
     assert user_query_id is not None, 'user_query_id should not be None at this point'
-    results_response = data_client.get_statement_result(Id=user_query_id)
+
+    # Only fetch results when the statement produced a result set (e.g. SET does not).
+    describe_response = data_client.describe_statement(Id=user_query_id)
+    if describe_response.get('HasResultSet'):
+        results_response = data_client.get_statement_result(Id=user_query_id)
+    else:
+        results_response = {'Records': [], 'ColumnMetadata': []}
     return results_response, user_query_id
 
 

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -323,6 +323,90 @@ class TestExecuteProtectedStatement:
         assert calls[2][1]['sql'] == 'END;'
 
     @pytest.mark.asyncio
+    async def test_execute_protected_statement_no_result_set(self, mocker):
+        """Statements with no result set (e.g. SET) must not call get_statement_result."""
+        # Mock discover_clusters
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
+
+        # Mock session manager
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+
+        # Mock _execute_statement
+        mock_execute_statement = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement'
+        )
+        mock_execute_statement.side_effect = ['begin-stmt-id', 'user-stmt-id', 'end-stmt-id']
+
+        # Mock data client: user statement finished but produced no result set
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': False,
+        }
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        results_response, query_id = await _execute_protected_statement(
+            'test-cluster',
+            'test-db',
+            "SET search_path TO 'public'",
+            allow_read_write=False,
+        )
+
+        # get_statement_result must NOT be called for statements with no result set
+        mock_data_client.get_statement_result.assert_not_called()
+        # describe_statement is used to detect whether a result set exists
+        mock_data_client.describe_statement.assert_called_once_with(Id='user-stmt-id')
+        assert query_id == 'user-stmt-id'
+        assert results_response == {'Records': [], 'ColumnMetadata': []}
+
+    @pytest.mark.asyncio
+    async def test_execute_protected_statement_with_result_set(self, mocker):
+        """Statements with a result set must fetch results via get_statement_result."""
+        # Mock discover_clusters
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
+
+        # Mock session manager
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+
+        # Mock _execute_statement
+        mock_execute_statement = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement'
+        )
+        mock_execute_statement.side_effect = ['begin-stmt-id', 'user-stmt-id', 'end-stmt-id']
+
+        # Mock data client: user statement finished and produced a result set
+        expected_result = {'Records': [[{'longValue': 1}]], 'ColumnMetadata': [{'name': 'n'}]}
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': True,
+        }
+        mock_data_client.get_statement_result.return_value = expected_result
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        results_response, query_id = await _execute_protected_statement(
+            'test-cluster', 'test-db', 'SELECT 1 AS n', allow_read_write=False
+        )
+
+        mock_data_client.get_statement_result.assert_called_once_with(Id='user-stmt-id')
+        assert query_id == 'user-stmt-id'
+        assert results_response == expected_result
+
+    @pytest.mark.asyncio
     async def test_execute_protected_statement_transaction_breaker_error(self, mocker):
         """Test transaction breaker protection in read-only mode."""
         # Mock discover_clusters
@@ -1277,6 +1361,32 @@ class TestExecuteQuery:
         assert result['row_count'] == 1
         assert result['execution_time_ms'] == 123
         assert result['query_id'] == 'query-123'
+
+    @pytest.mark.asyncio
+    async def test_execute_query_no_result_set(self, mocker):
+        """SET-style statements with no result set return an empty, successful result."""
+        # Mock _execute_protected_statement to mimic a no-result-set statement
+        mock_execute_protected = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
+        )
+        mock_execute_protected.return_value = (
+            {'Records': [], 'ColumnMetadata': []},
+            'set-query-123',
+        )
+
+        mock_time = mocker.patch('time.time')
+        mock_time.side_effect = [1000.0, 1000.05]  # start_time, end_time
+
+        result = await execute_query(
+            'test-cluster',
+            'dev',
+            "SET search_path TO 'public'",
+        )
+
+        assert result['columns'] == []
+        assert result['rows'] == []
+        assert result['row_count'] == 0
+        assert result['query_id'] == 'set-query-123'
 
     @pytest.mark.asyncio
     async def test_execute_query_error_handling(self, mocker):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

Fixes #N/A

## Summary

### Changes

> Please provide a summary of what's being changed

`execute_query` always called `get_statement_result`, which fails with `Query does not have result` for statements that return no result set (e.g. `SET`).  `_execute_protected_statement` now checks `HasResultSet` first and returns an empty result when there is none. Added tests for both branches.

### User experience

> Please share what the user experience looks like before and after this change

Before: `SET ...` returned a `Query does not have result` error despite succeeding.
After: it returns a successful empty result (`columns: []`, `rows: []`, `row_count: 0`).
Result-returning queries are unaffected.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [N/A] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**:

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
