### PR TITLE
fix(cloudwatch-applicationsignals): get_endpoint_performance returns 0 endpoints for all Application Signals services

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/endpoint_metrics.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/endpoint_metrics.py
@@ -25,15 +25,17 @@ shaped like the service_events ``get_endpoints`` output.
 import logging
 from .aws_clients import get_applicationsignals_client, get_cloudwatch_client
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 logger = logging.getLogger(__name__)
 
-# Application Signals operation metric types.
-_METRIC_LATENCY = 'Latency'
-_METRIC_FAULT = 'Fault'
-_METRIC_ERROR = 'Error'
+# Application Signals operation metric types. The list_service_operations API returns
+# these MetricType values in UPPERCASE (LATENCY/FAULT/ERROR); matching is done
+# case-insensitively (see _index_metric_refs) to be robust to either form.
+_METRIC_LATENCY = 'LATENCY'
+_METRIC_FAULT = 'FAULT'
+_METRIC_ERROR = 'ERROR'
 
 
 def _period_for_hours(hours: int) -> int:
@@ -46,10 +48,23 @@ def _period_for_hours(hours: int) -> int:
 
 
 def _find_service_key_attributes(
-    service_name: str, start_time, end_time
+    service_name: str,
+    start_time,
+    end_time,
+    environment: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Find KeyAttributes for a service by name (paginated list_services)."""
+    """Find KeyAttributes for a service by name (paginated list_services).
+
+    Returns the matched service's KeyAttributes, or ``None`` if no service resolves.
+
+    Matching is tolerant: an exact ``Name`` match wins; when ``environment`` is given it
+    must also match ``KeyAttributes.Environment``. A case-insensitive ``Name`` match is
+    accepted as a fallback. A name match whose environment differs (when an environment
+    was requested) is skipped, not returned.
+    """
     client = get_applicationsignals_client()
+    ci_match: Optional[Dict[str, Any]] = None
+    target = service_name.lower()
     next_token = None
     while True:
         params = {'StartTime': start_time, 'EndTime': end_time, 'MaxResults': 100}
@@ -58,11 +73,23 @@ def _find_service_key_attributes(
         response = client.list_services(**params)
         for service in response.get('ServiceSummaries', []):
             key_attrs = service.get('KeyAttributes', {})
-            if key_attrs.get('Name') == service_name:
+            name = key_attrs.get('Name')
+            if name is None:
+                continue
+            if name != service_name and name.lower() != target:
+                continue
+            if environment and key_attrs.get('Environment') != environment:
+                # Name matches but environment doesn't — keep scanning for an exact
+                # env match.
+                continue
+            if name == service_name:
                 return key_attrs
+            # Case-insensitive match — remember it but prefer a later exact match.
+            if ci_match is None:
+                ci_match = key_attrs
         next_token = response.get('NextToken')
         if not next_token:
-            return None
+            return ci_match
 
 
 def _sum_datapoints(metric_ref: Dict[str, Any], start_time, end_time, period: int):
@@ -119,21 +146,37 @@ def get_endpoint_red_metrics(
     operation: Optional[str] = None,
     limit: int = 20,
     percentile: float = 99,
-) -> List[Dict[str, Any]]:
+    environment: Optional[str] = None,
+) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
     """Return per-operation RED metric summaries for a service from Application Signals.
 
     Each summary mirrors the service_events ``get_endpoints`` shape:
     operation, total_requests, total_faults, total_errors, avg_duration_ms,
-    p{N}_duration_ms. Returns ``[]`` when the service or its operations are not found.
+    p{N}_duration_ms.
+
+    Returns ``(summaries, not_found)``. On success ``not_found`` is ``None``. When the
+    service name does not resolve in Application Signals, ``summaries`` is ``[]`` and
+    ``not_found`` is a diagnostic dict (``status``/``message``/``did_you_mean``) so the
+    caller can tell "service not found" apart from "found but no operations".
     """
     end_time = datetime.now(timezone.utc)
     start_time = end_time - timedelta(hours=hours)
     period = _period_for_hours(hours)
 
-    key_attrs = _find_service_key_attributes(service_name, start_time, end_time)
+    key_attrs = _find_service_key_attributes(
+        service_name, start_time, end_time, environment=environment
+    )
     if not key_attrs:
         logger.debug("AppSignals service '%s' not found for endpoint RED metrics", service_name)
-        return []
+        env_suffix = f" in environment '{environment}'" if environment else ''
+        not_found = {
+            'status': 'service_not_found',
+            'message': (
+                f"No Application Signals service named '{service_name}'{env_suffix} "
+                'was found in this region/time window.'
+            ),
+        }
+        return [], not_found
 
     client = get_applicationsignals_client()
     operations: List[Dict[str, Any]] = []
@@ -148,7 +191,7 @@ def get_endpoint_red_metrics(
         if next_token:
             params['NextToken'] = next_token
         response = client.list_service_operations(**params)
-        operations.extend(response.get('Operations', []))
+        operations.extend(response.get('ServiceOperations', []))  # type: ignore[arg-type]
         next_token = response.get('NextToken')
         if not next_token:
             break
@@ -160,8 +203,10 @@ def get_endpoint_red_metrics(
         if op_filter and op_filter not in op_name.lower():
             continue
 
-        metric_refs = op.get('MetricReferences', [])
-        by_type = {ref.get('MetricType'): ref for ref in metric_refs}
+        # MetricType is returned UPPERCASE by the API; index case-insensitively.
+        by_type = {
+            (ref.get('MetricType') or '').upper(): ref for ref in op.get('MetricReferences', [])
+        }
 
         total_requests = 0
         total_faults = 0
@@ -194,4 +239,4 @@ def get_endpoint_red_metrics(
         if len(summaries) >= limit:
             break
 
-    return summaries
+    return summaries, None

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -362,13 +362,14 @@ async def get_endpoints(
         from ..endpoint_metrics import get_endpoint_red_metrics
 
         try:
-            formatted = await asyncio.to_thread(
+            formatted, not_found = await asyncio.to_thread(
                 get_endpoint_red_metrics,
                 service_name=service_name,
                 hours=hours,
                 operation=operation,
                 limit=limit,
                 percentile=percentile,
+                environment=environment,
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error(f'Application Signals endpoint metrics error: {e}')
@@ -379,6 +380,16 @@ async def get_endpoints(
                 'error': str(e),
                 'endpoints': [],
                 'data_source': 'application_signals',
+            }
+
+        if not_found is not None:
+            return {
+                'total_endpoints': 0,
+                'returned': 0,
+                'time_range_hours': hours,
+                'endpoints': [],
+                'data_source': 'application_signals',
+                **not_found,
             }
 
         if operation and len(formatted) == 1:

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_endpoint_metrics.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_endpoint_metrics.py
@@ -214,30 +214,43 @@ class TestLatencyStats:
 class TestGetEndpointRedMetrics:
     """Tests for the get_endpoint_red_metrics entry point."""
 
-    def test_service_not_found_returns_empty(self):
-        """When the service KeyAttributes are not found, an empty list is returned."""
+    def test_service_not_found_returns_not_found(self):
+        """When the service KeyAttributes are not found, a not-found diagnostic is returned."""
         mock_as = MagicMock()
         mock_as.list_services.return_value = {'ServiceSummaries': [], 'NextToken': None}
         with patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as):
-            result = get_endpoint_red_metrics('missing', hours=24)
-        assert result == []
+            summaries, not_found = get_endpoint_red_metrics('missing', hours=24)
+        assert summaries == []
+        assert not_found is not None
+        assert not_found['status'] == 'service_not_found'
+        assert 'missing' in not_found['message']
+
+    def test_not_found_message_includes_environment(self):
+        """When an environment is given, the not-found message names it."""
+        mock_as = MagicMock()
+        mock_as.list_services.return_value = {'ServiceSummaries': [], 'NextToken': None}
+        with patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as):
+            _, not_found = get_endpoint_red_metrics('missing', environment='eks:prod')
+        assert not_found is not None
+        assert 'eks:prod' in not_found['message']
 
     def test_happy_path_all_metric_types(self):
-        """A full operation with Latency/Fault/Error metrics produces a complete summary."""
+        """A full operation with LATENCY/FAULT/ERROR metrics produces a complete summary."""
         key_attrs = {'Name': 'svc', 'Type': 'Service'}
         mock_as = MagicMock()
         mock_as.list_services.return_value = {
             'ServiceSummaries': [{'KeyAttributes': key_attrs}],
             'NextToken': None,
         }
+        # The API returns operations under "ServiceOperations" with UPPERCASE MetricType.
         mock_as.list_service_operations.return_value = {
-            'Operations': [
+            'ServiceOperations': [
                 {
                     'Name': 'GET /orders',
                     'MetricReferences': [
-                        {'MetricType': 'Latency', 'Namespace': 'NS', 'MetricName': 'Latency'},
-                        {'MetricType': 'Fault', 'Namespace': 'NS', 'MetricName': 'Fault'},
-                        {'MetricType': 'Error', 'Namespace': 'NS', 'MetricName': 'Error'},
+                        {'MetricType': 'LATENCY', 'Namespace': 'NS', 'MetricName': 'Latency'},
+                        {'MetricType': 'FAULT', 'Namespace': 'NS', 'MetricName': 'Fault'},
+                        {'MetricType': 'ERROR', 'Namespace': 'NS', 'MetricName': 'Error'},
                     ],
                 }
             ],
@@ -265,10 +278,11 @@ class TestGetEndpointRedMetrics:
             patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as),
             patch.object(endpoint_metrics, 'get_cloudwatch_client', return_value=mock_cw),
         ):
-            result = get_endpoint_red_metrics('svc', hours=24, percentile=99)
+            summaries, not_found = get_endpoint_red_metrics('svc', hours=24, percentile=99)
 
-        assert len(result) == 1
-        summary = result[0]
+        assert not_found is None
+        assert len(summaries) == 1
+        summary = summaries[0]
         assert summary['operation'] == 'GET /orders'
         assert summary['service_name'] == 'svc'
         assert summary['total_requests'] == 10
@@ -288,7 +302,7 @@ class TestGetEndpointRedMetrics:
             'NextToken': None,
         }
         mock_as.list_service_operations.return_value = {
-            'Operations': [
+            'ServiceOperations': [
                 {'Name': 'GET /orders', 'MetricReferences': []},
                 {'Name': 'POST /payments', 'MetricReferences': []},
             ],
@@ -299,12 +313,13 @@ class TestGetEndpointRedMetrics:
             patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as),
             patch.object(endpoint_metrics, 'get_cloudwatch_client', return_value=mock_cw),
         ):
-            result = get_endpoint_red_metrics('svc', operation='PAYMENTS')
-        assert len(result) == 1
-        assert result[0]['operation'] == 'POST /payments'
+            summaries, not_found = get_endpoint_red_metrics('svc', operation='PAYMENTS')
+        assert not_found is None
+        assert len(summaries) == 1
+        assert summaries[0]['operation'] == 'POST /payments'
         # No metric refs -> defaults, and CloudWatch was never queried.
-        assert result[0]['total_requests'] == 0
-        assert result[0]['avg_duration_ms'] is None
+        assert summaries[0]['total_requests'] == 0
+        assert summaries[0]['avg_duration_ms'] is None
         mock_cw.get_metric_statistics.assert_not_called()
 
     def test_operations_paginated(self):
@@ -315,12 +330,13 @@ class TestGetEndpointRedMetrics:
             'NextToken': None,
         }
         mock_as.list_service_operations.side_effect = [
-            {'Operations': [{'Name': 'op-a', 'MetricReferences': []}], 'NextToken': 'next'},
-            {'Operations': [{'Name': 'op-b', 'MetricReferences': []}], 'NextToken': None},
+            {'ServiceOperations': [{'Name': 'op-a', 'MetricReferences': []}], 'NextToken': 'next'},
+            {'ServiceOperations': [{'Name': 'op-b', 'MetricReferences': []}], 'NextToken': None},
         ]
         with patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as):
-            result = get_endpoint_red_metrics('svc')
-        assert {r['operation'] for r in result} == {'op-a', 'op-b'}
+            summaries, not_found = get_endpoint_red_metrics('svc')
+        assert not_found is None
+        assert {r['operation'] for r in summaries} == {'op-a', 'op-b'}
         assert mock_as.list_service_operations.call_count == 2
         _, kwargs = mock_as.list_service_operations.call_args
         assert kwargs['NextToken'] == 'next'
@@ -333,12 +349,13 @@ class TestGetEndpointRedMetrics:
             'NextToken': None,
         }
         mock_as.list_service_operations.return_value = {
-            'Operations': [{'Name': f'op-{i}', 'MetricReferences': []} for i in range(5)],
+            'ServiceOperations': [{'Name': f'op-{i}', 'MetricReferences': []} for i in range(5)],
             'NextToken': None,
         }
         with patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as):
-            result = get_endpoint_red_metrics('svc', limit=2)
-        assert len(result) == 2
+            summaries, not_found = get_endpoint_red_metrics('svc', limit=2)
+        assert not_found is None
+        assert len(summaries) == 2
 
     def test_failure_path_raises(self):
         """An AWS failure during operation listing propagates to the caller."""
@@ -355,3 +372,42 @@ class TestGetEndpointRedMetrics:
             except RuntimeError as e:
                 raised = str(e) == 'boom'
         assert raised
+
+    def test_case_insensitive_name_match(self):
+        """A case-insensitive Name match resolves the service (exact match preferred)."""
+        mock_as = MagicMock()
+        mock_as.list_services.return_value = {
+            'ServiceSummaries': [
+                {'KeyAttributes': {'Name': 'Billing-Service', 'Type': 'Service'}}
+            ],
+            'NextToken': None,
+        }
+        mock_as.list_service_operations.return_value = {
+            'ServiceOperations': [{'Name': 'GET /x', 'MetricReferences': []}],
+            'NextToken': None,
+        }
+        with patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as):
+            summaries, not_found = get_endpoint_red_metrics('billing-service')
+        assert not_found is None
+        assert len(summaries) == 1
+
+    def test_environment_disambiguates_same_name(self):
+        """When environment is given, only the service in that environment resolves."""
+        mock_as = MagicMock()
+        mock_as.list_services.return_value = {
+            'ServiceSummaries': [
+                {'KeyAttributes': {'Name': 'svc', 'Environment': 'eks:dev'}},
+                {'KeyAttributes': {'Name': 'svc', 'Environment': 'eks:prod'}},
+            ],
+            'NextToken': None,
+        }
+        mock_as.list_service_operations.return_value = {
+            'ServiceOperations': [],
+            'NextToken': None,
+        }
+        with patch.object(endpoint_metrics, 'get_applicationsignals_client', return_value=mock_as):
+            _, not_found = get_endpoint_red_metrics('svc', environment='eks:prod')
+        assert not_found is None
+        # The prod KeyAttributes (not dev) were used for the operations query.
+        _, kwargs = mock_as.list_service_operations.call_args
+        assert kwargs['KeyAttributes']['Environment'] == 'eks:prod'

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_endpoint_metrics.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_endpoint_metrics.py
@@ -109,6 +109,39 @@ class TestFindServiceKeyAttributes:
             result = _find_service_key_attributes('missing', _NOW, _LATER)
         assert result is None
 
+    def test_summary_without_name_is_skipped(self):
+        """A service summary whose KeyAttributes lack a Name is skipped, not matched."""
+        mock_client = MagicMock()
+        mock_client.list_services.return_value = {
+            'ServiceSummaries': [
+                {'KeyAttributes': {'Type': 'Service'}},  # no Name -> skipped
+                {'KeyAttributes': {'Name': 'target', 'Type': 'Service'}},
+            ],
+            'NextToken': None,
+        }
+        with patch.object(
+            endpoint_metrics, 'get_applicationsignals_client', return_value=mock_client
+        ):
+            result = _find_service_key_attributes('target', _NOW, _LATER)
+        assert result == {'Name': 'target', 'Type': 'Service'}
+
+    def test_first_case_insensitive_match_wins(self):
+        """With multiple case-insensitive (non-exact) matches, the first is kept."""
+        mock_client = MagicMock()
+        mock_client.list_services.return_value = {
+            'ServiceSummaries': [
+                {'KeyAttributes': {'Name': 'SVC', 'Environment': 'eks:a'}},
+                {'KeyAttributes': {'Name': 'Svc', 'Environment': 'eks:b'}},
+            ],
+            'NextToken': None,
+        }
+        with patch.object(
+            endpoint_metrics, 'get_applicationsignals_client', return_value=mock_client
+        ):
+            result = _find_service_key_attributes('svc', _NOW, _LATER)
+        # First case-insensitive match is retained; the second does not overwrite it.
+        assert result == {'Name': 'SVC', 'Environment': 'eks:a'}
+
 
 class TestSumDatapoints:
     """Tests for _sum_datapoints aggregation."""

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -395,17 +395,21 @@ class TestGetEndpoints:
         )
 
         state.set_appsignals_enabled(True)
-        mock_red.return_value = [
-            {
-                'operation': 'GET /api/orders',
-                'service_name': 'orders',
-                'total_requests': 100,
-                'total_faults': 3,
-                'total_errors': 1,
-                'avg_duration_ms': 12.0,
-                'p99_duration_ms': 40.0,
-            }
-        ]
+        # get_endpoint_red_metrics returns (summaries, not_found).
+        mock_red.return_value = (
+            [
+                {
+                    'operation': 'GET /api/orders',
+                    'service_name': 'orders',
+                    'total_requests': 100,
+                    'total_faults': 3,
+                    'total_errors': 1,
+                    'avg_duration_ms': 12.0,
+                    'p99_duration_ms': 40.0,
+                }
+            ],
+            None,
+        )
 
         result = asyncio.get_event_loop().run_until_complete(
             get_endpoints(hours=24, service_name='orders')
@@ -416,6 +420,34 @@ class TestGetEndpoints:
         assert result['total_endpoints'] == 1
         assert result['endpoints'][0]['operation'] == 'GET /api/orders'
         mock_red.assert_called_once()
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
+    )
+    def test_appsignals_service_not_found_surfaces_diagnostic(self, mock_red):
+        """When the AppSignals service does not resolve, the not-found diagnostic is surfaced."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            get_endpoints,
+        )
+
+        state.set_appsignals_enabled(True)
+        mock_red.return_value = (
+            [],
+            {
+                'status': 'service_not_found',
+                'message': "No Application Signals service named 'orders' was found.",
+            },
+        )
+
+        result = asyncio.get_event_loop().run_until_complete(
+            get_endpoints(hours=24, service_name='orders')
+        )
+
+        assert result['data_source'] == 'application_signals'
+        assert result['total_endpoints'] == 0
+        assert result['status'] == 'service_not_found'
+        assert 'orders' in result['message']
 
 
 # ============================================================================
@@ -955,7 +987,7 @@ class TestGetEndpointsAppSignals:
         )
 
         state.set_appsignals_enabled(True)
-        mock_red.return_value = [{'operation': 'GET /api/orders', 'total_requests': 5}]
+        mock_red.return_value = ([{'operation': 'GET /api/orders', 'total_requests': 5}], None)
 
         result = _run(get_endpoints(operation='GET /api/orders', service_name='orders'))
 


### PR DESCRIPTION
## Summary

### Changes

`get_endpoint_performance` always returned `total_endpoints: 0` on the Application Signals path — even for services that clearly have operation-level metrics. Two bugs in `endpoint_metrics.get_endpoint_red_metrics`:

1. **Wrong response key.** `list_service_operations` returns operations under **`ServiceOperations`**, but the code read **`Operations`** → always `[]`. (Verified live: `billing-service-python` returns 11 `ServiceOperations`.)
2. **Wrong MetricType case.** The API returns `LATENCY`/`FAULT`/`ERROR` (uppercase) but the module constants were title-case (`Latency`/`Fault`/`Error`), so even when operations were present, every RED-metric lookup missed and produced zeros. MetricType is now indexed **case-insensitively**.

Together these meant the AppSignals endpoint path was effectively broken for every enabled service.

Additional robustness fixes in the same path:
- **Thread `environment` through** `get_endpoints` → `get_endpoint_red_metrics` → `_find_service_key_attributes` (it was accepted but ignored on the AppSignals path); use it to disambiguate same-named services across environments.
- **Case-insensitive service-name matching** (exact match still preferred).
- On an unresolved service name, return a structured **`service_not_found`** diagnostic instead of a bare empty list, so callers can distinguish "no such service" from "found but no operations in window".

### User experience

Before: "show me endpoint performance for `<service>`" → `total_endpoints: 0`, leading to an incorrect conclusion that the service has no operation-level metrics / isn't instrumented.

After (verified live, profile `telemend` / `us-east-1`):
- `billing-service-python` → real per-operation RED metrics, e.g. `GET ^summary/$` p99 ≈ 2737ms over 81k requests, `GET ^billings/$` avg ≈ 2738ms — actionable performance data.
- A wrong/misspelled name → `service_not_found` diagnostic instead of a silent empty result.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (unit tests + live verification against a real account)
* [x] Changes are documented

Is this a breaking change? (N)

**Note for reviewers:** the same exact-`Name`-match pattern exists in `service_tools.py` and `service_audit_utils.py`; left as-is here to keep this fix scoped to the reported endpoint path — flagging as a follow-up candidate.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
