### PR TITLE
feat(aws-documentation-mcp-server): surface optional response and per-result metadata in search_documentation

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/models.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/models.py
@@ -13,8 +13,63 @@
 # limitations under the License.
 """Data models for AWS Documentation MCP Server."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Dict, List, Optional
+
+
+class DiscoveredService(BaseModel):
+    """AWS service inferred from the query that may be relevant beyond the top results."""
+
+    name: str
+    description: Optional[str] = None
+
+
+class RelatedTaskUrl(BaseModel):
+    """Doc URL associated with a related task."""
+
+    url_name: str
+    url_description: Optional[str] = None
+
+
+class RelatedTask(BaseModel):
+    """Related operation or workflow with its own doc URLs."""
+
+    name: str
+    description: Optional[str] = None
+    urls: Optional[List[RelatedTaskUrl]] = None
+
+
+class Relationship(BaseModel):
+    """Named connection between concepts surfaced alongside search results."""
+
+    relation: Optional[str] = None
+    to: Optional[str] = None
+    to_description: Optional[str] = None
+    from_: Optional[str] = Field(default=None, alias='from')
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ResponseMetadata(BaseModel):
+    """Optional response-level metadata surfaced alongside search results."""
+
+    discovered_services: Optional[List[DiscoveredService]] = None
+    related_tasks: Optional[List[RelatedTask]] = None
+    relationships: Optional[List[Relationship]] = None
+
+
+class AdditionalUrl(BaseModel):
+    """Doc URL related to a search result, with section anchors for citation."""
+
+    url: str
+    section_title: Optional[str] = None
+    section_anchor: Optional[str] = None
+
+
+class SearchResultMetadata(BaseModel):
+    """Optional per-result metadata surfaced alongside an individual search result."""
+
+    additional_urls: Optional[List[AdditionalUrl]] = None
 
 
 class SearchResult(BaseModel):
@@ -25,6 +80,7 @@ class SearchResult(BaseModel):
     title: str
     context: Optional[str] = None
     sections: Optional[List[str]] = None
+    metadata: Optional[SearchResultMetadata] = None
 
 
 class SearchResponse(BaseModel):
@@ -33,6 +89,7 @@ class SearchResponse(BaseModel):
     search_results: List[SearchResult]
     facets: Optional[Dict[str, List[str]]] = None
     query_id: str
+    metadata: Optional[ResponseMetadata] = None
 
 
 class RecommendationResult(BaseModel):

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -40,8 +40,8 @@ from awslabs.aws_documentation_mcp_server.util import (
 )
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
-from pydantic import Field
-from typing import List, Optional
+from pydantic import BaseModel, Field, ValidationError
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 
 SEARCH_API_URL = 'https://proxy.search.docs.aws.com/search'
@@ -49,6 +49,23 @@ RECOMMENDATIONS_API_URL = 'https://api.contentrecs.docs.aws.com/v1/recommendatio
 SESSION_UUID = str(uuid.uuid4())
 SUPPORTED_METADATA_KEYS = ('discovered_services', 'related_tasks', 'relationships')
 SUPPORTED_RESULT_METADATA_KEYS = ('additional_urls',)
+
+_ModelT = TypeVar('_ModelT', bound=BaseModel)
+
+
+def _safe_model_validate(model: Type[_ModelT], data: Dict[str, Any]) -> Optional[_ModelT]:
+    """Validate optional metadata, dropping it (returning None) on any error.
+
+    Metadata is best-effort enrichment: a malformed block from the search backend
+    must never fail an otherwise-successful search. Log and drop instead of raising.
+    """
+    if not data:
+        return None
+    try:
+        return model.model_validate(data)
+    except (ValidationError, TypeError, KeyError, AttributeError) as e:
+        logger.warning(f'Dropping malformed {model.__name__} metadata: {e}')
+        return None
 
 
 # Dict for domain modifiers for search if search terms contain any of the terms
@@ -400,9 +417,7 @@ async def search_documentation(
             filtered_metadata = {
                 k: raw_metadata[k] for k in SUPPORTED_METADATA_KEYS if raw_metadata.get(k)
             }
-            response_metadata = (
-                ResponseMetadata.model_validate(filtered_metadata) if filtered_metadata else None
-            )
+            response_metadata = _safe_model_validate(ResponseMetadata, filtered_metadata)
 
         except json.JSONDecodeError as e:
             error_msg = f'Error parsing search results: {str(e)}'
@@ -472,10 +487,8 @@ async def search_documentation(
                 filtered_result_metadata = {
                     k: metadata[k] for k in SUPPORTED_RESULT_METADATA_KEYS if metadata.get(k)
                 }
-                search_result_metadata = (
-                    SearchResultMetadata.model_validate(filtered_result_metadata)
-                    if filtered_result_metadata
-                    else None
+                search_result_metadata = _safe_model_validate(
+                    SearchResultMetadata, filtered_result_metadata
                 )
                 search_result = SearchResult(
                     rank_order=i + 1,

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -21,8 +21,10 @@ import uuid
 # Import models
 from awslabs.aws_documentation_mcp_server.models import (
     RecommendationResult,
+    ResponseMetadata,
     SearchResponse,
     SearchResult,
+    SearchResultMetadata,
 )
 from awslabs.aws_documentation_mcp_server.server_utils import (
     DEFAULT_USER_AGENT,
@@ -45,6 +47,8 @@ from typing import List, Optional
 SEARCH_API_URL = 'https://proxy.search.docs.aws.com/search'
 RECOMMENDATIONS_API_URL = 'https://api.contentrecs.docs.aws.com/v1/recommendations'
 SESSION_UUID = str(uuid.uuid4())
+SUPPORTED_METADATA_KEYS = ('discovered_services', 'related_tasks', 'relationships')
+SUPPORTED_RESULT_METADATA_KEYS = ('additional_urls',)
 
 
 # Dict for domain modifiers for search if search terms contain any of the terms
@@ -291,8 +295,14 @@ async def search_documentation(
         - title: The page title
         - context: A brief excerpt or summary (if available)
         - sections: Table of contents (when available) - these section titles can be used with the read_sections tool for targeted content extraction
+        - metadata: Optional per-result context (when available). May include:
+            - additional_urls: Other doc URLs related to the same result `{url, section_title, section_anchor}` - pass `section_title` to read_sections to fetch content; use `url#section_anchor` when citing
     - facets: Available filters (product_types, guide_types) for refining searches
     - query_id: Unique identifier for this search session
+    - metadata: Optional response-level context (when available). May include:
+        - discovered_services: AWS services inferred from the query that may be relevant beyond the top results
+        - related_tasks: Related operations or workflows the user may want to follow up on, each with its own doc URLs
+        - relationships: Named connections between information in the search results, useful for understanding how the returned topics relate to each other
 
 
     Args:
@@ -386,6 +396,13 @@ async def search_documentation(
                         facets['product_types'] = value
                     elif key == 'aws-docs-search-guide':
                         facets['guide_types'] = value
+            raw_metadata = data.get('metadata') or {}
+            filtered_metadata = {
+                k: raw_metadata[k] for k in SUPPORTED_METADATA_KEYS if raw_metadata.get(k)
+            }
+            response_metadata = (
+                ResponseMetadata.model_validate(filtered_metadata) if filtered_metadata else None
+            )
 
         except json.JSONDecodeError as e:
             error_msg = f'Error parsing search results: {str(e)}'
@@ -428,7 +445,7 @@ async def search_documentation(
 
                 if 'sections' in metadata:
                     try:
-                        sections_data = metadata['sections']
+                        sections_data = metadata.pop('sections')
                         logger.debug(f'Found sections: {sections_data}')
                         logger.debug(f'Raw sections data type: {type(sections_data)}')
 
@@ -452,12 +469,21 @@ async def search_documentation(
                         f'Found {len(sections)} sections for {title}: {url}, sections: {sections}'
                     )
 
+                filtered_result_metadata = {
+                    k: metadata[k] for k in SUPPORTED_RESULT_METADATA_KEYS if metadata.get(k)
+                }
+                search_result_metadata = (
+                    SearchResultMetadata.model_validate(filtered_result_metadata)
+                    if filtered_result_metadata
+                    else None
+                )
                 search_result = SearchResult(
                     rank_order=i + 1,
                     url=text_suggestion.get('link', ''),
                     title=text_suggestion.get('title', ''),
                     context=context,
                     sections=sections if sections else None,
+                    metadata=search_result_metadata,
                 )
 
                 results.append(search_result)
@@ -465,7 +491,10 @@ async def search_documentation(
     logger.debug(f'Found {len(results)} search results for: {search_phrase}')
     logger.debug(f'Search query ID: {query_id}')
     final_search_response = SearchResponse(
-        search_results=results, facets=facets if facets else None, query_id=query_id
+        search_results=results,
+        facets=facets if facets else None,
+        query_id=query_id,
+        metadata=response_metadata,
     )
     add_search_result_cache_item(final_search_response)
     return final_search_response

--- a/src/aws-documentation-mcp-server/tests/test_models.py
+++ b/src/aws-documentation-mcp-server/tests/test_models.py
@@ -91,6 +91,7 @@ class TestSearchResponse:
         assert len(response.search_results) == 1
         assert response.facets is None
         assert response.query_id == 'test-query-id'
+        assert response.metadata is None
 
 
 class TestRecommendationResult:

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -819,6 +819,88 @@ class TestSearchDocumentation:
 
             mock_post.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_search_documentation_surfaces_known_response_metadata_fields(self):
+        """Known response-level metadata fields are surfaced; unknown fields are dropped."""
+        ctx = MockContext()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'queryId': 'qid',
+            'suggestions': [
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/x',
+                        'title': 'X',
+                        'suggestionBody': 'desc',
+                    }
+                }
+            ],
+            'metadata': {
+                'discovered_services': [{'name': 'Amazon S3'}],
+                'related_tasks': [
+                    {
+                        'name': 'enable Object Lock',
+                        'description': '...',
+                        'urls': [
+                            {
+                                'url_name': '/AmazonS3/latest/userguide/lock.html',
+                                'url_description': 'Object Lock overview',
+                            }
+                        ],
+                    }
+                ],
+                'unknown_field_a': 'should-not-appear',
+                'unknown_field_b': {'foo': 'bar'},
+            },
+        }
+
+        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            response = await search_documentation(
+                ctx, search_phrase='test', limit=10, product_types=None, guide_types=None
+            )
+
+            assert response.metadata is not None
+            assert response.metadata.discovered_services is not None
+            assert response.metadata.discovered_services[0].name == 'Amazon S3'
+            assert response.metadata.related_tasks is not None
+            assert response.metadata.related_tasks[0].name == 'enable Object Lock'
+            metadata_dump = response.metadata.model_dump(exclude_none=True)
+            assert 'unknown_field_a' not in metadata_dump
+            assert 'unknown_field_b' not in metadata_dump
+
+    @pytest.mark.asyncio
+    async def test_search_documentation_no_metadata_when_proxy_omits_it(self):
+        """Responses without a metadata block leave SearchResponse.metadata as None."""
+        ctx = MockContext()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'queryId': 'qid',
+            'suggestions': [
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/x',
+                        'title': 'X',
+                        'suggestionBody': 'desc',
+                    }
+                }
+            ],
+        }
+
+        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            response = await search_documentation(
+                ctx, search_phrase='test', limit=10, product_types=None, guide_types=None
+            )
+
+            assert response.metadata is None
+
 
 class TestRecommend:
     """Tests for the recommend function."""

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -901,6 +901,79 @@ class TestSearchDocumentation:
 
             assert response.metadata is None
 
+    @pytest.mark.asyncio
+    async def test_search_documentation_drops_malformed_response_metadata(self):
+        """A malformed response-level metadata block is dropped, not raised."""
+        ctx = MockContext()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'queryId': 'qid',
+            'suggestions': [
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/x',
+                        'title': 'X',
+                        'suggestionBody': 'desc',
+                    }
+                }
+            ],
+            # discovered_services items require a string `name`; a non-dict entry
+            # makes model_validate raise (ValidationError) unless guarded.
+            'metadata': {'discovered_services': ['not-a-dict']},
+        }
+
+        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            response = await search_documentation(
+                ctx, search_phrase='test', limit=10, product_types=None, guide_types=None
+            )
+
+            # Search succeeded; bad metadata was dropped rather than raised.
+            assert len(response.search_results) == 1
+            assert response.search_results[0].url == 'https://docs.aws.amazon.com/x'
+            assert response.metadata is None
+
+    @pytest.mark.asyncio
+    async def test_search_documentation_drops_malformed_result_metadata(self):
+        """A malformed per-result metadata block is dropped, not raised."""
+        ctx = MockContext()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'queryId': 'qid',
+            'suggestions': [
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/x',
+                        'title': 'X',
+                        'suggestionBody': 'desc',
+                        'metadata': {
+                            'sections': ['Overview'],
+                            # additional_urls entries require a string `url`; a bare
+                            # string entry makes model_validate raise unless guarded.
+                            'additional_urls': ['not-a-dict'],
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            response = await search_documentation(
+                ctx, search_phrase='test', limit=10, product_types=None, guide_types=None
+            )
+
+            result = response.search_results[0]
+            assert result.url == 'https://docs.aws.amazon.com/x'
+            assert result.sections == ['Overview']
+            assert result.metadata is None
+
 
 class TestRecommend:
     """Tests for the recommend function."""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

This change enriches search results with optional metadata so agents can navigate documentation more effectively.

### Changes

* **Per-result metadata:** each `SearchResult` may now carry an optional `metadata.additional_urls` list (`{url, section_title, section_anchor}`) pointing to other documentation pages related to that result, so an agent can navigate directly to them.
* **Response-level metadata:** `SearchResponse` may now carry an optional `metadata` object with query-level context - `discovered_services` (relevant AWS services beyond the top results), `related_tasks` (follow-up operations, each with its own doc URLs), and `relationships` (named connections between the returned topics).
* **Docstring:** `search_documentation` now documents these fields and how to use them
* **Tests:** added unit tests for the new metadata projection and for the no-metadata case (fields remain `null`).

### User experience

**Before:**

* User asks: *"How do I encrypt an S3 bucket and back it up with the right permissions?"*
* Agent searches for `"S3 encryption"`
* Agent gets a flat list of pages with no indication of which related services, tasks, or pages matter.

**After:**

* User asks: *"How do I encrypt an S3 bucket and back it up with the right permissions?"*
* Agent searches for `"S3 encryption"`
* Each result can carry `metadata.additional_urls` pointing to closely related pages, and the response can include top-level `metadata`:
  * `related_tasks` - follow-up operations (e.g. *"suspend versioning"*) each with their own doc URLs
  * `discovered_services` - relevant services beyond the top hits (e.g. AWS Backup) the agent might otherwise miss
  * `relationships` - how the returned topics connect (e.g. *Object Lock relates to Versioning*)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
