### PR TITLE
feat(security-agent-mcp-server): add diff scan, threat model review, and path validation

### DIFF
--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
@@ -116,6 +116,19 @@ class SecurityAgentClient:
             codeReviewId=code_review_id,
         )
 
+    def start_code_review_job_with_diff(
+        self,
+        agent_space_id: str,
+        code_review_id: str,
+        diff_s3_uri: str,
+    ) -> dict:
+        """Start a diff scan job with diffSource."""
+        return self._client().start_code_review_job(
+            agentSpaceId=agent_space_id,
+            codeReviewId=code_review_id,
+            diffSource={'s3Uri': diff_s3_uri},
+        )
+
     def batch_get_code_review_jobs(self, agent_space_id: str, job_ids: list[str]) -> dict:
         """Get status of code review jobs."""
         return self._client().batch_get_code_review_jobs(
@@ -152,6 +165,62 @@ class SecurityAgentClient:
         return self._client().batch_get_findings(
             agentSpaceId=agent_space_id,
             findingIds=finding_ids,
+        )
+
+    # --- Threat model operations ---
+
+    def create_threat_model(
+        self,
+        agent_space_id: str,
+        title: str,
+        service_role: str,
+        assets: dict,
+        scope_docs: Optional[list[dict]] = None,
+    ) -> dict:
+        """Create a threat model resource with source assets and scope documents."""
+        kwargs: dict[str, Any] = {
+            'agentSpaceId': agent_space_id,
+            'title': title,
+            'serviceRole': service_role,
+            'assets': assets,
+        }
+        if scope_docs:
+            kwargs['scopeDocs'] = scope_docs
+        return self._client().create_threat_model(**kwargs)
+
+    def start_threat_model_job(self, agent_space_id: str, threat_model_id: str) -> dict:
+        """Start a threat model job."""
+        return self._client().start_threat_model_job(
+            agentSpaceId=agent_space_id,
+            threatModelId=threat_model_id,
+        )
+
+    def batch_get_threat_model_jobs(self, agent_space_id: str, job_ids: list[str]) -> dict:
+        """Get status of threat model jobs."""
+        return self._client().batch_get_threat_model_jobs(
+            agentSpaceId=agent_space_id,
+            threatModelJobIds=job_ids,
+        )
+
+    def list_threats(self, agent_space_id: str, threat_job_id: str) -> dict:
+        """List all threats for a threat model job, handling pagination."""
+        client = self._client()
+        all_threats: list[dict] = []
+        kwargs: dict[str, Any] = {'agentSpaceId': agent_space_id, 'threatJobId': threat_job_id}
+        while True:
+            result = client.list_threats(**kwargs)
+            all_threats.extend(result.get('threats', []))
+            next_token = result.get('nextToken')
+            if not next_token:
+                break
+            kwargs['nextToken'] = next_token
+        return {'threats': all_threats}
+
+    def batch_get_threats(self, agent_space_id: str, threat_ids: list[str]) -> dict:
+        """Get detailed threats by ID."""
+        return self._client().batch_get_threats(
+            agentSpaceId=agent_space_id,
+            threatIds=threat_ids,
         )
 
     # --- Non-SecurityAgent helpers (S3, IAM, STS) ---
@@ -252,6 +321,8 @@ class SecurityAgentClient:
                         'Resource': [
                             f'arn:aws:s3:::security-agent-scans-{account_id}-{self.region}',
                             f'arn:aws:s3:::security-agent-scans-{account_id}-{self.region}/*',
+                            f'arn:aws:s3:::security-agent-threat-model-{account_id}-{self.region}',
+                            f'arn:aws:s3:::security-agent-threat-model-{account_id}-{self.region}/*',
                         ],
                     },
                     {

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/consts.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/consts.py
@@ -38,6 +38,31 @@ Tools: `start_security_scan`, `get_scan_status`, `get_scan_findings`, `list_scan
 2. Poll with `get_scan_status` until COMPLETED (or call `get_scan_findings` anytime for partial results)
 3. `get_scan_findings` → vulnerabilities with remediation guidance and code locations
 
+### Diff Scan (fast incremental scan)
+Tools: `start_diff_scan`, `get_scan_status`, `get_scan_findings`
+
+For scanning only changed code with full repo as context. No prior scan required.
+
+1. `start_diff_scan(path=".", base_ref="HEAD")` → generates git diff, uploads current repo + diff patch, starts diff scan
+2. Poll with `get_scan_status` until COMPLETED (10-15 min vs ~45 min for full scan)
+3. `get_scan_findings` → vulnerabilities focused on changed code
+
+base_ref options:
+- "HEAD" (default) — scan uncommitted workspace changes (staged + unstaged)
+- "main" or any ref — scan all changes on branch vs that ref
+
+### Threat Model Review (design/spec-guided)
+Tools: `start_threat_model_review`, `get_scan_status`, `get_scan_findings`
+
+Analyzes source code guided by design/requirement specs (e.g., Kiro design.md and
+requirements.md). The specs are used as scope documents the agent focuses on, prioritized
+over general source code analysis. No prior scan required.
+
+1. `start_threat_model_review(path=".", specs=["/abs/design.md", "/abs/requirements.md"])`
+   → zips + uploads the source dir, uploads the specs as scope docs, creates a threat model, starts a job
+2. Poll with `get_scan_status` until COMPLETED
+3. `get_scan_findings` → identified threats (severity, STRIDE, impact, recommendation)
+
 ### Penetration Test and All Other Operations (via generic API)
 Tools: `call_api`, `get_api_guide`
 

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
@@ -15,7 +15,9 @@
 """Scanner — orchestrates zip, upload, create code review, start job, poll status, fetch findings."""
 
 import gitignorefile
+import hashlib
 import os
+import subprocess
 import tempfile
 import uuid
 import zipfile
@@ -27,7 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 
-MAX_ZIP_SIZE = 512 * 1024 * 1024  # 512MB
+MAX_ZIP_SIZE = 2 * 1024 * 1024 * 1024  # 2GB
 
 EXCLUDE_DIRS = {
     '.git',
@@ -61,6 +63,64 @@ class Scanner:
         self._client = client
         self._state = state
 
+    @staticmethod
+    def _workspace_id(abs_path: str) -> str:
+        """Stable short identifier for a workspace path, used as the S3 key prefix."""
+        return hashlib.md5(abs_path.encode(), usedforsecurity=False).hexdigest()[:12]
+
+    def _zip_and_upload_source(self, path: str, abs_path: str, s3_bucket: str) -> tuple[str, int]:
+        """Zip the workspace and upload to a stable per-workspace S3 key, overwriting any prior upload.
+
+        Returns (s3_url, zip_size_bytes).
+        """
+        zip_path = self._zip_code(path)
+        zip_size = os.path.getsize(zip_path)
+        if zip_size > MAX_ZIP_SIZE:
+            os.unlink(zip_path)
+            raise ValueError(
+                f'Code too large ({zip_size // 1024 // 1024}MB). Max {MAX_ZIP_SIZE // 1024 // 1024}MB.'
+            )
+        try:
+            s3_key = f'security-scans/source/{self._workspace_id(abs_path)}/source.zip'
+            s3_url = self._client.upload_to_s3(s3_bucket, s3_key, zip_path)
+        finally:
+            if os.path.exists(zip_path):
+                os.unlink(zip_path)
+        return s3_url, zip_size
+
+    def _zip_committed_and_upload(
+        self, abs_path: str, base_ref: str, s3_bucket: str
+    ) -> tuple[str, int]:
+        """Zip the committed state at base_ref using git archive and upload.
+
+        Returns (s3_url, zip_size_bytes).
+        """
+        tmp = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+        tmp.close()
+        try:
+            result = subprocess.run(
+                ['git', 'archive', '--format=zip', '-o', tmp.name, '--', base_ref],
+                cwd=abs_path,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                raise ValueError(f'git archive failed: {result.stderr.strip()}')
+
+            zip_size = os.path.getsize(tmp.name)
+            if zip_size > MAX_ZIP_SIZE:
+                raise ValueError(
+                    f'Code too large ({zip_size // 1024 // 1024}MB). '
+                    f'Max {MAX_ZIP_SIZE // 1024 // 1024}MB.'
+                )
+            s3_key = f'security-scans/source/{self._workspace_id(abs_path)}/source.zip'
+            s3_url = self._client.upload_to_s3(s3_bucket, s3_key, tmp.name)
+        finally:
+            if os.path.exists(tmp.name):
+                os.unlink(tmp.name)
+        return s3_url, zip_size
+
     async def start_scan(self, path: str = '.', title: Optional[str] = None) -> dict:
         """Package code, upload to S3, and start a security scan.
 
@@ -87,22 +147,11 @@ class Scanner:
         scan_id = f'scan-{uuid.uuid4().hex[:8]}'
         title = title or f'pre-cr-{datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")}'
 
-        # 1. Zip code
-        zip_path = self._zip_code(path)
-        zip_size = os.path.getsize(zip_path)
-        if zip_size > MAX_ZIP_SIZE:
-            os.unlink(zip_path)
-            return {
-                'error': f'Code too large ({zip_size // 1024 // 1024}MB). Max {MAX_ZIP_SIZE // 1024 // 1024}MB.'
-            }
-
-        # 2. Upload to S3
+        # 1+2. Zip code and upload to stable per-workspace S3 key (overwrites prior uploads)
         try:
-            s3_key = f'security-scans/{scan_id}/source.zip'
-            s3_url = self._client.upload_to_s3(s3_bucket, s3_key, zip_path)
-        finally:
-            if os.path.exists(zip_path):
-                os.unlink(zip_path)
+            s3_url, zip_size = self._zip_and_upload_source(path, abs_path, s3_bucket)
+        except ValueError as e:
+            return {'error': str(e)}
 
         # 3. Get or create code review for this workspace
         code_review_id = self._state.get_code_review_id(abs_path)
@@ -149,6 +198,7 @@ class Scanner:
                 'job_id': job_id,
                 'agent_space_id': agent_space_id,
                 'status': 'IN_PROGRESS',
+                'scan_type': 'FULL',
                 'title': title,
                 'path': abs_path,
                 'started_at': datetime.now(timezone.utc).isoformat(),
@@ -161,8 +211,256 @@ class Scanner:
             'code_review_id': code_review_id,
             'job_id': job_id,
             'status': 'STARTED',
+            'scan_type': 'FULL',
             'title': title,
             'message': 'Security scan started. Ask the user if they want you to poll for status periodically, or if they prefer to check back later.',
+        }
+
+    async def start_diff_scan(
+        self, path: str = '.', base_ref: str = 'HEAD', title: Optional[str] = None
+    ) -> dict:
+        """Run a diff scan — analyzes only changed code with full repo context.
+
+        Uploads the committed state at base_ref as the baseline source, and the
+        diff (base_ref vs working tree) as the changes to focus on.
+        """
+        config = self._state.get_config()
+        agent_space_id = config.get('agent_space_id')
+        service_role = config.get('service_role')
+        s3_bucket = config.get('s3_bucket')
+
+        if not agent_space_id or not service_role:
+            return {'error': 'Not configured. Run setup_check and setup first.'}
+        if not s3_bucket:
+            return {'error': 'No S3 bucket configured. Run setup first.'}
+
+        # Verify agent space still exists
+        space = self._client.get_agent_space(agent_space_id)
+        if not space:
+            self._state.clear_config_keys('agent_space_id')
+            return {'error': f'Agent space {agent_space_id} no longer exists. Run setup again.'}
+
+        abs_path = os.path.abspath(path)
+
+        # 1. Generate diff: base_ref vs working tree (fail fast if no changes)
+        diff_cmd = ['git', 'diff', base_ref, '--']
+
+        try:
+            diff_result = subprocess.run(
+                diff_cmd,
+                cwd=abs_path,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except FileNotFoundError:
+            return {'error': 'git is not installed or not in PATH.'}
+        except subprocess.TimeoutExpired:
+            return {'error': 'git diff timed out (>60s). Try a narrower base_ref.'}
+
+        if diff_result.returncode != 0:
+            return {
+                'error': f'git diff failed: {diff_result.stderr.strip()}. '
+                f'Verify that "{base_ref}" is a valid ref in this repo.'
+            }
+
+        diff_content = diff_result.stdout
+        if not diff_content.strip():
+            return {'error': f'No diff found for {" ".join(diff_cmd)}. Nothing to scan.'}
+
+        scan_id = f'scan-{uuid.uuid4().hex[:8]}'
+        title = title or f'diff-{base_ref}-{datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")}'
+
+        # 2. Zip committed state at base_ref (baseline) and upload
+        try:
+            s3_url, zip_size = self._zip_committed_and_upload(abs_path, base_ref, s3_bucket)
+        except ValueError as e:
+            return {'error': str(e)}
+
+        # 3. Get or create code review for this workspace
+        code_review_id = self._state.get_code_review_id(abs_path)
+        if not code_review_id:
+            cr_result = self._client.create_code_review(
+                agent_space_id=agent_space_id,
+                title=title,
+                service_role=service_role,
+                s3_url=s3_url,
+            )
+            code_review_id = cr_result['codeReviewId']
+            self._state.set_code_review_id(abs_path, code_review_id)
+
+        # 4. Upload diff patch to a scan-specific S3 key
+        diff_tmp = tempfile.NamedTemporaryFile(suffix='.patch', delete=False, mode='w')
+        diff_tmp.write(diff_content)
+        diff_tmp.close()
+        try:
+            s3_key_diff = f'security-scans/diffs/{scan_id}/diff.patch'
+            self._client.upload_to_s3(s3_bucket, s3_key_diff, diff_tmp.name)
+            diff_s3_uri = f's3://{s3_bucket}/{s3_key_diff}'
+        finally:
+            if os.path.exists(diff_tmp.name):
+                os.unlink(diff_tmp.name)
+
+        # 5. Start code review job with diffSource (recreate CodeReview if deleted externally)
+        try:
+            job_result = self._client.start_code_review_job_with_diff(
+                agent_space_id=agent_space_id,
+                code_review_id=code_review_id,
+                diff_s3_uri=diff_s3_uri,
+            )
+        except (RuntimeError, ClientError) as e:
+            is_not_found = (
+                isinstance(e, ClientError)
+                and e.response['Error']['Code'] == 'ResourceNotFoundException'
+            ) or (isinstance(e, RuntimeError) and 'ResourceNotFoundException' in str(e))
+            if is_not_found:
+                cr_result = self._client.create_code_review(
+                    agent_space_id=agent_space_id,
+                    title=title,
+                    service_role=service_role,
+                    s3_url=s3_url,
+                )
+                code_review_id = cr_result['codeReviewId']
+                self._state.set_code_review_id(abs_path, code_review_id)
+                job_result = self._client.start_code_review_job_with_diff(
+                    agent_space_id=agent_space_id,
+                    code_review_id=code_review_id,
+                    diff_s3_uri=diff_s3_uri,
+                )
+            else:
+                raise
+
+        job_id = job_result['codeReviewJobId']
+
+        self._state.save_scan(
+            scan_id,
+            {
+                'scan_id': scan_id,
+                'code_review_id': code_review_id,
+                'job_id': job_id,
+                'agent_space_id': agent_space_id,
+                'status': 'IN_PROGRESS',
+                'scan_type': 'DIFF',
+                'base_ref': base_ref,
+                'title': title,
+                'path': abs_path,
+                'started_at': datetime.now(timezone.utc).isoformat(),
+                'zip_size_bytes': zip_size,
+                'diff_size_bytes': len(diff_content.encode('utf-8')),
+            },
+        )
+
+        return {
+            'scan_id': scan_id,
+            'code_review_id': code_review_id,
+            'job_id': job_id,
+            'status': 'STARTED',
+            'scan_type': 'DIFF',
+            'base_ref': base_ref,
+            'title': title,
+            'message': 'Diff scan started. Should complete in 10-15 minutes. '
+            'Use get_scan_status to check progress.',
+        }
+
+    async def start_threat_model_review(
+        self,
+        path: str = '.',
+        specs: Optional[list[str]] = None,
+        title: Optional[str] = None,
+    ) -> dict:
+        """Run a threat model review — analyzes source code guided by design/requirement specs.
+
+        Uploads the current repo (overwriting prior uploads) and the provided spec
+        documents (e.g., Kiro design.md / requirements.md), creates a threat model
+        with the source as an asset and the specs as scope docs, then starts a job.
+        """
+        config = self._state.get_config()
+        agent_space_id = config.get('agent_space_id')
+        service_role = config.get('service_role')
+        s3_bucket = config.get('threat_model_s3_bucket')
+
+        if not agent_space_id or not service_role:
+            return {'error': 'Not configured. Run setup_check and setup first.'}
+        if not s3_bucket:
+            return {'error': 'No threat-model S3 bucket configured. Run setup first.'}
+        if not specs:
+            return {
+                'error': 'No specs provided. Provide at least one design/requirements doc path.'
+            }
+
+        missing = [s for s in specs if not os.path.isfile(s)]
+        if missing:
+            return {'error': f'Spec files not found: {", ".join(missing)}'}
+
+        # Verify agent space still exists
+        space = self._client.get_agent_space(agent_space_id)
+        if not space:
+            self._state.clear_config_keys('agent_space_id')
+            return {'error': f'Agent space {agent_space_id} no longer exists. Run setup again.'}
+
+        abs_path = os.path.abspath(path)
+        scan_id = f'scan-{uuid.uuid4().hex[:8]}'
+        title = title or f'threatmodel-{datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")}'
+
+        # 1. Zip and upload current repo to stable per-workspace S3 key (overwrites prior)
+        try:
+            s3_url, zip_size = self._zip_and_upload_source(path, abs_path, s3_bucket)
+        except ValueError as e:
+            return {'error': str(e)}
+
+        # 2. Upload each spec doc to a scan-specific S3 key -> scope docs
+        scope_docs = []
+        for i, spec in enumerate(specs):
+            s3_key_spec = (
+                f'security-scans/threat-models/{scan_id}/specs/{i}_{os.path.basename(spec)}'
+            )
+            self._client.upload_to_s3(s3_bucket, s3_key_spec, spec)
+            scope_docs.append({'s3Location': f's3://{s3_bucket}/{s3_key_spec}'})
+
+        # 3. Create threat model (source as asset, specs as scope docs)
+        tm_result = self._client.create_threat_model(
+            agent_space_id=agent_space_id,
+            title=title,
+            service_role=service_role,
+            assets={'sourceCode': [{'s3Location': s3_url}]},
+            scope_docs=scope_docs,
+        )
+        threat_model_id = tm_result['threatModelId']
+
+        # 4. Start threat model job
+        job_result = self._client.start_threat_model_job(
+            agent_space_id=agent_space_id,
+            threat_model_id=threat_model_id,
+        )
+        job_id = job_result['threatModelJobId']
+
+        self._state.save_scan(
+            scan_id,
+            {
+                'scan_id': scan_id,
+                'threat_model_id': threat_model_id,
+                'job_id': job_id,
+                'agent_space_id': agent_space_id,
+                'status': 'IN_PROGRESS',
+                'scan_type': 'THREAT_MODEL',
+                'title': title,
+                'path': abs_path,
+                'specs': specs,
+                'started_at': datetime.now(timezone.utc).isoformat(),
+                'zip_size_bytes': zip_size,
+            },
+        )
+
+        return {
+            'scan_id': scan_id,
+            'threat_model_id': threat_model_id,
+            'job_id': job_id,
+            'status': 'STARTED',
+            'scan_type': 'THREAT_MODEL',
+            'title': title,
+            'spec_count': len(specs),
+            'message': 'Threat model review started. Use get_scan_status to check progress '
+            'and get_scan_findings to retrieve identified threats.',
         }
 
     async def get_status(self, scan_id: Optional[str] = None) -> dict:
@@ -171,11 +469,19 @@ class Scanner:
         if not scan:
             return {'error': 'No scan found. Start one with start_security_scan.'}
 
-        result = self._client.batch_get_code_review_jobs(
-            agent_space_id=scan['agent_space_id'],
-            job_ids=[scan['job_id']],
-        )
-        jobs = result.get('codeReviewJobs', [])
+        if scan.get('scan_type') == 'THREAT_MODEL':
+            result = self._client.batch_get_threat_model_jobs(
+                agent_space_id=scan['agent_space_id'],
+                job_ids=[scan['job_id']],
+            )
+            jobs = result.get('threatModelJobs', [])
+        else:
+            result = self._client.batch_get_code_review_jobs(
+                agent_space_id=scan['agent_space_id'],
+                job_ids=[scan['job_id']],
+            )
+            jobs = result.get('codeReviewJobs', [])
+
         if not jobs:
             return {'error': f'Job {scan["job_id"]} not found.'}
 
@@ -209,6 +515,9 @@ class Scanner:
         # Get current status for context
         status_result = await self.get_status(scan_id=scan['scan_id'])
         scan_status = status_result.get('status', 'UNKNOWN')
+
+        if scan.get('scan_type') == 'THREAT_MODEL':
+            return self._get_threat_findings(scan, scan_status, severity)
 
         result = self._client.list_findings(
             agent_space_id=scan['agent_space_id'],
@@ -260,16 +569,71 @@ class Scanner:
             result['note'] = 'Scan still in progress. More findings may appear. Check again later.'
         return result
 
+    def _get_threat_findings(self, scan: dict, scan_status: str, severity: Optional[str]) -> dict:
+        """Get threats (findings) for a threat model scan."""
+        summaries = self._client.list_threats(
+            agent_space_id=scan['agent_space_id'],
+            threat_job_id=scan['job_id'],
+        ).get('threats', [])
+
+        if severity:
+            severity_order = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL']
+            severity_upper = severity.upper()
+            if severity_upper in severity_order:
+                allowed = set(severity_order[: severity_order.index(severity_upper) + 1])
+                summaries = [t for t in summaries if t.get('severity', '').upper() in allowed]
+
+        threat_ids = [t.get('threatId') for t in summaries if t.get('threatId')]
+        threats = []
+        if threat_ids:
+            batch_result = self._client.batch_get_threats(
+                agent_space_id=scan['agent_space_id'],
+                threat_ids=threat_ids,
+            )
+            threats = [
+                {
+                    'threatId': t.get('threatId'),
+                    'statement': t.get('statement'),
+                    'severity': t.get('severity'),
+                    'status': t.get('status'),
+                    'stride': t.get('stride'),
+                    'threatImpact': t.get('threatImpact'),
+                    'recommendation': t.get('recommendation'),
+                    'impactedAssets': t.get('impactedAssets'),
+                }
+                for t in batch_result.get('threats', [])
+            ]
+
+        result = {
+            'scan_id': scan['scan_id'],
+            'title': scan.get('title'),
+            'scan_status': scan_status,
+            'total_findings': len(threats),
+            'findings': threats,
+        }
+        if scan_status not in ('COMPLETED', 'PARTIALLY_COMPLETED'):
+            result['note'] = 'Scan still in progress. More threats may appear. Check again later.'
+        return result
+
     async def stop_scan(self, scan_id: str) -> dict:
         """Stop a running scan."""
         scan = self._state.get_scan(scan_id)
         if not scan:
             return {'error': 'No scan found.'}
 
-        self._client.stop_code_review_job(
-            agent_space_id=scan['agent_space_id'],
-            code_review_job_id=scan['job_id'],
-        )
+        if scan.get('scan_type') == 'THREAT_MODEL':
+            self._client.call(
+                'StopThreatModelJob',
+                {
+                    'agentSpaceId': scan['agent_space_id'],
+                    'threatModelJobId': scan['job_id'],
+                },
+            )
+        else:
+            self._client.stop_code_review_job(
+                agent_space_id=scan['agent_space_id'],
+                code_review_job_id=scan['job_id'],
+            )
         scan['status'] = 'STOPPED'
         self._state.save_scan(scan['scan_id'], scan)
         return {'scan_id': scan['scan_id'], 'status': 'STOPPED'}

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -126,7 +126,13 @@ async def _validate_path(ctx: Context, path: str, must_be_dir: bool = True) -> s
 def _client_prefix(ctx: Context) -> str:
     """Extract a kebab-case prefix from the MCP client name, or 'ide' as fallback."""
     try:
-        name = ctx.session.client_params.clientInfo.name
+        session = ctx.session
+        if session is None:
+            return 'ide'
+        client_params = session.client_params
+        if client_params is None:
+            return 'ide'
+        name = client_params.clientInfo.name  # type: ignore[union-attr]
         if not isinstance(name, str):
             return 'ide'
         return name.lower().replace(' ', '-')

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -108,7 +108,7 @@ async def _validate_path(ctx: Context, path: str, must_be_dir: bool = True) -> s
     resolved = os.path.realpath(os.path.abspath(path))
     root = os.path.realpath(_ALLOWED_ROOT) if _ALLOWED_ROOT else os.path.realpath(os.getcwd())
 
-    if not (resolved == root or resolved.startswith(root + os.sep)):
+    if root != os.sep and not (resolved == root or resolved.startswith(root + os.sep)):
         raise ValueError(
             f'Path "{path}" resolves to "{resolved}" which is outside the allowed workspace '
             f'root "{root}". Set the WORKSPACE_ROOT environment variable to the directory '

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -25,7 +25,7 @@ from awslabs.security_agent_mcp_server.consts import (
 from awslabs.security_agent_mcp_server.scanner import Scanner
 from awslabs.security_agent_mcp_server.state import StateManager
 from botocore.exceptions import ClientError
-from datetime import datetime
+from datetime import datetime, timezone
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
@@ -94,6 +94,79 @@ _state = StateManager(region=_region)
 _scanner = Scanner(client=_client, state=_state)
 
 
+_ALLOWED_ROOT: str | None = os.environ.get('WORKSPACE_ROOT')
+
+
+async def _validate_path(ctx: Context, path: str, must_be_dir: bool = True) -> str:
+    """Resolve path and verify it's within the configured workspace root.
+
+    Prevents scanning arbitrary directories (e.g. ~/.aws, /etc) which would
+    upload their contents to S3. The allowed root is determined by:
+    1. WORKSPACE_ROOT env var (set by IDE/power config)
+    2. Server process cwd (fallback)
+    """
+    resolved = os.path.realpath(os.path.abspath(path))
+    root = os.path.realpath(_ALLOWED_ROOT) if _ALLOWED_ROOT else os.path.realpath(os.getcwd())
+
+    if not (resolved == root or resolved.startswith(root + os.sep)):
+        raise ValueError(
+            f'Path "{path}" resolves to "{resolved}" which is outside the allowed workspace '
+            f'root "{root}". Set the WORKSPACE_ROOT environment variable to the directory '
+            f'you want to allow scanning.'
+        )
+
+    if must_be_dir and not os.path.isdir(resolved):
+        raise ValueError(f'Path "{resolved}" does not exist or is not a directory.')
+    if not must_be_dir and not os.path.isfile(resolved):
+        raise ValueError(f'Path "{resolved}" does not exist or is not a file.')
+
+    return resolved
+
+
+def _client_prefix(ctx: Context) -> str:
+    """Extract a kebab-case prefix from the MCP client name, or 'ide' as fallback."""
+    try:
+        name = ctx.session.client_params.clientInfo.name
+        if not isinstance(name, str):
+            return 'ide'
+        return name.lower().replace(' ', '-')
+    except (AttributeError, TypeError):
+        return 'ide'
+
+
+def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
+    """Lazily create and register the per-account S3 bucket for the given kind.
+
+    kind 'scans' -> security-agent-scans-... (full/diff scans);
+    'threat-model' -> security-agent-threat-model-... (threat model reviews).
+    """
+    config_key = 's3_bucket' if kind == 'scans' else 'threat_model_s3_bucket'
+    if config.get(config_key):
+        return
+    account_id = _client.get_caller_identity()['Account']
+    bucket = f'security-agent-{kind}-{account_id}-{_region}'
+    try:
+        _client.create_s3_bucket(bucket)
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') != 'BucketAlreadyOwnedByYou':
+            raise
+
+    # Register bucket on agent space so the service can access it
+    agent_space_id = config['agent_space_id']
+    space = _client.get_agent_space(agent_space_id)
+    existing_buckets = space.get('awsResources', {}).get('s3Buckets', [])
+    if bucket not in existing_buckets:
+        existing_buckets.append(bucket)
+        _client.update_agent_space(
+            agent_space_id,
+            space.get('name', 'security-scans'),
+            space.get('awsResources', {}).get('iamRoles', []),
+            existing_buckets,
+        )
+
+    _state.update_config(**{config_key: bucket})
+
+
 @mcp.tool()
 async def setup_check(ctx: Context) -> str:
     """Check if AWS Security Agent prerequisites are configured.
@@ -131,6 +204,7 @@ async def setup_check(ctx: Context) -> str:
                     )
             except Exception as list_err:
                 logger.warning(f'Could not list existing agent spaces: {list_err}')
+                result['list_agent_spaces_error'] = str(list_err)
 
         logger.info(f'Setup check: ready={result["ready"]}')
         return json.dumps(result, default=_json_serial)
@@ -262,32 +336,15 @@ async def start_security_scan(
             return json.dumps({'error': 'Not configured. Run setup first.'}, default=_json_serial)
 
         # Lazy S3 bucket creation on first scan
-        if not config.get('s3_bucket'):
-            identity = _client.get_caller_identity()
-            account_id = identity['Account']
-            s3_bucket = f'security-agent-scans-{account_id}-{_region}'
-            try:
-                _client.create_s3_bucket(s3_bucket)
-            except ClientError as e:
-                if e.response.get('Error', {}).get('Code') == 'BucketAlreadyOwnedByYou':
-                    pass
-                else:
-                    raise
-            _state.update_config(s3_bucket=s3_bucket)
+        _ensure_s3_bucket(config)
 
-            # Register bucket on agent space so service can access it
-            agent_space_id = config['agent_space_id']
-            space = _client.get_agent_space(agent_space_id)
-            existing_buckets = space.get('awsResources', {}).get('s3Buckets', [])
-            if s3_bucket not in existing_buckets:
-                existing_buckets.append(s3_bucket)
-                _client.update_agent_space(
-                    agent_space_id,
-                    space.get('name', 'security-scans'),
-                    space.get('awsResources', {}).get('iamRoles', []),
-                    existing_buckets,
-                )
-
+        path = await _validate_path(ctx, path)
+        prefix = _client_prefix(ctx)
+        title = (
+            f'{prefix}-{title}'
+            if title
+            else f'{prefix}-pre-cr-{datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")}'
+        )
         logger.info(f'Starting security scan on path: {path}')
         result = await _scanner.start_scan(path=path, title=title)
         return json.dumps(result, default=_json_serial)
@@ -296,9 +353,120 @@ async def start_security_scan(
         logger.error(f'Error in start_security_scan: {e}')
         await ctx.error(err['error'])
         return json.dumps(err, default=_json_serial)
+    except ValueError as e:
+        logger.error(f'Error in start_security_scan: {e}')
+        return json.dumps({'error': str(e)}, default=_json_serial)
     except Exception as e:
         logger.error(f'Error in start_security_scan: {e}')
         await ctx.error(f'Scan failed: {e}')
+        raise
+
+
+@mcp.tool()
+async def start_diff_scan(
+    ctx: Context,
+    path: str = Field(
+        default='.',
+        description='Absolute path to the code directory to scan. CRITICAL: Assistant must provide the user\'s current workspace absolute path, NOT ".". The MCP server runs as a subprocess and "." resolves to its own directory, not the user\'s workspace.',
+    ),
+    base_ref: str = Field(
+        default='HEAD',
+        description='Git ref to diff against. "HEAD" for uncommitted changes, or a branch/commit like "main".',
+    ),
+    title: Optional[str] = Field(
+        default=None,
+        description='Title for the diff scan. Auto-generated if not provided.',
+    ),
+) -> str:
+    """Start a diff security scan — analyzes only changed code with full repo as context.
+
+    Faster than a full scan (10-15 min vs ~45 min). Uploads the current repo and
+    the diff patch; the agent focuses on changes while having full source for context.
+    No prior scan required.
+    """
+    try:
+        config = _state.get_config()
+        if not config.get('agent_space_id') or not config.get('service_role'):
+            return json.dumps({'error': 'Not configured. Run setup first.'}, default=_json_serial)
+
+        _ensure_s3_bucket(config)
+
+        path = await _validate_path(ctx, path)
+        prefix = _client_prefix(ctx)
+        title = (
+            f'{prefix}-{title}'
+            if title
+            else f'{prefix}-diff-{base_ref}-{datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")}'
+        )
+        logger.info(f'Starting diff scan on path: {path}, base_ref: {base_ref}')
+        result = await _scanner.start_diff_scan(path=path, base_ref=base_ref, title=title)
+        return json.dumps(result, default=_json_serial)
+    except ClientError as e:
+        err = _translate_client_error(e)
+        logger.error(f'Error in start_diff_scan: {e}')
+        await ctx.error(err['error'])
+        return json.dumps(err, default=_json_serial)
+    except ValueError as e:
+        logger.error(f'Error in start_diff_scan: {e}')
+        return json.dumps({'error': str(e)}, default=_json_serial)
+    except Exception as e:
+        logger.error(f'Error in start_diff_scan: {e}')
+        await ctx.error(f'Diff scan failed: {e}')
+        raise
+
+
+@mcp.tool()
+async def start_threat_model_review(
+    ctx: Context,
+    path: str = Field(
+        default='.',
+        description='Absolute path to the source code directory to threat model. CRITICAL: Assistant must provide the user\'s current workspace absolute path, NOT ".". The MCP server runs as a subprocess and "." resolves to its own directory, not the user\'s workspace.',
+    ),
+    specs: list[str] = Field(
+        default_factory=list,
+        description='Absolute paths to spec documents (e.g., Kiro design.md and requirements.md) for the agent to focus on during threat modeling. At least one is required.',
+    ),
+    title: Optional[str] = Field(
+        default=None,
+        description='Title for the threat model review. Auto-generated if not provided.',
+    ),
+) -> str:
+    """Start a threat model review — analyzes source code guided by design/requirement specs.
+
+    Uploads the source directory and the provided spec documents, creates a threat
+    model with the source as an asset and the specs as scope documents, and starts
+    a threat model job. Returns a scan_id for polling with get_scan_status; retrieve
+    identified threats with get_scan_findings. No prior scan required.
+    """
+    try:
+        config = _state.get_config()
+        if not config.get('agent_space_id') or not config.get('service_role'):
+            return json.dumps({'error': 'Not configured. Run setup first.'}, default=_json_serial)
+
+        _ensure_s3_bucket(config, 'threat-model')
+
+        path = await _validate_path(ctx, path)
+        specs = [await _validate_path(ctx, s, must_be_dir=False) for s in specs]
+        prefix = _client_prefix(ctx)
+        title = (
+            f'{prefix}-{title}'
+            if title
+            else f'{prefix}-threatmodel-{datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")}'
+        )
+        logger.info(f'Starting threat model review on path: {path}, specs: {len(specs)}')
+        result = await _scanner.start_threat_model_review(path=path, specs=specs, title=title)
+        return json.dumps(result, default=_json_serial)
+    except ClientError as e:
+        err = _translate_client_error(e)
+        logger.error(f'Error in start_threat_model_review: {e}')
+        await ctx.error(err['error'])
+        return json.dumps(err, default=_json_serial)
+    except ValueError as e:
+        logger.error(f'Error in start_threat_model_review: {e}')
+        return json.dumps({'error': str(e)}, default=_json_serial)
+    except Exception as e:
+        logger.error(f'Error in start_threat_model_review: {e}')
+        await ctx.error(f'Threat model review failed: {e}')
         raise
 
 

--- a/src/security-agent-mcp-server/pyproject.toml
+++ b/src/security-agent-mcp-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "An AWS Labs Model Context Protocol (MCP) server for AWS Security 
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "boto3>=1.43.19",
+    "boto3>=1.43.32",
     "filelock>=3.0.0",
     "loguru>=0.7.0",
     "mcp[cli]>=1.6.0",

--- a/src/security-agent-mcp-server/tests/test_aws_client.py
+++ b/src/security-agent-mcp-server/tests/test_aws_client.py
@@ -133,10 +133,10 @@ class TestSecurityAgentClient:
             client.call('../evil', {})
 
     @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
-    def test_call_unknown_operation(self, mock_boto3):
-        """Operations not in the SecurityAgent service model are rejected."""
+    def test_call_unknown_operation_rejected(self, mock_boto3):
+        """Operations not in the SDK are rejected."""
         mock_client = MagicMock()
-        mock_client.meta.service_model.operation_names = ['ListPentests', 'CreatePentest']
+        mock_client.meta.service_model.operation_names = ['ListPentests']
         mock_boto3.Session.return_value.client.return_value = mock_client
 
         client = SecurityAgentClient()
@@ -347,3 +347,111 @@ class TestSecurityAgentClient:
 
         assert url == 's3://bkt/k.zip'
         mock_s3.upload_file.assert_called_once_with('/tmp/source.zip', 'bkt', 'k.zip')
+
+
+class TestDiffScanAndThreatModel:
+    """Tests for diff scan and threat model operations using standard SDK."""
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_start_code_review_job_with_diff_success(self, mock_boto3):
+        """Diff scan job calls start_code_review_job with diffSource."""
+        mock_client = MagicMock()
+        mock_client.start_code_review_job.return_value = {'codeReviewJobId': 'cj-diff'}
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        result = client.start_code_review_job_with_diff('as-1', 'cr-1', 's3://b/k')
+        assert result == {'codeReviewJobId': 'cj-diff'}
+        mock_client.start_code_review_job.assert_called_once_with(
+            agentSpaceId='as-1', codeReviewId='cr-1', diffSource={'s3Uri': 's3://b/k'}
+        )
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_create_threat_model_with_scope_docs(self, mock_boto3):
+        """create_threat_model includes scopeDocs when provided."""
+        mock_client = MagicMock()
+        mock_client.create_threat_model.return_value = {'threatModelId': 'tm-1'}
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        result = client.create_threat_model(
+            agent_space_id='as-1',
+            title='t',
+            service_role='arn:role',
+            assets={'sourceCode': []},
+            scope_docs=[{'s3Location': 's3://b/spec.md'}],
+        )
+        assert result == {'threatModelId': 'tm-1'}
+        kwargs = mock_client.create_threat_model.call_args.kwargs
+        assert kwargs['scopeDocs'] == [{'s3Location': 's3://b/spec.md'}]
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_create_threat_model_without_scope_docs(self, mock_boto3):
+        """create_threat_model omits scopeDocs when not provided."""
+        mock_client = MagicMock()
+        mock_client.create_threat_model.return_value = {'threatModelId': 'tm-2'}
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        client.create_threat_model(
+            agent_space_id='as-1', title='t', service_role='arn:role', assets={}
+        )
+        kwargs = mock_client.create_threat_model.call_args.kwargs
+        assert 'scopeDocs' not in kwargs
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_start_threat_model_job(self, mock_boto3):
+        """start_threat_model_job calls the SDK method."""
+        mock_client = MagicMock()
+        mock_client.start_threat_model_job.return_value = {'threatModelJobId': 'tj-1'}
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        result = client.start_threat_model_job('as-1', 'tm-1')
+        assert result == {'threatModelJobId': 'tj-1'}
+        mock_client.start_threat_model_job.assert_called_once_with(
+            agentSpaceId='as-1', threatModelId='tm-1'
+        )
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_batch_get_threat_model_jobs(self, mock_boto3):
+        """batch_get_threat_model_jobs calls the SDK method."""
+        mock_client = MagicMock()
+        mock_client.batch_get_threat_model_jobs.return_value = {'threatModelJobs': []}
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        result = client.batch_get_threat_model_jobs('as-1', ['tj-1', 'tj-2'])
+        assert result == {'threatModelJobs': []}
+        mock_client.batch_get_threat_model_jobs.assert_called_once_with(
+            agentSpaceId='as-1', threatModelJobIds=['tj-1', 'tj-2']
+        )
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_list_threats_pagination(self, mock_boto3):
+        """list_threats follows nextToken until exhausted and concatenates."""
+        mock_client = MagicMock()
+        mock_client.list_threats.side_effect = [
+            {'threats': [{'threatId': 't-1'}], 'nextToken': 'tok'},
+            {'threats': [{'threatId': 't-2'}]},
+        ]
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        result = client.list_threats('as-1', 'tj-1')
+        assert len(result['threats']) == 2
+        assert mock_client.list_threats.call_count == 2
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_batch_get_threats(self, mock_boto3):
+        """batch_get_threats calls the SDK method."""
+        mock_client = MagicMock()
+        mock_client.batch_get_threats.return_value = {'threats': [{'threatId': 't-1'}]}
+        mock_boto3.Session.return_value.client.return_value = mock_client
+
+        client = SecurityAgentClient()
+        result = client.batch_get_threats('as-1', ['t-1'])
+        assert result == {'threats': [{'threatId': 't-1'}]}
+        mock_client.batch_get_threats.assert_called_once_with(
+            agentSpaceId='as-1', threatIds=['t-1']
+        )

--- a/src/security-agent-mcp-server/tests/test_integ_basic.py
+++ b/src/security-agent-mcp-server/tests/test_integ_basic.py
@@ -103,6 +103,10 @@ class TestIntegScanFlow:
     """Integration tests for the scan flow."""
 
     @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path',
+        new=AsyncMock(return_value='/app'),
+    )
     @patch('awslabs.security_agent_mcp_server.server._scanner')
     @patch('awslabs.security_agent_mcp_server.server._state')
     async def test_full_scan_flow(self, mock_state, mock_scanner, mock_context):

--- a/src/security-agent-mcp-server/tests/test_scanner.py
+++ b/src/security-agent-mcp-server/tests/test_scanner.py
@@ -15,6 +15,7 @@
 """Tests for Scanner."""
 
 import pytest
+import subprocess
 from awslabs.security_agent_mcp_server.scanner import Scanner
 from awslabs.security_agent_mcp_server.state import StateManager
 from botocore.exceptions import ClientError
@@ -970,3 +971,157 @@ class TestThreatModelStatusAndFindings:
         called_ids = client.batch_get_threats.call_args.kwargs['threat_ids']
         assert called_ids == ['t-h']
         assert findings['total_findings'] == 1
+
+
+class TestDiffScanEdgeCases:
+    """Cover remaining diff scan edge cases."""
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.scanner.subprocess.run')
+    async def test_diff_scan_timeout(self, mock_run, mock_client, mock_state, tmp_path):
+        """Git diff timeout returns error."""
+        mock_client.get_agent_space.return_value = {'name': 'sec'}
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd='git', timeout=60)
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_diff_scan(path=str(tmp_path), base_ref='HEAD')
+        assert 'timed out' in result['error']
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.scanner.subprocess.run')
+    async def test_diff_scan_zip_committed_failure(
+        self, mock_run, mock_client, mock_state, tmp_path
+    ):
+        """_zip_committed_and_upload ValueError propagates."""
+        mock_client.get_agent_space.return_value = {'name': 'sec'}
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout='diff content\n', stderr=''),
+            MagicMock(returncode=1, stdout='', stderr='fatal: not a valid ref'),
+        ]
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_diff_scan(path=str(tmp_path), base_ref='HEAD')
+        assert 'error' in result
+        assert 'git archive failed' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_no_bucket(self, mock_client, tmp_path, monkeypatch):
+        """Missing s3_bucket returns error."""
+        monkeypatch.setattr('awslabs.security_agent_mcp_server.state.STATE_DIR', tmp_path)
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.CONFIG_FILE', tmp_path / 'config.json'
+        )
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.SCANS_FILE', tmp_path / 'scans.json'
+        )
+        state = StateManager()
+        state.update_config(agent_space_id='as-1', service_role='arn:role')
+        scanner = Scanner(client=mock_client, state=state)
+        result = await scanner.start_diff_scan(path=str(tmp_path), base_ref='HEAD')
+        assert 'error' in result
+        assert 'S3 bucket' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_agent_space_gone(self, mock_client, mock_state, tmp_path):
+        """Agent space that no longer exists returns error."""
+        mock_client.get_agent_space.return_value = {}
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_diff_scan(path=str(tmp_path), base_ref='HEAD')
+        assert 'error' in result
+        assert 'no longer exists' in result['error']
+
+
+class TestThreatModelEdgeCases:
+    """Cover remaining threat model edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_threat_model_no_bucket(self, mock_client, tmp_path, monkeypatch):
+        """Missing threat_model_s3_bucket returns error."""
+        monkeypatch.setattr('awslabs.security_agent_mcp_server.state.STATE_DIR', tmp_path)
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.CONFIG_FILE', tmp_path / 'config.json'
+        )
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.SCANS_FILE', tmp_path / 'scans.json'
+        )
+        state = StateManager()
+        state.update_config(agent_space_id='as-1', service_role='arn:role')
+        scanner = Scanner(client=mock_client, state=state)
+        result = await scanner.start_threat_model_review(
+            path=str(tmp_path), specs=[str(tmp_path / 'a.md')]
+        )
+        assert 'error' in result
+        assert 'threat-model S3 bucket' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_threat_model_agent_space_gone(self, mock_client, mock_state, tmp_path):
+        """Agent space that no longer exists returns error."""
+        spec = tmp_path / 'design.md'
+        spec.write_text('spec')
+        mock_client.get_agent_space.return_value = {}
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_threat_model_review(path=str(tmp_path), specs=[str(spec)])
+        assert 'error' in result
+        assert 'no longer exists' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_threat_model_zip_failure(self, mock_client, mock_state, tmp_path):
+        """_zip_and_upload_source ValueError propagates."""
+        spec = tmp_path / 'design.md'
+        spec.write_text('spec')
+        mock_client.get_agent_space.return_value = {'name': 'sec'}
+        scanner = Scanner(client=mock_client, state=mock_state)
+        with patch.object(scanner, '_zip_and_upload_source', side_effect=ValueError('too large')):
+            result = await scanner.start_threat_model_review(path=str(tmp_path), specs=[str(spec)])
+        assert 'error' in result
+        assert 'too large' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_threat_findings_in_progress_note(self, mock_client):
+        """Threat findings add note when scan still in progress."""
+        state = MagicMock()
+        state.get_config.return_value = {'agent_space_id': 'as-1'}
+        state.get_scan.return_value = {
+            'scan_id': 'tm-1',
+            'scan_type': 'THREAT_MODEL',
+            'agent_space_id': 'as-1',
+            'job_id': 'tj-1',
+            'title': 'test',
+            'started_at': '2026-01-01T00:00:00+00:00',
+        }
+        mock_client.batch_get_threat_model_jobs.return_value = {
+            'threatModelJobs': [{'status': 'IN_PROGRESS'}]
+        }
+        mock_client.list_threats.return_value = {'threats': []}
+        scanner = Scanner(client=mock_client, state=state)
+        result = await scanner.get_findings('tm-1')
+        assert 'note' in result
+        assert 'still in progress' in result['note']
+
+
+class TestStartScanEdgeCases:
+    """Cover start_scan missing bucket and archive errors."""
+
+    @pytest.mark.asyncio
+    async def test_start_scan_no_bucket(self, mock_client, tmp_path, monkeypatch):
+        """Missing s3_bucket returns error."""
+        monkeypatch.setattr('awslabs.security_agent_mcp_server.state.STATE_DIR', tmp_path)
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.CONFIG_FILE', tmp_path / 'config.json'
+        )
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.SCANS_FILE', tmp_path / 'scans.json'
+        )
+        state = StateManager()
+        state.update_config(agent_space_id='as-1', service_role='arn:role')
+        scanner = Scanner(client=mock_client, state=state)
+        result = await scanner.start_scan(path=str(tmp_path))
+        assert 'error' in result
+        assert 'S3 bucket' in result['error']
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.scanner.subprocess.run')
+    async def test_git_archive_failure(self, mock_run, mock_client, mock_state, tmp_path):
+        """Git archive failure raises ValueError."""
+        mock_run.return_value = MagicMock(returncode=1, stderr='fatal: bad ref')
+        scanner = Scanner(client=mock_client, state=mock_state)
+        with pytest.raises(ValueError, match='git archive failed'):
+            scanner._zip_committed_and_upload(str(tmp_path), 'HEAD', 'bucket')

--- a/src/security-agent-mcp-server/tests/test_scanner.py
+++ b/src/security-agent-mcp-server/tests/test_scanner.py
@@ -18,7 +18,7 @@ import pytest
 from awslabs.security_agent_mcp_server.scanner import Scanner
 from awslabs.security_agent_mcp_server.state import StateManager
 from botocore.exceptions import ClientError
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -56,6 +56,34 @@ def mock_client():
         }
     )
     client.stop_code_review_job = MagicMock(return_value={})
+    client.start_code_review_job_with_diff = MagicMock(
+        return_value={'codeReviewJobId': 'cj-diff-789'}
+    )
+    client.create_threat_model = MagicMock(return_value={'threatModelId': 'tm-123'})
+    client.start_threat_model_job = MagicMock(return_value={'threatModelJobId': 'tmj-456'})
+    client.batch_get_threat_model_jobs = MagicMock(
+        return_value={'threatModelJobs': [{'status': 'COMPLETED'}]}
+    )
+    client.list_threats = MagicMock(
+        return_value={'threats': [{'threatId': 't-1', 'severity': 'HIGH'}]}
+    )
+    client.batch_get_threats = MagicMock(
+        return_value={
+            'threats': [
+                {
+                    'threatId': 't-1',
+                    'statement': 'Unauthenticated access to admin API',
+                    'severity': 'HIGH',
+                    'status': 'OPEN',
+                    'stride': ['SPOOFING'],
+                    'threatImpact': 'Account takeover',
+                    'recommendation': 'Require authentication',
+                    'impactedAssets': ['admin-api'],
+                }
+            ]
+        }
+    )
+    client.get_agent_space = MagicMock(return_value={'agentSpaceId': 'as-test'})
     return client
 
 
@@ -74,6 +102,7 @@ def mock_state(tmp_path, monkeypatch):
         agent_space_id='as-test',
         service_role='arn:aws:iam::123:role/TestRole',
         s3_bucket='test-bucket',
+        threat_model_s3_bucket='test-tm-bucket',
     )
     return sm
 
@@ -215,6 +244,32 @@ class TestScanner:
         scanner = Scanner(client=mock_client, state=mock_state)
         result = await scanner.stop_scan('nonexistent')
         assert 'error' in result
+
+    @pytest.mark.asyncio
+    async def test_stop_scan_threat_model(self, mock_client, mock_state):
+        """Stops a threat model scan via StopThreatModelJob."""
+        scanner = Scanner(client=mock_client, state=mock_state)
+        mock_state.save_scan(
+            'scan-tm',
+            {
+                'scan_id': 'scan-tm',
+                'job_id': 'tj-123',
+                'agent_space_id': 'as-test',
+                'scan_type': 'THREAT_MODEL',
+                'started_at': '2026-01-01T00:00:00+00:00',
+            },
+        )
+        mock_client.call = MagicMock(return_value={})
+        result = await scanner.stop_scan('scan-tm')
+        assert result['status'] == 'STOPPED'
+        mock_client.call.assert_called_once_with(
+            'StopThreatModelJob',
+            {
+                'agentSpaceId': 'as-test',
+                'threatModelJobId': 'tj-123',
+            },
+        )
+        mock_client.stop_code_review_job.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_start_scan_not_configured(self, mock_client, tmp_path, monkeypatch):
@@ -466,3 +521,452 @@ class TestScanner:
         result = await scanner.get_findings('scan-1')
         assert 'note' in result
         assert 'in progress' in result['note'].lower()
+
+
+class TestDiffScan:
+    """Tests for start_diff_scan."""
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_success_no_prior_review(self, mock_client, mock_state, tmp_path):
+        """Creates a CodeReview on first diff scan and starts the job."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='diff --git a/app.py b/app.py\n+new line\n',
+                stderr='',
+            )
+            result = await scanner.start_diff_scan(path=str(code_dir), base_ref='HEAD')
+
+        assert result['scan_type'] == 'DIFF'
+        assert result['status'] == 'STARTED'
+        assert result['job_id'] == 'cj-diff-789'
+        assert result['base_ref'] == 'HEAD'
+        mock_client.upload_to_s3.assert_called()
+        mock_client.create_code_review.assert_called_once()
+        mock_client.start_code_review_job_with_diff.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_reuses_existing_code_review(self, mock_client, mock_state, tmp_path):
+        """Reuses existing CodeReview when one exists for the workspace."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+        mock_state.set_code_review_id(str(code_dir), 'cr-existing')
+
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='diff --git a/app.py b/app.py\n+new line\n',
+                stderr='',
+            )
+            result = await scanner.start_diff_scan(path=str(code_dir))
+
+        assert result['code_review_id'] == 'cr-existing'
+        mock_client.create_code_review.assert_not_called()
+        mock_client.start_code_review_job_with_diff.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_empty_diff(self, mock_client, mock_state, tmp_path):
+        """Returns error when there are no changes to scan."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            result = await scanner.start_diff_scan(path=str(code_dir))
+
+        assert 'error' in result
+        assert 'No diff' in result['error']
+        mock_client.upload_to_s3.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_git_failure(self, mock_client, mock_state, tmp_path):
+        """Returns error when git diff fails (e.g., bad ref)."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=128, stdout='', stderr='fatal: bad revision'
+            )
+            result = await scanner.start_diff_scan(path=str(code_dir), base_ref='nonexistent')
+
+        assert 'error' in result
+        assert 'git diff failed' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_git_not_installed(self, mock_client, mock_state, tmp_path):
+        """Returns error when git binary is missing."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            result = await scanner.start_diff_scan(path=str(code_dir))
+
+        assert 'error' in result
+        assert 'git is not installed' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_not_configured(self, mock_client, mock_state, tmp_path):
+        """Returns error when setup is not complete."""
+        mock_state.clear()
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_diff_scan(path=str(tmp_path))
+        assert 'error' in result
+        assert 'Not configured' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_branch_ref(self, mock_client, mock_state, tmp_path):
+        """Uses 'git diff base_ref' and 'git archive base_ref' for branch mode."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='diff --git a/app.py b/app.py\n+new line\n',
+                stderr='',
+            )
+            await scanner.start_diff_scan(path=str(code_dir), base_ref='main')
+
+        # Verify calls: first is git diff, second is git archive
+        calls = mock_run.call_args_list
+        diff_args = calls[0][0][0]
+        archive_args = calls[1][0][0]
+        assert diff_args == ['git', 'diff', 'main', '--']
+        assert archive_args[:3] == ['git', 'archive', '--format=zip']
+        assert '--' in archive_args and 'main' in archive_args
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_uploads_repo_and_diff(self, mock_client, mock_state, tmp_path):
+        """Uploads both the source repo zip and the diff patch to S3."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='diff --git a/app.py b/app.py\n+new line\n',
+                stderr='',
+            )
+            await scanner.start_diff_scan(path=str(code_dir))
+
+        # 2 uploads expected: source.zip and diff.patch
+        assert mock_client.upload_to_s3.call_count == 2
+        keys = [call.args[1] for call in mock_client.upload_to_s3.call_args_list]
+        assert any('source.zip' in k for k in keys)
+        assert any('diff.patch' in k for k in keys)
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_recreates_code_review_if_deleted(
+        self, mock_client, mock_state, tmp_path
+    ):
+        """If StartCodeReviewJob fails with ResourceNotFoundException, recreates the CodeReview."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+        mock_state.set_code_review_id(str(code_dir), 'cr-stale')
+
+        # First call raises ResourceNotFoundException via RuntimeError, second call succeeds
+        mock_client.start_code_review_job_with_diff = MagicMock(
+            side_effect=[
+                RuntimeError(
+                    'StartCodeReviewJob with diffSource failed (404): ResourceNotFoundException'
+                ),
+                {'codeReviewJobId': 'cj-recreated'},
+            ]
+        )
+        mock_client.create_code_review = MagicMock(return_value={'codeReviewId': 'cr-new'})
+
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='diff --git a/app.py b/app.py\n+new line\n',
+                stderr='',
+            )
+            result = await scanner.start_diff_scan(path=str(code_dir))
+
+        assert result['code_review_id'] == 'cr-new'
+        assert result['job_id'] == 'cj-recreated'
+        assert mock_client.create_code_review.call_count == 1
+        assert mock_client.start_code_review_job_with_diff.call_count == 2
+
+
+class TestThreatModelReview:
+    """Tests for start_threat_model_review and threat-model status/findings."""
+
+    def _make_specs(self, tmp_path):
+        design = tmp_path / 'design.md'
+        reqs = tmp_path / 'requirements.md'
+        design.write_text('# Design')
+        reqs.write_text('# Requirements')
+        return [str(design), str(reqs)]
+
+    @pytest.mark.asyncio
+    async def test_threat_model_review_success(self, mock_client, mock_state, tmp_path):
+        """Creates a threat model with specs as scope docs and starts a job."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+        specs = self._make_specs(tmp_path)
+
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_threat_model_review(path=str(code_dir), specs=specs)
+
+        assert result['scan_type'] == 'THREAT_MODEL'
+        assert result['status'] == 'STARTED'
+        assert result['threat_model_id'] == 'tm-123'
+        assert result['job_id'] == 'tmj-456'
+        assert result['spec_count'] == 2
+        mock_client.create_threat_model.assert_called_once()
+        mock_client.start_threat_model_job.assert_called_once()
+
+        # source is sent as an asset, specs as scope docs
+        kwargs = mock_client.create_threat_model.call_args.kwargs
+        assert kwargs['assets']['sourceCode'][0]['s3Location']
+        assert len(kwargs['scope_docs']) == 2
+        assert all('s3Location' in d for d in kwargs['scope_docs'])
+
+    @pytest.mark.asyncio
+    async def test_threat_model_review_uploads_source_and_specs(
+        self, mock_client, mock_state, tmp_path
+    ):
+        """Uploads the source zip plus one object per spec."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        (code_dir / 'app.py').write_text('print("hello")')
+        specs = self._make_specs(tmp_path)
+
+        scanner = Scanner(client=mock_client, state=mock_state)
+        await scanner.start_threat_model_review(path=str(code_dir), specs=specs)
+
+        # 1 source zip + 2 specs
+        assert mock_client.upload_to_s3.call_count == 3
+        keys = [call.args[1] for call in mock_client.upload_to_s3.call_args_list]
+        assert any('source.zip' in k for k in keys)
+        assert any(k.endswith('design.md') for k in keys)
+        assert any(k.endswith('requirements.md') for k in keys)
+
+    @pytest.mark.asyncio
+    async def test_threat_model_review_no_specs(self, mock_client, mock_state, tmp_path):
+        """Returns error when no specs are provided."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_threat_model_review(path=str(code_dir), specs=[])
+        assert 'error' in result
+        assert 'No specs' in result['error']
+        mock_client.create_threat_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_threat_model_review_missing_spec_file(self, mock_client, mock_state, tmp_path):
+        """Returns error when a spec path does not exist."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_threat_model_review(
+            path=str(code_dir), specs=[str(tmp_path / 'missing.md')]
+        )
+        assert 'error' in result
+        assert 'not found' in result['error']
+        mock_client.upload_to_s3.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_threat_model_review_not_configured(self, mock_client, mock_state, tmp_path):
+        """Returns error when setup is not complete."""
+        mock_state.clear()
+        scanner = Scanner(client=mock_client, state=mock_state)
+        result = await scanner.start_threat_model_review(path=str(tmp_path), specs=[str(tmp_path)])
+        assert 'error' in result
+        assert 'Not configured' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_threat_model_status_uses_threat_job_api(self, mock_client, mock_state):
+        """get_status routes THREAT_MODEL scans to batch_get_threat_model_jobs."""
+        scanner = Scanner(client=mock_client, state=mock_state)
+        mock_state.save_scan(
+            'scan-tm',
+            {
+                'scan_id': 'scan-tm',
+                'job_id': 'tmj-456',
+                'threat_model_id': 'tm-123',
+                'scan_type': 'THREAT_MODEL',
+                'started_at': '2026-01-01T00:00:00+00:00',
+                'agent_space_id': 'as-test',
+            },
+        )
+        status = await scanner.get_status('scan-tm')
+        assert status['status'] == 'COMPLETED'
+        mock_client.batch_get_threat_model_jobs.assert_called_once()
+        mock_client.batch_get_code_review_jobs.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_threat_model_findings(self, mock_client, mock_state):
+        """get_findings returns threats for a THREAT_MODEL scan."""
+        scanner = Scanner(client=mock_client, state=mock_state)
+        mock_state.save_scan(
+            'scan-tm',
+            {
+                'scan_id': 'scan-tm',
+                'job_id': 'tmj-456',
+                'threat_model_id': 'tm-123',
+                'scan_type': 'THREAT_MODEL',
+                'started_at': '2026-01-01T00:00:00+00:00',
+                'agent_space_id': 'as-test',
+            },
+        )
+        findings = await scanner.get_findings('scan-tm')
+        assert findings['total_findings'] == 1
+        assert findings['findings'][0]['threatId'] == 't-1'
+        assert findings['findings'][0]['recommendation'] == 'Require authentication'
+        mock_client.list_threats.assert_called_once()
+        mock_client.batch_get_threats.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_threat_model_findings_severity_filter(self, mock_client, mock_state):
+        """Severity filter excludes threats below the requested minimum."""
+        mock_client.list_threats.return_value = {
+            'threats': [
+                {'threatId': 't-1', 'severity': 'HIGH'},
+                {'threatId': 't-2', 'severity': 'LOW'},
+            ]
+        }
+        scanner = Scanner(client=mock_client, state=mock_state)
+        mock_state.save_scan(
+            'scan-tm',
+            {
+                'scan_id': 'scan-tm',
+                'job_id': 'tmj-456',
+                'scan_type': 'THREAT_MODEL',
+                'started_at': '2026-01-01T00:00:00+00:00',
+                'agent_space_id': 'as-test',
+            },
+        )
+        await scanner.get_findings('scan-tm', severity='HIGH')
+        # only the HIGH threat id is fetched in detail
+        threat_ids = mock_client.batch_get_threats.call_args.kwargs['threat_ids']
+        assert threat_ids == ['t-1']
+
+
+class TestThreatModelStatusAndFindings:
+    """Status + findings for threat-model scans (separate code path from code reviews)."""
+
+    @pytest.fixture
+    def tm_state_with_scan(self, tmp_path, monkeypatch):
+        """State with a saved THREAT_MODEL scan."""
+        monkeypatch.setattr('awslabs.security_agent_mcp_server.state.STATE_DIR', tmp_path)
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.CONFIG_FILE', tmp_path / 'config.json'
+        )
+        monkeypatch.setattr(
+            'awslabs.security_agent_mcp_server.state.SCANS_FILE', tmp_path / 'scans.json'
+        )
+        sm = StateManager()
+        sm.update_config(agent_space_id='as-test', service_role='arn:role')
+        sm.save_scan(
+            'tm-scan',
+            {
+                'scan_id': 'tm-scan',
+                'job_id': 'tj-1',
+                'agent_space_id': 'as-test',
+                'scan_type': 'THREAT_MODEL',
+                'title': 'tm-test',
+                'started_at': '2026-01-01T00:00:00+00:00',
+            },
+        )
+        return sm
+
+    @pytest.mark.asyncio
+    async def test_get_status_threat_model(self, tm_state_with_scan):
+        """get_status routes to batch_get_threat_model_jobs for THREAT_MODEL scans."""
+        client = MagicMock()
+        client.batch_get_threat_model_jobs = MagicMock(
+            return_value={'threatModelJobs': [{'status': 'COMPLETED', 'steps': []}]}
+        )
+        scanner = Scanner(client=client, state=tm_state_with_scan)
+        status = await scanner.get_status('tm-scan')
+        assert status['status'] == 'COMPLETED'
+        client.batch_get_threat_model_jobs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_findings_threat_model(self, tm_state_with_scan):
+        """get_findings routes to list_threats + batch_get_threats for THREAT_MODEL scans."""
+        client = MagicMock()
+        client.batch_get_threat_model_jobs = MagicMock(
+            return_value={'threatModelJobs': [{'status': 'COMPLETED', 'steps': []}]}
+        )
+        client.list_threats = MagicMock(
+            return_value={
+                'threats': [
+                    {'threatId': 't-1', 'severity': 'HIGH'},
+                    {'threatId': 't-2', 'severity': 'LOW'},
+                ]
+            }
+        )
+        client.batch_get_threats = MagicMock(
+            return_value={
+                'threats': [
+                    {
+                        'threatId': 't-1',
+                        'statement': 'Spoofing',
+                        'severity': 'HIGH',
+                        'stride': 'S',
+                        'threatImpact': 'high',
+                        'recommendation': 'Add MFA',
+                    },
+                    {
+                        'threatId': 't-2',
+                        'statement': 'Info disclosure',
+                        'severity': 'LOW',
+                        'stride': 'I',
+                    },
+                ]
+            }
+        )
+        scanner = Scanner(client=client, state=tm_state_with_scan)
+        findings = await scanner.get_findings('tm-scan')
+        assert findings['total_findings'] == 2
+        assert findings['findings'][0]['stride'] == 'S'
+        client.list_threats.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_findings_threat_model_severity_filter(self, tm_state_with_scan):
+        """Severity filter is applied before batch_get_threats."""
+        client = MagicMock()
+        client.batch_get_threat_model_jobs = MagicMock(
+            return_value={'threatModelJobs': [{'status': 'COMPLETED', 'steps': []}]}
+        )
+        client.list_threats = MagicMock(
+            return_value={
+                'threats': [
+                    {'threatId': 't-h', 'severity': 'HIGH'},
+                    {'threatId': 't-l', 'severity': 'LOW'},
+                ]
+            }
+        )
+        client.batch_get_threats = MagicMock(
+            return_value={'threats': [{'threatId': 't-h', 'severity': 'HIGH'}]}
+        )
+        scanner = Scanner(client=client, state=tm_state_with_scan)
+        findings = await scanner.get_findings('tm-scan', severity='HIGH')
+        called_ids = client.batch_get_threats.call_args.kwargs['threat_ids']
+        assert called_ids == ['t-h']
+        assert findings['total_findings'] == 1

--- a/src/security-agent-mcp-server/tests/test_server.py
+++ b/src/security-agent-mcp-server/tests/test_server.py
@@ -26,6 +26,8 @@ def test_server_has_expected_tools():
         'setup_check',
         'setup',
         'start_security_scan',
+        'start_diff_scan',
+        'start_threat_model_review',
         'get_scan_status',
         'get_scan_findings',
         'list_scans',
@@ -49,7 +51,7 @@ def test_server_has_instructions():
 
 def test_server_tool_count():
     """Verify correct number of tools."""
-    assert len(mcp._tool_manager._tools) == 9
+    assert len(mcp._tool_manager._tools) == 11
 
 
 class TestSetupCheck:
@@ -229,6 +231,9 @@ class TestStartSecurityScan:
     """Tests for start_security_scan lazy bucket creation."""
 
     @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path', new=AsyncMock(return_value='.')
+    )
     @patch('awslabs.security_agent_mcp_server.server._scanner')
     @patch('awslabs.security_agent_mcp_server.server._state')
     @patch('awslabs.security_agent_mcp_server.server._client')
@@ -249,6 +254,9 @@ class TestStartSecurityScan:
         assert 'scan-1' in result
 
     @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path', new=AsyncMock(return_value='.')
+    )
     @patch('awslabs.security_agent_mcp_server.server._scanner')
     @patch('awslabs.security_agent_mcp_server.server._state')
     @patch('awslabs.security_agent_mcp_server.server._client')
@@ -375,6 +383,9 @@ class TestStartSecurityScanBucketRegistration:
     """Covers bucket-registration path in start_security_scan."""
 
     @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path', new=AsyncMock(return_value='.')
+    )
     @patch('awslabs.security_agent_mcp_server.server._scanner')
     @patch('awslabs.security_agent_mcp_server.server._state')
     @patch('awslabs.security_agent_mcp_server.server._client')
@@ -814,6 +825,9 @@ class TestErrorContract:
         assert _json.loads(result)['error_code'] == 'AccessDeniedException'
 
     @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path', new=AsyncMock(return_value='.')
+    )
     @patch('awslabs.security_agent_mcp_server.server._scanner')
     @patch('awslabs.security_agent_mcp_server.server._state')
     async def test_start_security_scan_clienterror_returns_structured(
@@ -842,3 +856,229 @@ class TestErrorContract:
         import json as _json
 
         assert _json.loads(result)['error_code'] == 'ValidationException'
+
+
+class TestStartDiffScan:
+    """Tests for start_diff_scan tool."""
+
+    @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path', new=AsyncMock(return_value='.')
+    )
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_success(self, mock_state, mock_scanner):
+        """Delegates to scanner.start_diff_scan when configured."""
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            's3_bucket': 'bucket',
+        }
+        mock_scanner.start_diff_scan = AsyncMock(
+            return_value={'scan_id': 'scan-diff-1', 'scan_type': 'DIFF'}
+        )
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_diff_scan
+
+        result = await start_diff_scan(ctx, path='.', base_ref='HEAD', title='diff-test')
+        assert 'scan-diff-1' in result
+        assert 'DIFF' in result
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_not_configured(self, mock_state):
+        """Returns error when agent_space_id missing."""
+        mock_state.get_config.return_value = {}
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_diff_scan
+
+        result = await start_diff_scan(ctx, path='.', base_ref='HEAD', title=None)
+        assert 'Not configured' in result
+
+    @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path',
+        new=AsyncMock(return_value='/tmp/test'),
+    )
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    @patch('awslabs.security_agent_mcp_server.server._ensure_s3_bucket')
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    async def test_lazily_creates_bucket(self, mock_scanner, mock_ensure_bucket, mock_state):
+        """Calls _ensure_s3_bucket when bucket not yet configured."""
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+        }
+        mock_scanner.start_diff_scan = AsyncMock(return_value={'scan_id': 'scan-123'})
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_diff_scan
+
+        result = await start_diff_scan(ctx, path='/tmp/test', base_ref='HEAD', title=None)
+        mock_ensure_bucket.assert_called_once_with(mock_state.get_config.return_value)
+        assert 'scan-123' in result
+
+
+class TestStartThreatModelReview:
+    """Tests for the start_threat_model_review tool."""
+
+    @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path',
+        new=AsyncMock(side_effect=lambda ctx, p, **kw: p),
+    )
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_success(self, mock_state, mock_client, mock_scanner):
+        """Delegates to scanner.start_threat_model_review when configured."""
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            'threat_model_s3_bucket': 'tm-bucket',
+        }
+        mock_scanner.start_threat_model_review = AsyncMock(
+            return_value={'scan_id': 'tm-scan-1', 'scan_type': 'THREAT_MODEL'}
+        )
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_threat_model_review
+
+        result = await start_threat_model_review(
+            ctx, path='/abs/path', specs=['/abs/path/design.md'], title='tm-test'
+        )
+        assert 'tm-scan-1' in result
+        mock_scanner.start_threat_model_review.assert_called_once_with(
+            path='/abs/path', specs=['/abs/path/design.md'], title='ide-tm-test'
+        )
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_not_configured(self, mock_state):
+        """Returns error when agent_space_id/service_role missing."""
+        mock_state.get_config.return_value = {}
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_threat_model_review
+
+        result = await start_threat_model_review(ctx, path='.', specs=[], title=None)
+        assert 'Not configured' in result
+
+    @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path',
+        new=AsyncMock(side_effect=lambda ctx, p, **kw: p),
+    )
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_lazy_creates_threat_model_bucket(self, mock_state, mock_client, mock_scanner):
+        """When threat_model_s3_bucket missing, _ensure_s3_bucket creates+registers it."""
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+        }
+        mock_client.get_caller_identity.return_value = {'Account': '123'}
+        mock_client.create_s3_bucket.return_value = 'security-agent-threat-model-123-us-east-1'
+        mock_client.get_agent_space.return_value = {
+            'name': 'sec',
+            'awsResources': {'iamRoles': ['arn:role'], 's3Buckets': []},
+        }
+        mock_state.update_config = MagicMock()
+        mock_scanner.start_threat_model_review = AsyncMock(return_value={'scan_id': 'tm-scan-1'})
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_threat_model_review
+
+        await start_threat_model_review(ctx, path='/abs', specs=['/abs/design.md'], title='t')
+        # Bucket creation called with the threat-model name
+        mock_client.create_s3_bucket.assert_called_once()
+        bucket_arg = mock_client.create_s3_bucket.call_args.args[0]
+        assert bucket_arg.startswith('security-agent-threat-model-')
+        # Registered on agent space
+        mock_client.update_agent_space.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        'awslabs.security_agent_mcp_server.server._validate_path',
+        new=AsyncMock(side_effect=lambda ctx, p, **kw: p),
+    )
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_unexpected_error_propagates(self, mock_state, mock_scanner):
+        """Non-ClientError surfaces via ctx.error and re-raises."""
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            'threat_model_s3_bucket': 'tm-bucket',
+        }
+        mock_scanner.start_threat_model_review = AsyncMock(side_effect=RuntimeError('boom'))
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import start_threat_model_review
+
+        with pytest.raises(RuntimeError):
+            await start_threat_model_review(ctx, path='.', specs=['/x'], title=None)
+        ctx.error.assert_awaited()
+
+
+class TestEnsureS3BucketHelper:
+    """Tests for the _ensure_s3_bucket helper used by both scan tools."""
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_skips_when_already_configured(self, mock_state, mock_client):
+        """If bucket already in config, helper returns immediately without API calls."""
+        from awslabs.security_agent_mcp_server.server import _ensure_s3_bucket
+
+        config = {'s3_bucket': 'already-set', 'agent_space_id': 'as-1'}
+        _ensure_s3_bucket(config, 'scans')
+        mock_client.get_caller_identity.assert_not_called()
+        mock_client.create_s3_bucket.assert_not_called()
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    def test_handles_bucket_already_owned(self, mock_state, mock_client):
+        """BucketAlreadyOwnedByYou is swallowed (idempotent setup)."""
+        from awslabs.security_agent_mcp_server.server import _ensure_s3_bucket
+        from botocore.exceptions import ClientError
+
+        config = {'agent_space_id': 'as-1'}
+        mock_client.get_caller_identity.return_value = {'Account': '123'}
+        mock_client.create_s3_bucket.side_effect = ClientError(
+            {'Error': {'Code': 'BucketAlreadyOwnedByYou', 'Message': 'owned'}},
+            'CreateBucket',
+        )
+        mock_client.get_agent_space.return_value = {
+            'name': 'sec',
+            'awsResources': {'iamRoles': [], 's3Buckets': []},
+        }
+        # Should not raise
+        _ensure_s3_bucket(config, 'scans')
+        # Despite create error, bucket still gets registered with the agent space
+        mock_client.update_agent_space.assert_called_once()
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    def test_unexpected_create_error_raises(self, mock_state, mock_client):
+        """Non-BucketAlreadyOwnedByYou ClientError surfaces."""
+        from awslabs.security_agent_mcp_server.server import _ensure_s3_bucket
+        from botocore.exceptions import ClientError
+
+        config = {'agent_space_id': 'as-1'}
+        mock_client.get_caller_identity.return_value = {'Account': '123'}
+        mock_client.create_s3_bucket.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'no'}}, 'CreateBucket'
+        )
+        with pytest.raises(ClientError):
+            _ensure_s3_bucket(config, 'scans')

--- a/src/security-agent-mcp-server/tests/test_server.py
+++ b/src/security-agent-mcp-server/tests/test_server.py
@@ -1082,3 +1082,216 @@ class TestEnsureS3BucketHelper:
         )
         with pytest.raises(ClientError):
             _ensure_s3_bucket(config, 'scans')
+
+
+class TestValidatePath:
+    """Tests for _validate_path workspace boundary enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_valid_path_within_workspace(self, tmp_path):
+        """Valid path within WORKSPACE_ROOT resolves successfully."""
+        import awslabs.security_agent_mcp_server.server as srv
+
+        subdir = tmp_path / 'project'
+        subdir.mkdir()
+        original = srv._ALLOWED_ROOT
+        srv._ALLOWED_ROOT = str(tmp_path)
+        try:
+            ctx = MagicMock()
+            result = await srv._validate_path(ctx, str(subdir))
+            assert result == str(subdir.resolve())
+        finally:
+            srv._ALLOWED_ROOT = original
+
+    @pytest.mark.asyncio
+    async def test_path_outside_workspace_raises(self, tmp_path):
+        """Path outside WORKSPACE_ROOT raises ValueError."""
+        import awslabs.security_agent_mcp_server.server as srv
+
+        original = srv._ALLOWED_ROOT
+        srv._ALLOWED_ROOT = str(tmp_path / 'workspace')
+        (tmp_path / 'workspace').mkdir()
+        try:
+            ctx = MagicMock()
+            with pytest.raises(ValueError, match='outside the allowed workspace'):
+                await srv._validate_path(ctx, '/etc')
+        finally:
+            srv._ALLOWED_ROOT = original
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_dir_raises(self, tmp_path):
+        """Non-existent directory raises ValueError."""
+        import awslabs.security_agent_mcp_server.server as srv
+
+        original = srv._ALLOWED_ROOT
+        srv._ALLOWED_ROOT = str(tmp_path)
+        try:
+            ctx = MagicMock()
+            with pytest.raises(ValueError, match='does not exist'):
+                await srv._validate_path(ctx, str(tmp_path / 'nonexistent'))
+        finally:
+            srv._ALLOWED_ROOT = original
+
+    @pytest.mark.asyncio
+    async def test_file_validation(self, tmp_path):
+        """File path validates with must_be_dir=False."""
+        import awslabs.security_agent_mcp_server.server as srv
+
+        f = tmp_path / 'spec.md'
+        f.write_text('hello')
+        original = srv._ALLOWED_ROOT
+        srv._ALLOWED_ROOT = str(tmp_path)
+        try:
+            ctx = MagicMock()
+            result = await srv._validate_path(ctx, str(f), must_be_dir=False)
+            assert result == str(f.resolve())
+        finally:
+            srv._ALLOWED_ROOT = original
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file_raises(self, tmp_path):
+        """Non-existent file raises ValueError with must_be_dir=False."""
+        import awslabs.security_agent_mcp_server.server as srv
+
+        original = srv._ALLOWED_ROOT
+        srv._ALLOWED_ROOT = str(tmp_path)
+        try:
+            ctx = MagicMock()
+            with pytest.raises(ValueError, match='does not exist'):
+                await srv._validate_path(ctx, str(tmp_path / 'nofile.md'), must_be_dir=False)
+        finally:
+            srv._ALLOWED_ROOT = original
+
+
+class TestClientPrefix:
+    """Tests for _client_prefix."""
+
+    def test_extracts_client_name(self):
+        """Extracts and kebab-cases client name from session."""
+        from awslabs.security_agent_mcp_server.server import _client_prefix
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = 'Kiro IDE'
+        assert _client_prefix(ctx) == 'kiro-ide'
+
+    def test_none_session_returns_fallback(self):
+        """Returns 'ide' when session is None."""
+        from awslabs.security_agent_mcp_server.server import _client_prefix
+
+        ctx = MagicMock()
+        ctx.session = None
+        assert _client_prefix(ctx) == 'ide'
+
+    def test_non_string_name_returns_fallback(self):
+        """Returns 'ide' when name is not a string."""
+        from awslabs.security_agent_mcp_server.server import _client_prefix
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = 123
+        assert _client_prefix(ctx) == 'ide'
+
+    def test_attribute_error_returns_fallback(self):
+        """Returns 'ide' on AttributeError."""
+        from awslabs.security_agent_mcp_server.server import _client_prefix
+
+        ctx = MagicMock()
+        type(ctx.session.client_params).clientInfo = property(
+            lambda self: (_ for _ in ()).throw(AttributeError)
+        )
+        assert _client_prefix(ctx) == 'ide'
+
+
+class TestStartDiffScanErrors:
+    """Tests for start_diff_scan error paths."""
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._validate_path')
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    async def test_client_error_returns_structured(
+        self, mock_client, mock_state, mock_scanner, mock_validate
+    ):
+        """ClientError returns structured error JSON."""
+        from awslabs.security_agent_mcp_server.server import start_diff_scan
+        from botocore.exceptions import ClientError
+
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            's3_bucket': 'bucket',
+        }
+        mock_validate.return_value = '.'
+        mock_scanner.start_diff_scan = AsyncMock(
+            side_effect=ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'no'}}, 'Op')
+        )
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        result = await start_diff_scan(ctx, path='.', base_ref='HEAD')
+        assert 'error' in result
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_value_error_returns_message(self, mock_state):
+        """ValueError from _validate_path returns error message."""
+        from awslabs.security_agent_mcp_server.server import start_diff_scan
+
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            's3_bucket': 'bucket',
+        }
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        result = await start_diff_scan(ctx, path='/etc/passwd', base_ref='HEAD')
+        assert 'error' in result
+
+
+class TestStartThreatModelErrors:
+    """Tests for start_threat_model_review error paths."""
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._validate_path')
+    @patch('awslabs.security_agent_mcp_server.server._scanner')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    async def test_client_error_returns_structured(
+        self, mock_client, mock_state, mock_scanner, mock_validate
+    ):
+        """ClientError returns structured error JSON."""
+        from awslabs.security_agent_mcp_server.server import start_threat_model_review
+        from botocore.exceptions import ClientError
+
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            'threat_model_s3_bucket': 'bucket',
+        }
+        mock_validate.return_value = '.'
+        mock_scanner.start_threat_model_review = AsyncMock(
+            side_effect=ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'no'}}, 'Op')
+        )
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        result = await start_threat_model_review(ctx, path='.', specs=[])
+        assert 'error' in result
+
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    async def test_value_error_returns_message(self, mock_state):
+        """ValueError from _validate_path returns error message."""
+        from awslabs.security_agent_mcp_server.server import start_threat_model_review
+
+        mock_state.get_config.return_value = {
+            'agent_space_id': 'as-1',
+            'service_role': 'arn:role',
+            'threat_model_s3_bucket': 'bucket',
+        }
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        result = await start_threat_model_review(ctx, path='/etc/passwd', specs=[])
+        assert 'error' in result

--- a/src/security-agent-mcp-server/uv.lock
+++ b/src/security-agent-mcp-server/uv.lock
@@ -80,7 +80,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.43.19" },
+    { name = "boto3", specifier = ">=1.43.32" },
     { name = "filelock", specifier = ">=3.0.0" },
     { name = "gitignorefile", specifier = ">=1.1.0" },
     { name = "idna", specifier = ">=3.15" },
@@ -112,30 +112,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.19"
+version = "1.43.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/da/229987ebb70daf5928f959aa8f4dd77dfcf425e6b0e7ff03aaef61ccc333/boto3-1.43.19.tar.gz", hash = "sha256:8b84704719dd3960ac12a8f37d9ff5adb853715baa9742f84fdbe2de0305c4cb", size = 113225, upload-time = "2026-06-01T19:33:06.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/34/5cd5603cf76730cac3e92c04bf7f076d5a2686fc57af8371e3f37f30ac88/boto3-1.43.32.tar.gz", hash = "sha256:15544d42af8aa8f775ea636f77c9c97fbc90ff28c0e5a0d1d47c8acd9f5b1982", size = 113169, upload-time = "2026-06-17T20:30:08.475Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/cc/77097be39d83068f864767b710cee0d8f9cd61331de816dd2675a596c328/boto3-1.43.19-py3-none-any.whl", hash = "sha256:ec6825193b75fbb6bfbf12181e4960d00ad2f404343586765394ce620e63783c", size = 140535, upload-time = "2026-06-01T19:33:03.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/ab658327b0d628b6deb14dd0e4898557f495a7b236e5db0f437c4c2c0a38/boto3-1.43.32-py3-none-any.whl", hash = "sha256:a3d7d7a9489c18cc9c806aca9be689677779d17ddbf919fe300146576c1bdee2", size = 140533, upload-time = "2026-06-17T20:30:06.615Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.19"
+version = "1.43.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/a7/298986789785b74a954e2347114993be7e6b070417159125a6865f2687b6/botocore-1.43.19.tar.gz", hash = "sha256:18ac2fdd76c89b940707eb10493ff58678adad337d03215caec2d408ccd43cc0", size = 15435441, upload-time = "2026-06-01T19:32:53.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/f2/3052825265c331886a92da823212ae4830471efd726ac901349d1a6b7c51/botocore-1.43.32.tar.gz", hash = "sha256:88ed52268b8f7e8ff8f9df5adbbf61e5bbb5dc618ee50de4346cabe93a482792", size = 15580749, upload-time = "2026-06-17T20:29:57.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/75/fe4d45bdd08afd66f3d5273db58f3d8a29365e52ce3a0851f7f5e5900943/botocore-1.43.19-py3-none-any.whl", hash = "sha256:99dbdccbf748974750601e805cecc9362a85d11fee89d6d58cd3f4ff302e6ff9", size = 15117709, upload-time = "2026-06-01T19:32:47.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/20/b09c65e5903dc61ebbb3e000f725403e8c3dfc7b0f4697db84b5902032d0/botocore-1.43.32-py3-none-any.whl", hash = "sha256:429796537fde1301df90d394808985d88cd51b36a6e769e5c12f6a6877605428", size = 15264015, upload-time = "2026-06-17T20:29:54.138Z" },
 ]
 
 [[package]]
@@ -1526,14 +1526,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Summary

### Changes

 Adds two major capabilities to the AWS Security Agent MCP server:

  1. **Diff scan** (`start_diff_scan`): Fast incremental security scanning that analyzes only changed code (git diff) with the full repo as context. Supports any git ref as baseline (HEAD for uncommitted changes, main for branch changes).

  2. **Threat model review** (`start_threat_model_review`): STRIDE-based threat analysis guided by design/requirement spec documents. Uploads source code and spec files (e.g., design.md, requirements.md) as scoped inputs for focused threat identification.


  Additional fixes:
  - Restricts all scan paths to the `WORKSPACE_ROOT` environment variable boundary, preventing path traversal outside the IDE workspace.
  - Add `_ensure_s3_bucket` for lazy bucket creation with full hardening (SSE, public access block, TLS-only policy, 30-day lifecycle)


### User experience

  **Before:** Users could only run full repository scans. No way to scan just changed code, no threat modeling capability, and no workspace path boundary enforcement.

  **After:**
  - "Scan my changes" → `start_diff_scan(path=".", base_ref="HEAD")` returns findings focused on changed code
  - "Review my design for threats" → `start_threat_model_review(path=".", specs=["/path/to/design.md"])` produces STRIDE-classified threats with impact and remediation


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: NA

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
