### PR TITLE
feat(cloudwatch-applicationsignals): support error patterns + before/after comparison 

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/promql_query.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/promql_query.py
@@ -274,12 +274,14 @@ def errors_by_operation_exception(
 ) -> str:
     """Build the per-(operation, exception) error-count query on the ``count`` metric.
 
-    ``sum by (operation, exception) (increase({"count","@resource.service.name"="svc"
-    [,"operation"="op"][,env]}[window]))``. The ``count`` metric is not a histogram, so
-    ``increase`` over the window yields the absolute error count per operation/exception
-    pair (matching the CloudWatch "Errors" page). Only series carrying an ``exception``
-    label are errors, so no extra status filter is needed. When ``top`` is given, wraps
-    in ``topk(top, ...)``.
+    ``sum by (operation, exception) (sum_over_time({"count","@resource.service.name"="svc"
+    [,"operation"="op"][,env]}[window]))``. The ``count`` metric stores per-interval error
+    counts (NOT a cumulative counter), so the total over the window is ``sum_over_time``
+    — adding every interval's value. (``increase``/``rate`` are wrong here: they assume a
+    monotonic counter and compute deltas between samples, which badly undercounts and does
+    not match the CloudWatch "Errors" page.) Only series carrying an ``exception`` label
+    are errors, so no extra status filter is needed. When ``top`` is given, wraps in
+    ``topk(top, ...)``.
     """
     matchers: Dict[str, str] = {LABEL_SERVICE_NAME: service_name}
     if environment:
@@ -287,7 +289,7 @@ def errors_by_operation_exception(
     if operation:
         matchers[LABEL_OPERATION] = operation
     sel = build_selector(METRIC_COUNT, matchers)
-    expr = f'sum by ({LABEL_OPERATION}, {LABEL_EXCEPTION}) (increase({sel}[{window}]))'
+    expr = f'sum by ({LABEL_OPERATION}, {LABEL_EXCEPTION}) (sum_over_time({sel}[{window}]))'
     if top is not None:
         expr = f'topk({top}, {expr})'
     return expr

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/promql_query.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/promql_query.py
@@ -46,6 +46,9 @@ LABEL_STATUS = 'status'
 # Endpoint/operation the function executed under (e.g. "POST /checkout"). Added to
 # the service.function.duration metric so function metrics can be filtered by endpoint.
 LABEL_OPERATION = 'operation'
+# Exception label on the ``count`` metric. Value is "<dotted.path> <ExceptionName>"
+# (e.g. "...WebAsyncUtils.getAsyncManager NotFound"); the short name is the last token.
+LABEL_EXCEPTION = 'exception'
 
 DEFAULT_RATE_WINDOW = '5m'
 
@@ -259,3 +262,71 @@ def vector_to_function_records(result: List[dict], value_key: str) -> Dict[str, 
             except (ValueError, TypeError):
                 rec['line'] = line
     return records
+
+
+def errors_by_operation_exception(
+    service_name: str,
+    window: str = DEFAULT_RATE_WINDOW,
+    *,
+    operation: Optional[str] = None,
+    environment: Optional[str] = None,
+    top: Optional[int] = None,
+) -> str:
+    """Build the per-(operation, exception) error-count query on the ``count`` metric.
+
+    ``sum by (operation, exception) (increase({"count","@resource.service.name"="svc"
+    [,"operation"="op"][,env]}[window]))``. The ``count`` metric is not a histogram, so
+    ``increase`` over the window yields the absolute error count per operation/exception
+    pair (matching the CloudWatch "Errors" page). Only series carrying an ``exception``
+    label are errors, so no extra status filter is needed. When ``top`` is given, wraps
+    in ``topk(top, ...)``.
+    """
+    matchers: Dict[str, str] = {LABEL_SERVICE_NAME: service_name}
+    if environment:
+        matchers[LABEL_ENVIRONMENT] = environment
+    if operation:
+        matchers[LABEL_OPERATION] = operation
+    sel = build_selector(METRIC_COUNT, matchers)
+    expr = f'sum by ({LABEL_OPERATION}, {LABEL_EXCEPTION}) (increase({sel}[{window}]))'
+    if top is not None:
+        expr = f'topk({top}, {expr})'
+    return expr
+
+
+def _exception_short_name(exception: str) -> str:
+    """Return the short exception name (last whitespace token) from the label value.
+
+    The ``exception`` label is "<dotted.path> <ExceptionName>"; the CloudWatch Errors
+    page shows just the trailing name. Falls back to the full string when there is no
+    whitespace.
+    """
+    return exception.rsplit(' ', 1)[-1] if exception else exception
+
+
+def vector_to_error_patterns(
+    result: Optional[List[dict]], top: Optional[int] = None
+) -> List[Dict]:
+    """Map an instant-vector ``count`` result to per-(operation, exception) error rows.
+
+    Returns ``[{operation, exception, exception_type, count}]`` sorted by count
+    descending. Series without an ``exception`` label or a finite value are dropped.
+    """
+    rows: List[Dict] = []
+    for entry in result or []:
+        metric = entry.get('metric', {})
+        exception = metric.get(LABEL_EXCEPTION)
+        val = _value_of(entry)
+        if not exception or val is None:
+            continue
+        rows.append(
+            {
+                'operation': metric.get(LABEL_OPERATION),
+                'exception': exception,
+                'exception_type': _exception_short_name(exception),
+                'count': int(round(val)),
+            }
+        )
+    rows.sort(key=lambda r: r['count'], reverse=True)
+    if top is not None:
+        rows = rows[:top]
+    return rows

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -370,25 +370,17 @@ async def get_endpoints(
     **Output is limited to avoid large responses.** Use `operation` parameter
     to filter to a specific API if you know the operation name.
 
-    **Error patterns (optional):** When a `service_name` is given and the service
-    emits the `count` MetricV2 metric (only when ServiceEvents is enabled in the SDK),
-    the response also includes an `error_patterns` list — per-(operation, exception)
-    error counts over the window, matching the CloudWatch "Errors" page. This is the
-    right field for "what error patterns does my service have / changed?". It is scoped
-    by `operation` when provided, otherwise service-wide. The field is OMITTED when the
-    metric is unavailable or there are no errors — its absence never fails the call.
-    (For a service-wide error-pattern overview, `get_service_health_overview` also
-    includes this breakdown.)
+    **For service-wide error patterns** (which exceptions on which operations, with
+    counts — the CloudWatch "Errors" page data), use `get_service_health_overview`,
+    which returns an `error_patterns` breakdown.
 
     Args:
         hours: Time range to query in hours (default 24).
         operation: Filter by operation name (e.g., "POST /api/users"). Substring match. Optional.
-            When exactly one endpoint matches, detail mode is returned. Also scopes
-            `error_patterns` to that operation.
-        limit: Maximum number of endpoints to return (default 20). Also caps `error_patterns`.
+            When exactly one endpoint matches, detail mode is returned.
+        limit: Maximum number of endpoints to return (default 20).
         service_name: Service name to query. Optional — from user prompt or prior tool output.
-            Required to query Application Signals and to compute `error_patterns`; the
-            CW-logs source scans all services when omitted.
+            Required to query Application Signals; the CW-logs source scans all services when omitted.
         environment: Environment name. Optional — from user prompt or prior tool output.
         percentile: Percentile to compute for duration (default 99). E.g., 99 for p99, 50 for p50.
             The result appears as `p{N}_duration_ms` in each endpoint entry.
@@ -397,30 +389,11 @@ async def get_endpoints(
         Dict with total endpoints count and limited list of endpoint summaries
         (including `p{N}_duration_ms`), or a single endpoint when one matches.
         Includes a `data_source` field indicating which backend provided the data.
-        When available, also includes `error_patterns` (list of
-        `{operation, exception, exception_type, count}`, sorted by count desc) and
-        `error_patterns_source: "metrics_v2"`.
     """
     logger.debug(
         f'get_endpoints called: hours={hours}, operation={operation}, service_name={service_name}'
     )
     pkey = f'p{int(percentile)}'
-
-    # Optional per-(operation, exception) error patterns from the `count` MetricV2
-    # metric (only present when ServiceEvents is enabled in the SDK). Computed once and
-    # merged into whichever response shape is returned below; None -> field omitted.
-    error_patterns = None
-    if service_name:
-        error_patterns = await asyncio.to_thread(
-            _fetch_error_patterns, service_name, hours, operation, environment, limit
-        )
-
-    def _with_error_patterns(payload: dict) -> dict:
-        """Attach the optional error_patterns block to a response dict."""
-        if error_patterns:
-            payload['error_patterns'] = error_patterns
-            payload['error_patterns_source'] = 'metrics_v2'
-        return payload
 
     # Application Signals path: endpoint RED metrics come from AppSignals, not CW logs.
     if state.is_appsignals_enabled() and service_name:
@@ -461,19 +434,17 @@ async def get_endpoints(
             result = formatted[0]
             result['time_range_hours'] = hours
             result['data_source'] = 'application_signals'
-            return _with_error_patterns(result)
+            return result
 
-        return _with_error_patterns(
-            {
-                'total_endpoints': len(formatted),
-                'returned': len(formatted),
-                'filter_operation': operation,
-                'percentile': pkey,
-                'time_range_hours': hours,
-                'endpoints': formatted,
-                'data_source': 'application_signals',
-            }
-        )
+        return {
+            'total_endpoints': len(formatted),
+            'returned': len(formatted),
+            'filter_operation': operation,
+            'percentile': pkey,
+            'time_range_hours': hours,
+            'endpoints': formatted,
+            'data_source': 'application_signals',
+        }
 
     # ServiceEvents CloudWatch Logs path: endpoint_summary records.
     try:
@@ -503,19 +474,17 @@ async def get_endpoints(
         result = formatted[0]
         result['time_range_hours'] = hours
         result['data_source'] = 'service_events'
-        return _with_error_patterns(result)
+        return result
 
-    return _with_error_patterns(
-        {
-            'total_endpoints': len(formatted),
-            'returned': len(formatted),
-            'filter_operation': operation,
-            'percentile': pkey,
-            'time_range_hours': hours,
-            'endpoints': formatted,
-            'data_source': 'service_events',
-        }
-    )
+    return {
+        'total_endpoints': len(formatted),
+        'returned': len(formatted),
+        'filter_operation': operation,
+        'percentile': pkey,
+        'time_range_hours': hours,
+        'endpoints': formatted,
+        'data_source': 'service_events',
+    }
 
 
 # =============================================================================

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -457,12 +457,12 @@ def _merge_comparison_rows(before_rows: list, after_rows: list) -> list:
     after = {_key(r): r for r in after_rows}
     rows = []
     for key in set(before) | set(after):
-        b = before.get(key)
-        a = after.get(key)
-        sample = a if a is not None else b
-        assert sample is not None  # key came from the union, so one side is present
-        prior = b.get('count', 0) if b else 0
-        recent = a.get('count', 0) if a else 0
+        b = before.get(key) or {}
+        a = after.get(key) or {}
+        # The key comes from the union, so at least one side is non-empty.
+        sample = a or b
+        prior = b.get('count', 0)
+        recent = a.get('count', 0)
         rows.append(
             {
                 'operation': sample.get('operation'),
@@ -1452,14 +1452,15 @@ async def get_health_overview(
     )
     overview['top_error_functions'] = top_error_functions
     overview['recent_incidents'] = recent_incidents
-    if error_patterns:
+    # error_patterns is only populated when service_name was given; the explicit
+    # service_name check also narrows the Optional for the comparison call below.
+    if error_patterns and service_name:
         # Per-(operation, exception) error breakdown (CloudWatch "Errors" page data).
         overview['error_patterns'] = error_patterns
         overview['error_patterns_source'] = 'metrics_v2'
         # Errors are present, so compare them across two windows (deployment-anchored
         # when a deploy is recent, else last-vs-previous day). Best-effort: a None
         # result (query failure) simply omits the block.
-        assert service_name is not None  # error_patterns is only set when service_name is
         comparison = await _fetch_error_pattern_comparison(
             service_name, environment, latest_deployment_dt
         )

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -377,6 +377,8 @@ async def get_endpoints(
     right field for "what error patterns does my service have / changed?". It is scoped
     by `operation` when provided, otherwise service-wide. The field is OMITTED when the
     metric is unavailable or there are no errors — its absence never fails the call.
+    (For a service-wide error-pattern overview, `get_service_health_overview` also
+    includes this breakdown.)
 
     Args:
         hours: Time range to query in hours (default 24).
@@ -978,12 +980,17 @@ async def get_health_overview(
 ) -> dict:
     """Get a health overview of the system.
 
-    **PRIMARY ENTRY POINT for general health & performance questions.** Use this
-    FIRST for any broad, open-ended ask such as "is anything wrong with my app?",
-    "are there any performance issues?", or "how healthy is service X?". It is a
-    FAST, minimal-data tool that consolidates the signals those questions need:
+    **PRIMARY ENTRY POINT for general health, performance, AND error-pattern
+    questions.** Use this FIRST for any broad, open-ended ask such as "is anything
+    wrong with my app?", "are there any performance issues?", "how healthy is service
+    X?", or **"do you see any erroring pattern / did errors change for service X?"**.
+    It is a FAST, minimal-data tool that consolidates the signals those questions need:
     SLO compliance/breaches, **recent incident events** (errors, timeouts, slow
-    requests), and the top error-prone functions — in a single call.
+    requests), the top error-prone functions, and — when a `service_name` is given —
+    the **`error_patterns` breakdown (which exceptions on which operations, with
+    counts)** that matches the CloudWatch "Errors" page. A "what errors / which
+    exceptions / did the error pattern change?" question is answered HERE; you do not
+    need a separate endpoint call for the service-wide error breakdown.
 
     **MANDATORY for broad health/performance intent:** A general "any issues?"
     question MUST be answered starting from this tool, because it includes recent
@@ -1028,6 +1035,12 @@ async def get_health_overview(
     - Sampled error count (from top 50 error functions — not an exhaustive total)
     - Top 50 error-prone functions (name and error count only)
     - Top 10 recent incidents (minimal info: endpoint, trigger_type, timestamp)
+    - error_patterns: (when `service_name` is given and the `count` MetricV2 metric is
+      available — i.e. ServiceEvents enabled in the SDK) per-(operation, exception)
+      error counts `{operation, exception, exception_type, count}`, sorted by count desc.
+      This is the operation×exception error breakdown shown on the CloudWatch "Errors"
+      page; use it to answer "which errors / did the error pattern change?". Omitted
+      when no service_name or the metric is unavailable.
     - note: Reminder that counts are sampled, not exhaustive totals
     - ALERT: (when SLO breaches detected)
     - slo_compliance: SLO breach summary when Application Signals is enabled
@@ -1100,6 +1113,12 @@ async def get_health_overview(
             logger.warning(f'SLO compliance check failed: {e}')
             return None
 
+    # Per-(operation, exception) error patterns from the `count` MetricV2 metric.
+    # Service-scoped, so only fetched when a service_name is given; optional (omitted
+    # when the metric is unavailable). This is what answers "any erroring pattern /
+    # did error patterns change?" as part of the overall health picture.
+    want_error_patterns = bool(service_name)
+
     # --- Run all independent queries in parallel ---
     tasks = [
         asyncio.to_thread(_fetch_error_functions),
@@ -1110,6 +1129,10 @@ async def get_health_overview(
         tasks.append(asyncio.to_thread(_fetch_slo_compliance))
     if detail == 'comprehensive':
         tasks.append(asyncio.to_thread(_fetch_endpoints))
+    if want_error_patterns:
+        tasks.append(
+            asyncio.to_thread(_fetch_error_patterns, service_name, hours, None, environment, 20)
+        )
 
     results = await asyncio.gather(*tasks)
 
@@ -1126,6 +1149,9 @@ async def get_health_overview(
     if appsignals_enabled:
         idx += 1
     ep_response = results[idx] if detail == 'comprehensive' else None
+    if detail == 'comprehensive':
+        idx += 1
+    error_patterns = results[idx] if want_error_patterns else None
 
     # Format top error functions (records from CloudWatch Metrics V2)
     sampled_error_count = 0
@@ -1168,6 +1194,10 @@ async def get_health_overview(
     )
     overview['top_error_functions'] = top_error_functions
     overview['recent_incidents'] = recent_incidents
+    if error_patterns:
+        # Per-(operation, exception) error breakdown (CloudWatch "Errors" page data).
+        overview['error_patterns'] = error_patterns
+        overview['error_patterns_source'] = 'metrics_v2'
     overview['time_range_hours'] = hours
 
     # Extract cloud context from incidents if available

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -306,6 +306,40 @@ def search_functions(
 # =============================================================================
 
 
+def _fetch_error_patterns(
+    service_name: str,
+    hours: int,
+    operation: Optional[str],
+    environment: Optional[str],
+    limit: int,
+) -> Optional[list]:
+    """Per-(operation, exception) error counts from the ``count`` MetricV2 metric.
+
+    Returns a list of ``{operation, exception, exception_type, count}`` rows, or
+    ``None`` when there is nothing to report. This metric is only emitted when
+    ServiceEvents is enabled in the SDK, so callers treat it as OPTIONAL: any query
+    failure or empty result yields ``None`` and the field is omitted from the response.
+    """
+    from . import promql_client, promql_query
+
+    try:
+        query = promql_query.errors_by_operation_exception(
+            service_name,
+            window=promql_query.hours_to_window(hours),
+            operation=operation,
+            environment=environment,
+            top=limit,
+        )
+        result = promql_client.instant_query(query).get('result', [])
+        patterns = promql_query.vector_to_error_patterns(result, top=limit)
+        return patterns or None
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        # Error-pattern data is optional (requires ServiceEvents in the SDK); never
+        # let its absence break the endpoint response.
+        logger.debug(f'Error-pattern query skipped for {service_name}: {e}')
+        return None
+
+
 async def get_endpoints(
     hours: int = 24,
     operation: Optional[str] = None,
@@ -336,13 +370,23 @@ async def get_endpoints(
     **Output is limited to avoid large responses.** Use `operation` parameter
     to filter to a specific API if you know the operation name.
 
+    **Error patterns (optional):** When a `service_name` is given and the service
+    emits the `count` MetricV2 metric (only when ServiceEvents is enabled in the SDK),
+    the response also includes an `error_patterns` list — per-(operation, exception)
+    error counts over the window, matching the CloudWatch "Errors" page. This is the
+    right field for "what error patterns does my service have / changed?". It is scoped
+    by `operation` when provided, otherwise service-wide. The field is OMITTED when the
+    metric is unavailable or there are no errors — its absence never fails the call.
+
     Args:
         hours: Time range to query in hours (default 24).
         operation: Filter by operation name (e.g., "POST /api/users"). Substring match. Optional.
-            When exactly one endpoint matches, detail mode is returned.
-        limit: Maximum number of endpoints to return (default 20).
+            When exactly one endpoint matches, detail mode is returned. Also scopes
+            `error_patterns` to that operation.
+        limit: Maximum number of endpoints to return (default 20). Also caps `error_patterns`.
         service_name: Service name to query. Optional — from user prompt or prior tool output.
-            Required to query Application Signals; the CW-logs source scans all services when omitted.
+            Required to query Application Signals and to compute `error_patterns`; the
+            CW-logs source scans all services when omitted.
         environment: Environment name. Optional — from user prompt or prior tool output.
         percentile: Percentile to compute for duration (default 99). E.g., 99 for p99, 50 for p50.
             The result appears as `p{N}_duration_ms` in each endpoint entry.
@@ -351,11 +395,30 @@ async def get_endpoints(
         Dict with total endpoints count and limited list of endpoint summaries
         (including `p{N}_duration_ms`), or a single endpoint when one matches.
         Includes a `data_source` field indicating which backend provided the data.
+        When available, also includes `error_patterns` (list of
+        `{operation, exception, exception_type, count}`, sorted by count desc) and
+        `error_patterns_source: "metrics_v2"`.
     """
     logger.debug(
         f'get_endpoints called: hours={hours}, operation={operation}, service_name={service_name}'
     )
     pkey = f'p{int(percentile)}'
+
+    # Optional per-(operation, exception) error patterns from the `count` MetricV2
+    # metric (only present when ServiceEvents is enabled in the SDK). Computed once and
+    # merged into whichever response shape is returned below; None -> field omitted.
+    error_patterns = None
+    if service_name:
+        error_patterns = await asyncio.to_thread(
+            _fetch_error_patterns, service_name, hours, operation, environment, limit
+        )
+
+    def _with_error_patterns(payload: dict) -> dict:
+        """Attach the optional error_patterns block to a response dict."""
+        if error_patterns:
+            payload['error_patterns'] = error_patterns
+            payload['error_patterns_source'] = 'metrics_v2'
+        return payload
 
     # Application Signals path: endpoint RED metrics come from AppSignals, not CW logs.
     if state.is_appsignals_enabled() and service_name:
@@ -396,17 +459,19 @@ async def get_endpoints(
             result = formatted[0]
             result['time_range_hours'] = hours
             result['data_source'] = 'application_signals'
-            return result
+            return _with_error_patterns(result)
 
-        return {
-            'total_endpoints': len(formatted),
-            'returned': len(formatted),
-            'filter_operation': operation,
-            'percentile': pkey,
-            'time_range_hours': hours,
-            'endpoints': formatted,
-            'data_source': 'application_signals',
-        }
+        return _with_error_patterns(
+            {
+                'total_endpoints': len(formatted),
+                'returned': len(formatted),
+                'filter_operation': operation,
+                'percentile': pkey,
+                'time_range_hours': hours,
+                'endpoints': formatted,
+                'data_source': 'application_signals',
+            }
+        )
 
     # ServiceEvents CloudWatch Logs path: endpoint_summary records.
     try:
@@ -436,17 +501,19 @@ async def get_endpoints(
         result = formatted[0]
         result['time_range_hours'] = hours
         result['data_source'] = 'service_events'
-        return result
+        return _with_error_patterns(result)
 
-    return {
-        'total_endpoints': len(formatted),
-        'returned': len(formatted),
-        'filter_operation': operation,
-        'percentile': pkey,
-        'time_range_hours': hours,
-        'endpoints': formatted,
-        'data_source': 'service_events',
-    }
+    return _with_error_patterns(
+        {
+            'total_endpoints': len(formatted),
+            'returned': len(formatted),
+            'filter_operation': operation,
+            'percentile': pkey,
+            'time_range_hours': hours,
+            'endpoints': formatted,
+            'data_source': 'service_events',
+        }
+    )
 
 
 # =============================================================================

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -351,6 +351,26 @@ _DEPLOYMENT_WINDOW_HOURS = 3
 _TIME_WINDOW_HOURS = 24
 
 
+def _parse_deployment_timestamp(ts: Optional[str]) -> Optional[datetime]:
+    """Parse a raw deployment ``deployed_at`` string to a tz-aware UTC datetime.
+
+    The SDK attribute (``aws.service_events.deployment.timestamp``) is not normalized
+    upstream, so a value without a ``Z``/offset (e.g. ``2026-06-17T13:12:00``) parses
+    to a NAIVE datetime — which then raises ``TypeError`` when subtracted from an aware
+    ``datetime.now(timezone.utc)``. Coerce naive values to UTC here so every caller gets
+    an aware datetime. Returns ``None`` for missing/``"unknown"``/unparseable input.
+    """
+    if not ts or ts == 'unknown':
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def _latest_deployment_dt(service_name: str, environment: Optional[str]) -> Optional[datetime]:
     """Return the most recent deployment timestamp for the service, or ``None``.
 
@@ -365,12 +385,8 @@ def _latest_deployment_dt(service_name: str, environment: Optional[str]) -> Opti
         return None
     latest: Optional[datetime] = None
     for d in deployments:
-        ts = d.get('deployed_at')
-        if not ts or ts == 'unknown':
-            continue
-        try:
-            dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
-        except (ValueError, TypeError):
+        dt = _parse_deployment_timestamp(d.get('deployed_at'))
+        if dt is None:
             continue
         if latest is None or dt > latest:
             latest = dt
@@ -1636,14 +1652,10 @@ def find_deployment(
         }
 
         # Compute hours_since_deployment
-        deployed_at = d.get('deployed_at', '')
-        if deployed_at and deployed_at != 'unknown':
-            try:
-                dep_time = datetime.fromisoformat(deployed_at.replace('Z', '+00:00'))
-                delta_hours = (now - dep_time).total_seconds() / 3600
-                dep['hours_since_deployment'] = max(1, int(delta_hours) + 1)
-            except (ValueError, TypeError):
-                pass
+        dep_time = _parse_deployment_timestamp(d.get('deployed_at'))
+        if dep_time is not None:
+            delta_hours = (now - dep_time).total_seconds() / 3600
+            dep['hours_since_deployment'] = max(1, int(delta_hours) + 1)
 
         deployments.append(dep)
 

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -340,6 +340,236 @@ def _fetch_error_patterns(
         return None
 
 
+# Cap fetched per window before merging; the displayed table is sliced smaller.
+_COMPARISON_FETCH_TOP = 50
+_COMPARISON_DISPLAY_TOP = 20
+# A deployment is only used as the comparison cut line when this recent.
+_DEPLOYMENT_CUT_MAX_AGE_HOURS = 24
+# Fixed half-window (hours) on each side of a deployment cut line.
+_DEPLOYMENT_WINDOW_HOURS = 3
+# No-deployment fallback: compare the last N hours with the previous N hours.
+_TIME_WINDOW_HOURS = 24
+
+
+def _latest_deployment_dt(service_name: str, environment: Optional[str]) -> Optional[datetime]:
+    """Return the most recent deployment timestamp for the service, or ``None``.
+
+    Best-effort: used only to pick a comparison cut line, so any query failure or a
+    missing/unparseable timestamp yields ``None`` (the caller falls back to a fixed
+    time-window comparison). Looks back one week, matching ``find_deployment``.
+    """
+    try:
+        deployments = cw_logs.query_deployments(service_name=service_name, hours=168, limit=10)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.debug(f'Deployment lookup skipped for {service_name}: {e}')
+        return None
+    latest: Optional[datetime] = None
+    for d in deployments:
+        ts = d.get('deployed_at')
+        if not ts or ts == 'unknown':
+            continue
+        try:
+            dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+        except (ValueError, TypeError):
+            continue
+        if latest is None or dt > latest:
+            latest = dt
+    return latest
+
+
+def _duration_str(seconds: float) -> str:
+    """Format a PromQL range-window duration in seconds (min 60s)."""
+    return f'{max(60, int(round(seconds)))}s'
+
+
+def _query_error_patterns_window(
+    service_name: str,
+    environment: Optional[str],
+    window_seconds: float,
+    end_dt: datetime,
+    limit: int,
+) -> Optional[list]:
+    """Per-(operation, exception) error counts over a window ENDING at ``end_dt``.
+
+    Evaluates ``sum_over_time(count[window])`` at the instant ``end_dt`` (Prometheus
+    ``time`` param), so the result covers ``(end_dt - window, end_dt]``. Returns parsed
+    rows, an empty list when the window had no errors, or ``None`` on query failure.
+    """
+    from . import promql_client, promql_query
+
+    try:
+        query = promql_query.errors_by_operation_exception(
+            service_name,
+            window=_duration_str(window_seconds),
+            environment=environment,
+        )
+        result = promql_client.instant_query(query, time_param=str(end_dt.timestamp())).get(
+            'result', []
+        )
+        return promql_query.vector_to_error_patterns(result, top=limit)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.debug(f'Error-pattern comparison window query skipped for {service_name}: {e}')
+        return None
+
+
+def _pct_change(prior: int, recent: int) -> Optional[int]:
+    """Percent change from ``prior`` to ``recent`` (None when there is no baseline)."""
+    if prior == 0:
+        return None
+    return round((recent - prior) / prior * 100)
+
+
+def _change_status(prior: int, recent: int) -> str:
+    """Classify a before/after count change for rendering arrows."""
+    if prior == 0 and recent > 0:
+        return 'new'
+    if recent == 0 and prior > 0:
+        return 'cleared'
+    if recent > prior:
+        return 'up'
+    if recent < prior:
+        return 'down'
+    return 'flat'
+
+
+def _merge_comparison_rows(before_rows: list, after_rows: list) -> list:
+    """Merge two windows' error rows by (operation, exception) into comparison rows.
+
+    Each row carries prior/recent counts, delta, percent change, and a status. Sorted
+    by recent count desc (then prior count) so the biggest current contributors lead.
+    """
+
+    def _key(r):
+        return (r.get('operation'), r.get('exception'))
+
+    before = {_key(r): r for r in before_rows}
+    after = {_key(r): r for r in after_rows}
+    rows = []
+    for key in set(before) | set(after):
+        b = before.get(key)
+        a = after.get(key)
+        sample = a if a is not None else b
+        assert sample is not None  # key came from the union, so one side is present
+        prior = b.get('count', 0) if b else 0
+        recent = a.get('count', 0) if a else 0
+        rows.append(
+            {
+                'operation': sample.get('operation'),
+                'exception': sample.get('exception'),
+                'exception_type': sample.get('exception_type'),
+                'prior_count': prior,
+                'recent_count': recent,
+                'delta': recent - prior,
+                'pct_change': _pct_change(prior, recent),
+                'status': _change_status(prior, recent),
+            }
+        )
+    rows.sort(key=lambda r: (r['recent_count'], r['prior_count']), reverse=True)
+    return rows
+
+
+async def _fetch_error_pattern_comparison(
+    service_name: str,
+    environment: Optional[str],
+    deployment_dt: Optional[datetime],
+) -> Optional[dict]:
+    """Compare per-(operation, exception) error counts across two windows.
+
+    Cut line: a recent deployment (fixed ±3h around it) when one is available within
+    the last day; otherwise the last 24h vs the previous 24h. Returns a structured
+    comparison (windows, merged rows, totals) for the model to render, or ``None`` when
+    either window's query fails. Best-effort: never raises into the overview.
+    """
+    now = datetime.now(timezone.utc)
+
+    use_deploy = deployment_dt is not None and (now - deployment_dt) <= timedelta(
+        hours=_DEPLOYMENT_CUT_MAX_AGE_HOURS
+    )
+    if use_deploy and deployment_dt is not None:
+        win = timedelta(hours=_DEPLOYMENT_WINDOW_HOURS)
+        before_start, before_end = deployment_dt - win, deployment_dt
+        after_start, after_end = deployment_dt, min(deployment_dt + win, now)
+        after_partial = after_end < deployment_dt + win
+        after_hours = round((after_end - after_start).total_seconds() / 3600, 1)
+        strategy = 'deployment'
+        prior_label = f'Prior {_DEPLOYMENT_WINDOW_HOURS}h (before deploy)'
+        recent_label = (
+            f'Since deploy ({after_hours}h)'
+            if after_partial
+            else f'Last {_DEPLOYMENT_WINDOW_HOURS}h (after deploy)'
+        )
+    else:
+        win = timedelta(hours=_TIME_WINDOW_HOURS)
+        before_start, before_end = now - 2 * win, now - win
+        after_start, after_end = now - win, now
+        after_partial = False
+        strategy = 'time_window'
+        prior_label = f'Prior {_TIME_WINDOW_HOURS}h'
+        recent_label = f'Last {_TIME_WINDOW_HOURS}h'
+
+    before_rows, after_rows = await asyncio.gather(
+        asyncio.to_thread(
+            _query_error_patterns_window,
+            service_name,
+            environment,
+            (before_end - before_start).total_seconds(),
+            before_end,
+            _COMPARISON_FETCH_TOP,
+        ),
+        asyncio.to_thread(
+            _query_error_patterns_window,
+            service_name,
+            environment,
+            (after_end - after_start).total_seconds(),
+            after_end,
+            _COMPARISON_FETCH_TOP,
+        ),
+    )
+    if before_rows is None or after_rows is None:
+        return None
+
+    merged = _merge_comparison_rows(before_rows, after_rows)
+    prior_total = sum(r['prior_count'] for r in merged)
+    recent_total = sum(r['recent_count'] for r in merged)
+
+    comparison = {
+        'strategy': strategy,
+        'prior_window': {
+            'label': prior_label,
+            'start': before_start.isoformat(),
+            'end': before_end.isoformat(),
+        },
+        'recent_window': {
+            'label': recent_label,
+            'start': after_start.isoformat(),
+            'end': after_end.isoformat(),
+            'partial': after_partial,
+        },
+        'rows': merged[:_COMPARISON_DISPLAY_TOP],
+        'truncated': len(merged) > _COMPARISON_DISPLAY_TOP,
+        'totals': {
+            'prior_count': prior_total,
+            'recent_count': recent_total,
+            'delta': recent_total - prior_total,
+            'pct_change': _pct_change(prior_total, recent_total),
+        },
+    }
+    if use_deploy and deployment_dt is not None:
+        comparison['deployment'] = {'deployed_at': deployment_dt.isoformat()}
+    # The `count` metric is short-retention: if the prior window is entirely empty while
+    # the recent one has errors, the baseline is almost certainly missing (aged out),
+    # NOT a genuine zero — so every row would read as "new". Flag it so the comparison is
+    # not mistaken for a real before/after delta.
+    if prior_total == 0 and recent_total > 0:
+        comparison['baseline_unavailable'] = True
+        comparison['note'] = (
+            'The prior window has no data — the count metric has limited retention, so the '
+            'baseline likely aged out rather than being a true zero. Treat the "new"/Δ values '
+            'as current counts without a reliable comparison.'
+        )
+    return comparison
+
+
 async def get_endpoints(
     hours: int = 24,
     operation: Optional[str] = None,
@@ -957,9 +1187,13 @@ async def get_health_overview(
     SLO compliance/breaches, **recent incident events** (errors, timeouts, slow
     requests), the top error-prone functions, and — when a `service_name` is given —
     the **`error_patterns` breakdown (which exceptions on which operations, with
-    counts)** that matches the CloudWatch "Errors" page. A "what errors / which
-    exceptions / did the error pattern change?" question is answered HERE; you do not
-    need a separate endpoint call for the service-wide error breakdown.
+    counts)** that matches the CloudWatch "Errors" page. When errors are present, it
+    also attaches **`error_pattern_comparison`** — a before/after table of those error
+    counts across two windows (anchored on a recent deployment when one exists, else
+    last day vs previous day) so "did the error pattern change?" is answered with the
+    actual delta. A "what errors / which exceptions / did the error pattern change?"
+    question is answered HERE; you do not need a separate endpoint call for the
+    service-wide error breakdown.
 
     **MANDATORY for broad health/performance intent:** A general "any issues?"
     question MUST be answered starting from this tool, because it includes recent
@@ -1010,6 +1244,27 @@ async def get_health_overview(
       This is the operation×exception error breakdown shown on the CloudWatch "Errors"
       page; use it to answer "which errors / did the error pattern change?". Omitted
       when no service_name or the metric is unavailable.
+    - error_pattern_comparison: (present only when `error_patterns` has data) a
+      before/after comparison of those error counts across two windows, so you can
+      answer "did the error pattern change?" directly. Fields:
+        - `strategy`: "deployment" (cut line is a recent deploy, ±3h around it) or
+          "time_window" (last 24h vs previous 24h when no recent deployment).
+        - `deployment.deployed_at`: the cut-line timestamp (deployment strategy only).
+        - `prior_window` / `recent_window`: `{label, start, end[, partial]}` — use the
+          `label` fields as the comparison column headers.
+        - `rows`: per-(operation, exception) `{operation, exception, exception_type,
+          prior_count, recent_count, delta, pct_change, status}`. `status` is one of
+          up / down / flat / new / cleared; `pct_change` is null when prior is 0.
+        - `totals`: aggregate `{prior_count, recent_count, delta, pct_change}`.
+        - `truncated`: true when more rows existed than were returned.
+        - `baseline_unavailable` / `note`: present when the prior window had no data
+          while the recent window has errors. The `count` metric has limited retention,
+          so this usually means the baseline aged out (NOT that the errors are genuinely
+          new). When set, DO NOT report the rows as "new errors" — present them as
+          current counts and say the earlier baseline is unavailable for comparison.
+      RENDER THIS AS A MARKDOWN TABLE with columns: "Operation / Exception",
+      prior_window.label, recent_window.label, and "Change" (use ▲ for up/new, ▼ for
+      down/cleared, ≈ for flat, with the delta and pct_change), plus a Total row.
     - note: Reminder that counts are sampled, not exhaustive totals
     - ALERT: (when SLO breaches detected)
     - slo_compliance: SLO breach summary when Application Signals is enabled
@@ -1102,6 +1357,9 @@ async def get_health_overview(
         tasks.append(
             asyncio.to_thread(_fetch_error_patterns, service_name, hours, None, environment, 20)
         )
+        # Resolve the latest deployment timestamp in parallel; it is the comparison
+        # cut line when one is recent (only computed when there are errors to compare).
+        tasks.append(asyncio.to_thread(_latest_deployment_dt, service_name, environment))
 
     results = await asyncio.gather(*tasks)
 
@@ -1121,6 +1379,9 @@ async def get_health_overview(
     if detail == 'comprehensive':
         idx += 1
     error_patterns = results[idx] if want_error_patterns else None
+    if want_error_patterns:
+        idx += 1
+    latest_deployment_dt = results[idx] if want_error_patterns else None
 
     # Format top error functions (records from CloudWatch Metrics V2)
     sampled_error_count = 0
@@ -1167,6 +1428,15 @@ async def get_health_overview(
         # Per-(operation, exception) error breakdown (CloudWatch "Errors" page data).
         overview['error_patterns'] = error_patterns
         overview['error_patterns_source'] = 'metrics_v2'
+        # Errors are present, so compare them across two windows (deployment-anchored
+        # when a deploy is recent, else last-vs-previous day). Best-effort: a None
+        # result (query failure) simply omits the block.
+        assert service_name is not None  # error_patterns is only set when service_name is
+        comparison = await _fetch_error_pattern_comparison(
+            service_name, environment, latest_deployment_dt
+        )
+        if comparison:
+            overview['error_pattern_comparison'] = comparison
     overview['time_range_hours'] = hours
 
     # Extract cloud context from incidents if available

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/service_events/tools.py
@@ -382,6 +382,17 @@ def _duration_str(seconds: float) -> str:
     return f'{max(60, int(round(seconds)))}s'
 
 
+def _fmt_window(start: datetime, end: datetime) -> str:
+    """Render an absolute UTC time range for a comparison window caption.
+
+    Same-day windows collapse the date once (``2026-06-17 10:12–13:12 UTC``); spanning
+    windows show both dates (``2026-06-16 16:12 → 2026-06-17 16:12 UTC``).
+    """
+    if start.date() == end.date():
+        return f'{start:%Y-%m-%d %H:%M}–{end:%H:%M} UTC'
+    return f'{start:%Y-%m-%d %H:%M} → {end:%Y-%m-%d %H:%M} UTC'
+
+
 def _query_error_patterns_window(
     service_name: str,
     environment: Optional[str],
@@ -532,8 +543,18 @@ async def _fetch_error_pattern_comparison(
     prior_total = sum(r['prior_count'] for r in merged)
     recent_total = sum(r['recent_count'] for r in merged)
 
+    # One-line, human-readable statement of exactly what the trend compares, with
+    # absolute UTC ranges — so a "Trend"/"Change" column is never shown without naming
+    # its baseline. e.g. "Trend compares Last 3h (after deploy) [2026-06-17 13:12–16:12
+    # UTC] vs Prior 3h (before deploy) [2026-06-17 10:12–13:12 UTC]".
+    trend_basis = (
+        f'Trend compares {recent_label} [{_fmt_window(after_start, after_end)}] '
+        f'vs {prior_label} [{_fmt_window(before_start, before_end)}]'
+    )
+
     comparison = {
         'strategy': strategy,
+        'trend_basis': trend_basis,
         'prior_window': {
             'label': prior_label,
             'start': before_start.isoformat(),
@@ -1249,6 +1270,10 @@ async def get_health_overview(
       answer "did the error pattern change?" directly. Fields:
         - `strategy`: "deployment" (cut line is a recent deploy, ±3h around it) or
           "time_window" (last 24h vs previous 24h when no recent deployment).
+        - `trend_basis`: a one-line statement of EXACTLY which two windows the trend
+          compares, with absolute UTC ranges. You MUST print this verbatim as a caption
+          directly above (or below) the table whenever you show a Trend/Change column —
+          never present a trend/percentage without stating what it is measured against.
         - `deployment.deployed_at`: the cut-line timestamp (deployment strategy only).
         - `prior_window` / `recent_window`: `{label, start, end[, partial]}` — use the
           `label` fields as the comparison column headers.
@@ -1264,7 +1289,10 @@ async def get_health_overview(
           current counts and say the earlier baseline is unavailable for comparison.
       RENDER THIS AS A MARKDOWN TABLE with columns: "Operation / Exception",
       prior_window.label, recent_window.label, and "Change" (use ▲ for up/new, ▼ for
-      down/cleared, ≈ for flat, with the delta and pct_change), plus a Total row.
+      down/cleared, ≈ for flat, with the delta and pct_change), plus a Total row. The two
+      count columns MUST be headed with the window `label`s (which include the time
+      span) — do NOT collapse them into a single ambiguous "Count" column. Print the
+      `trend_basis` caption next to the table so the comparison windows are unambiguous.
     - note: Reminder that counts are sampled, not exhaustive totals
     - ALERT: (when SLO breaches detected)
     - slo_compliance: SLO breach summary when Application Signals is enabled

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_promql_query.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_promql_query.py
@@ -221,3 +221,87 @@ class TestVectorToFunctionRecords:
         """Entries without a parseable value are skipped entirely."""
         result = [{'metric': {'function.name': 'f1'}, 'value': [1, 'bad']}]
         assert promql_query.vector_to_function_records(result, 'v') == {}
+
+
+class TestErrorsByOperationException:
+    """Tests for the count-metric error-pattern builder."""
+
+    def test_basic_query_shape(self):
+        """Builds a sum-by-(operation, exception) increase query on the count metric."""
+        expr = promql_query.errors_by_operation_exception('svc', window='3h')
+        assert expr == (
+            'sum by (operation, exception) '
+            '(increase({"count","@resource.service.name"="svc"}[3h]))'
+        )
+
+    def test_operation_and_environment_filters(self):
+        """Operation and environment add quoted-label matchers to the selector."""
+        expr = promql_query.errors_by_operation_exception(
+            'svc', window='1h', operation='POST /x', environment='eks:e'
+        )
+        assert '"operation"="POST /x"' in expr
+        assert '"@resource.deployment.environment.name"="eks:e"' in expr
+        assert '"@resource.service.name"="svc"' in expr
+
+    def test_top_wraps_in_topk(self):
+        """A top value wraps the aggregation in topk()."""
+        expr = promql_query.errors_by_operation_exception('svc', window='3h', top=5)
+        assert expr.startswith('topk(5, ')
+
+
+class TestVectorToErrorPatterns:
+    """Tests for parsing the count-metric error-pattern result."""
+
+    def test_maps_and_sorts_rows(self):
+        """Rows map to {operation, exception, exception_type, count}, sorted by count."""
+        result = [
+            {
+                'metric': {'operation': 'GET /a', 'exception': 'foo.Bar NotFound'},
+                'value': [0, '10'],
+            },
+            {'metric': {'operation': 'POST /b', 'exception': 'baz Qux'}, 'value': [0, '30']},
+        ]
+        rows = promql_query.vector_to_error_patterns(result)
+        assert rows == [
+            {
+                'operation': 'POST /b',
+                'exception': 'baz Qux',
+                'exception_type': 'Qux',
+                'count': 30,
+            },
+            {
+                'operation': 'GET /a',
+                'exception': 'foo.Bar NotFound',
+                'exception_type': 'NotFound',
+                'count': 10,
+            },
+        ]
+
+    def test_drops_series_without_exception(self):
+        """Series with no exception label are dropped."""
+        result = [{'metric': {'operation': 'GET /c'}, 'value': [0, '99']}]
+        assert promql_query.vector_to_error_patterns(result) == []
+
+    def test_drops_non_finite_values(self):
+        """NaN/Inf counts are dropped (reusing the _value_of finite guard)."""
+        result = [{'metric': {'operation': 'GET /d', 'exception': 'x Y'}, 'value': [0, 'NaN']}]
+        assert promql_query.vector_to_error_patterns(result) == []
+
+    def test_exception_without_space_keeps_full_string(self):
+        """An exception label with no space uses the full string as the short name."""
+        result = [{'metric': {'operation': 'GET /e', 'exception': 'BareName'}, 'value': [0, '2']}]
+        rows = promql_query.vector_to_error_patterns(result)
+        assert rows[0]['exception_type'] == 'BareName'
+
+    def test_top_caps_rows(self):
+        """The top arg caps the number of returned rows (after sorting)."""
+        result = [
+            {'metric': {'operation': f'op{i}', 'exception': f'e E{i}'}, 'value': [0, str(i)]}
+            for i in range(5)
+        ]
+        rows = promql_query.vector_to_error_patterns(result, top=2)
+        assert [r['count'] for r in rows] == [4, 3]
+
+    def test_none_result_yields_empty(self):
+        """A None result yields an empty list."""
+        assert promql_query.vector_to_error_patterns(None) == []

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_promql_query.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_promql_query.py
@@ -227,11 +227,11 @@ class TestErrorsByOperationException:
     """Tests for the count-metric error-pattern builder."""
 
     def test_basic_query_shape(self):
-        """Builds a sum-by-(operation, exception) increase query on the count metric."""
+        """Builds a sum-by-(operation, exception) sum_over_time query on the count metric."""
         expr = promql_query.errors_by_operation_exception('svc', window='3h')
         assert expr == (
             'sum by (operation, exception) '
-            '(increase({"count","@resource.service.name"="svc"}[3h]))'
+            '(sum_over_time({"count","@resource.service.name"="svc"}[3h]))'
         )
 
     def test_operation_and_environment_filters(self):

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -1302,6 +1302,36 @@ class TestErrorPatternComparison:
         mock_deps.return_value = [{'deployed_at': 'unknown'}, {}]
         assert tools._latest_deployment_dt('svc', None) is None
 
+    def test_parse_deployment_timestamp_coerces_naive_to_utc(self):
+        """A timestamp without an offset is coerced to tz-aware UTC (no naive datetime)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+        from datetime import datetime, timezone
+
+        # Naive (no Z/offset) — fromisoformat succeeds but would otherwise be naive.
+        naive = tools._parse_deployment_timestamp('2026-06-17T13:12:00')
+        assert naive == datetime(2026, 6, 17, 13, 12, tzinfo=timezone.utc)
+        assert naive is not None and naive.tzinfo is not None
+        # Aware (Z) — preserved as UTC.
+        aware = tools._parse_deployment_timestamp('2026-06-17T13:12:00Z')
+        assert aware == datetime(2026, 6, 17, 13, 12, tzinfo=timezone.utc)
+        # Missing / unknown / unparseable -> None.
+        assert tools._parse_deployment_timestamp(None) is None
+        assert tools._parse_deployment_timestamp('unknown') is None
+        assert tools._parse_deployment_timestamp('not-a-date') is None
+
+    def test_comparison_does_not_raise_on_naive_deployment_dt(self):
+        """A naive deployment_dt must not raise when subtracted from aware now."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        # _latest_deployment_dt always returns aware datetimes now, but guard the
+        # comparison path directly against a naive value to prove no TypeError leaks.
+        naive_dt = tools._parse_deployment_timestamp('2026-06-17T13:12:00')
+        assert naive_dt is not None and naive_dt.tzinfo is not None
+        with patch.object(tools, '_query_error_patterns_window', side_effect=[[], []]):
+            cmp = _run(tools._fetch_error_pattern_comparison('svc', None, naive_dt))
+        # No exception; a structured (possibly empty) comparison is returned.
+        assert cmp is not None and 'strategy' in cmp
+
 
 # ============================================================================
 # TestGetIncidentsExtra — trigger filter, normalization, AppSignals fallback

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -1476,6 +1476,89 @@ class TestHealthOverview:
         assert 'service_stats' not in result
         assert result['data_source'] == 'service_events'
 
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs.query_incidents'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools.function_metrics.fetch_function_records'
+    )
+    def test_error_patterns_included_with_service_name(self, mock_fetch, mock_incidents, mock_err):
+        """error_patterns is folded into the overview when a service_name is given."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            get_health_overview,
+        )
+
+        mock_fetch.return_value = []
+        mock_incidents.return_value = []
+        mock_err.return_value = [
+            {
+                'operation': 'GET /a',
+                'exception': 'foo.Bar NotFound',
+                'exception_type': 'NotFound',
+                'count': 42,
+            }
+        ]
+
+        result = _run(get_health_overview(hours=24, service_name='svc'))
+
+        assert result['error_patterns_source'] == 'metrics_v2'
+        assert result['error_patterns'][0]['exception_type'] == 'NotFound'
+        assert result['error_patterns'][0]['count'] == 42
+        # The error-pattern fetch is scoped to the given service.
+        assert mock_err.call_args[0][0] == 'svc'
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs.query_incidents'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools.function_metrics.fetch_function_records'
+    )
+    def test_error_patterns_omitted_when_unavailable(self, mock_fetch, mock_incidents, mock_err):
+        """When the count metric returns nothing, error_patterns is omitted (not failed)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            get_health_overview,
+        )
+
+        mock_fetch.return_value = []
+        mock_incidents.return_value = []
+        mock_err.return_value = None
+
+        result = _run(get_health_overview(hours=24, service_name='svc'))
+
+        assert 'error_patterns' not in result
+        assert 'error_patterns_source' not in result
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs.query_incidents'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools.function_metrics.fetch_function_records'
+    )
+    def test_error_patterns_skipped_without_service_name(
+        self, mock_fetch, mock_incidents, mock_err
+    ):
+        """No service_name -> the error-pattern fetch is not even attempted."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            get_health_overview,
+        )
+
+        mock_fetch.return_value = []
+        mock_incidents.return_value = []
+
+        result = _run(get_health_overview(hours=24))
+
+        assert 'error_patterns' not in result
+        mock_err.assert_not_called()
+
 
 # ============================================================================
 # TestSloComplianceSummary and TestServiceInventory helpers

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -1161,6 +1161,27 @@ class TestErrorPatternComparison:
         assert cmp['recent_window']['partial'] is True
         assert cmp['rows'][0]['delta'] == 12
         assert mock_win.call_count == 2
+        # trend_basis names BOTH windows so a Trend column is never ambiguous.
+        assert cmp['trend_basis'].startswith('Trend compares ')
+        assert cmp['recent_window']['label'] in cmp['trend_basis']
+        assert cmp['prior_window']['label'] in cmp['trend_basis']
+        assert 'UTC' in cmp['trend_basis']
+
+    def test_fmt_window_same_day_and_spanning(self):
+        """Same-day windows collapse the date; spanning windows show both dates."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+        from datetime import datetime, timezone
+
+        same_day = tools._fmt_window(
+            datetime(2026, 6, 17, 10, 12, tzinfo=timezone.utc),
+            datetime(2026, 6, 17, 13, 12, tzinfo=timezone.utc),
+        )
+        assert same_day == '2026-06-17 10:12–13:12 UTC'
+        spanning = tools._fmt_window(
+            datetime(2026, 6, 16, 16, 12, tzinfo=timezone.utc),
+            datetime(2026, 6, 17, 16, 12, tzinfo=timezone.utc),
+        )
+        assert spanning == '2026-06-16 16:12 → 2026-06-17 16:12 UTC'
 
     def test_comparison_none_when_a_window_fails(self):
         """If either window query fails (None), the comparison is omitted."""

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -1220,6 +1220,88 @@ class TestErrorPatternComparison:
         assert 'note' in cmp
         assert cmp['rows'][0]['status'] == 'new'
 
+    def test_duration_str_floors_at_60s(self):
+        """Window durations format as whole seconds, floored at 60s."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        assert tools._duration_str(10) == '60s'  # floor
+        assert tools._duration_str(3600) == '3600s'
+        assert tools._duration_str(90.4) == '90s'  # rounded
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.promql_client.instant_query'
+    )
+    def test_query_window_parses_and_uses_time_param(self, mock_query):
+        """The window query evaluates at end_dt (Prometheus time param) and parses rows."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+        from datetime import datetime, timezone
+
+        mock_query.return_value = {
+            'result': [
+                {
+                    'metric': {'operation': 'GET /a', 'exception': 'foo.Bar NotFound'},
+                    'value': [0, '7'],
+                }
+            ]
+        }
+        end_dt = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+        rows = tools._query_error_patterns_window('svc', None, 3600, end_dt, 20)
+
+        assert rows == [
+            {
+                'operation': 'GET /a',
+                'exception': 'foo.Bar NotFound',
+                'exception_type': 'NotFound',
+                'count': 7,
+            }
+        ]
+        # The instant query is anchored at end_dt via the time param.
+        assert mock_query.call_args.kwargs['time_param'] == str(end_dt.timestamp())
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.promql_client.instant_query'
+    )
+    def test_query_window_swallows_errors(self, mock_query):
+        """A PromQL failure in a window query yields None (best-effort)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+        from datetime import datetime, timezone
+
+        mock_query.side_effect = RuntimeError('promql down')
+        end_dt = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+        assert tools._query_error_patterns_window('svc', 'env', 3600, end_dt, 20) is None
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs.query_deployments'
+    )
+    def test_latest_deployment_dt_picks_newest(self, mock_deps):
+        """_latest_deployment_dt returns the newest parseable deployment timestamp."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+        from datetime import datetime, timezone
+
+        mock_deps.return_value = [
+            {'deployed_at': '2026-06-10T00:00:00Z'},
+            {'deployed_at': 'unknown'},  # skipped
+            {'deployed_at': 'not-a-date'},  # skipped (unparseable)
+            {'deployed_at': '2026-06-12T08:30:00Z'},  # newest
+            {},  # no timestamp, skipped
+        ]
+        dt = tools._latest_deployment_dt('svc', None)
+        assert dt == datetime(2026, 6, 12, 8, 30, tzinfo=timezone.utc)
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs.query_deployments'
+    )
+    def test_latest_deployment_dt_none_on_error_or_empty(self, mock_deps):
+        """Query failure or no parseable timestamps yields None."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        mock_deps.side_effect = RuntimeError('logs down')
+        assert tools._latest_deployment_dt('svc', None) is None
+
+        mock_deps.side_effect = None
+        mock_deps.return_value = [{'deployed_at': 'unknown'}, {}]
+        assert tools._latest_deployment_dt('svc', None) is None
+
 
 # ============================================================================
 # TestGetIncidentsExtra — trigger filter, normalization, AppSignals fallback

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -1067,6 +1067,140 @@ class TestGetEndpointsAppSignals:
 
 
 # ============================================================================
+# TestErrorPatternComparison — before/after error-count comparison helpers
+# ============================================================================
+
+
+class TestErrorPatternComparison:
+    """Cover the error-pattern comparison helpers in tools.py."""
+
+    def test_pct_change_and_status(self):
+        """Percent change and status classification across the change cases."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        assert tools._pct_change(0, 5) is None  # no baseline
+        assert tools._pct_change(100, 130) == 30
+        assert tools._pct_change(100, 50) == -50
+        assert tools._change_status(0, 5) == 'new'
+        assert tools._change_status(5, 0) == 'cleared'
+        assert tools._change_status(5, 9) == 'up'
+        assert tools._change_status(9, 5) == 'down'
+        assert tools._change_status(5, 5) == 'flat'
+
+    def test_merge_rows_unions_and_sorts(self):
+        """Rows from both windows merge by (operation, exception), sorted by recent desc."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        before = [
+            {
+                'operation': 'GET /a',
+                'exception': 'x NotFound',
+                'exception_type': 'NotFound',
+                'count': 62,
+            },
+            {
+                'operation': 'GET /b',
+                'exception': 'y Found',
+                'exception_type': 'Found',
+                'count': 10,
+            },
+        ]
+        after = [
+            {
+                'operation': 'GET /b',
+                'exception': 'y Found',
+                'exception_type': 'Found',
+                'count': 30,
+            },
+            {'operation': 'POST /c', 'exception': 'z New', 'exception_type': 'New', 'count': 7},
+        ]
+        rows = tools._merge_comparison_rows(before, after)
+
+        # Sorted by recent_count desc: GET /b (30), POST /c (7), GET /a (0).
+        assert [r['recent_count'] for r in rows] == [30, 7, 0]
+        cleared = next(r for r in rows if r['operation'] == 'GET /a')
+        assert cleared['prior_count'] == 62 and cleared['recent_count'] == 0
+        assert cleared['status'] == 'cleared'
+        new_row = next(r for r in rows if r['operation'] == 'POST /c')
+        assert new_row['status'] == 'new' and new_row['pct_change'] is None
+
+    def test_comparison_uses_deployment_cut_line(self):
+        """A recent deployment drives the ±3h deployment-anchored windows."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+        from datetime import datetime, timedelta, timezone
+
+        # Deploy 2h ago -> recent window is partial (only 2h after deploy).
+        deploy_dt = datetime.now(timezone.utc) - timedelta(hours=2)
+        with patch.object(
+            tools,
+            '_query_error_patterns_window',
+            side_effect=[
+                [
+                    {
+                        'operation': 'GET /a',
+                        'exception': 'x NotFound',
+                        'exception_type': 'NotFound',
+                        'count': 8,
+                    }
+                ],
+                [
+                    {
+                        'operation': 'GET /a',
+                        'exception': 'x NotFound',
+                        'exception_type': 'NotFound',
+                        'count': 20,
+                    }
+                ],
+            ],
+        ) as mock_win:
+            cmp = _run(tools._fetch_error_pattern_comparison('svc', None, deploy_dt))
+
+        assert cmp is not None
+        assert cmp['strategy'] == 'deployment'
+        assert cmp['deployment']['deployed_at'] == deploy_dt.isoformat()
+        assert cmp['recent_window']['partial'] is True
+        assert cmp['rows'][0]['delta'] == 12
+        assert mock_win.call_count == 2
+
+    def test_comparison_none_when_a_window_fails(self):
+        """If either window query fails (None), the comparison is omitted."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        with patch.object(
+            tools,
+            '_query_error_patterns_window',
+            side_effect=[None, []],
+        ):
+            assert _run(tools._fetch_error_pattern_comparison('svc', None, None)) is None
+
+    def test_comparison_flags_missing_baseline(self):
+        """Empty prior + non-empty recent flags baseline_unavailable (count retention)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        with patch.object(
+            tools,
+            '_query_error_patterns_window',
+            side_effect=[
+                [],  # prior window aged out
+                [
+                    {
+                        'operation': 'GET /a',
+                        'exception': 'x NotFound',
+                        'exception_type': 'NotFound',
+                        'count': 1287,
+                    }
+                ],
+            ],
+        ):
+            cmp = _run(tools._fetch_error_pattern_comparison('svc', None, None))
+
+        assert cmp is not None
+        assert cmp['baseline_unavailable'] is True
+        assert 'note' in cmp
+        assert cmp['rows'][0]['status'] == 'new'
+
+
+# ============================================================================
 # TestGetIncidentsExtra — trigger filter, normalization, AppSignals fallback
 # ============================================================================
 
@@ -1427,6 +1561,12 @@ class TestHealthOverview:
         assert result['data_source'] == 'service_events'
 
     @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_pattern_comparison'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._latest_deployment_dt'
+    )
+    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
     )
     @patch(
@@ -1435,7 +1575,9 @@ class TestHealthOverview:
     @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools.function_metrics.fetch_function_records'
     )
-    def test_error_patterns_included_with_service_name(self, mock_fetch, mock_incidents, mock_err):
+    def test_error_patterns_included_with_service_name(
+        self, mock_fetch, mock_incidents, mock_err, mock_deploy, mock_cmp
+    ):
         """error_patterns is folded into the overview when a service_name is given."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
             get_health_overview,
@@ -1443,6 +1585,8 @@ class TestHealthOverview:
 
         mock_fetch.return_value = []
         mock_incidents.return_value = []
+        mock_deploy.return_value = None
+        mock_cmp.return_value = None
         mock_err.return_value = [
             {
                 'operation': 'GET /a',
@@ -1459,6 +1603,76 @@ class TestHealthOverview:
         assert result['error_patterns'][0]['count'] == 42
         # The error-pattern fetch is scoped to the given service.
         assert mock_err.call_args[0][0] == 'svc'
+        # With errors present, the comparison is attempted (scoped to the service).
+        mock_cmp.assert_called_once()
+        assert mock_cmp.call_args[0][0] == 'svc'
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._latest_deployment_dt'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs.query_incidents'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools.function_metrics.fetch_function_records'
+    )
+    def test_error_pattern_comparison_folded_in(
+        self, mock_fetch, mock_incidents, mock_err, mock_deploy
+    ):
+        """error_pattern_comparison is attached when error patterns have data."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools
+
+        mock_fetch.return_value = []
+        mock_incidents.return_value = []
+        mock_deploy.return_value = None
+        mock_err.return_value = [
+            {
+                'operation': 'GET /a',
+                'exception': 'x NotFound',
+                'exception_type': 'NotFound',
+                'count': 10,
+            }
+        ]
+        # Two windows: prior 5 vs recent 10 for the same key.
+        with patch.object(
+            tools,
+            '_query_error_patterns_window',
+            side_effect=[
+                [
+                    {
+                        'operation': 'GET /a',
+                        'exception': 'x NotFound',
+                        'exception_type': 'NotFound',
+                        'count': 5,
+                    }
+                ],
+                [
+                    {
+                        'operation': 'GET /a',
+                        'exception': 'x NotFound',
+                        'exception_type': 'NotFound',
+                        'count': 10,
+                    }
+                ],
+            ],
+        ):
+            result = _run(tools.get_health_overview(hours=24, service_name='svc'))
+
+        cmp = result['error_pattern_comparison']
+        assert cmp['strategy'] == 'time_window'
+        assert cmp['rows'][0]['prior_count'] == 5
+        assert cmp['rows'][0]['recent_count'] == 10
+        assert cmp['rows'][0]['pct_change'] == 100
+        assert cmp['rows'][0]['status'] == 'up'
+        assert cmp['totals'] == {
+            'prior_count': 5,
+            'recent_count': 10,
+            'delta': 5,
+            'pct_change': 100,
+        }
 
     @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -385,9 +385,12 @@ class TestGetEndpoints:
         assert result['data_source'] == 'service_events'
 
     @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_red_metrics_when_enabled(self, mock_red):
+    def test_appsignals_red_metrics_when_enabled(self, mock_red, mock_err):
         """Use Application Signals RED metrics when enabled."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -395,6 +398,7 @@ class TestGetEndpoints:
         )
 
         state.set_appsignals_enabled(True)
+        mock_err.return_value = None  # error patterns unavailable
         # get_endpoint_red_metrics returns (summaries, not_found).
         mock_red.return_value = (
             [
@@ -422,9 +426,12 @@ class TestGetEndpoints:
         mock_red.assert_called_once()
 
     @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_service_not_found_surfaces_diagnostic(self, mock_red):
+    def test_appsignals_service_not_found_surfaces_diagnostic(self, mock_red, mock_err):
         """When the AppSignals service does not resolve, the not-found diagnostic is surfaced."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -432,6 +439,7 @@ class TestGetEndpoints:
         )
 
         state.set_appsignals_enabled(True)
+        mock_err.return_value = None
         mock_red.return_value = (
             [],
             {
@@ -448,6 +456,40 @@ class TestGetEndpoints:
         assert result['total_endpoints'] == 0
         assert result['status'] == 'service_not_found'
         assert 'orders' in result['message']
+        # Not-found responses do not carry error patterns.
+        assert 'error_patterns' not in result
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
+    )
+    def test_appsignals_includes_error_patterns_when_available(self, mock_red, mock_err):
+        """error_patterns is merged into the response when the count metric returns rows."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            get_endpoints,
+        )
+
+        state.set_appsignals_enabled(True)
+        mock_red.return_value = ([{'operation': 'GET /a', 'total_requests': 5}], None)
+        mock_err.return_value = [
+            {
+                'operation': 'GET /a',
+                'exception': 'foo.Bar NotFound',
+                'exception_type': 'NotFound',
+                'count': 12,
+            }
+        ]
+
+        result = asyncio.get_event_loop().run_until_complete(
+            get_endpoints(hours=24, service_name='orders')
+        )
+
+        assert result['error_patterns_source'] == 'metrics_v2'
+        assert result['error_patterns'][0]['exception_type'] == 'NotFound'
+        assert result['error_patterns'][0]['count'] == 12
 
 
 # ============================================================================
@@ -977,9 +1019,12 @@ class TestGetEndpointsAppSignals:
     """Cover the Application Signals branches of get_endpoints."""
 
     @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_detail_mode_single_match(self, mock_red):
+    def test_appsignals_detail_mode_single_match(self, mock_red, mock_err):
         """Detail mode: a single AppSignals match returns the endpoint directly."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -987,6 +1032,7 @@ class TestGetEndpointsAppSignals:
         )
 
         state.set_appsignals_enabled(True)
+        mock_err.return_value = None
         mock_red.return_value = ([{'operation': 'GET /api/orders', 'total_requests': 5}], None)
 
         result = _run(get_endpoints(operation='GET /api/orders', service_name='orders'))
@@ -996,9 +1042,12 @@ class TestGetEndpointsAppSignals:
         assert result['time_range_hours'] == 24
 
     @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
+    )
+    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_error_returns_empty(self, mock_red):
+    def test_appsignals_error_returns_empty(self, mock_red, mock_err):
         """An AppSignals metrics error returns an empty AppSignals result."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -1006,6 +1055,7 @@ class TestGetEndpointsAppSignals:
         )
 
         state.set_appsignals_enabled(True)
+        mock_err.return_value = None
         mock_red.side_effect = RuntimeError('boom')
 
         result = _run(get_endpoints(service_name='orders'))
@@ -1013,6 +1063,57 @@ class TestGetEndpointsAppSignals:
         assert result['total_endpoints'] == 0
         assert result['data_source'] == 'application_signals'
         assert 'error' in result
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.promql_client.instant_query'
+    )
+    def test_fetch_error_patterns_maps_rows(self, mock_query):
+        """_fetch_error_patterns returns parsed rows when the count metric has data."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            _fetch_error_patterns,
+        )
+
+        mock_query.return_value = {
+            'result': [
+                {
+                    'metric': {'operation': 'GET /a', 'exception': 'foo.Bar NotFound'},
+                    'value': [0, '7'],
+                }
+            ]
+        }
+        rows = _fetch_error_patterns('svc', 24, None, None, 20)
+        assert rows == [
+            {
+                'operation': 'GET /a',
+                'exception': 'foo.Bar NotFound',
+                'exception_type': 'NotFound',
+                'count': 7,
+            }
+        ]
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.promql_client.instant_query'
+    )
+    def test_fetch_error_patterns_empty_returns_none(self, mock_query):
+        """An empty count result yields None (field omitted by the caller)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            _fetch_error_patterns,
+        )
+
+        mock_query.return_value = {'result': []}
+        assert _fetch_error_patterns('svc', 24, None, None, 20) is None
+
+    @patch(
+        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.promql_client.instant_query'
+    )
+    def test_fetch_error_patterns_swallows_errors(self, mock_query):
+        """A PromQL failure is swallowed and yields None (optional data)."""
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
+            _fetch_error_patterns,
+        )
+
+        mock_query.side_effect = RuntimeError('promql down')
+        assert _fetch_error_patterns('svc', 24, None, None, 20) is None
 
 
 # ============================================================================

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_server_tools.py
@@ -385,12 +385,9 @@ class TestGetEndpoints:
         assert result['data_source'] == 'service_events'
 
     @patch(
-        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
-    )
-    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_red_metrics_when_enabled(self, mock_red, mock_err):
+    def test_appsignals_red_metrics_when_enabled(self, mock_red):
         """Use Application Signals RED metrics when enabled."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -398,7 +395,6 @@ class TestGetEndpoints:
         )
 
         state.set_appsignals_enabled(True)
-        mock_err.return_value = None  # error patterns unavailable
         # get_endpoint_red_metrics returns (summaries, not_found).
         mock_red.return_value = (
             [
@@ -426,12 +422,9 @@ class TestGetEndpoints:
         mock_red.assert_called_once()
 
     @patch(
-        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
-    )
-    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_service_not_found_surfaces_diagnostic(self, mock_red, mock_err):
+    def test_appsignals_service_not_found_surfaces_diagnostic(self, mock_red):
         """When the AppSignals service does not resolve, the not-found diagnostic is surfaced."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -439,7 +432,6 @@ class TestGetEndpoints:
         )
 
         state.set_appsignals_enabled(True)
-        mock_err.return_value = None
         mock_red.return_value = (
             [],
             {
@@ -456,40 +448,6 @@ class TestGetEndpoints:
         assert result['total_endpoints'] == 0
         assert result['status'] == 'service_not_found'
         assert 'orders' in result['message']
-        # Not-found responses do not carry error patterns.
-        assert 'error_patterns' not in result
-
-    @patch(
-        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
-    )
-    @patch(
-        'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
-    )
-    def test_appsignals_includes_error_patterns_when_available(self, mock_red, mock_err):
-        """error_patterns is merged into the response when the count metric returns rows."""
-        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
-        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
-            get_endpoints,
-        )
-
-        state.set_appsignals_enabled(True)
-        mock_red.return_value = ([{'operation': 'GET /a', 'total_requests': 5}], None)
-        mock_err.return_value = [
-            {
-                'operation': 'GET /a',
-                'exception': 'foo.Bar NotFound',
-                'exception_type': 'NotFound',
-                'count': 12,
-            }
-        ]
-
-        result = asyncio.get_event_loop().run_until_complete(
-            get_endpoints(hours=24, service_name='orders')
-        )
-
-        assert result['error_patterns_source'] == 'metrics_v2'
-        assert result['error_patterns'][0]['exception_type'] == 'NotFound'
-        assert result['error_patterns'][0]['count'] == 12
 
 
 # ============================================================================
@@ -1019,12 +977,9 @@ class TestGetEndpointsAppSignals:
     """Cover the Application Signals branches of get_endpoints."""
 
     @patch(
-        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
-    )
-    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_detail_mode_single_match(self, mock_red, mock_err):
+    def test_appsignals_detail_mode_single_match(self, mock_red):
         """Detail mode: a single AppSignals match returns the endpoint directly."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -1032,7 +987,6 @@ class TestGetEndpointsAppSignals:
         )
 
         state.set_appsignals_enabled(True)
-        mock_err.return_value = None
         mock_red.return_value = ([{'operation': 'GET /api/orders', 'total_requests': 5}], None)
 
         result = _run(get_endpoints(operation='GET /api/orders', service_name='orders'))
@@ -1042,12 +996,9 @@ class TestGetEndpointsAppSignals:
         assert result['time_range_hours'] == 24
 
     @patch(
-        'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools._fetch_error_patterns'
-    )
-    @patch(
         'awslabs.cloudwatch_applicationsignals_mcp_server.endpoint_metrics.get_endpoint_red_metrics'
     )
-    def test_appsignals_error_returns_empty(self, mock_red, mock_err):
+    def test_appsignals_error_returns_empty(self, mock_red):
         """An AppSignals metrics error returns an empty AppSignals result."""
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import state
         from awslabs.cloudwatch_applicationsignals_mcp_server.service_events.tools import (
@@ -1055,7 +1006,6 @@ class TestGetEndpointsAppSignals:
         )
 
         state.set_appsignals_enabled(True)
-        mock_err.return_value = None
         mock_red.side_effect = RuntimeError('boom')
 
         result = _run(get_endpoints(service_name='orders'))


### PR DESCRIPTION
## Summary

Adds the per-(operation × exception) error breakdown — the data behind the CloudWatch **Errors** page — to **`get_service_health_overview`**, plus a before/after comparison so "did the error pattern change?" is answered in one call.

### Highlights

- **`error_patterns`**: per-(operation, exception) error counts from the `count` MetricV2 metric (PromQL `sum_over_time`), sorted by count. Optional — omitted when the metric is unavailable, never fails the overview.
- **`error_pattern_comparison`**: before/after counts across two windows, anchored on a recent deployment (±3h) when one exists, else last day vs previous day. Each row has prior/recent counts, delta, % change, and status (up/down/flat/new/cleared).
- **`trend_basis`** caption names both comparison windows with absolute UTC ranges, so a trend is never shown without stating what it's measured against.
- **`baseline_unavailable`** guard: when the prior window aged out (the `count` metric is short-retention), flags it so rows aren't misreported as brand-new.

Verified live (`telemend` / `us-east-1`, `customers-service-java`) and matches the CloudWatch Errors page. No IAM change — reuses the existing `monitoring` SigV4 PromQL path.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (unit tests + live verification)
* [x] Changes are documented (tool docstring)

Is this a breaking change? (N) — additive optional fields.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).