### PR TITLE
fix: use semver pattern in version test instead of hardcoded value

### DIFF
--- a/src/security-agent-mcp-server/tests/test_init.py
+++ b/src/security-agent-mcp-server/tests/test_init.py
@@ -14,9 +14,12 @@
 
 """Tests for package initialization."""
 
+import re
 from awslabs.security_agent_mcp_server import __version__
 
 
 def test_version():
-    """Verify version is set."""
-    assert __version__ == '0.1.0'
+    """Verify version is set and follows semantic versioning."""
+    assert re.match(r'^\d+\.\d+\.\d+$', __version__), (
+        f"Version '{__version__}' does not follow semantic versioning"
+    )


### PR DESCRIPTION

Fixes

## Summary
fix: use semver pattern in version test instead of hardcoded value

### Changes

fix: use semver pattern in version test instead of hardcoded value

### User experience

No changes in user experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
