### PR TITLE
docs(healthlake-mcp-server): correct changelog heading

### DIFF
--- a/src/healthlake-mcp-server/CHANGELOG.md
+++ b/src/healthlake-mcp-server/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.13
+## 0.0.14 - 2026-05-05
 
 ### Fixed
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #N/A

## Summary

Corrects the changelog heading for the HealthLake MCP server so it matches the version actually published to PyPI.

### Changes

The fixes for pagination, error mapping, and the export job (#3335) were labeled `0.0.13` in the changelog, but the first published release carrying these fixes was **`0.0.14`** (2026-05-05).

This change renames the changelog heading `## 0.0.13` → `## 0.0.14 - 2026-05-05`, leaving all existing bullet entries intact. It is a documentation-only change — no code, dependencies, or behavior are affected.

### User experience

The changelog heading now matches the published PyPI release (0.0.14, 2026-05-05) instead of the never-published 0.0.13, so the changelog, pyproject.toml, __init__.py, and PyPI all agree on the version that carried the fixes.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
