### PR TITLE
fix: preserve agent space resources, retry api guide load, handle null severity

### DIFF
--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
@@ -67,16 +67,10 @@ class SecurityAgentClient:
         self,
         agent_space_id: str,
         name: str,
-        iam_roles: Optional[list[str]] = None,
-        s3_buckets: Optional[list[str]] = None,
+        aws_resources: Optional[dict] = None,
     ) -> dict:
-        """Update an agent space with roles and buckets."""
+        """Update an agent space, replacing its awsResources with the provided dict."""
         kwargs: dict[str, Any] = {'agentSpaceId': agent_space_id, 'name': name}
-        aws_resources: dict[str, Any] = {}
-        if iam_roles:
-            aws_resources['iamRoles'] = iam_roles
-        if s3_buckets:
-            aws_resources['s3Buckets'] = s3_buckets
         if aws_resources:
             kwargs['awsResources'] = aws_resources
         return self._client().update_agent_space(**kwargs)

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
@@ -532,7 +532,7 @@ class Scanner:
                 min_idx = severity_order.index(severity_upper)
                 allowed = set(severity_order[: min_idx + 1])
                 findings_summaries = [
-                    f for f in findings_summaries if f.get('riskLevel', '').upper() in allowed
+                    f for f in findings_summaries if (f.get('riskLevel') or '').upper() in allowed
                 ]
 
         # Batch get full details (including remediationCode and codeLocations)
@@ -581,7 +581,7 @@ class Scanner:
             severity_upper = severity.upper()
             if severity_upper in severity_order:
                 allowed = set(severity_order[: severity_order.index(severity_upper) + 1])
-                summaries = [t for t in summaries if t.get('severity', '').upper() in allowed]
+                summaries = [t for t in summaries if (t.get('severity') or '').upper() in allowed]
 
         threat_ids = [t.get('threatId') for t in summaries if t.get('threatId')]
         threats = []

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -160,14 +160,15 @@ def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
     # Register bucket on agent space so the service can access it
     agent_space_id = config['agent_space_id']
     space = _client.get_agent_space(agent_space_id)
-    existing_buckets = space.get('awsResources', {}).get('s3Buckets', [])
+    aws_resources = dict(space.get('awsResources', {}))
+    existing_buckets = list(aws_resources.get('s3Buckets', []))
     if bucket not in existing_buckets:
         existing_buckets.append(bucket)
+        aws_resources['s3Buckets'] = existing_buckets
         _client.update_agent_space(
             agent_space_id,
             space.get('name', 'security-scans'),
-            space.get('awsResources', {}).get('iamRoles', []),
-            existing_buckets,
+            aws_resources,
         )
 
     _state.update_config(**{config_key: bucket})
@@ -292,11 +293,13 @@ async def setup(
             # Ensure role is registered on existing space
             space_details = _client.get_agent_space(agent_space_id)
             space_name = space_details.get('name', name or 'security-scans')
-            existing_roles = space_details.get('awsResources', {}).get('iamRoles', [])
+            aws_resources = dict(space_details.get('awsResources', {}))
+            existing_roles = list(aws_resources.get('iamRoles', []))
 
             if service_role not in existing_roles:
                 existing_roles.append(service_role)
-                _client.update_agent_space(agent_space_id, space_name, existing_roles, None)
+                aws_resources['iamRoles'] = existing_roles
+                _client.update_agent_space(agent_space_id, space_name, aws_resources)
 
         _state.update_config(agent_space_id=agent_space_id)
 
@@ -626,12 +629,13 @@ async def get_api_guide(ctx: Context) -> str:
             _cached_operations = sorted(client.meta.service_model.operation_names)
         except Exception as load_err:
             logger.warning(f'Could not load SecurityAgent service model: {load_err}')
-            _cached_operations = ['(Could not load service model — use documentation link)']
+
+    operations = _cached_operations or ['(Could not load service model — use documentation link)']
 
     return json.dumps(
         {
             'documentation': 'https://docs.aws.amazon.com/securityagent/latest/APIReference/API_Operations.html',
-            'operations': _cached_operations,
+            'operations': operations,
             'usage': 'Call call_api(operation="OperationName", params={...}). See documentation link for parameter details.',
             'examples': {
                 'ListAgentSpaces': {},

--- a/src/security-agent-mcp-server/tests/test_aws_client.py
+++ b/src/security-agent-mcp-server/tests/test_aws_client.py
@@ -184,13 +184,15 @@ class TestSecurityAgentClient:
 
     @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
     def test_update_agent_space_with_resources(self, mock_boto3):
-        """update_agent_space forwards iam_roles and s3_buckets to awsResources."""
+        """update_agent_space forwards the full awsResources dict unchanged."""
         mock_client = MagicMock()
         mock_client.update_agent_space.return_value = {'agentSpaceId': 'as-1'}
         mock_boto3.Session.return_value.client.return_value = mock_client
 
         client = SecurityAgentClient()
-        client.update_agent_space('as-1', 'name', iam_roles=['arn:role-a'], s3_buckets=['bkt'])
+        client.update_agent_space(
+            'as-1', 'name', {'iamRoles': ['arn:role-a'], 's3Buckets': ['bkt']}
+        )
         kwargs = mock_client.update_agent_space.call_args.kwargs
         assert kwargs['agentSpaceId'] == 'as-1'
         assert kwargs['awsResources']['iamRoles'] == ['arn:role-a']
@@ -198,7 +200,7 @@ class TestSecurityAgentClient:
 
     @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
     def test_update_agent_space_no_resources(self, mock_boto3):
-        """When no roles/buckets provided, awsResources is omitted."""
+        """When no resources provided, awsResources is omitted."""
         mock_client = MagicMock()
         mock_boto3.Session.return_value.client.return_value = mock_client
 

--- a/src/security-agent-mcp-server/tests/test_server.py
+++ b/src/security-agent-mcp-server/tests/test_server.py
@@ -160,6 +160,35 @@ class TestSetup:
         assert 'ready' in result
         assert 'arn:my-role' in result
 
+    @pytest.mark.asyncio
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    async def test_preserves_existing_resources_when_adding_role(self, mock_client, mock_state):
+        """All existing awsResources are preserved when registering a new role on the space."""
+        mock_client.get_caller_identity.return_value = {'Account': '123456789012'}
+        mock_client.get_agent_space.return_value = {
+            'name': 'existing',
+            'awsResources': {
+                'iamRoles': ['arn:other-role'],
+                's3Buckets': ['pentest-bucket', 'code-review-bucket'],
+            },
+        }
+        mock_client.update_agent_space.return_value = {}
+        mock_state.get_config.return_value = {}
+        mock_state.update_config = MagicMock()
+        ctx = MagicMock()
+        ctx.error = AsyncMock()
+
+        from awslabs.security_agent_mcp_server.server import setup
+
+        await setup(ctx, name=None, agent_space_id='as-exist', service_role_arn='arn:my-role')
+
+        # Verify the update call preserved buckets AND merged the new role
+        aws_resources_arg = mock_client.update_agent_space.call_args[0][2]
+        assert aws_resources_arg['s3Buckets'] == ['pentest-bucket', 'code-review-bucket']
+        assert 'arn:other-role' in aws_resources_arg['iamRoles']
+        assert 'arn:my-role' in aws_resources_arg['iamRoles']
+
 
 class TestCallApi:
     """Tests for call_api tool."""
@@ -410,6 +439,10 @@ class TestStartSecurityScanBucketRegistration:
 
         await start_security_scan(ctx, path='.', title='t')
         mock_client.update_agent_space.assert_called_once()
+        # Existing iamRoles preserved when the new bucket is registered
+        aws_resources_arg = mock_client.update_agent_space.call_args[0][2]
+        assert aws_resources_arg['iamRoles'] == ['arn:role']
+        assert any('security-agent-scans-' in b for b in aws_resources_arg['s3Buckets'])
 
     @pytest.mark.asyncio
     @patch('awslabs.security_agent_mcp_server.server._scanner')


### PR DESCRIPTION
## Summary

### Changes

Fixes three small bugs in the AWS Security Agent MCP server:
  
  1. **Agent space resource preservation** — `update_agent_space` replaced the agent space's `awsResources` wholesale, but `setup` (adding a service role) and `_ensure_s3_bucket` (registering a scan bucket) each  sent only a partial set. This silently dropped the other resources — e.g. running `setup` on an existing space wiped its configured S3 buckets, breaking pentest and full-repo code-review setups. The client method now takes the complete `awsResources` dict, and both call sites read the existing resources, merge in their addition, and send the full set. Any field present on the space is preserved, not just roles/buckets.

  2. **`get_api_guide` cache poisoning** — a transient failure to load the boto3 service model cached an error placeholder permanently, so every later call returned "Could not load service model" until the server restarted. The cache is now only populated on success and retries on the next call.

  3. **Null severity crash** — `get_scan_findings` with a severity filter crashed with `AttributeError` when the API returned a finding/threat with `riskLevel`/`severity` set to `null`. Both filters now coerce null to an empty string.


### User experience

 **Before:**
  - Running `setup` against an existing agent space removed its S3 buckets, breaking already-configured pentest/code-review workflows.
  - A one-time network/credential blip during `get_api_guide` permanently broke API discovery for the session.
  - Filtering findings by severity could crash if any finding had a null severity.

  **After:**
  - `setup` and bucket registration preserve all existing agent space resources.
  - `get_api_guide` recovers automatically after a transient failure.
  - Severity filtering tolerates null severities and returns the matching findings.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: NA

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
