### PR TITLE
test(cloudwatch-applicationsignals): add tool registry + golden dataset eval tests

### DIFF
--- a/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
@@ -122,6 +122,10 @@ python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
 asyncio_mode = "auto"
+markers = [
+    "eval: Tool registry + golden dataset eval tests (no AWS/LLM)",
+    "llm_eval: Real LLM eval tests (requires AWS Bedrock + anthropic, local only)",
+]
 
 [tool.coverage.run]
 source = ["awslabs"]

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/eval_cases.json
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/eval_cases.json
@@ -1,0 +1,179 @@
+[
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "total_functions",
+        "returned",
+        "filter",
+        "sort_by",
+        "time_range_hours",
+        "functions",
+        "data_source"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "data_source": "cloudwatch_metrics_v2",
+        "filter": null,
+        "sort_by": "calls",
+        "time_range_hours": 24
+      }
+    },
+    "description": "list_functions returns expected structure with default params",
+    "id": "list_functions_default",
+    "params": {},
+    "tool": "list_functions"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "total_functions",
+        "functions",
+        "filter"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "filter": "errors",
+        "time_range_hours": 12
+      }
+    },
+    "description": "list_functions with filter=errors returns only error functions",
+    "id": "list_functions_with_error_filter",
+    "params": {
+      "filter": "errors",
+      "hours": 12
+    },
+    "tool": "list_functions"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "function_name",
+        "error"
+      ],
+      "output_type": "dict"
+    },
+    "description": "get_function_details returns error when function not found in the metrics source",
+    "id": "get_function_details_not_found",
+    "params": {
+      "function_name": "b827df4e-a6f4-58e5-898e-353965809da6"
+    },
+    "tool": "get_function_details"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "query",
+        "total_matches",
+        "returned",
+        "functions"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "query": "process"
+      }
+    },
+    "description": "search_functions returns matching functions and metadata",
+    "id": "search_functions_by_name",
+    "params": {
+      "query": "process"
+    },
+    "tool": "search_functions"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "total_endpoints",
+        "returned",
+        "filter_operation",
+        "percentile",
+        "time_range_hours",
+        "endpoints"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "data_source": "service_events",
+        "time_range_hours": 24
+      }
+    },
+    "description": "get_endpoints returns endpoint summaries with expected keys",
+    "id": "get_endpoints_default",
+    "params": {},
+    "tool": "get_endpoints"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "total_unique_incidents",
+        "time_range_hours",
+        "incidents",
+        "data_source"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "data_source": "service_events",
+        "time_range_hours": 24
+      }
+    },
+    "description": "get_incidents returns incident summaries",
+    "id": "get_incidents_default",
+    "params": {},
+    "tool": "get_incidents"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "snapshot_id",
+        "error"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "error": "No data found"
+      }
+    },
+    "description": "get_incident_details returns error when snapshot not found",
+    "id": "get_incident_details_not_found",
+    "params": {
+      "snapshot_id": "snap_c361cdc6-9f6b-4a80-ac7a-edeaee1ed29c"
+    },
+    "tool": "get_incident_details"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "data_source"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "data_source": "service_events"
+      }
+    },
+    "description": "get_health_overview returns health summary",
+    "id": "get_health_overview_default",
+    "params": {},
+    "tool": "get_health_overview"
+  },
+  {
+    "assertions": {
+      "output_contains_keys": [
+        "query_git_commit_sha",
+        "time_range_hours",
+        "found",
+        "total_deployments",
+        "deployments"
+      ],
+      "output_type": "dict",
+      "output_value": {
+        "found": false,
+        "query_git_commit_sha": "nonexistent-commit",
+        "time_range_hours": 168,
+        "total_deployments": 0
+      }
+    },
+    "description": "find_deployment with no matching commit returns empty results gracefully",
+    "id": "find_deployment_no_results",
+    "params": {
+      "git_commit_sha": "nonexistent-commit"
+    },
+    "tool": "find_deployment"
+  }
+]

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_eval.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_dynamic_instrumentation_eval.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-style eval tests for the dynamic instrumentation MCP tools."""
+
+import pytest
+from awslabs.cloudwatch_applicationsignals_mcp_server.dynamic_instrumentation.registration import (
+    register_tools,
+)
+from mcp.server.fastmcp import FastMCP
+
+
+DYNAMIC_INSTRUMENTATION_TOOLS = [
+    'create_instrumentation',
+    'list_instrumentations',
+    'get_instrumentation',
+    'delete_instrumentation',
+    'batch_delete_instrumentations_by_scope',
+    'batch_delete_instrumentations_by_arns',
+    'get_instrumentation_configuration_status',
+    'check_instrumentation_status',
+    'search_snapshots_for_status_event',
+    'get_sample_snapshot_for_breakpoint',
+]
+
+_REQUIRED_PARAMS = [
+    ('create_instrumentation', 'instrumentation_type'),
+    ('create_instrumentation', 'service'),
+    ('create_instrumentation', 'environment'),
+    ('batch_delete_instrumentations_by_arns', 'resource_arns'),
+    ('check_instrumentation_status', 'location_hash'),
+    ('check_instrumentation_status', 'start_time'),
+    ('check_instrumentation_status', 'end_time'),
+    ('search_snapshots_for_status_event', 'status_timestamp'),
+    ('get_sample_snapshot_for_breakpoint', 'status_timestamp'),
+]
+
+_PARAM_DEFAULTS = [
+    ('search_snapshots_for_status_event', 'limit', 10),
+    ('search_snapshots_for_status_event', 'max_timeout', 30),
+    ('get_sample_snapshot_for_breakpoint', 'max_timeout', 30),
+]
+
+_DYNAMIC_MCP = None
+
+
+def _get_dynamic_mcp():
+    """Build a local MCP registry for the dynamic instrumentation feature package."""
+    global _DYNAMIC_MCP
+    if _DYNAMIC_MCP is None:
+        mcp = FastMCP('DynamicInstrumentationTest')
+        register_tools(mcp)
+        _DYNAMIC_MCP = mcp
+    return _DYNAMIC_MCP
+
+
+def _get_tools_by_name() -> dict:
+    """Return {name: Tool} for every registered dynamic instrumentation tool."""
+    return {tool.name: tool for tool in _get_dynamic_mcp()._tool_manager.list_tools()}
+
+
+def _get_tool_params(tool) -> dict:
+    """Return the 'properties' dict from a tool's JSON Schema parameters."""
+    return tool.parameters.get('properties', {})
+
+
+def _get_tool_required(tool) -> list:
+    """Return the list of required parameter names for a tool."""
+    return tool.parameters.get('required', [])
+
+
+@pytest.mark.eval
+class TestDynamicInstrumentationToolRegistry:
+    """Validate dynamic instrumentation MCP registration and schema metadata."""
+
+    def test_all_dynamic_instrumentation_tools_registered(self):
+        """Every dynamic instrumentation tool name resolves to a registered tool."""
+        registered = _get_tools_by_name()
+        for name in DYNAMIC_INSTRUMENTATION_TOOLS:
+            assert name in registered, (
+                f"Dynamic instrumentation tool '{name}' not registered. "
+                f'Registered: {sorted(registered.keys())}'
+            )
+
+    @pytest.mark.parametrize('tool_name', DYNAMIC_INSTRUMENTATION_TOOLS)
+    def test_tool_has_description(self, tool_name):
+        """Each tool carries a non-trivial description for the LLM to read."""
+        tool = _get_tools_by_name()[tool_name]
+        assert len(tool.description) > 20, (
+            f"Tool '{tool_name}' description too short ({len(tool.description)} chars)"
+        )
+
+    @pytest.mark.parametrize('tool_name', DYNAMIC_INSTRUMENTATION_TOOLS)
+    def test_tool_has_valid_schema(self, tool_name):
+        """Each tool exposes a JSON Schema object for its parameters."""
+        tool = _get_tools_by_name()[tool_name]
+        schema = tool.parameters
+        assert isinstance(schema, dict)
+        assert schema.get('type') == 'object'
+
+    def test_no_duplicate_tool_names(self):
+        """No two registered tools share a name."""
+        names = [tool.name for tool in _get_dynamic_mcp()._tool_manager.list_tools()]
+        assert len(names) == len(set(names)), (
+            f'Duplicates: {[name for name in names if names.count(name) > 1]}'
+        )
+
+    @pytest.mark.parametrize('tool_name,param_name', _REQUIRED_PARAMS)
+    def test_required_param(self, tool_name, param_name):
+        """Parameters that must be supplied are marked required in the schema."""
+        tool = _get_tools_by_name()[tool_name]
+        assert param_name in _get_tool_required(tool), (
+            f"'{param_name}' must be required for {tool_name}"
+        )
+
+    @pytest.mark.parametrize('tool_name,param_name,default_value', _PARAM_DEFAULTS)
+    def test_param_default(self, tool_name, param_name, default_value):
+        """Optional parameters expose the expected default value."""
+        tool = _get_tools_by_name()[tool_name]
+        params = _get_tool_params(tool)
+        assert param_name in params, f"'{param_name}' not in {tool_name} params"
+        assert params[param_name].get('default') == default_value, (
+            f'{tool_name}.{param_name} default should be {default_value!r}, '
+            f'got {params[param_name].get("default")!r}'
+        )

--- a/src/cloudwatch-applicationsignals-mcp-server/tests/test_tool_eval.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/tests/test_tool_eval.py
@@ -1,0 +1,272 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool evaluation tests for the ServiceEvents MCP tools.
+
+Two Bedrock-free sections (both ``@pytest.mark.eval``):
+
+1. **Tool registry**:
+   Validates that all core ServiceEvents tools are registered with proper
+   schemas, descriptions, required parameters, and defaults.
+
+2. **Predetermined eval**:
+   Loads golden cases from ``eval_cases.json``, calls each tool as a plain
+   Python function with mocked AWS dependencies, and validates the output
+   against declarative assertions (key presence, value equality, type).
+
+Neither section needs AWS credentials or an LLM. The LLM-based eval (tool
+selection + output quality via Bedrock) lives in ``test_tool_eval_llm.py``,
+which is intentionally kept out of the committed test suite.
+"""
+
+import inspect
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Tool registry: schema & registration checks
+# ---------------------------------------------------------------------------
+
+CORE_TOOLS = [
+    'list_monitored_functions',
+    'get_function_metrics',
+    'search_functions_by_name',
+    'get_endpoint_performance',
+    'get_recent_incidents',
+    'get_incident_root_cause',
+    'get_service_health_overview',
+    'find_deployment',
+]
+
+
+def _get_mcp():
+    """Lazy-import the FastMCP instance to avoid collection-time ImportError."""
+    from awslabs.cloudwatch_applicationsignals_mcp_server.server import mcp
+
+    return mcp
+
+
+def _get_tools_by_name() -> dict:
+    """Return {name: Tool} for every registered tool."""
+    return {t.name: t for t in _get_mcp()._tool_manager.list_tools()}
+
+
+def _get_tool_params(tool) -> dict:
+    """Return the 'properties' dict from a tool's JSON Schema parameters."""
+    return tool.parameters.get('properties', {})
+
+
+def _get_tool_required(tool) -> list:
+    """Return the list of required parameter names for a tool."""
+    return tool.parameters.get('required', [])
+
+
+REQUIRED_PARAMS = [
+    ('get_function_metrics', 'function_name'),
+    ('search_functions_by_name', 'query'),
+    ('get_incident_root_cause', 'snapshot_id'),
+]
+
+PARAM_DEFAULTS = [
+    ('get_service_health_overview', 'detail', 'overview'),
+    ('get_incident_root_cause', 'hours', 72),
+    ('find_deployment', 'hours', 168),
+]
+
+
+@pytest.mark.eval
+class TestToolRegistry:
+    """Validate that all core tools are registered with adequate metadata."""
+
+    def test_all_core_tools_registered(self):
+        """Every core tool name resolves to a registered MCP tool."""
+        registered = _get_tools_by_name()
+        for name in CORE_TOOLS:
+            assert name in registered, (
+                f"Core tool '{name}' not registered. Registered: {sorted(registered.keys())}"
+            )
+
+    @pytest.mark.parametrize('tool_name', CORE_TOOLS)
+    def test_tool_has_description(self, tool_name):
+        """Each tool carries a non-trivial description for the LLM to read."""
+        tool = _get_tools_by_name()[tool_name]
+        assert len(tool.description) > 20, (
+            f"Tool '{tool_name}' description too short ({len(tool.description)} chars)"
+        )
+
+    @pytest.mark.parametrize('tool_name', CORE_TOOLS)
+    def test_tool_has_valid_schema(self, tool_name):
+        """Each tool exposes a JSON Schema object for its parameters."""
+        tool = _get_tools_by_name()[tool_name]
+        schema = tool.parameters
+        assert isinstance(schema, dict)
+        assert schema.get('type') == 'object'
+
+    def test_no_duplicate_tool_names(self):
+        """No two registered tools share a name."""
+        names = [t.name for t in _get_mcp()._tool_manager.list_tools()]
+        assert len(names) == len(set(names)), (
+            f'Duplicates: {[n for n in names if names.count(n) > 1]}'
+        )
+
+    @pytest.mark.parametrize('tool_name,param_name', REQUIRED_PARAMS)
+    def test_required_param(self, tool_name, param_name):
+        """Parameters that must be supplied are marked required in the schema."""
+        tool = _get_tools_by_name()[tool_name]
+        assert param_name in _get_tool_required(tool), (
+            f"'{param_name}' must be required for {tool_name}"
+        )
+
+    @pytest.mark.parametrize('tool_name,param_name,default_value', PARAM_DEFAULTS)
+    def test_param_default(self, tool_name, param_name, default_value):
+        """Optional parameters expose the expected default value."""
+        tool = _get_tools_by_name()[tool_name]
+        params = _get_tool_params(tool)
+        assert param_name in params, f"'{param_name}' not in {tool_name} params"
+        assert params[param_name].get('default') == default_value, (
+            f'{tool_name}.{param_name} default should be {default_value!r}, '
+            f'got {params[param_name].get("default")!r}'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Predetermined eval: golden dataset
+# ---------------------------------------------------------------------------
+
+EVAL_CASES_PATH = Path(__file__).parent / 'eval_cases.json'
+EVAL_CASES = json.loads(EVAL_CASES_PATH.read_text())
+
+# Map tool name -> callable (imported from the service_events tools module)
+_TOOL_FUNCS = {}
+
+
+def _get_tool_funcs():
+    """Lazy-load tool functions from the service_events tools module."""
+    if not _TOOL_FUNCS:
+        from awslabs.cloudwatch_applicationsignals_mcp_server.service_events import tools as t
+
+        _TOOL_FUNCS['list_functions'] = t.list_functions
+        _TOOL_FUNCS['get_function_details'] = t.get_function_details
+        _TOOL_FUNCS['search_functions'] = t.search_functions
+        _TOOL_FUNCS['get_endpoints'] = t.get_endpoints
+        _TOOL_FUNCS['get_incidents'] = t.get_incidents
+        _TOOL_FUNCS['get_incident_details'] = t.get_incident_details
+        _TOOL_FUNCS['get_health_overview'] = t.get_health_overview
+        _TOOL_FUNCS['find_deployment'] = t.find_deployment
+    return _TOOL_FUNCS
+
+
+# ---------------------------------------------------------------------------
+# Mock factories
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_function_metrics_patches():
+    """Patch dict for function_metrics (CloudWatch Metrics V2 / PromQL) with empty data."""
+    return {
+        'fetch_function_records': MagicMock(return_value=[]),
+        'search_function_names': MagicMock(return_value=[]),
+    }
+
+
+def _make_mock_cw_logs_patches():
+    """Patch dict for cw_logs (CloudWatch Logs) query helpers with empty data."""
+    return {
+        'query_endpoint_summaries': MagicMock(return_value=[]),
+        'query_incidents': MagicMock(return_value=[]),
+        'query_incident_by_id': MagicMock(return_value=None),
+        'query_deployments': MagicMock(return_value=[]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_assertions(output, assertions):
+    """Validate ``output`` against a dict of declarative assertions."""
+    if 'output_type' in assertions:
+        expected_type = {'dict': dict, 'list': list, 'str': str, 'int': int}[
+            assertions['output_type']
+        ]
+        assert isinstance(output, expected_type), (
+            f'Expected type {assertions["output_type"]}, got {type(output).__name__}'
+        )
+
+    if 'output_contains_keys' in assertions:
+        for key in assertions['output_contains_keys']:
+            assert key in output, (
+                f"Expected key '{key}' in output. Keys present: {list(output.keys())}"
+            )
+
+    if 'output_not_contains_keys' in assertions:
+        for key in assertions['output_not_contains_keys']:
+            assert key not in output, f"Key '{key}' should NOT be in output but was found"
+
+    if 'output_value' in assertions:
+        for key, expected in assertions['output_value'].items():
+            assert key in output, f"Expected key '{key}' for value check, not found in output"
+            assert output[key] == expected, (
+                f"output['{key}'] = {output[key]!r}, expected {expected!r}"
+            )
+
+    if 'each_item_in_list' in assertions:
+        spec = assertions['each_item_in_list']
+        list_key = spec['list_key']
+        must_have = spec['must_have_keys']
+        items = output.get(list_key, [])
+        for i, item in enumerate(items):
+            for k in must_have:
+                assert k in item, f"Item {i} in '{list_key}' missing key '{k}'"
+
+
+# ---------------------------------------------------------------------------
+# Predetermined eval tests
+# ---------------------------------------------------------------------------
+
+
+def _case_ids():
+    return [c['id'] for c in EVAL_CASES]
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize('case', EVAL_CASES, ids=_case_ids())
+async def test_tool_eval(case):
+    """Run a single predetermined eval case against the actual tool function."""
+    tool_name = case['tool']
+    params = case.get('params', {})
+    assertions = case['assertions']
+
+    funcs = _get_tool_funcs()
+    assert tool_name in funcs, f'Unknown tool: {tool_name}'
+
+    func = funcs[tool_name]
+
+    fm_module = 'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.function_metrics'
+    cw_module = 'awslabs.cloudwatch_applicationsignals_mcp_server.service_events.cw_logs'
+
+    with (
+        patch.multiple(fm_module, **_make_mock_function_metrics_patches()),
+        patch.multiple(cw_module, **_make_mock_cw_logs_patches()),
+    ):
+        if inspect.iscoroutinefunction(func):
+            output = await func(**params)
+        else:
+            output = func(**params)
+
+    _check_assertions(output, assertions)


### PR DESCRIPTION
## Description

Adds Bedrock-free **eval tests** for the CloudWatch Application Signals MCP server's ServiceEvents and dynamic instrumentation tools. These provide a top-level quality gate on top of the existing unit/integration coverage, validating that tools stay correctly registered and return the expected output shapes.

### What's added

- **`tests/test_tool_eval.py`**
  - **Tool registry checks**: the 8 core ServiceEvents tools (`list_monitored_functions`, `get_function_metrics`, `search_functions_by_name`, `get_endpoint_performance`, `get_recent_incidents`, `get_incident_root_cause`, `get_service_health_overview`, `find_deployment`) are registered with non-trivial descriptions, valid JSON Schemas, the right required params, and the right defaults.
  - **Predetermined golden dataset** (`eval_cases.json`): calls each tool as a plain function with `function_metrics`/`cw_logs` mocked and checks output type/keys/values via declarative assertions.
- **`tests/test_dynamic_instrumentation_eval.py`**: registry/schema checks for the 10 dynamic instrumentation tools.
- **`pyproject.toml`**: registers the `eval` and `llm_eval` pytest markers (avoids `PytestUnknownMarkWarning`).

### Notes

- Both files are marked `@pytest.mark.eval` and require **no AWS credentials and no LLM** — they run as part of the standard `pytest` suite (no marker filter needed) and complete in ~1s.
- The `llm_eval` marker is registered for a separate, optional local LLM-eval suite (Bedrock-backed) that is intentionally **not** included here, since upstream CI has no Bedrock access.

## Testing

- Full package suite on a clean checkout of this branch: **1444 passed** (1377 existing + 67 new), zero failures.
- `ruff check`, `ruff format --check`, `pyright` (0 errors), `bandit` (0 issues), and all pre-commit hooks pass.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
