### PR TITLE
docs: fix typo in vibe coding tips

### DIFF
--- a/VIBE_CODING_TIPS_TRICKS.md
+++ b/VIBE_CODING_TIPS_TRICKS.md
@@ -144,7 +144,7 @@ Examples of rules:
 
 ## Tooling
 
-To foster an environment where AI coding agents excel, follow software developement best practices (clear requirements, modular code, good documentation,...) and use tools (static code analysis, code coverage, CI/CD pipeline, tests, formatter,...).
+To foster an environment where AI coding agents excel, follow software development best practices (clear requirements, modular code, good documentation,...) and use tools (static code analysis, code coverage, CI/CD pipeline, tests, formatter,...).
 
 When you assign tasks to a coding agent, it can autonomously iterate by running test cases and static analysis tools, correcting itself as needed. This minimizes manual intervention and streamlines the development process.
 


### PR DESCRIPTION
Fixes a small spelling typo in VIBE_CODING_TIPS_TRICKS.md: `developement` → `development`.

This is a documentation-only change.