### PR TITLE
feat(aws-documentation-mcp-server): surface per-result recommended sections in search_documentation

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/models.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/models.py
@@ -79,6 +79,7 @@ class SearchResult(BaseModel):
     url: str
     title: str
     context: Optional[str] = None
+    recommended_sections: Optional[List[str]] = None
     sections: Optional[List[str]] = None
     metadata: Optional[SearchResultMetadata] = None
 

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -311,7 +311,8 @@ async def search_documentation(
         - url: The documentation page URL
         - title: The page title
         - context: A brief excerpt or summary (if available)
-        - sections: Table of contents (when available) - these section titles can be used with the read_sections tool for targeted content extraction
+        - recommended_sections: A subset of section titles ranked as most relevant to the query, in rank order (when available) - Pass these directly to read_sections for targeted content extraction
+        - sections: All available section titles for this page (when available) - individual titles can be used with the read_sections tool for targeted content extraction
         - metadata: Optional per-result context (when available). May include:
             - additional_urls: Other doc URLs related to the same result `{url, section_title, section_anchor}` - pass `section_title` to read_sections to fetch content; use `url#section_anchor` when citing
     - facets: Available filters (product_types, guide_types) for refining searches
@@ -484,6 +485,19 @@ async def search_documentation(
                         f'Found {len(sections)} sections for {title}: {url}, sections: {sections}'
                     )
 
+                # Surface relevant sections distinctly from full table of contents.
+                recommended_data = metadata.pop('recommended_sections', None)
+                recommended_sections = (
+                    [s for s in recommended_data if isinstance(s, str) and s != '']
+                    if isinstance(recommended_data, list)
+                    else []
+                )
+
+                if recommended_sections:
+                    logger.info(
+                        f'Found {len(recommended_sections)} recommended sections for {title}: {url}'
+                    )
+
                 filtered_result_metadata = {
                     k: metadata[k] for k in SUPPORTED_RESULT_METADATA_KEYS if metadata.get(k)
                 }
@@ -496,6 +510,7 @@ async def search_documentation(
                     title=text_suggestion.get('title', ''),
                     context=context,
                     sections=sections if sections else None,
+                    recommended_sections=recommended_sections if recommended_sections else None,
                     metadata=search_result_metadata,
                 )
 

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -820,6 +820,108 @@ class TestSearchDocumentation:
             mock_post.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_search_documentation_with_recommended_sections(self):
+        """recommended_sections is lifted to a top-level field, parallel to sections."""
+        search_phrase = 'S3 object lock'
+        ctx = MockContext()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'queryId': 'test-query-recommended',
+            'suggestions': [
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/s3/latest/userguide/object-lock-managing.html',
+                        'title': 'S3 Object Lock',
+                        'metadata': {
+                            'seo_abstract': 'Managing S3 Object Lock',
+                            'sections': ['Permissions', 'Bypassing governance mode'],
+                            'recommended_sections': [
+                                'Managing S3 Lifecycle policies with Object Lock',
+                                'Uploading objects to an Object Lock enabled bucket',
+                            ],
+                        },
+                    }
+                },
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/s3/latest/userguide/basic.html',
+                        'title': 'Basic',
+                        'summary': 'No recommended sections here',
+                        'metadata': {},
+                    }
+                },
+            ],
+        }
+
+        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            results = await search_documentation(
+                ctx, search_phrase=search_phrase, limit=10, product_types=None, guide_types=None
+            )
+
+            first_result = results.search_results[0]
+            # Both fields surface independently at the top level
+            assert first_result.sections == ['Permissions', 'Bypassing governance mode']
+            assert first_result.recommended_sections == [
+                'Managing S3 Lifecycle policies with Object Lock',
+                'Uploading objects to an Object Lock enabled bucket',
+            ]
+
+            # No error on absent recommended_sections
+            second_result = results.search_results[1]
+            assert second_result.recommended_sections is None
+
+            mock_post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_documentation_recommended_sections_filters_and_ignores_non_list(self):
+        """Empty/non-string entries are dropped; a non-list value yields None."""
+        ctx = MockContext()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'queryId': 'test-query-rec-edge',
+            'suggestions': [
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/s3/latest/userguide/a.html',
+                        'title': 'A',
+                        'metadata': {
+                            # falsy and non-string entries are filtered out
+                            'recommended_sections': ['Keep me', '', None, 42, 'Also keep'],
+                        },
+                    }
+                },
+                {
+                    'textExcerptSuggestion': {
+                        'link': 'https://docs.aws.amazon.com/s3/latest/userguide/b.html',
+                        'title': 'B',
+                        'metadata': {
+                            # non-list value is ignored entirely
+                            'recommended_sections': 'not-a-list',
+                        },
+                    }
+                },
+            ],
+        }
+
+        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            results = await search_documentation(
+                ctx, search_phrase='test', limit=10, product_types=None, guide_types=None
+            )
+
+            assert results.search_results[0].recommended_sections == ['Keep me', 'Also keep']
+            assert results.search_results[1].recommended_sections is None
+
+            mock_post.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_search_documentation_surfaces_known_response_metadata_fields(self):
         """Known response-level metadata fields are surfaced; unknown fields are dropped."""
         ctx = MockContext()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

This change surfaces a query-relevant subset of a page's section titles on each search result, so agents know which sections to read first instead of scanning the whole table of contents.

### Changes

* **Per-result `recommended_sections`:** each `SearchResult` may now carry an optional `recommended_sections` list - the section titles the backend ranked as most relevant to the query, a subset of the full `sections` table of contents. It is lifted out of per-result `metadata` to a top-level field, exactly like `sections`.
* **Field ordering:** `recommended_sections` is emitted before `sections` so the agent sees the curated subset first.
* **Docstring:** `search_documentation` now documents `recommended_sections` and advises preferring it when deciding which sections to pass to `read_sections`.
* **Tests:** added a unit test for the `recommended_sections` projection and for the no-recommended-sections case (field remains `null`).

### User experience

**Before:**

* User asks: *"How do I configure S3 Object Lock lifecycle policies?"*
* Agent searches for `"S3 Object Lock"`
* A result returns `sections` with the page's full table of contents (10+ headings) and no signal about which ones matter, so the agent either reads the whole page or guesses a section.

**After:**

* User asks: *"How do I configure S3 Object Lock lifecycle policies?"*
* Agent searches for `"S3 Object Lock"`
* The result carries `recommended_sections` (e.g. *"Managing S3 Lifecycle policies with Object Lock"*) alongside the full `sections` TOC, so the agent passes the most relevant heading straight to `read_sections` for targeted extraction.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
