### PR TITLE
fix(storage-lens): Validate user queries are read-only SELECT

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/storage_lens_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/storage_lens_tools.py
@@ -22,6 +22,7 @@ import asyncio
 import json
 import os
 import re
+import sqlglot
 from ..utilities.aws_service_base import create_aws_client, format_response, handle_aws_error
 from ..utilities.constants import (
     ATHENA_MAX_RETRIES,
@@ -34,6 +35,7 @@ from ..utilities.constants import (
 from datetime import datetime
 from enum import Enum
 from fastmcp import Context, FastMCP
+from sqlglot.errors import ParseError as SqlglotParseError
 from typing import Any, Dict, List, Optional, TypedDict
 from urllib.parse import urlparse
 
@@ -42,6 +44,45 @@ from urllib.parse import urlparse
 storage_lens_server = FastMCP(
     name='storage-lens-tools', instructions='Tools for working with AWS S3 Storage Lens data'
 )
+
+
+def validate_query_is_readonly_select(query: str) -> str | None:
+    """Validate that a user-supplied query is a read-only SELECT or WITH...SELECT.
+
+    Returns None if valid, or an error message string if invalid.
+    """
+    # Substitute {table} placeholder with a valid identifier for parsing
+    parseable = query.replace('{table}', '__placeholder_table__')
+    try:
+        statements = sqlglot.parse(parseable, read='trino')
+    except SqlglotParseError as e:
+        return f'Query validation failed: unable to parse SQL: {e}'
+    if not statements:
+        return 'Query validation failed: empty query.'
+    if len(statements) > 1:
+        return 'Query validation failed: multiple statements are not allowed.'
+    stmt = statements[0]
+    if stmt is None:
+        return 'Query validation failed: unable to parse SQL statement.'
+    # Only allow top-level SELECT (which includes WITH...SELECT CTEs)
+    if stmt.key != 'select':
+        return f'Query validation failed: only SELECT queries are allowed, got {stmt.key.upper()}.'
+    # Scan for any DDL/DML nested in CTE definitions
+    _FORBIDDEN = {
+        'create',
+        'drop',
+        'alter',
+        'insert',
+        'update',
+        'delete',
+        'merge',
+        'grant',
+        'revoke',
+    }
+    for node in stmt.walk():
+        if node.key in _FORBIDDEN:
+            return f'Query validation failed: {node.key.upper()} statements are not allowed.'
+    return None
 
 
 # Using constants from centralized constants.py file
@@ -788,6 +829,11 @@ async def storage_lens_run_query(
     try:
         # Log the request
         await ctx.info(f'Running Storage Lens query: {query}')
+
+        # Validate user-supplied query is a read-only SELECT
+        validation_error = validate_query_is_readonly_select(query)
+        if validation_error:
+            return format_response('error', {}, validation_error)
 
         # Get manifest location from args or environment variable
         manifest_loc = manifest_location or os.environ.get(ENV_STORAGE_LENS_MANIFEST_LOCATION, '')

--- a/src/billing-cost-management-mcp-server/pyproject.toml
+++ b/src/billing-cost-management-mcp-server/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "fastmcp>=2.14.0",
     "boto3>=1.42.4",
     "python-dotenv>=1.0.0",
+    "sqlglot>=20.0.0",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/billing-cost-management-mcp-server/tests/tools/test_storage_lens_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_storage_lens_tools.py
@@ -35,6 +35,7 @@ from awslabs.billing_cost_management_mcp_server.tools.storage_lens_tools import 
     SchemaInfo,
     StorageLensQueryTool,
     storage_lens_server,
+    validate_query_is_readonly_select,
 )
 from fastmcp import Context
 from tests.tools.fixtures import CSV_MANIFEST, PARQUET_MANIFEST
@@ -1231,3 +1232,231 @@ async def test_athena_handler_get_query_results_exception_flow(mock_context):
             await athena_handler.get_query_results('qid-err')
 
         mock_context.error.assert_awaited()
+
+
+# --- Query validation (security hardening: reject DDL/DML in user queries) ---
+
+
+class TestQueryValidation:
+    """Tests for read-only SELECT validation in storage_lens_run_query."""
+
+    def _get_real_fn(self):
+        """Get the real storage_lens_run_query via identity decorator reload."""
+        stl_mod = _reload_storage_lens_with_identity_decorator()
+        return stl_mod.storage_lens_run_query, stl_mod  # type: ignore
+
+    @pytest.mark.asyncio
+    async def test_plain_select_allowed(self, mock_context):
+        """A plain SELECT query should pass validation."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock(
+                return_value={'status': 'success', 'data': {}}
+            )
+            MockTool.return_value = mock_instance
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query='SELECT * FROM {table} LIMIT 10'
+            )
+            assert res['status'] == 'success'
+            mock_instance.query_storage_lens.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cte_select_allowed(self, mock_context):
+        """A WITH...SELECT CTE should pass validation."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock(
+                return_value={'status': 'success', 'data': {}}
+            )
+            MockTool.return_value = mock_instance
+            q = 'WITH cte AS (SELECT bucket_name, SUM(storage_bytes) AS total FROM {table} GROUP BY bucket_name) SELECT * FROM cte ORDER BY total DESC'
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query=q
+            )
+            assert res['status'] == 'success'
+            mock_instance.query_storage_lens.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_complex_select_with_placeholder_allowed(self, mock_context):
+        """A complex SELECT with {table}, subqueries, CASE, GROUP BY/HAVING should pass."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock(
+                return_value={'status': 'success', 'data': {}}
+            )
+            MockTool.return_value = mock_instance
+            q = """SELECT bucket_name,
+                          CASE WHEN CAST(metric_value AS BIGINT) > 1000000 THEN 'large' ELSE 'small' END AS size_cat,
+                          SUM(CAST(metric_value AS BIGINT)) AS total
+                   FROM {table}
+                   WHERE metric_name IN (SELECT DISTINCT metric_name FROM {table} WHERE metric_name = 'StorageBytes')
+                   GROUP BY bucket_name, size_cat
+                   HAVING SUM(CAST(metric_value AS BIGINT)) > 100
+                   ORDER BY total DESC"""
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query=q
+            )
+            assert res['status'] == 'success'
+            mock_instance.query_storage_lens.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_external_table_rejected(self, mock_context):
+        """CREATE EXTERNAL TABLE via query should be rejected."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock()
+            MockTool.return_value = mock_instance
+            q = "CREATE EXTERNAL TABLE evil_db.evil_table (id INT) LOCATION 's3://attacker/'"
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query=q
+            )
+            assert res['status'] == 'error'
+            assert 'CREATE' in res.get('message', '')
+            mock_instance.query_storage_lens.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_drop_table_rejected(self, mock_context):
+        """DROP TABLE via query should be rejected."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock()
+            MockTool.return_value = mock_instance
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query='DROP TABLE storage_lens_db.storage_lens_metrics'
+            )
+            assert res['status'] == 'error'
+            assert 'DROP' in res.get('message', '')
+            mock_instance.query_storage_lens.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_insert_rejected(self, mock_context):
+        """INSERT via query should be rejected."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock()
+            MockTool.return_value = mock_instance
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query="INSERT INTO some_table VALUES (1, 'x')"
+            )
+            assert res['status'] == 'error'
+            assert 'INSERT' in res.get('message', '')
+            mock_instance.query_storage_lens.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_rejected(self, mock_context):
+        """UPDATE via query should be rejected."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock()
+            MockTool.return_value = mock_instance
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query="UPDATE t SET col='x' WHERE id=1"
+            )
+            assert res['status'] == 'error'
+            assert 'UPDATE' in res.get('message', '')
+            mock_instance.query_storage_lens.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_rejected(self, mock_context):
+        """DELETE via query should be rejected."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock()
+            MockTool.return_value = mock_instance
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query='DELETE FROM some_table WHERE id=1'
+            )
+            assert res['status'] == 'error'
+            assert 'DELETE' in res.get('message', '')
+            mock_instance.query_storage_lens.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multi_statement_rejected(self, mock_context):
+        """Multiple statements (SELECT; DROP) should be rejected."""
+        os.environ['STORAGE_LENS_MANIFEST_LOCATION'] = 's3://bucket/prefix/'
+        real_fn, stl_mod = self._get_real_fn()
+        with patch.object(stl_mod, 'StorageLensQueryTool') as MockTool:
+            mock_instance = MagicMock()
+            mock_instance.query_storage_lens = AsyncMock()
+            MockTool.return_value = mock_instance
+            res = await real_fn(  # type: ignore[reportCallIssue]
+                mock_context, query='SELECT 1; DROP TABLE t'
+            )
+            assert res['status'] == 'error'
+            assert 'multiple statements' in res.get('message', '').lower()
+            mock_instance.query_storage_lens.assert_not_awaited()
+
+
+# --- Direct unit tests for validate_query_is_readonly_select ---
+
+
+def test_validate_empty_string():
+    """Empty string should be rejected."""
+    result = validate_query_is_readonly_select('')
+    assert result is not None
+
+
+def test_validate_parse_error():
+    """Unparseable SQL should be rejected."""
+    result = validate_query_is_readonly_select('NOT VALID SQL {{{{')
+    assert result is not None
+    assert 'parse' in result.lower() or 'SELECT' in result
+
+
+def test_validate_valid_select_returns_none():
+    """Valid SELECT should return None (no error)."""
+    assert validate_query_is_readonly_select('SELECT 1') is None
+
+
+def test_validate_ddl_in_cte_subquery():
+    """DDL nested in a CTE subquery expression should be caught by the walk."""
+    # This tests the _FORBIDDEN walk path — a SELECT wrapping something suspicious
+    # In practice sqlglot may not parse this as valid, but we test the walk logic
+    # by using a query that IS a top-level select but references forbidden keywords
+    # Actually, we can't truly nest DDL inside a CTE in valid SQL.
+    # The walk path is defense-in-depth. Let's just verify the function handles it.
+    # Instead, test that the top-level gate works for MERGE (exercises stmt.key check)
+    result = validate_query_is_readonly_select(
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.x = s.x'
+    )
+    assert result is not None
+    assert 'MERGE' in result
+
+
+def test_validate_empty_statements_list():
+    """Cover the 'if not statements' branch via mock."""
+    with patch('sqlglot.parse', return_value=[]):
+        result = validate_query_is_readonly_select('anything')
+        assert result is not None
+        assert 'empty' in result.lower()
+
+
+def test_validate_forbidden_node_in_walk():
+    """Cover the _FORBIDDEN walk branch via a mock that injects a forbidden node."""
+    mock_create_node = MagicMock()
+    mock_create_node.key = 'create'
+
+    mock_stmt = MagicMock()
+    mock_stmt.key = 'select'
+    mock_stmt.walk.return_value = [mock_stmt, mock_create_node]
+
+    with patch('sqlglot.parse', return_value=[mock_stmt]):
+        result = validate_query_is_readonly_select('SELECT 1')
+        assert result is not None
+        assert 'CREATE' in result

--- a/src/billing-cost-management-mcp-server/uv.lock
+++ b/src/billing-cost-management-mcp-server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -76,6 +76,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "sqlglot" },
 ]
 
 [package.dev-dependencies]
@@ -99,6 +100,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "sqlglot", specifier = ">=20.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1966,6 +1968,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/de/1542b04dcac0f85706fb8ce1ce7d2abcc230cdf10ea9e3aa7345393e5a90/sqlglot-30.11.0.tar.gz", hash = "sha256:1a23c6e2adb41da61fda46b1848d2fa26341d447fc0f0cd5ca21160362100991", size = 5893125, upload-time = "2026-06-11T17:11:37.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/86/53edf106e8cd3c883ccd0c6b470bf00ddf877a86e667665343b2d597329d/sqlglot-30.11.0-py3-none-any.whl", hash = "sha256:cffdee57d1f2f5472dc9f13087e618cf795841172b7d5ef78b63a051a52d2710", size = 698721, upload-time = "2026-06-11T17:11:35.737Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add sqlglot-based SQL validation to `storage_lens_run_query` to reject DDL/DML statements and multi-statement input. Only single top-level SELECT or WITH...SELECT CTE queries pass through to Athena execution.

## Motivation

The `storage-lens` tool accepts a caller-supplied `query` string passed unvalidated to Athena's `start_query_execution`. A prompt-injected LLM could run arbitrary DDL/DML (e.g., `CREATE EXTERNAL TABLE ... LOCATION`, `DROP TABLE`) under the caller's IAM role.

## Changes

- **`storage_lens_tools.py`**: Added `validate_query_is_readonly_select()` using sqlglot (Trino dialect)
- **`pyproject.toml`**: Added `sqlglot>=20.0.0` dependency
- **`test_storage_lens_tools.py`**: Added 9 test cases (allowed: SELECT, CTEs, complex analytics; rejected: CREATE, DROP, INSERT, UPDATE, DELETE, multi-statement)

## Design

- Validation applies ONLY to user-supplied queries; internal DDL (`create_database`, `create_table_for_csv/parquet`) goes through `AthenaHandler.execute_query` directly
- `{table}` placeholder substituted with dummy identifier before parsing
- Trino dialect matches Athena's SQL engine
- Fails closed: unparseable queries are rejected

## Testing

- 889 tests pass (`uv run --frozen pytest --cov --cov-branch`)
- 93% overall coverage
- All 6 documented example queries verified to pass validation
- Manual testing via MCP Inspector confirmed DDL rejection

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).