### PR TITLE
fix(billing-cost-management-mcp-server): make getCostCategories honor cost_category_name

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -565,8 +565,11 @@ async def get_cost_categories(
     Returns:
         Cost categories response
     """
-    operation = 'getCostCategories' if not cost_category_name else 'getCostCategoryValues'
-    await ctx.info(f'Calling {operation} API')
+    operation = 'getCostCategories'
+    await ctx.info(
+        f'Calling {operation} API'
+        + (f' for cost category {cost_category_name!r}' if cost_category_name else '')
+    )
 
     try:
         # Get date range with defaults
@@ -580,26 +583,24 @@ async def get_cost_categories(
         if search_string:
             request_params['SearchString'] = str(search_string)
 
+        # When CostCategoryName is provided the API returns CostCategoryValues
+        # (the values inside that category) instead of CostCategoryNames.
         if cost_category_name:
             request_params['CostCategoryName'] = str(cost_category_name)
 
         if billing_view_arn:
             request_params['BillingViewArn'] = billing_view_arn
 
+        # Response field name depends on whether CostCategoryName was supplied.
+        result_key = 'CostCategoryValues' if cost_category_name else 'CostCategoryNames'
+
         # Handle pagination
         if next_token or max_pages:
-            api_function = (
-                ce_client.get_cost_categories
-                if not cost_category_name
-                else ce_client.get_cost_category_values
-            )
-            result_key = 'CostCategories' if not cost_category_name else 'CostCategoryValues'
-
             # For paginated requests, use the paginate utility
             results, pagination_metadata = await paginate_aws_response(
                 ctx,
                 operation,
-                lambda **params: api_function(**params),
+                lambda **params: ce_client.get_cost_categories(**params),
                 request_params,
                 result_key,
                 'NextPageToken',
@@ -611,10 +612,7 @@ async def get_cost_categories(
             response = {result_key: results, 'Pagination': pagination_metadata}
         else:
             # For single page, make direct call
-            if cost_category_name:
-                response = ce_client.get_cost_category_values(**request_params)
-            else:
-                response = ce_client.get_cost_categories(**request_params)
+            response = ce_client.get_cost_categories(**request_params)
 
         return format_response('success', response)
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
@@ -100,11 +100,12 @@ USE THIS TOOL FOR:
    Example 2: {"operation": "getTagsOrValues", "tag_key": "Environment"}
    Returns: List of available cost allocation tags with automatic pagination. If tag values for a particular key are needed, pass the tag key as a parameter.
 
-7. getCostCategories - Available cost categories
+7. getCostCategories - Available cost categories or values inside a category
    Required: operation="getCostCategories", start_date, end_date
-   Optional: search_string, next_token, max_pages, billing_view_arn
-   Example: {"operation": "getCostCategories", "start_date": "2024-01-01", "end_date": "2024-08-01"}
-   Returns: List of available cost categories with automatic pagination
+   Optional: cost_category_name, search_string, next_token, max_pages, billing_view_arn
+   Example 1 (list category names): {"operation": "getCostCategories", "start_date": "2024-01-01", "end_date": "2024-08-01"}
+   Example 2 (list values inside a category): {"operation": "getCostCategories", "cost_category_name": "CostCenters", "start_date": "2024-01-01", "end_date": "2024-08-01"}
+   Notes: Without cost_category_name the response contains CostCategoryNames. With cost_category_name set the response contains CostCategoryValues for that category. Pagination is automatic.
 
 8. getSavingsPlansUtilization - Savings Plans utilization data
    Required: operation="getSavingsPlansUtilization", start_date, end_date
@@ -315,14 +316,17 @@ async def cost_explorer(
                 billing_view_arn,
             )
 
-        elif operation == 'getCostCategories' or operation == 'getCostCategoryValues':
+        elif operation == 'getCostCategories':
+            # When `cost_category_name` is provided, the same AWS API
+            # (GetCostCategories) returns the values inside that category
+            # instead of the list of category names.
             return await get_cost_categories(
                 ctx,
                 ce_client,
                 start_date,
                 end_date,
                 search_string,
-                cost_category_name if operation == 'getCostCategoryValues' else None,
+                cost_category_name,
                 next_token,
                 max_pages,
                 billing_view_arn,

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -101,9 +101,6 @@ def mock_ce_client():
     mock_client.get_tag_values.return_value = {'TagValues': ['dev', 'prod', 'test']}
 
     mock_client.get_cost_categories.return_value = {'CostCategoryNames': ['Department', 'Team']}
-    mock_client.get_cost_category_values.return_value = {
-        'CostCategoryValues': ['Engineering', 'Marketing']
-    }
 
     mock_client.get_savings_plans_utilization.return_value = {
         'SavingsPlansUtilizationsByTime': [
@@ -827,15 +824,19 @@ class TestGetCostCategories:
         assert result['data'] is not None
 
     async def test_get_cost_category_values(self, mock_context, mock_ce_client):
-        """Test get_cost_categories with cost_category_name to get values."""
+        """Test get_cost_categories with cost_category_name to get values.
+
+        AWS GetCostCategories is a single API: passing CostCategoryName makes
+        it return CostCategoryValues from the same get_cost_categories method.
+        """
         result = await get_cost_categories(
             mock_context,
             mock_ce_client,
             cost_category_name='Department',
         )
 
-        mock_ce_client.get_cost_category_values.assert_called_once()
-        call_kwargs = mock_ce_client.get_cost_category_values.call_args[1]
+        mock_ce_client.get_cost_categories.assert_called_once()
+        call_kwargs = mock_ce_client.get_cost_categories.call_args[1]
         assert 'CostCategoryName' in call_kwargs
         assert call_kwargs['CostCategoryName'] == 'Department'
 

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
@@ -550,12 +550,14 @@ async def test_get_tags_and_values(mock_context, mock_ce_client):
 @pytest.mark.asyncio
 async def test_get_cost_categories(mock_context, mock_ce_client):
     """Test the get_cost_categories function."""
-    # Mock cost category values response
-    mock_ce_client.get_cost_category_values.return_value = {
-        'CostCategoryValues': ['Engineering', 'Marketing']
-    }
+    # AWS GetCostCategories returns CostCategoryNames or CostCategoryValues from
+    # the same API depending on whether CostCategoryName is supplied.
+    mock_ce_client.get_cost_categories.side_effect = [
+        {'CostCategoryNames': ['Department', 'Project']},
+        {'CostCategoryValues': ['Engineering', 'Marketing']},
+    ]
 
-    # Test getCostCategories operation
+    # Test getCostCategories operation (list category names)
     categories_result = await get_cost_categories(
         mock_context,
         mock_ce_client,
@@ -563,8 +565,8 @@ async def test_get_cost_categories(mock_context, mock_ce_client):
         end_date='2023-01-31',
     )
 
-    # Test getCostCategoryValues operation
-    await get_cost_categories(
+    # Test getCostCategories operation with cost_category_name (list values)
+    values_result = await get_cost_categories(
         mock_context,
         mock_ce_client,
         start_date='2023-01-01',
@@ -572,23 +574,30 @@ async def test_get_cost_categories(mock_context, mock_ce_client):
         cost_category_name='Department',
     )
 
-    # Verify getCostCategories call
-    mock_ce_client.get_cost_categories.assert_called_once()
-    categories_call_kwargs = mock_ce_client.get_cost_categories.call_args[1]
-    assert 'TimePeriod' in categories_call_kwargs
-    assert categories_call_kwargs['TimePeriod']['Start'] == '2023-01-01'
-    assert categories_call_kwargs['TimePeriod']['End'] == '2023-01-31'
+    # Both calls should hit ce_client.get_cost_categories — there is no
+    # separate get_cost_category_values method on the boto3 client.
+    assert mock_ce_client.get_cost_categories.call_count == 2
 
-    # Verify getCostCategories result
+    # Verify first call: no CostCategoryName, returns names
+    first_call_kwargs = mock_ce_client.get_cost_categories.call_args_list[0][1]
+    assert 'TimePeriod' in first_call_kwargs
+    assert first_call_kwargs['TimePeriod']['Start'] == '2023-01-01'
+    assert first_call_kwargs['TimePeriod']['End'] == '2023-01-31'
+    assert 'CostCategoryName' not in first_call_kwargs
+
+    # Verify first result
     assert categories_result['status'] == 'success'
     assert 'data' in categories_result
 
-    # Verify getCostCategoryValues call
-    mock_ce_client.get_cost_category_values.assert_called_once()
-    category_values_call_kwargs = mock_ce_client.get_cost_category_values.call_args[1]
-    assert 'TimePeriod' in category_values_call_kwargs
-    assert 'CostCategoryName' in category_values_call_kwargs
-    assert category_values_call_kwargs['CostCategoryName'] == 'Department'
+    # Verify second call: CostCategoryName set, returns values
+    second_call_kwargs = mock_ce_client.get_cost_categories.call_args_list[1][1]
+    assert 'TimePeriod' in second_call_kwargs
+    assert 'CostCategoryName' in second_call_kwargs
+    assert second_call_kwargs['CostCategoryName'] == 'Department'
+
+    # Verify second result
+    assert values_result['status'] == 'success'
+    assert 'data' in values_result
 
 
 @pytest.mark.asyncio
@@ -1195,10 +1204,12 @@ async def test_ce_real_get_cost_categories_and_values_routing_reload_identity_de
         )
         assert res1['status'] == 'success'
 
-        # getCostCategoryValues
+        # getCostCategoryValues is no longer routed — it's not in the tool's
+        # public surface and the same behavior is reachable by passing
+        # cost_category_name to getCostCategories.
         res2 = await real_fn(  # type: ignore
             mock_context,
-            operation='getCostCategoryValues',
+            operation='getCostCategories',
             start_date='2023-01-01',
             end_date='2023-01-31',
             search_string='Dept',
@@ -1215,7 +1226,7 @@ async def test_ce_real_get_cost_categories_and_values_routing_reload_identity_de
             '2023-01-01',
             '2023-01-31',
             'Dept',
-            None,  # cost_category_name for getCostCategories
+            None,  # cost_category_name omitted on the first call
             'p1',
             2,
             None,


### PR DESCRIPTION


## Summary

The `getCostCategories` operation silently dropped the `cost_category_name` argument, so callers that asked for the values inside a category got the list of category names instead. The handler also tried to dispatch to a non-existent boto3 method `ce_client.get_cost_category_values`, which would have raised AttributeError if the dispatcher had ever forwarded the argument.

### Changes

AWS Cost Explorer exposes a single GetCostCategories API: passing CostCategoryName makes it return CostCategoryValues from the same call. Collapse the handler to always use ce_client.get_cost_categories, fix the paginated result key (CostCategoryNames / CostCategoryValues), drop the undocumented getCostCategoryValues operation alias, and document cost_category_name in the tool description.

### User experience

It is a bug fix. User can now use `getCostCategories` to get cost category values as well. 
Align with public API https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetCostCategories.html

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
