### PR TITLE
fix(postgres-mcp-server): correct CLI args and prerequisites in README

### DIFF
--- a/src/postgres-mcp-server/README.md
+++ b/src/postgres-mcp-server/README.md
@@ -13,8 +13,7 @@ An AWS Labs Model Context Protocol (MCP) server for Aurora Postgres
 1. Install `uv` from [Astral](https://docs.astral.sh/uv/getting-started/installation/) or the [GitHub README](https://github.com/astral-sh/uv#installation)
 2. Install Python using `uv python install 3.10`
 3. This MCP server can only be run locally on the same host as your LLM client.
-4. Docker runtime
-5. Set up AWS credentials with access to AWS services
+4. Set up AWS credentials with access to AWS services
    - You need an AWS account with appropriate permissions
    - Configure AWS credentials with `aws configure` or environment variables
 
@@ -22,7 +21,7 @@ An AWS Labs Model Context Protocol (MCP) server for Aurora Postgres
 
 | Kiro | Cursor | VS Code |
 |:----:|:------:|:-------:|
-| [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=awslabs.postgres-mcp-server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.postgres-mcp-server%40latest%22%2C%22--connection-string%22%2C%22postgresql%3A//%5Busername%5D%3A%5Bpassword%5D%40%5Bhost%5D%3A%5Bport%5D/%5Bdatabase%5D%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%7D) | [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en/install-mcp?name=awslabs.postgres-mcp-server&config=eyJjb21tYW5kIjoidXZ4IGF3c2xhYnMucG9zdGdyZXMtbWNwLXNlcnZlckBsYXRlc3QgLS1jb25uZWN0aW9uLXN0cmluZyBwb3N0Z3Jlc3FsOi8vW3VzZXJuYW1lXTpbcGFzc3dvcmRdQFtob3N0XTpbcG9ydF0vW2RhdGFiYXNlXSIsImVudiI6eyJGQVNUTUNQX0xPR19MRVZFTCI6IkVSUk9SIn0sImRpc2FibGVkIjpmYWxzZSwiYXV0b0FwcHJvdmUiOltdLCJ0cmFuc3BvcnRUeXBlIjoic3RkaW8iLCJhdXRvU3RhcnQiOnRydWV9) | [![Install on VS Code](https://img.shields.io/badge/Install_on-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=PostgreSQL%20MCP%20Server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.postgres-mcp-server%40latest%22%2C%22--connection-string%22%2C%22postgresql%3A%2F%2F%5Busername%5D%3A%5Bpassword%5D%40%5Bhost%5D%3A%5Bport%5D%2F%5Bdatabase%5D%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%5D%2C%22transportType%22%3A%22stdio%22%2C%22autoStart%22%3Atrue%7D) |
+| [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=awslabs.postgres-mcp-server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.postgres-mcp-server%40latest%22%2C%22--db_endpoint%22%2C%22%5Bhost%5D%22%2C%22--port%22%2C%22%5Bport%5D%22%2C%22--database%22%2C%22%5Bdatabase%5D%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%7D) | [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en/install-mcp?name=awslabs.postgres-mcp-server&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJhd3NsYWJzLnBvc3RncmVzLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwiLS1kYl9lbmRwb2ludCIsIltob3N0XSIsIi0tcG9ydCIsIltwb3J0XSIsIi0tZGF0YWJhc2UiLCJbZGF0YWJhc2VdIl0sImVudiI6eyJGQVNUTUNQX0xPR19MRVZFTCI6IkVSUk9SIn0sImRpc2FibGVkIjpmYWxzZSwiYXV0b0FwcHJvdmUiOltdLCJ0cmFuc3BvcnRUeXBlIjoic3RkaW8iLCJhdXRvU3RhcnQiOnRydWV9) | [![Install on VS Code](https://img.shields.io/badge/Install_on-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=PostgreSQL%20MCP%20Server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22awslabs.postgres-mcp-server%40latest%22%2C%22--db_endpoint%22%2C%22%5Bhost%5D%22%2C%22--port%22%2C%22%5Bport%5D%22%2C%22--database%22%2C%22%5Bdatabase%5D%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%5D%2C%22transportType%22%3A%22stdio%22%2C%22autoStart%22%3Atrue%7D) |
 
 Configure the MCP server in your MCP client configuration (e.g., for Kiro, edit `~/.kiro/settings/mcp.json`):
 
@@ -169,7 +168,7 @@ Make sure the AWS profile has permissions to access the [RDS data API](https://d
 
 ### Postgres Authentication
 
-The MCP server supports IAM and username/password methods for Postgres authentication. You must use AWS secret manager to store the credential and to specify the --secretManagerARN in MCP configuration file.
+The MCP server supports IAM and username/password methods for Postgres authentication. You must use AWS Secrets Manager to store the credential and specify the `--secret_arn` argument when starting the MCP server.
 
 
 ### Security Consideration


### PR DESCRIPTION
## Summary

Fix three documentation errors in `src/postgres-mcp-server/README.md` discovered while setting up the MCP server:

1. **Remove Docker from prerequisites** — Docker is only needed to build the image from source. It is not required when using `uvx` (the recommended install method).

2. **Fix badge URLs: `--connection-string` → `--db_endpoint`/`--port`/`--database`** — The one-click install badge URLs for Kiro, Cursor, and VS Code encoded `--connection-string postgresql://...` which is not a recognized CLI argument. The actual argparse-defined flags are `--db_endpoint`, `--port`, and `--database` (verified against `server.py` lines 1086–1092).

3. **Fix `--secretManagerARN` → `--secret_arn`** — The Postgres Authentication section referenced `--secretManagerARN` which does not exist. The correct flag as defined in `server.py` line 1094 is `--secret_arn`.

## Verification

```bash
uvx awslabs.postgres-mcp-server@latest --help
# Shows: --db_endpoint, --port, --database, --secret_arn
# No --connection-string or --secretManagerARN flags exist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)