### PR TITLE
fix(billing-cost-management): fix SQL-offload and pagination paths for Cost Explorer operations

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/aws_pricing_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/aws_pricing_operations.py
@@ -378,10 +378,7 @@ async def get_pricing_from_api(
         }
 
         # Offload large responses to SQLite via the size gate; small responses
-        # pass through (no ``data_stored`` key) and fall through to the
-        # human-readable processing below. Previously this used
-        # ``convert_api_response_to_table`` directly, which always converted —
-        # so the processing branch below was unreachable.
+        # fall through to the human-readable processing below.
         table_response = await convert_response_if_needed(
             ctx, raw_response, 'aws_pricing_get_products', service_code=service_code
         )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/aws_pricing_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/aws_pricing_operations.py
@@ -26,7 +26,7 @@ from ..utilities.aws_service_base import (
     parse_json,
 )
 from ..utilities.logging_utils import get_context_logger
-from ..utilities.sql_utils import convert_api_response_to_table
+from ..utilities.sql_utils import convert_response_if_needed
 from fastmcp import Context
 from typing import Any, Dict, Optional
 
@@ -377,9 +377,13 @@ async def get_pricing_from_api(
             'PriceList': all_price_list,
         }
 
-        # Convert large responses to SQL table
-        table_response = await convert_api_response_to_table(
-            ctx, raw_response, 'getPricing', service_code=service_code
+        # Offload large responses to SQLite via the size gate; small responses
+        # pass through (no ``data_stored`` key) and fall through to the
+        # human-readable processing below. Previously this used
+        # ``convert_api_response_to_table`` directly, which always converted —
+        # so the processing branch below was unreachable.
+        table_response = await convert_response_if_needed(
+            ctx, raw_response, 'aws_pricing_get_products', service_code=service_code
         )
 
         # If table was created, return that, otherwise process the response for easier consumption

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -172,6 +172,8 @@ async def get_cost_and_usage_with_resources(
     metrics: Optional[str] = None,
     group_by: Optional[str] = None,
     filter_expr: Optional[str] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
     billing_view_arn: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Get resource-level cost and usage data.
@@ -187,6 +189,8 @@ async def get_cost_and_usage_with_resources(
         metrics: List of metrics as JSON string
         group_by: Optional grouping as JSON string
         filter_expr: Optional filters as JSON string
+        next_token: Pagination token
+        max_pages: Maximum number of pages to fetch
         billing_view_arn: Optional ARN of a billing view to scope the query.
             If not provided, defaults to the account's primary billing view.
 
@@ -230,11 +234,59 @@ async def get_cost_and_usage_with_resources(
         if billing_view_arn:
             request_params['BillingViewArn'] = billing_view_arn
 
-        # Make API call
-        await ctx.info('Calling getCostAndUsageWithResources API')
-        response = ce_client.get_cost_and_usage_with_resources(**request_params)
+        # Handle pagination — same NextPageToken contract as getCostAndUsage.
+        if next_token or max_pages:
+            # paginate_aws_response only sets the token on iter 2+, so inject
+            # the caller's token into the first boto3 request explicitly.
+            if next_token:
+                request_params['NextPageToken'] = next_token
 
-        return format_response('success', response)
+            results, pagination_metadata = await paginate_aws_response(
+                ctx,
+                'getCostAndUsageWithResources',
+                lambda **params: ce_client.get_cost_and_usage_with_resources(**params),
+                request_params,
+                'ResultsByTime',
+                'NextPageToken',
+                'NextPageToken',
+                max_pages,
+            )
+
+            response = {'ResultsByTime': results, 'Pagination': pagination_metadata}
+            pagination_envelope = {
+                'next_page_token': pagination_metadata.get('next_token'),
+                'has_more': pagination_metadata.get('has_more', False),
+                'pages_fetched': pagination_metadata.get('pages_fetched'),
+            }
+        else:
+            await ctx.info('Calling getCostAndUsageWithResources API')
+            response = ce_client.get_cost_and_usage_with_resources(**request_params)
+            pagination_envelope = {
+                'next_page_token': response.get('NextPageToken'),
+                'has_more': bool(response.get('NextPageToken')),
+                'pages_fetched': 1,
+            }
+
+        # Forward through the SQL offload — same ResultsByTime shape as
+        # getCostAndUsage, so the cost_and_usage typed converter handles it.
+        table_response = await convert_response_if_needed(
+            ctx,
+            response,
+            'cost_explorer_get_cost_and_usage_with_resources',
+            granularity=granularity,
+            start_date=start,
+            end_date=end,
+            group_by=group_by,
+            metrics=metrics,
+            **pagination_envelope,
+        )
+
+        return format_response(
+            'success',
+            table_response
+            if isinstance(table_response, dict) and 'data_stored' in table_response
+            else response,
+        )
 
     except Exception as e:
         return await handle_aws_error(ctx, e, 'getCostAndUsageWithResources', 'Cost Explorer')
@@ -315,11 +367,39 @@ async def get_dimension_values(
 
             # Format paginated response
             response = {'DimensionValues': results, 'Pagination': pagination_metadata}
+            pagination_envelope = {
+                'next_page_token': pagination_metadata.get('next_token'),
+                'has_more': pagination_metadata.get('has_more', False),
+                'pages_fetched': pagination_metadata.get('pages_fetched'),
+            }
         else:
             # For single page, make direct call
             response = ce_client.get_dimension_values(**request_params)
+            pagination_envelope = {
+                'next_page_token': response.get('NextPageToken'),
+                'has_more': bool(response.get('NextPageToken')),
+                'pages_fetched': 1,
+            }
 
-        return format_response('success', response)
+        # Forward pagination metadata as **metadata so it survives SQL offload
+        # — the typed dimension_values converter only walks DimensionValues.
+        table_response = await convert_response_if_needed(
+            ctx,
+            response,
+            'cost_explorer_get_dimension_values',
+            dimension=dimension,
+            start_date=start,
+            end_date=end,
+            search_string=search_string,
+            **pagination_envelope,
+        )
+
+        return format_response(
+            'success',
+            table_response
+            if isinstance(table_response, dict) and 'data_stored' in table_response
+            else response,
+        )
 
     except Exception as e:
         # Use shared error handling
@@ -393,7 +473,24 @@ async def get_cost_forecast(
         await ctx.info('Calling getCostForecast API')
         response = ce_client.get_cost_forecast(**request_params)
 
-        return format_response('success', response)
+        # Forecast responses can be large with DAILY granularity over months —
+        # offload through the SQL gate so callers get a queryable table.
+        table_response = await convert_response_if_needed(
+            ctx,
+            response,
+            'cost_explorer_get_cost_forecast',
+            metric=metric,
+            granularity=granularity,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        return format_response(
+            'success',
+            table_response
+            if isinstance(table_response, dict) and 'data_stored' in table_response
+            else response,
+        )
 
     except Exception as e:
         # Use shared error handling
@@ -466,7 +563,22 @@ async def get_usage_forecast(
         await ctx.info('Calling getUsageForecast API')
         response = ce_client.get_usage_forecast(**request_params)
 
-        return format_response('success', response)
+        table_response = await convert_response_if_needed(
+            ctx,
+            response,
+            'cost_explorer_get_usage_forecast',
+            metric=metric,
+            granularity=granularity,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        return format_response(
+            'success',
+            table_response
+            if isinstance(table_response, dict) and 'data_stored' in table_response
+            else response,
+        )
 
     except Exception as e:
         # Use shared error handling
@@ -542,11 +654,39 @@ async def get_tags(
 
             # Format paginated response
             response = {result_key: results, 'Pagination': pagination_metadata}
+            pagination_envelope = {
+                'next_page_token': pagination_metadata.get('next_token'),
+                'has_more': pagination_metadata.get('has_more', False),
+                'pages_fetched': pagination_metadata.get('pages_fetched'),
+            }
         else:
             # For single page, make direct call
             response = ce_client.get_tags(**request_params)
+            pagination_envelope = {
+                'next_page_token': response.get('NextPageToken'),
+                'has_more': bool(response.get('NextPageToken')),
+                'pages_fetched': 1,
+            }
 
-        return format_response('success', response)
+        # Forward pagination metadata as **metadata so it survives SQL offload
+        # — the typed tags converter only walks the Tags array.
+        table_response = await convert_response_if_needed(
+            ctx,
+            response,
+            'cost_explorer_get_tags',
+            start_date=start,
+            end_date=end,
+            search_string=search_string,
+            tag_key=tag_key,
+            **pagination_envelope,
+        )
+
+        return format_response(
+            'success',
+            table_response
+            if isinstance(table_response, dict) and 'data_stored' in table_response
+            else response,
+        )
 
     except Exception as e:
         # Use shared error handling
@@ -631,11 +771,40 @@ async def get_cost_categories(
 
             # Format paginated response
             response = {result_key: results, 'Pagination': pagination_metadata}
+            pagination_envelope = {
+                'next_page_token': pagination_metadata.get('next_token'),
+                'has_more': pagination_metadata.get('has_more', False),
+                'pages_fetched': pagination_metadata.get('pages_fetched'),
+            }
         else:
             # For single page, make direct call
             response = ce_client.get_cost_categories(**request_params)
+            pagination_envelope = {
+                'next_page_token': response.get('NextPageToken'),
+                'has_more': bool(response.get('NextPageToken')),
+                'pages_fetched': 1,
+            }
 
-        return format_response('success', response)
+        # Forward pagination metadata as **metadata so it survives SQL offload
+        # — the typed cost_categories converter walks CostCategoryNames /
+        # CostCategoryValues arrays.
+        table_response = await convert_response_if_needed(
+            ctx,
+            response,
+            'cost_explorer_get_cost_categories',
+            start_date=start,
+            end_date=end,
+            search_string=search_string,
+            cost_category_name=cost_category_name,
+            **pagination_envelope,
+        )
+
+        return format_response(
+            'success',
+            table_response
+            if isinstance(table_response, dict) and 'data_stored' in table_response
+            else response,
+        )
 
     except Exception as e:
         # Use shared error handling

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -123,21 +123,9 @@ async def get_cost_and_usage(
             )
 
             response = {'ResultsByTime': results, 'Pagination': pagination_metadata}
-            pagination_envelope = {
-                'next_page_token': pagination_metadata.get('next_token'),
-                'has_more': pagination_metadata.get('has_more', False),
-                'pages_fetched': pagination_metadata.get('pages_fetched'),
-            }
         else:
             response = ce_client.get_cost_and_usage(**request_params)
-            pagination_envelope = {
-                'next_page_token': response.get('NextPageToken'),
-                'has_more': bool(response.get('NextPageToken')),
-                'pages_fetched': 1,
-            }
 
-        # Forward pagination metadata as **metadata so it survives SQL offload
-        # — the typed cost_and_usage converter only walks ResultsByTime.
         table_response = await convert_response_if_needed(
             ctx,
             response,
@@ -147,16 +135,9 @@ async def get_cost_and_usage(
             end_date=end,
             group_by=group_by,
             metrics=metrics,
-            **pagination_envelope,
         )
 
-        # Return the response (either the original or the SQL table info)
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         # Use shared error handling
@@ -253,22 +234,10 @@ async def get_cost_and_usage_with_resources(
             )
 
             response = {'ResultsByTime': results, 'Pagination': pagination_metadata}
-            pagination_envelope = {
-                'next_page_token': pagination_metadata.get('next_token'),
-                'has_more': pagination_metadata.get('has_more', False),
-                'pages_fetched': pagination_metadata.get('pages_fetched'),
-            }
         else:
             await ctx.info('Calling getCostAndUsageWithResources API')
             response = ce_client.get_cost_and_usage_with_resources(**request_params)
-            pagination_envelope = {
-                'next_page_token': response.get('NextPageToken'),
-                'has_more': bool(response.get('NextPageToken')),
-                'pages_fetched': 1,
-            }
 
-        # Forward through the SQL offload — same ResultsByTime shape as
-        # getCostAndUsage, so the cost_and_usage typed converter handles it.
         table_response = await convert_response_if_needed(
             ctx,
             response,
@@ -278,15 +247,9 @@ async def get_cost_and_usage_with_resources(
             end_date=end,
             group_by=group_by,
             metrics=metrics,
-            **pagination_envelope,
         )
 
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         return await handle_aws_error(ctx, e, 'getCostAndUsageWithResources', 'Cost Explorer')
@@ -367,22 +330,10 @@ async def get_dimension_values(
 
             # Format paginated response
             response = {'DimensionValues': results, 'Pagination': pagination_metadata}
-            pagination_envelope = {
-                'next_page_token': pagination_metadata.get('next_token'),
-                'has_more': pagination_metadata.get('has_more', False),
-                'pages_fetched': pagination_metadata.get('pages_fetched'),
-            }
         else:
             # For single page, make direct call
             response = ce_client.get_dimension_values(**request_params)
-            pagination_envelope = {
-                'next_page_token': response.get('NextPageToken'),
-                'has_more': bool(response.get('NextPageToken')),
-                'pages_fetched': 1,
-            }
 
-        # Forward pagination metadata as **metadata so it survives SQL offload
-        # — the typed dimension_values converter only walks DimensionValues.
         table_response = await convert_response_if_needed(
             ctx,
             response,
@@ -391,15 +342,9 @@ async def get_dimension_values(
             start_date=start,
             end_date=end,
             search_string=search_string,
-            **pagination_envelope,
         )
 
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         # Use shared error handling
@@ -485,12 +430,7 @@ async def get_cost_forecast(
             end_date=end_date,
         )
 
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         # Use shared error handling
@@ -573,12 +513,7 @@ async def get_usage_forecast(
             end_date=end_date,
         )
 
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         # Use shared error handling
@@ -654,22 +589,10 @@ async def get_tags(
 
             # Format paginated response
             response = {result_key: results, 'Pagination': pagination_metadata}
-            pagination_envelope = {
-                'next_page_token': pagination_metadata.get('next_token'),
-                'has_more': pagination_metadata.get('has_more', False),
-                'pages_fetched': pagination_metadata.get('pages_fetched'),
-            }
         else:
             # For single page, make direct call
             response = ce_client.get_tags(**request_params)
-            pagination_envelope = {
-                'next_page_token': response.get('NextPageToken'),
-                'has_more': bool(response.get('NextPageToken')),
-                'pages_fetched': 1,
-            }
 
-        # Forward pagination metadata as **metadata so it survives SQL offload
-        # — the typed tags converter only walks the Tags array.
         table_response = await convert_response_if_needed(
             ctx,
             response,
@@ -678,15 +601,9 @@ async def get_tags(
             end_date=end,
             search_string=search_string,
             tag_key=tag_key,
-            **pagination_envelope,
         )
 
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         # Use shared error handling
@@ -771,23 +688,10 @@ async def get_cost_categories(
 
             # Format paginated response
             response = {result_key: results, 'Pagination': pagination_metadata}
-            pagination_envelope = {
-                'next_page_token': pagination_metadata.get('next_token'),
-                'has_more': pagination_metadata.get('has_more', False),
-                'pages_fetched': pagination_metadata.get('pages_fetched'),
-            }
         else:
             # For single page, make direct call
             response = ce_client.get_cost_categories(**request_params)
-            pagination_envelope = {
-                'next_page_token': response.get('NextPageToken'),
-                'has_more': bool(response.get('NextPageToken')),
-                'pages_fetched': 1,
-            }
 
-        # Forward pagination metadata as **metadata so it survives SQL offload
-        # — the typed cost_categories converter walks CostCategoryNames /
-        # CostCategoryValues arrays.
         table_response = await convert_response_if_needed(
             ctx,
             response,
@@ -796,15 +700,9 @@ async def get_cost_categories(
             end_date=end,
             search_string=search_string,
             cost_category_name=cost_category_name,
-            **pagination_envelope,
         )
 
-        return format_response(
-            'success',
-            table_response
-            if isinstance(table_response, dict) and 'data_stored' in table_response
-            else response,
-        )
+        return format_response('success', table_response)
 
     except Exception as e:
         # Use shared error handling

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -25,7 +25,7 @@ from ..utilities.aws_service_base import (
     paginate_aws_response,
     parse_json,
 )
-from ..utilities.sql_utils import convert_api_response_to_table
+from ..utilities.sql_utils import convert_response_if_needed
 from datetime import datetime, timedelta
 from fastmcp import Context
 from typing import Any, Dict, Optional
@@ -124,11 +124,15 @@ async def get_cost_and_usage(
             # For single page, make direct call
             response = ce_client.get_cost_and_usage(**request_params)
 
-        # Convert large responses to SQL table
-        table_response = await convert_api_response_to_table(
+        # Offload large responses to SQLite via the size gate; small responses
+        # pass through and are returned inline. ``convert_response_if_needed``
+        # returns either {status, data_stored, table_name, ...} (large) or
+        # {status, data, response_size_bytes} (small) — the ``data_stored``
+        # check below picks the right shape for ``format_response``.
+        table_response = await convert_response_if_needed(
             ctx,
             response,
-            'getCostAndUsage',
+            'cost_explorer_get_cost_and_usage',
             granularity=granularity,
             start_date=start,
             end_date=end,

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -106,7 +106,11 @@ async def get_cost_and_usage(
 
         # Use shared pagination utility
         if next_token or max_pages:
-            # For paginated requests, use the paginate utility
+            # paginate_aws_response only sets the token on iter 2+, so inject
+            # the caller's token into the first boto3 request explicitly.
+            if next_token:
+                request_params['NextPageToken'] = next_token
+
             results, pagination_metadata = await paginate_aws_response(
                 ctx,
                 'getCostAndUsage',
@@ -118,17 +122,22 @@ async def get_cost_and_usage(
                 max_pages,
             )
 
-            # Format paginated response
             response = {'ResultsByTime': results, 'Pagination': pagination_metadata}
+            pagination_envelope = {
+                'next_page_token': pagination_metadata.get('next_token'),
+                'has_more': pagination_metadata.get('has_more', False),
+                'pages_fetched': pagination_metadata.get('pages_fetched'),
+            }
         else:
-            # For single page, make direct call
             response = ce_client.get_cost_and_usage(**request_params)
+            pagination_envelope = {
+                'next_page_token': response.get('NextPageToken'),
+                'has_more': bool(response.get('NextPageToken')),
+                'pages_fetched': 1,
+            }
 
-        # Offload large responses to SQLite via the size gate; small responses
-        # pass through and are returned inline. ``convert_response_if_needed``
-        # returns either {status, data_stored, table_name, ...} (large) or
-        # {status, data, response_size_bytes} (small) — the ``data_stored``
-        # check below picks the right shape for ``format_response``.
+        # Forward pagination metadata as **metadata so it survives SQL offload
+        # — the typed cost_and_usage converter only walks ResultsByTime.
         table_response = await convert_response_if_needed(
             ctx,
             response,
@@ -138,6 +147,7 @@ async def get_cost_and_usage(
             end_date=end,
             group_by=group_by,
             metrics=metrics,
+            **pagination_envelope,
         )
 
         # Return the response (either the original or the SQL table info)
@@ -290,7 +300,8 @@ async def get_dimension_values(
 
         # Handle pagination
         if next_token or max_pages:
-            # For paginated requests, use the paginate utility
+            if next_token:
+                request_params['NextPageToken'] = next_token
             results, pagination_metadata = await paginate_aws_response(
                 ctx,
                 'getDimensionValues',
@@ -516,7 +527,8 @@ async def get_tags(
             api_function = ce_client.get_tags
             result_key = 'Tags' if not tag_key else 'TagValues'
 
-            # For paginated requests, use the paginate utility
+            if next_token:
+                request_params['NextPageToken'] = next_token
             results, pagination_metadata = await paginate_aws_response(
                 ctx,
                 operation,
@@ -600,6 +612,11 @@ async def get_cost_categories(
 
         # Handle pagination
         if next_token or max_pages:
+            result_key = 'CostCategories' if not cost_category_name else 'CostCategoryValues'
+
+            if next_token:
+                request_params['NextPageToken'] = next_token
+
             # For paginated requests, use the paginate utility
             results, pagination_metadata = await paginate_aws_response(
                 ctx,
@@ -669,7 +686,8 @@ async def get_savings_plans_utilization(
 
         # Handle pagination
         if next_token or max_pages:
-            # For paginated requests, use the paginate utility
+            if next_token:
+                request_params['NextToken'] = next_token
             results, pagination_metadata = await paginate_aws_response(
                 ctx,
                 'getSavingsPlansUtilization',

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
@@ -66,7 +66,7 @@ USE THIS TOOL FOR:
 
 2. getCostAndUsageWithResources - Resource-level cost data (limited to last 14 days)
    Required: operation="getCostAndUsageWithResources", filter, granularity, start_date, end_date
-   Optional: metrics, group_by, billing_view_arn
+   Optional: metrics, group_by, next_token, max_pages, billing_view_arn
    Notes: RESOURCE_ID must be included in either filter OR group_by parameters. This operation is limited to past 14 days of data from current date. Hourly granularity is only available for EC2-Instances resource-level data. All other resource-level data is available at daily granularity.
    Example: {"operation": "getCostAndUsageWithResources", "start_date": "2025-08-07", "end_date": "2025-08-21", "granularity": "DAILY", "filter": "{\"Dimensions\": {\"Key\": \"SERVICE\", \"Values\": [\"Amazon Elastic Compute Cloud - Compute\"]}}", "group_by": "[{\"Type\": \"DIMENSION\", \"Key\": \"RESOURCE_ID\"}]"}
    Returns: Cost data with resource-level granularity
@@ -244,6 +244,8 @@ async def cost_explorer(
                 metrics,
                 group_by,
                 filter,
+                next_token,
+                max_pages,
                 billing_view_arn,
             )
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -339,14 +339,23 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
     """Get specific converter function for API.
 
     Args:
-        operation_name: Name of the API operation
+        operation_name: Name of the API operation. MUST match the string the
+            tool layer passes to ``convert_api_response_to_table`` /
+            ``convert_response_if_needed`` — i.e. the namespaced snake_case
+            identifier (``cost_explorer_get_cost_and_usage``,
+            ``aws_pricing_get_products``, …). Namespacing by service avoids
+            cross-service collisions as the offload feature expands.
 
     Returns:
         Optional[str]: Type of specialized converter to use, or None for generic
     """
-    # Map of operation names to specialized converter types
+    # Map of operation names to specialized converter types. Keys are the exact
+    # ``operation_name`` strings the callers pass; mismatches silently fall
+    # through to the generic ``(key, value)`` flatten branch and lose all
+    # typed-column structure, so keep these in sync with the call sites in
+    # tools/cost_explorer_operations.py and tools/aws_pricing_operations.py.
     converters = {
-        'aws_pricing_get_products': 'pricing_products',
+        # Cost Explorer
         'cost_explorer_get_cost_and_usage': 'cost_and_usage',
         'cost_explorer_get_cost_and_usage_with_resources': 'cost_and_usage',
         'cost_explorer_get_dimension_values': 'dimension_values',
@@ -354,6 +363,8 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
         'cost_explorer_get_usage_forecast': 'forecast',
         'cost_explorer_get_tags': 'tags',
         'cost_explorer_get_cost_categories': 'cost_categories',
+        # AWS Pricing
+        'aws_pricing_get_products': 'pricing_products',
     }
 
     return converters.get(operation_name)

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -340,22 +340,15 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
 
     Args:
         operation_name: Name of the API operation. MUST match the string the
-            tool layer passes to ``convert_api_response_to_table`` /
-            ``convert_response_if_needed`` — i.e. the namespaced snake_case
-            identifier (``cost_explorer_get_cost_and_usage``,
-            ``aws_pricing_get_products``, …). Namespacing by service avoids
-            cross-service collisions as the offload feature expands.
+            caller passes to ``convert_api_response_to_table`` /
+            ``convert_response_if_needed`` (e.g. ``cost_explorer_get_cost_and_usage``).
 
     Returns:
         Optional[str]: Type of specialized converter to use, or None for generic
     """
-    # Map of operation names to specialized converter types. Keys are the exact
-    # ``operation_name`` strings the callers pass; mismatches silently fall
-    # through to the generic ``(key, value)`` flatten branch and lose all
-    # typed-column structure, so keep these in sync with the call sites in
-    # tools/cost_explorer_operations.py and tools/aws_pricing_operations.py.
+    # Keys must match operation_name strings the callers pass; mismatches
+    # silently fall through to the generic (key, value) flatten branch.
     converters = {
-        # Cost Explorer
         'cost_explorer_get_cost_and_usage': 'cost_and_usage',
         'cost_explorer_get_cost_and_usage_with_resources': 'cost_and_usage',
         'cost_explorer_get_dimension_values': 'dimension_values',
@@ -363,7 +356,6 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
         'cost_explorer_get_usage_forecast': 'forecast',
         'cost_explorer_get_tags': 'tags',
         'cost_explorer_get_cost_categories': 'cost_categories',
-        # AWS Pricing
         'aws_pricing_get_products': 'pricing_products',
     }
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -362,49 +362,110 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
     return converters.get(operation_name)
 
 
-async def convert_response_if_needed(
-    ctx: Context, response: Dict[str, Any], api_name: str, **metadata
+def _derive_pagination_envelope(
+    response: Dict[str, Any], token_key: str = 'NextPageToken'
 ) -> Dict[str, Any]:
-    """Convert API response to SQL if it exceeds size threshold.
+    """Extract pagination metadata from a response so it survives SQL offload.
+
+    Recognizes two shapes produced upstream:
+
+    - Multi-page wrapper built by callers after `paginate_aws_response`:
+      ``{'<ResultsKey>': [...], 'Pagination': {next_token, has_more, pages_fetched, ...}}``
+    - Single-page raw boto3 response with a continuation-token field (e.g.
+      ``NextPageToken``).
+
+    Args:
+        response: The API response (or paginated wrapper) being offloaded.
+        token_key: Name of the continuation-token field in the single-page
+            boto3 response. Defaults to ``NextPageToken`` (used by Cost
+            Explorer ops); pass e.g. ``NextToken`` for AWS Pricing.
+
+    Returns:
+        Dict with ``next_page_token``, ``has_more``, ``pages_fetched`` keys.
+        Empty dict if the response carries no pagination markers (e.g. a
+        forecast response), so unrelated APIs aren't polluted with bogus
+        pagination metadata.
+    """
+    if 'Pagination' in response and isinstance(response['Pagination'], dict):
+        pag_meta = response['Pagination']
+        return {
+            'next_page_token': pag_meta.get('next_token'),
+            'has_more': pag_meta.get('has_more', False),
+            'pages_fetched': pag_meta.get('pages_fetched'),
+        }
+    if token_key in response:
+        token = response.get(token_key)
+        return {
+            'next_page_token': token,
+            'has_more': bool(token),
+            'pages_fetched': 1,
+        }
+    return {}
+
+
+async def convert_response_if_needed(
+    ctx: Context,
+    response: Dict[str, Any],
+    api_name: str,
+    pagination_token_key: str = 'NextPageToken',
+    **metadata,
+) -> Dict[str, Any]:
+    """Offload an API response to SQL if it exceeds the size threshold.
+
+    Auto-derives pagination metadata (`next_page_token`, `has_more`,
+    `pages_fetched`) from the response shape so callers don't have to
+    pass it explicitly. Explicit kwargs in `metadata` override the
+    derived values.
+
+    Return contract — always returns something the caller can pass
+    straight through to `format_response`:
+    - Offload happened: the offload sentinel dict (with `data_stored=True`,
+      `table_name`, sample queries, etc.).
+    - No offload (size below threshold): the original `response`.
+    - Conversion errored: log + return the original `response`.
+
+    The original response is returned on no-offload and on error so
+    callers don't need to unwrap a size-meta or error envelope.
 
     Args:
         ctx: MCP context
         response: API response data
-        api_name: Name of the API operation (e.g., 'aws_pricing_get_products')
-        **metadata: Additional metadata to include in response
+        api_name: Name of the API operation (e.g. 'aws_pricing_get_products')
+        pagination_token_key: Name of the continuation-token field in
+            single-page boto3 responses. Defaults to 'NextPageToken'.
+        **metadata: Additional metadata to include in the offload sentinel.
 
     Returns:
-        Either SQL table info or formatted response
+        Either the offload sentinel dict or the original response.
     """
     # Get context logger for consistent logging
     ctx_logger = get_context_logger(ctx, __name__)
 
+    # Pull pagination markers out of the response so they survive offload —
+    # caller-provided metadata still wins on key conflict.
+    metadata = {**_derive_pagination_envelope(response, pagination_token_key), **metadata}
+
     try:
-        # Calculate response size
         response_size = len(json.dumps(response).encode('utf-8'))
 
-        if should_convert_to_sql(response_size):
-            # Convert large response to SQL
-            await ctx_logger.info(
-                f'Response size {response_size / 1024:.2f}KB exceeds threshold, converting to SQL'
-            )
-            return await convert_api_response_to_table(ctx, response, api_name, **metadata)
-        else:
-            # Return original response with size info
+        if not should_convert_to_sql(response_size):
             await ctx_logger.debug(
                 f'Response size {response_size / 1024:.2f}KB below threshold, returning directly'
             )
-            return {'status': 'success', 'data': response, 'response_size_bytes': response_size}
+            return response
+
+        await ctx_logger.info(
+            f'Response size {response_size / 1024:.2f}KB exceeds threshold, converting to SQL'
+        )
+        return await convert_api_response_to_table(ctx, response, api_name, **metadata)
     except Exception as e:
-        error_message = f'Error processing response for {api_name}: {str(e)}'
-        await ctx_logger.error(error_message, exc_info=True)
-        # Return error response with original data to ensure no data loss
-        return {
-            'status': 'error',
-            'message': error_message,
-            'data': response,
-            'response_size_bytes': len(json.dumps(response).encode('utf-8')),
-        }
+        # Offload is an optimization — if it fails, fall back to the original
+        # response rather than propagating an error envelope the caller would
+        # have to unwrap anyway.
+        await ctx_logger.error(
+            f'Error processing response for {api_name}: {str(e)}', exc_info=True
+        )
+        return response
 
 
 async def convert_api_response_to_table(

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -853,6 +853,35 @@ async def convert_api_response_to_table(
                 }
             )
 
+        elif converter_type == 'cost_categories':
+            # Cost Categories queries
+
+            # Category names only
+            names_query = (
+                create_safe_sql_statement('SELECT', table_name, 'category_value')
+                + " WHERE category_type = 'name' ORDER BY category_value"
+            )
+            sample_queries.append(
+                {
+                    'name': 'Cost category names',
+                    'description': 'Lists all cost category names alphabetically',
+                    'sql': names_query,
+                }
+            )
+
+            # Category values only
+            values_query = (
+                create_safe_sql_statement('SELECT', table_name, 'category_value')
+                + " WHERE category_type = 'value' ORDER BY category_value"
+            )
+            sample_queries.append(
+                {
+                    'name': 'Cost category values',
+                    'description': 'Lists all cost category values alphabetically',
+                    'sql': values_query,
+                }
+            )
+
         else:
             # Generic key-value pair queries for other types
             key_query = (

--- a/src/billing-cost-management-mcp-server/tests/tools/test_aws_pricing_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_aws_pricing_tools.py
@@ -965,7 +965,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     async def test_get_pricing_from_api_table_conversion(
         self, mock_convert_table, mock_create_client, mock_context
@@ -993,7 +993,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     async def test_get_pricing_from_api_no_results(
         self, mock_convert_table, mock_create_client, mock_context
@@ -1018,7 +1018,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     @patch(
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.get_context_logger'
@@ -1060,7 +1060,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     @patch(
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.get_context_logger'
@@ -1098,7 +1098,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     async def test_get_pricing_from_api_pagination_with_max_results_limit(
         self, mock_convert_table, mock_create_client, mock_context
@@ -1133,7 +1133,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     @patch('awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.parse_json')
     async def test_get_pricing_from_api_with_filters(
@@ -1168,7 +1168,7 @@ class TestGetPricingFromApiAdditional:
         'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.create_aws_client'
     )
     @patch(
-        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_api_response_to_table'
+        'awslabs.billing_cost_management_mcp_server.tools.aws_pricing_operations.convert_response_if_needed'
     )
     async def test_get_pricing_from_api_filters_with_none_values(
         self, mock_convert_table, mock_create_client, mock_context

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -335,6 +335,79 @@ class TestGetCostAndUsage:
         assert result['status'] == 'error'
         assert 'message' in result
 
+    async def test_caller_next_token_is_used_on_first_request(
+        self, mock_context, mock_ce_client
+    ):
+        """Caller-supplied next_token must be injected into the first boto3 call."""
+        mock_ce_client.get_cost_and_usage.return_value = {
+            'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-02', 'End': '2023-01-03'}}],
+        }
+
+        await get_cost_and_usage(
+            mock_context,
+            mock_ce_client,
+            start_date='2023-01-01',
+            end_date='2023-01-31',
+            next_token='resume-from-here',
+            max_pages=1,
+        )
+
+        first_call_kwargs = mock_ce_client.get_cost_and_usage.call_args_list[0][1]
+        assert first_call_kwargs.get('NextPageToken') == 'resume-from-here'
+
+    async def test_single_page_surfaces_next_page_token_for_agent(
+        self, mock_context, mock_ce_client
+    ):
+        """Small responses preserve the raw boto3 NextPageToken in result.data."""
+        mock_ce_client.get_cost_and_usage.return_value = {
+            'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-01', 'End': '2023-01-02'}}],
+            'NextPageToken': 'continue-here',
+        }
+
+        result = await get_cost_and_usage(
+            mock_context,
+            mock_ce_client,
+            start_date='2023-01-01',
+            end_date='2023-01-31',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'].get('NextPageToken') == 'continue-here'
+
+    async def test_pagination_metadata_forwarded_to_sql_offload(
+        self, mock_context, mock_ce_client
+    ):
+        """Pagination kwargs must be forwarded to convert_response_if_needed for the SQL offload path."""
+        mock_ce_client.get_cost_and_usage.return_value = {
+            'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-01', 'End': '2023-01-02'}}],
+            'NextPageToken': 'continue-here',
+        }
+
+        with patch(
+            'awslabs.billing_cost_management_mcp_server.tools.cost_explorer_operations.convert_response_if_needed',
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = {
+                'status': 'success',
+                'data_stored': True,
+                'table_name': 'getCostAndUsage_xyz',
+                'next_page_token': 'continue-here',
+                'has_more': True,
+                'pages_fetched': 1,
+            }
+
+            await get_cost_and_usage(
+                mock_context,
+                mock_ce_client,
+                start_date='2023-01-01',
+                end_date='2023-01-31',
+            )
+
+        helper_kwargs = mock_helper.call_args.kwargs
+        assert helper_kwargs.get('next_page_token') == 'continue-here'
+        assert helper_kwargs.get('has_more') is True
+        assert helper_kwargs.get('pages_fetched') == 1
+
 
 @pytest.mark.asyncio
 class TestGetCostAndUsageWithResources:
@@ -934,3 +1007,66 @@ class TestGetSavingsPlansUtilization:
         # Verify error was properly handled
         assert result['status'] == 'error'
         assert 'message' in result
+
+
+# Pagination contract — agent-supplied next_token must be injected into the
+# first boto3 request for every paginated CE operation. Pre-fix, only its
+# truthiness was used (as a flag to enable paginate-mode); the value was lost.
+
+@pytest.mark.parametrize(
+    'op_func, ce_method, result_key, token_key, kwargs',
+    [
+        (
+            get_cost_and_usage,
+            'get_cost_and_usage',
+            'ResultsByTime',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_dimension_values,
+            'get_dimension_values',
+            'DimensionValues',
+            'NextPageToken',
+            {'dimension': 'SERVICE', 'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_tags,
+            'get_tags',
+            'Tags',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_cost_categories,
+            'get_cost_categories',
+            'CostCategories',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_savings_plans_utilization,
+            'get_savings_plans_utilization',
+            'SavingsPlansUtilizationsByTime',
+            'NextToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_caller_next_token_injected_into_first_request(
+    mock_context, mock_ce_client, op_func, ce_method, result_key, token_key, kwargs
+):
+    """Caller's next_token reaches the first boto3 call for every paginated CE op."""
+    getattr(mock_ce_client, ce_method).return_value = {result_key: []}
+
+    await op_func(
+        mock_context,
+        mock_ce_client,
+        next_token='resume-from-here',
+        max_pages=1,
+        **kwargs,
+    )
+
+    first_call_kwargs = getattr(mock_ce_client, ce_method).call_args_list[0][1]
+    assert first_call_kwargs.get(token_key) == 'resume-from-here'

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -375,36 +375,37 @@ class TestGetCostAndUsage:
     async def test_pagination_metadata_forwarded_to_sql_offload(
         self, mock_context, mock_ce_client
     ):
-        """Pagination kwargs must be forwarded to convert_response_if_needed for the SQL offload path."""
+        """Pagination markers in the response must surface in the offload result.
+
+        convert_response_if_needed auto-derives next_page_token / has_more /
+        pages_fetched from the response shape (NextPageToken for single-page,
+        or the Pagination sub-dict for the paginate_aws_response wrapper),
+        so the operation no longer passes them as kwargs.
+        """
         mock_ce_client.get_cost_and_usage.return_value = {
             'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-01', 'End': '2023-01-02'}}],
             'NextPageToken': 'continue-here',
         }
 
+        # Force SQL offload so we can inspect the offload result, regardless
+        # of the small response size that would otherwise stay inline.
         with patch(
-            'awslabs.billing_cost_management_mcp_server.tools.cost_explorer_operations.convert_response_if_needed',
-            new_callable=AsyncMock,
-        ) as mock_helper:
-            mock_helper.return_value = {
-                'status': 'success',
-                'data_stored': True,
-                'table_name': 'getCostAndUsage_xyz',
-                'next_page_token': 'continue-here',
-                'has_more': True,
-                'pages_fetched': 1,
-            }
-
-            await get_cost_and_usage(
+            'awslabs.billing_cost_management_mcp_server.utilities.sql_utils.should_convert_to_sql',
+            return_value=True,
+        ):
+            result = await get_cost_and_usage(
                 mock_context,
                 mock_ce_client,
                 start_date='2023-01-01',
                 end_date='2023-01-31',
             )
 
-        helper_kwargs = mock_helper.call_args.kwargs
-        assert helper_kwargs.get('next_page_token') == 'continue-here'
-        assert helper_kwargs.get('has_more') is True
-        assert helper_kwargs.get('pages_fetched') == 1
+        assert result['status'] == 'success'
+        data = result['data']
+        assert data.get('data_stored') is True
+        assert data.get('next_page_token') == 'continue-here'
+        assert data.get('has_more') is True
+        assert data.get('pages_fetched') == 1
 
 
 @pytest.mark.asyncio

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -335,9 +335,7 @@ class TestGetCostAndUsage:
         assert result['status'] == 'error'
         assert 'message' in result
 
-    async def test_caller_next_token_is_used_on_first_request(
-        self, mock_context, mock_ce_client
-    ):
+    async def test_caller_next_token_is_used_on_first_request(self, mock_context, mock_ce_client):
         """Caller-supplied next_token must be injected into the first boto3 call."""
         mock_ce_client.get_cost_and_usage.return_value = {
             'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-02', 'End': '2023-01-03'}}],
@@ -1013,6 +1011,7 @@ class TestGetSavingsPlansUtilization:
 # first boto3 request for every paginated CE operation. Pre-fix, only its
 # truthiness was used (as a flag to enable paginate-mode); the value was lost.
 
+
 @pytest.mark.parametrize(
     'op_func, ce_method, result_key, token_key, kwargs',
     [
@@ -1022,6 +1021,13 @@ class TestGetSavingsPlansUtilization:
             'ResultsByTime',
             'NextPageToken',
             {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_cost_and_usage_with_resources,
+            'get_cost_and_usage_with_resources',
+            'ResultsByTime',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-07'},
         ),
         (
             get_dimension_values,

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -1076,3 +1076,69 @@ async def test_caller_next_token_injected_into_first_request(
 
     first_call_kwargs = getattr(mock_ce_client, ce_method).call_args_list[0][1]
     assert first_call_kwargs.get(token_key) == 'resume-from-here'
+
+
+@pytest.mark.parametrize(
+    'op_func, ce_method, result_key, token_key, kwargs',
+    [
+        (
+            get_cost_and_usage,
+            'get_cost_and_usage',
+            'ResultsByTime',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_cost_and_usage_with_resources,
+            'get_cost_and_usage_with_resources',
+            'ResultsByTime',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-07'},
+        ),
+        (
+            get_dimension_values,
+            'get_dimension_values',
+            'DimensionValues',
+            'NextPageToken',
+            {'dimension': 'SERVICE', 'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_tags,
+            'get_tags',
+            'Tags',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_cost_categories,
+            'get_cost_categories',
+            'CostCategories',
+            'NextPageToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+        (
+            get_savings_plans_utilization,
+            'get_savings_plans_utilization',
+            'SavingsPlansUtilizationsByTime',
+            'NextToken',
+            {'start_date': '2023-01-01', 'end_date': '2023-01-31'},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_max_pages_without_next_token_omits_token_from_first_request(
+    mock_context, mock_ce_client, op_func, ce_method, result_key, token_key, kwargs
+):
+    """When max_pages is set but next_token is None, the first boto3 request must not carry a token."""
+    getattr(mock_ce_client, ce_method).return_value = {result_key: []}
+
+    await op_func(
+        mock_context,
+        mock_ce_client,
+        next_token=None,
+        max_pages=1,
+        **kwargs,
+    )
+
+    first_call_kwargs = getattr(mock_ce_client, ce_method).call_args_list[0][1]
+    assert token_key not in first_call_kwargs

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
@@ -940,6 +940,8 @@ async def test_ce_real_get_cost_and_usage_with_resources_passes_args_reload_iden
             '[{"Type":"DIMENSION","Key":"SERVICE"}]',
             '{"Tags":{"Key":"Environment","Values":["prod"]}}',
             None,
+            None,
+            None,
         )
 
 
@@ -1361,6 +1363,8 @@ async def test_ce_real_get_cost_and_usage_with_resources_with_billing_view_arn(
             '2024-01-10',
             '2024-01-20',
             'DAILY',
+            None,
+            None,
             None,
             None,
             None,

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
@@ -90,36 +90,23 @@ class TestShouldConvertToSql:
         # Assert
         assert result is True
 
-    @patch('os.getenv')
-    def test_should_convert_with_force_enabled(self, mock_getenv):
+    def test_should_convert_with_force_enabled(self):
         """Test should_convert_to_sql with FORCE_SQL_CONVERSION enabled."""
         # Setup - Force conversion regardless of size
         small_size = 100  # Very small response
 
-        # Mock the getenv to return 'true' for MCP_FORCE_SQL
-        mock_getenv.side_effect = (
-            lambda key, default=None: 'true' if key == 'MCP_FORCE_SQL' else default
+        # Patch the module-level FORCE_SQL_CONVERSION constant directly instead of
+        # reloading the module. The previous approach (del sys.modules[...] +
+        # reimport) created a divergent module instance — sys.modules was
+        # restored on exit but the parent package's `sql_utils` attribute was
+        # left pointing at the new module, which broke `patch(...string path...)`
+        # in later tests and made the suite flaky under random test ordering.
+        from awslabs.billing_cost_management_mcp_server.utilities import (
+            sql_utils as sql_utils_mod,
         )
 
-        # Reset module constants by reloading the module
-        with patch.dict('sys.modules'):
-            # Clear the module to force reload
-            import sys
-
-            if 'awslabs.billing_cost_management_mcp_server.utilities.sql_utils' in sys.modules:
-                del sys.modules['awslabs.billing_cost_management_mcp_server.utilities.sql_utils']
-
-            # Now reimport with our patched environment
-            from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
-                FORCE_SQL_CONVERSION,
-                should_convert_to_sql,
-            )
-
-            # Verify patched value took effect
-            assert FORCE_SQL_CONVERSION is True
-
-            # Execute
-        result = should_convert_to_sql(small_size)
+        with patch.object(sql_utils_mod, 'FORCE_SQL_CONVERSION', True):
+            result = sql_utils_mod.should_convert_to_sql(small_size)
 
         # Assert
         assert result is True
@@ -141,11 +128,23 @@ class TestGetSessionDbPath:
         mock_dirname.return_value = '/mock/path'
         mock_abspath.return_value = '/mock/path/file'
 
-        path = get_session_db_path()
+        # Reset the module-level singleton so the mocked path computation runs,
+        # and restore it after so later tests don't get a poisoned path that
+        # doesn't exist on disk (causes sqlite3.OperationalError elsewhere).
+        from awslabs.billing_cost_management_mcp_server.utilities import (
+            sql_utils as sql_utils_mod,
+        )
 
-        # Just verify we get a path back
-        assert path is not None
-        assert isinstance(path, str)
+        saved = sql_utils_mod._SESSION_DB_PATH
+        sql_utils_mod._SESSION_DB_PATH = None
+        try:
+            path = get_session_db_path()
+
+            # Just verify we get a path back
+            assert path is not None
+            assert isinstance(path, str)
+        finally:
+            sql_utils_mod._SESSION_DB_PATH = saved
 
 
 class TestGetDbConnection:

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
@@ -669,13 +669,128 @@ class TestConvertResponseIfNeeded:
 
     @pytest.mark.asyncio
     async def test_convert_response_if_needed_with_small_response(self):
-        """Test convert response if needed with small response."""
+        """Below-threshold response is returned as-is, not wrapped in a size envelope."""
         mock_context = MagicMock(spec=Context)
         response = {'data': ['small']}
 
         result = await convert_response_if_needed(mock_context, response, 'test_api')
 
-        assert 'data' in result
+        assert result is response
+
+
+class TestDerivePaginationEnvelope:
+    """Tests for _derive_pagination_envelope auto-derivation from response shape."""
+
+    def test_from_paginated_wrapper(self):
+        """Response with Pagination sub-dict (paginate_aws_response output) populates the envelope."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _derive_pagination_envelope,
+        )
+
+        response = {
+            'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-01'}}],
+            'Pagination': {
+                'next_token': 'page2',
+                'has_more': True,
+                'pages_fetched': 3,
+                'complete_dataset': False,
+            },
+        }
+
+        envelope = _derive_pagination_envelope(response)
+
+        assert envelope == {
+            'next_page_token': 'page2',
+            'has_more': True,
+            'pages_fetched': 3,
+        }
+
+    def test_from_single_page_response_with_token(self):
+        """Single-page boto3 response with NextPageToken populates the envelope."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _derive_pagination_envelope,
+        )
+
+        response = {
+            'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-01'}}],
+            'NextPageToken': 'continue-here',
+        }
+
+        envelope = _derive_pagination_envelope(response)
+
+        assert envelope == {
+            'next_page_token': 'continue-here',
+            'has_more': True,
+            'pages_fetched': 1,
+        }
+
+    def test_from_single_page_response_with_null_token(self):
+        """Final-page boto3 response (NextPageToken present but None) marks has_more=False."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _derive_pagination_envelope,
+        )
+
+        response = {
+            'ResultsByTime': [{'TimePeriod': {'Start': '2023-01-01'}}],
+            'NextPageToken': None,
+        }
+
+        envelope = _derive_pagination_envelope(response)
+
+        assert envelope == {
+            'next_page_token': None,
+            'has_more': False,
+            'pages_fetched': 1,
+        }
+
+    def test_custom_token_key(self):
+        """token_key override picks up alternative continuation-token field names (e.g. NextToken)."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _derive_pagination_envelope,
+        )
+
+        response = {'PriceList': ['{...}'], 'NextToken': 'page2'}
+
+        envelope = _derive_pagination_envelope(response, token_key='NextToken')
+
+        assert envelope == {
+            'next_page_token': 'page2',
+            'has_more': True,
+            'pages_fetched': 1,
+        }
+
+    def test_non_paginated_response_returns_empty(self):
+        """Forecast / pricing responses without pagination markers get an empty envelope so unrelated APIs aren't polluted."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _derive_pagination_envelope,
+        )
+
+        response = {'ForecastResultsByTime': [{'MeanValue': '10.0'}]}
+
+        envelope = _derive_pagination_envelope(response)
+
+        assert envelope == {}
+
+    @pytest.mark.asyncio
+    async def test_caller_metadata_overrides_derived_envelope(self):
+        """Explicit kwargs to convert_response_if_needed take precedence over derived values."""
+        mock_context = MagicMock(spec=Context)
+        mock_context.info = AsyncMock()
+        response = {'ResultsByTime': [], 'NextPageToken': 'derived-token'}
+
+        # Force offload so the envelope reaches the offload result
+        with patch(
+            'awslabs.billing_cost_management_mcp_server.utilities.sql_utils.should_convert_to_sql',
+            return_value=True,
+        ):
+            result = await convert_response_if_needed(
+                mock_context,
+                response,
+                'cost_explorer_get_cost_and_usage',
+                next_page_token='caller-override',
+            )
+
+        assert result.get('next_page_token') == 'caller-override'
 
 
 @pytest.mark.asyncio
@@ -1248,24 +1363,21 @@ class TestConvertResponseIfNeededErrorHandling:
 
     @patch('awslabs.billing_cost_management_mcp_server.utilities.sql_utils.json.dumps')
     async def test_convert_response_if_needed_json_error(self, mock_json_dumps, mock_context):
-        """Test convert_response_if_needed handles JSON error."""
-        # Setup - Make json.dumps fail on first call but succeed on subsequent calls
-        mock_json_dumps.side_effect = [TypeError('JSON encoding error'), '{"data": "test"}']
+        """Test convert_response_if_needed falls back to the original response on JSON error."""
+        # Make json.dumps fail so size computation throws
+        mock_json_dumps.side_effect = TypeError('JSON encoding error')
         response = {'data': 'test'}
 
-        # Execute
         result = await convert_response_if_needed(mock_context, response, 'test_api')
 
-        # Assert
-        assert result['status'] == 'error'
-        assert 'Error processing response for test_api' in result['message']
-        assert 'JSON encoding error' in result['message']
-        assert result['data'] == response  # Original data should be preserved
+        # Offload is an optimization — failure falls back to the original response,
+        # not an error envelope the caller would have to unwrap.
+        assert result is response
 
     async def test_convert_response_if_needed_conversion_error(self, mock_context):
-        """Test convert_response_if_needed handles conversion error."""
-        # Create a large response that will trigger conversion
-        response = {'data': 'x' * 30000}  # Large enough to exceed threshold
+        """Test convert_response_if_needed falls back to the original response on conversion error."""
+        # Large enough to trigger the offload branch
+        response = {'data': 'x' * 30000}
 
         with patch.object(
             sys.modules['awslabs.billing_cost_management_mcp_server.utilities.sql_utils'],
@@ -1273,14 +1385,9 @@ class TestConvertResponseIfNeededErrorHandling:
         ) as mock_convert:
             mock_convert.side_effect = ValueError('Conversion error')
 
-            # Execute
             result = await convert_response_if_needed(mock_context, response, 'test_api')
 
-            # Assert
-            assert result['status'] == 'error'
-            assert 'Error processing response for test_api' in result['message']
-            assert 'Conversion error' in result['message']
-            assert result['data'] == response  # Original data should be preserved
+            assert result is response
 
 
 class TestInsertDataEdgeCases:


### PR DESCRIPTION

## Summary

Fixes the SQL-offload and pagination paths for the Cost Explorer operations in `billing-cost-management-mcp-server`. 

### Changes

Four commits, all on the same theme:

**SQL offload — dispatch and size gate** (`241bf9a1`)
- Fix dispatch mismatch in `_get_specialized_converter`: keys were
  snake_case but call sites passed camelCase (`getCostAndUsage`,
  `getPricing`), so every lookup returned `None` and all typed-schema
  branches (`cost_and_usage`, `pricing_products`, `dimension_values`,
  `forecast`, `tags`, `cost_categories`) were unreachable. Responses
  fell through to the generic flatten branch and produced a
  `(key TEXT, value TEXT)` table with the entire `ResultsByTime` /
  `PriceList` stuffed into a single stringified-JSON cell.
- Wire `convert_response_if_needed` size gate so small responses
  (median ~11 rows in real evals) are returned inline instead of being
  round-tripped through SQLite. The "fall back to inline response"
  branches at the call sites had been dead code.

**Pagination** (`01b7f598`)
- Honor agent-supplied `next_token`. `paginate_aws_response` started
  with `current_token=None` and only set the token on iteration 2+, so
  the caller value was lost on iteration 1.
- Preserve `NextPageToken` when a response is offloaded to SQL
  (previously dropped).

**Extend SQL offload + pagination to remaining Cost Explorer ops** (`b3a9f935`)
- Wire the size gate for the Cost Explorer ops whose typed converters
  existed but were never dispatched: `getCostAndUsageWithResources`,
  `getDimensionValues`, `getCostForecast`, `getUsageForecast`,
  `getTags`, `getCostCategories`.
- Add `next_token` / `max_pages` pagination to
  `get_cost_and_usage_with_resources`.

**Cost categories sample queries** (`3e75f4c7`)
- The `cost_categories` typed branch creates a table with
  `category_type` / `category_value` columns. The sample-queries
  section had no matching branch and fell through to the generic
  `else` branch, which emitted queries referencing nonexistent
  `key` / `value` columns. Add a `cost_categories` branch with two
  queries that target the real schema.

### User experience

**Before**
- SQL offload was net-negative for the agent. Every offloaded response
  produced a `(key, value)` table with the entire payload stringified
  into one cell — the "specialized" sample queries returned to the
  agent referenced columns that did not exist.
- Even tiny responses got round-tripped through SQLite, forcing an
  extra `session-sql` call to read data that could have been inline.
- Pagination did not work beyond page 1. Agents could not retrieve
  the rest of a paginated result set on any Cost Explorer operation,
  and `NextPageToken` was lost whenever offload triggered.

**After**
- Each Cost Explorer op offloads only when the response exceeds the
  size threshold, and the offloaded data lands in a properly-typed
  table (`time_period_start`, `metric_name`, `amount`, etc. for cost
  and usage; `category_type`, `category_value` for cost categories;
  and so on).
- Small responses come back inline — no extra round-trip.
- Pagination works on all paginated Cost Explorer operations, both
  inline and offloaded. The agent can supply `next_token` and walk
  through pages.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
