### PR TITLE
feat(healthomics): adds support for  scratch storage modes

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/consts.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/consts.py
@@ -66,6 +66,14 @@ CACHE_BEHAVIOR_ALWAYS = 'CACHE_ALWAYS'
 CACHE_BEHAVIOR_ON_FAILURE = 'CACHE_ON_FAILURE'
 CACHE_BEHAVIORS = [CACHE_BEHAVIOR_ALWAYS, CACHE_BEHAVIOR_ON_FAILURE]
 
+# Scratch storage modes
+SCRATCH_STORAGE_MODE_LOCAL = 'LOCAL'
+SCRATCH_STORAGE_MODE_SHARED = 'SHARED'
+SCRATCH_STORAGE_MODES = [SCRATCH_STORAGE_MODE_LOCAL, SCRATCH_STORAGE_MODE_SHARED]
+
+# MCP server default scratch storage mode (diverges from the HealthOmics API default of SHARED)
+DEFAULT_SCRATCH_STORAGE_MODE = SCRATCH_STORAGE_MODE_LOCAL
+
 # Run statuses
 RUN_STATUS_PENDING = 'PENDING'
 RUN_STATUS_STARTING = 'STARTING'
@@ -207,6 +215,7 @@ ERROR_INVALID_WORKFLOW_TYPE = 'Invalid workflow type. Must be one of: {}'
 ERROR_INVALID_EXPORT_TYPE = 'Invalid export type. Must be one of: {}'
 ERROR_INVALID_STORAGE_TYPE = 'Invalid storage type. Must be one of: {}'
 ERROR_INVALID_CACHE_BEHAVIOR = 'Invalid cache behavior. Must be one of: {}'
+ERROR_INVALID_SCRATCH_STORAGE_MODE = "Invalid scratch storage mode '{}'. Must be one of: {}"
 ERROR_INVALID_RUN_STATUS = 'Invalid run status. Must be one of: {}'
 ERROR_STATIC_STORAGE_REQUIRES_CAPACITY = (
     'Storage capacity is required when using STATIC storage type'

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/models/core.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/models/core.py
@@ -38,6 +38,13 @@ class StorageType(str, Enum):
     DYNAMIC = 'DYNAMIC'
 
 
+class ScratchStorageMode(str, Enum):
+    """Enum for scratch storage modes."""
+
+    LOCAL = 'LOCAL'
+    SHARED = 'SHARED'
+
+
 class CacheBehavior(str, Enum):
     """Enum for cache behaviors."""
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/run_batch.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/run_batch.py
@@ -17,9 +17,12 @@
 from awslabs.aws_healthomics_mcp_server.consts import (
     BATCH_STATUSES,
     DEFAULT_MAX_RESULTS,
+    DEFAULT_SCRATCH_STORAGE_MODE,
     ERROR_INVALID_BATCH_RUN_SETTINGS,
     ERROR_INVALID_BATCH_STATUS,
+    ERROR_INVALID_SCRATCH_STORAGE_MODE,
     ERROR_INVALID_SUBMISSION_STATUS,
+    SCRATCH_STORAGE_MODES,
     SUBMISSION_STATUSES,
 )
 from awslabs.aws_healthomics_mcp_server.utils.aws_utils import (
@@ -79,6 +82,16 @@ async def start_run_batch(
         None, description='Cache behavior: CACHE_ALWAYS or CACHE_ON_FAILURE'
     ),
     retention_mode: Optional[str] = Field(None, description='Retention mode: RETAIN or REMOVE'),
+    scratch_storage_mode: Optional[str] = Field(
+        None,
+        description=(
+            'Scratch storage mode applied to all runs in the batch. Allowed values: '
+            'LOCAL (mount local EBS ephemeral scratch storage at /tmp for CPU tasks) or '
+            'SHARED (use shared scratch storage). '
+            'Defaults to LOCAL when omitted (the MCP server default; note the HealthOmics '
+            'API default is SHARED).'
+        ),
+    ),
     request_id: Optional[str] = Field(None, description='Idempotency token'),
     tags: Optional[Dict[str, str]] = Field(None, description='Tags for the batch'),
     aws_profile: Optional[str] = Field(
@@ -108,6 +121,7 @@ async def start_run_batch(
         cache_id: Optional run cache ID
         cache_behavior: Optional cache behavior
         retention_mode: Optional retention mode
+        scratch_storage_mode: Optional scratch storage mode (LOCAL or SHARED); defaults to LOCAL
         request_id: Optional idempotency token
         tags: Optional tags for the batch
         aws_profile: Optional AWS profile name override
@@ -121,6 +135,23 @@ async def start_run_batch(
         validation_error = _validate_batch_run_settings(batch_run_settings)
         if validation_error:
             return await handle_tool_error(ctx, ValueError(validation_error), 'Invalid parameters')
+
+        # Resolve and validate scratch storage mode before any API call
+        effective_scratch_storage_mode = (
+            scratch_storage_mode
+            if scratch_storage_mode is not None
+            else DEFAULT_SCRATCH_STORAGE_MODE
+        )
+        if effective_scratch_storage_mode not in SCRATCH_STORAGE_MODES:
+            return await handle_tool_error(
+                ctx,
+                ValueError(
+                    ERROR_INVALID_SCRATCH_STORAGE_MODE.format(
+                        effective_scratch_storage_mode, SCRATCH_STORAGE_MODES
+                    )
+                ),
+                'Invalid scratch storage mode',
+            )
 
         client = get_omics_client(region_name=aws_region, profile_name=aws_profile)
 
@@ -157,6 +188,10 @@ async def start_run_batch(
 
         if retention_mode is not None:
             default_run_setting['retentionMode'] = retention_mode
+
+        # Always inject the effective scratch storage mode so all runs in the batch
+        # use the MCP server default (LOCAL) unless the caller overrides it.
+        default_run_setting['scratchStorageMode'] = effective_scratch_storage_mode
 
         # Build API params
         params: Dict[str, Any] = {

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_execution.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_execution.py
@@ -17,10 +17,12 @@
 from awslabs.aws_healthomics_mcp_server.consts import (
     CACHE_BEHAVIORS,
     DEFAULT_MAX_RESULTS,
+    DEFAULT_SCRATCH_STORAGE_MODE,
     ERROR_CONFIGURATION_NAME_REQUIRES_VPC_MODE,
     ERROR_INVALID_CACHE_BEHAVIOR,
     ERROR_INVALID_NETWORKING_MODE,
     ERROR_INVALID_RUN_STATUS,
+    ERROR_INVALID_SCRATCH_STORAGE_MODE,
     ERROR_INVALID_STORAGE_TYPE,
     ERROR_STATIC_STORAGE_REQUIRES_CAPACITY,
     ERROR_VPC_MODE_REQUIRES_CONFIGURATION_NAME,
@@ -28,6 +30,7 @@ from awslabs.aws_healthomics_mcp_server.consts import (
     NETWORKING_MODE_VPC,
     NETWORKING_MODES,
     RUN_STATUSES,
+    SCRATCH_STORAGE_MODES,
     STORAGE_TYPE_STATIC,
     STORAGE_TYPES,
 )
@@ -177,6 +180,16 @@ async def start_run(
         None,
         description='Configuration name (required when networking_mode is VPC)',
     ),
+    scratch_storage_mode: Optional[str] = Field(
+        None,
+        description=(
+            'Scratch storage mode for the run. Allowed values: '
+            'LOCAL (mount local EBS ephemeral scratch storage at /tmp for CPU tasks) or '
+            'SHARED (use shared scratch storage). '
+            'Defaults to LOCAL when omitted (the MCP server default; note the HealthOmics '
+            'API default is SHARED).'
+        ),
+    ),
     aws_profile: Optional[str] = Field(
         None,
         description='AWS profile name for this operation. Overrides the default credential chain.',
@@ -208,6 +221,7 @@ async def start_run(
         run_group_id: Optional ID of a run group to associate with this run
         networking_mode: Optional networking mode (RESTRICTED or VPC)
         configuration_name: Optional configuration name (required when networking_mode is VPC)
+        scratch_storage_mode: Optional scratch storage mode (LOCAL or SHARED); defaults to LOCAL
         aws_profile: Optional AWS profile name override
         aws_region: Optional AWS region override
 
@@ -271,6 +285,22 @@ async def start_run(
             'Invalid networking configuration',
         )
 
+    # Resolve and validate scratch storage mode (MCP server defaults to LOCAL)
+    effective_scratch_storage_mode = (
+        scratch_storage_mode if scratch_storage_mode is not None else DEFAULT_SCRATCH_STORAGE_MODE
+    )
+
+    if effective_scratch_storage_mode not in SCRATCH_STORAGE_MODES:
+        return await handle_tool_error(
+            ctx,
+            ValueError(
+                ERROR_INVALID_SCRATCH_STORAGE_MODE.format(
+                    effective_scratch_storage_mode, SCRATCH_STORAGE_MODES
+                )
+            ),
+            'Invalid scratch storage mode',
+        )
+
     # Ensure output URI ends with a slash
     try:
         output_uri = ensure_s3_uri_ends_with_slash(output_uri)
@@ -286,6 +316,7 @@ async def start_run(
         'outputUri': output_uri,
         'parameters': parameters,
         'storageType': storage_type,
+        'scratchStorageMode': effective_scratch_storage_mode,
     }
 
     if workflow_version_name:
@@ -324,6 +355,7 @@ async def start_run(
             'networkingMode': networking_mode
             if networking_mode is not None
             else NETWORKING_MODE_RESTRICTED,
+            'scratchStorageMode': effective_scratch_storage_mode,
         }
     except Exception as e:
         return await handle_tool_error(ctx, e, 'Error starting run')
@@ -571,7 +603,12 @@ async def get_run(
                 result[field] = response[field].isoformat()
 
         # Handle optional string fields
-        for field in ['statusMessage', 'failureReason', 'workflowVersionName']:
+        for field in [
+            'statusMessage',
+            'failureReason',
+            'workflowVersionName',
+            'scratchStorageMode',
+        ]:
             if field in response:
                 result[field] = response[field]
 

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -5,7 +5,8 @@ description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmi
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "boto3>=1.42.78",
+    "boto3>=1.43.36",
+    "botocore>=1.43.36",
     "loguru>=0.7.0",
     "mcp[cli]>=1.23.0",
     "pydantic>=2.10.6",

--- a/src/aws-healthomics-mcp-server/tests/test_consts.py
+++ b/src/aws-healthomics-mcp-server/tests/test_consts.py
@@ -199,6 +199,60 @@ class TestErrorMessages:
         # ERROR_STATIC_STORAGE_REQUIRES_CAPACITY doesn't have placeholders
 
 
+class TestScratchStorageModes:
+    """Test cases for scratch storage mode constants.
+
+    Feature: local-temp-storage
+    Validates: Requirements MCP server defaults to LOCAL scratch storage,
+    Validation of the scratch storage mode value
+    """
+
+    def test_scratch_storage_mode_constants(self):
+        """Test individual scratch storage mode constants."""
+        assert consts.SCRATCH_STORAGE_MODE_LOCAL == 'LOCAL'
+        assert consts.SCRATCH_STORAGE_MODE_SHARED == 'SHARED'
+
+    def test_scratch_storage_modes_list(self):
+        """Test SCRATCH_STORAGE_MODES contains exactly LOCAL and SHARED in order."""
+        assert consts.SCRATCH_STORAGE_MODES == ['LOCAL', 'SHARED']
+        assert consts.SCRATCH_STORAGE_MODE_LOCAL in consts.SCRATCH_STORAGE_MODES
+        assert consts.SCRATCH_STORAGE_MODE_SHARED in consts.SCRATCH_STORAGE_MODES
+        assert len(consts.SCRATCH_STORAGE_MODES) == 2
+
+    def test_default_scratch_storage_mode_is_local(self):
+        """Test the MCP server default scratch storage mode is LOCAL."""
+        assert consts.DEFAULT_SCRATCH_STORAGE_MODE == 'LOCAL'
+        assert consts.DEFAULT_SCRATCH_STORAGE_MODE in consts.SCRATCH_STORAGE_MODES
+
+
+class TestScratchStorageErrorTemplate:
+    """Test cases for the invalid scratch storage mode error template.
+
+    Feature: local-temp-storage
+    Validates: Requirements Validation of the scratch storage mode value
+    """
+
+    def test_error_template_has_two_placeholders(self):
+        """Test the template exposes placeholders for the value and allowed list."""
+        assert isinstance(consts.ERROR_INVALID_SCRATCH_STORAGE_MODE, str)
+        # Two positional placeholders: rejected value and allowed-values list.
+        assert consts.ERROR_INVALID_SCRATCH_STORAGE_MODE.count('{}') == 2
+
+    def test_error_template_includes_rejected_value_and_allowed_list(self):
+        """Test the formatted message names the rejected value and the allowed list."""
+        rejected = 'local'
+        message = consts.ERROR_INVALID_SCRATCH_STORAGE_MODE.format(
+            rejected, consts.SCRATCH_STORAGE_MODES
+        )
+
+        # The rejected value appears in the message.
+        assert rejected in message
+        # The complete list of allowed values appears in the message.
+        assert str(consts.SCRATCH_STORAGE_MODES) in message
+        assert 'LOCAL' in message
+        assert 'SHARED' in message
+
+
 class TestConstantsIntegration:
     """Integration tests for constants."""
 

--- a/src/aws-healthomics-mcp-server/tests/test_models.py
+++ b/src/aws-healthomics-mcp-server/tests/test_models.py
@@ -1125,3 +1125,34 @@ class TestSourceReferenceModel:
 
         with pytest.raises(ValidationError):
             SourceReference(type='INVALID_TYPE', value='main')  # type: ignore[arg-type]
+
+
+class TestScratchStorageModeEnum:
+    """Test cases for the ScratchStorageMode enum.
+
+    Feature: local-temp-storage
+    Validates: Requirements Scratch storage mode parameter on the single-run tool,
+    Scratch storage mode parameter on the batch-run tool
+    """
+
+    def test_members_equal_expected_strings(self):
+        """Test ScratchStorageMode members compare equal to their string values."""
+        from awslabs.aws_healthomics_mcp_server.models.core import ScratchStorageMode
+
+        assert ScratchStorageMode.LOCAL == 'LOCAL'
+        assert ScratchStorageMode.SHARED == 'SHARED'
+        assert ScratchStorageMode.LOCAL.value == 'LOCAL'
+        assert ScratchStorageMode.SHARED.value == 'SHARED'
+
+    def test_is_str_enum(self):
+        """Test ScratchStorageMode members are usable as strings."""
+        from awslabs.aws_healthomics_mcp_server.models.core import ScratchStorageMode
+
+        assert isinstance(ScratchStorageMode.LOCAL, str)
+        assert isinstance(ScratchStorageMode.SHARED, str)
+
+    def test_exactly_two_members(self):
+        """Test ScratchStorageMode defines exactly LOCAL and SHARED."""
+        from awslabs.aws_healthomics_mcp_server.models.core import ScratchStorageMode
+
+        assert [member.value for member in ScratchStorageMode] == ['LOCAL', 'SHARED']

--- a/src/aws-healthomics-mcp-server/tests/test_run_batch.py
+++ b/src/aws-healthomics-mcp-server/tests/test_run_batch.py
@@ -14,12 +14,14 @@
 
 """Unit tests for run batch tools."""
 
+import inspect as _inspect
 import pytest
 from awslabs.aws_healthomics_mcp_server.consts import (
     BATCH_STATUSES,
     ERROR_INVALID_BATCH_RUN_SETTINGS,
     SUBMISSION_STATUSES,
 )
+from awslabs.aws_healthomics_mcp_server.tools import run_batch as _run_batch
 from awslabs.aws_healthomics_mcp_server.tools.run_batch import (
     _validate_batch_run_settings,
     cancel_run_batch,
@@ -1311,3 +1313,416 @@ class TestDeleteBatch:
         mock_get_client.assert_called_once_with(
             region_name='sa-east-1', profile_name='admin-profile'
         )
+
+
+# --- Property-Based Tests: scratch storage mode ---
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+# Feature: local-temp-storage, Property: start_run_batch forwards the effective scratch
+# storage mode into default run settings
+class TestStartRunBatchForwardsEffectiveScratchStorageMode:
+    """start_run_batch forwards the effective scratch storage mode into default run settings.
+
+    For any caller input where scratch_storage_mode is either a valid member of
+    SCRATCH_STORAGE_MODES (LOCAL/SHARED) or None, when start_run_batch successfully starts a
+    batch, the defaultRunSetting passed to the HealthOmics start_run_batch API contains a
+    scratchStorageMode equal to the effective mode -- the caller-provided value when non-null,
+    or LOCAL when the caller value is None.
+
+    **Validates: Requirements MCP server defaults to LOCAL scratch storage, Scratch storage
+    mode parameter on the batch-run tool**
+    """
+
+    _sample_response = {
+        'id': 'batch-12345678',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:batch/batch-12345678',
+        'status': 'PENDING',
+        'uuid': 'uuid-12345678-1234-1234-1234-123456789012',
+        'tags': {'env': 'test'},
+    }
+
+    _batch_run_settings = {
+        'inlineSettings': [
+            {
+                'runSettingId': 'sample-001',
+                'name': 'Sample 001 Analysis',
+                'parameters': {'input_file': 's3://bucket/sample001.bam'},
+            },
+        ]
+    }
+
+    @given(scratch_storage_mode=st.one_of(st.sampled_from(['LOCAL', 'SHARED']), st.none()))
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_forwards_effective_mode_into_default_run_setting(self, scratch_storage_mode):
+        """defaultRunSetting['scratchStorageMode'] equals the effective mode (caller or LOCAL)."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.start_run_batch.return_value = self._sample_response
+
+        kwargs = {
+            'ctx': mock_ctx,
+            'workflow_id': 'workflow-123',
+            'role_arn': 'arn:aws:iam::123456789012:role/OmicsRole',
+            'output_uri': 's3://output-bucket/results/',
+            'batch_run_settings': self._batch_run_settings,
+        }
+        if scratch_storage_mode is not None:
+            kwargs['scratch_storage_mode'] = scratch_storage_mode
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await start_run_batch_wrapper.call(**kwargs)
+
+        assert 'error' not in result, f'Unexpected error: {result}'
+        mock_client.start_run_batch.assert_called_once()
+
+        expected_mode = scratch_storage_mode if scratch_storage_mode is not None else 'LOCAL'
+        call_kwargs = mock_client.start_run_batch.call_args.kwargs
+        assert 'defaultRunSetting' in call_kwargs
+        assert call_kwargs['defaultRunSetting'].get('scratchStorageMode') == expected_mode
+
+
+import copy  # noqa: E402
+
+
+# Feature: local-temp-storage, Property: start_run_batch rejects any invalid scratch storage
+# mode without calling the API
+class TestStartRunBatchRejectsInvalidScratchStorageMode:
+    """start_run_batch rejects any invalid scratch storage mode without calling the API.
+
+    For any non-null scratch_storage_mode value that is not an exact (case-sensitive) member of
+    SCRATCH_STORAGE_MODES -- including case variants, empty strings, and whitespace-only strings
+    -- start_run_batch returns an error response that names the rejected value and lists all
+    allowed values, leaves caller-provided run inputs unchanged, and never calls the HealthOmics
+    start_run_batch API.
+
+    **Validates: Requirements MCP server defaults to LOCAL scratch storage, Scratch storage
+    mode parameter on the batch-run tool, Validation of the scratch storage mode value**
+    """
+
+    @staticmethod
+    def _build_batch_run_settings():
+        return {
+            'inlineSettings': [
+                {
+                    'runSettingId': 'sample-001',
+                    'name': 'Sample 001 Analysis',
+                    'parameters': {'input_file': 's3://bucket/sample001.bam'},
+                },
+            ]
+        }
+
+    @given(
+        scratch_storage_mode=st.one_of(
+            # Arbitrary text that is not an exact valid mode.
+            st.text().filter(lambda value: value not in ('LOCAL', 'SHARED')),
+            # Explicit edge cases: case variants, trailing whitespace, empty, whitespace-only.
+            st.sampled_from(
+                [
+                    'local',
+                    'shared',
+                    'Local',
+                    'Shared',
+                    'LOCAL ',
+                    ' LOCAL',
+                    'SHARED ',
+                    'lOCAL',
+                    '',
+                    '   ',
+                    '\t',
+                    '\n',
+                ]
+            ),
+        )
+    )
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_mode_without_calling_api(self, scratch_storage_mode):
+        """Invalid modes are rejected; API not called; caller inputs unchanged."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+
+        batch_run_settings = self._build_batch_run_settings()
+        original_batch_run_settings = copy.deepcopy(batch_run_settings)
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await start_run_batch_wrapper.call(
+                ctx=mock_ctx,
+                workflow_id='workflow-123',
+                role_arn='arn:aws:iam::123456789012:role/OmicsRole',
+                output_uri='s3://output-bucket/results/',
+                batch_run_settings=batch_run_settings,
+                scratch_storage_mode=scratch_storage_mode,
+            )
+
+        # An error response is returned.
+        assert 'error' in result, f'Expected an error response, got: {result}'
+        error_message = result['error']
+
+        # The error names the rejected value and lists all allowed values.
+        assert str(scratch_storage_mode) in error_message
+        assert 'LOCAL' in error_message
+        assert 'SHARED' in error_message
+
+        # The HealthOmics start_run_batch API was never called.
+        mock_client.start_run_batch.assert_not_called()
+
+        # Caller-provided run inputs are left unchanged.
+        assert batch_run_settings == original_batch_run_settings
+
+
+# Feature: local-temp-storage, Property: start_run_batch response preserves the pre-scratch-storage schema
+class TestStartRunBatchResponsePreservesPreScratchStorageSchema:
+    """start_run_batch response preserves the pre-scratch-storage schema.
+
+    For any valid caller input and HealthOmics start_run_batch API response, when
+    start_run_batch succeeds, every field present in the pre-scratch-storage top-level response
+    schema (id, arn, status, uuid, tags) is present with unchanged name, type, and value.
+
+    **Validates: Requirements Backward compatibility**
+    """
+
+    _batch_run_settings = {
+        'inlineSettings': [
+            {
+                'runSettingId': 'sample-001',
+                'name': 'Sample 001 Analysis',
+                'parameters': {'input_file': 's3://bucket/sample001.bam'},
+            },
+        ]
+    }
+
+    @given(
+        scratch_storage_mode=st.one_of(st.sampled_from(['LOCAL', 'SHARED']), st.none()),
+        batch_id=st.text(min_size=1, max_size=40),
+        status=st.sampled_from(['PENDING', 'STARTING', 'RUNNING', 'COMPLETED', 'FAILED']),
+        uuid=st.text(min_size=1, max_size=40),
+        tags=st.dictionaries(
+            keys=st.text(min_size=1, max_size=10),
+            values=st.text(min_size=0, max_size=10),
+            max_size=5,
+        ),
+    )
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_response_preserves_legacy_top_level_fields(
+        self, scratch_storage_mode, batch_id, status, uuid, tags
+    ):
+        """Every legacy top-level field is present with unchanged name, type, and value."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+
+        # Known response dict the mocked HealthOmics API returns.
+        arn = f'arn:aws:omics:us-east-1:123456789012:batch/{batch_id}'
+        api_response = {
+            'id': batch_id,
+            'arn': arn,
+            'status': status,
+            'uuid': uuid,
+            'tags': tags,
+        }
+        mock_client.start_run_batch.return_value = api_response
+
+        kwargs = {
+            'ctx': mock_ctx,
+            'workflow_id': 'workflow-123',
+            'role_arn': 'arn:aws:iam::123456789012:role/OmicsRole',
+            'output_uri': 's3://output-bucket/results/',
+            'batch_run_settings': self._batch_run_settings,
+        }
+        if scratch_storage_mode is not None:
+            kwargs['scratch_storage_mode'] = scratch_storage_mode
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await start_run_batch_wrapper.call(**kwargs)
+
+        assert 'error' not in result, f'Unexpected error: {result}'
+
+        # Each legacy top-level field is present with unchanged name, type, and value.
+        for field in ('id', 'arn', 'status', 'uuid', 'tags'):
+            assert field in result, f'Missing legacy field: {field}'
+            expected_value = api_response[field]
+            assert result[field] == expected_value
+            assert type(result[field]) is type(expected_value)
+
+
+# ---------------------------------------------------------------------------
+# Scratch storage mode example tests (Feature: local-temp-storage)
+# ---------------------------------------------------------------------------
+
+
+def _build_batch_run_settings():
+    """Build minimal valid inline batch run settings for example tests."""
+    return {
+        'inlineSettings': [
+            {
+                'runSettingId': 'sample-001',
+                'name': 'Sample 001 Analysis',
+                'parameters': {'input_file': 's3://bucket/sample001.bam'},
+            },
+        ]
+    }
+
+
+def _build_start_run_batch_response():
+    """Build a minimal successful start_run_batch API response for example tests."""
+    return {
+        'id': 'batch-scratch-1',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:batch/batch-scratch-1',
+        'status': 'PENDING',
+        'uuid': 'uuid-batch-scratch-1',
+        'tags': {'env': 'test'},
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_run_batch_scratch_storage_mode_local_happy_path():
+    """LOCAL is injected into defaultRunSetting passed to the API.
+
+    Validates: Requirements Scratch storage mode parameter on the batch-run tool.
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run_batch.return_value = _build_start_run_batch_response()
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await start_run_batch_wrapper.call(
+            ctx=mock_ctx,
+            workflow_id='workflow-123',
+            role_arn='arn:aws:iam::123456789012:role/OmicsRole',
+            output_uri='s3://output-bucket/results/',
+            batch_run_settings=_build_batch_run_settings(),
+            scratch_storage_mode='LOCAL',
+        )
+
+    assert 'error' not in result, f'Unexpected error: {result}'
+    call_kwargs = mock_client.start_run_batch.call_args.kwargs
+    assert call_kwargs['defaultRunSetting']['scratchStorageMode'] == 'LOCAL'
+
+
+@pytest.mark.asyncio
+async def test_start_run_batch_scratch_storage_mode_shared_happy_path():
+    """SHARED is injected into defaultRunSetting passed to the API.
+
+    Validates: Requirements Scratch storage mode parameter on the batch-run tool.
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run_batch.return_value = _build_start_run_batch_response()
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await start_run_batch_wrapper.call(
+            ctx=mock_ctx,
+            workflow_id='workflow-123',
+            role_arn='arn:aws:iam::123456789012:role/OmicsRole',
+            output_uri='s3://output-bucket/results/',
+            batch_run_settings=_build_batch_run_settings(),
+            scratch_storage_mode='SHARED',
+        )
+
+    assert 'error' not in result, f'Unexpected error: {result}'
+    call_kwargs = mock_client.start_run_batch.call_args.kwargs
+    assert call_kwargs['defaultRunSetting']['scratchStorageMode'] == 'SHARED'
+
+
+@pytest.mark.asyncio
+async def test_start_run_batch_scratch_storage_mode_omitted_defaults_to_local():
+    """Omitting scratch_storage_mode applies the MCP default LOCAL in defaultRunSetting.
+
+    Validates: Requirements MCP server defaults to LOCAL scratch storage,
+    Scratch storage mode parameter on the batch-run tool.
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run_batch.return_value = _build_start_run_batch_response()
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await start_run_batch_wrapper.call(
+            ctx=mock_ctx,
+            workflow_id='workflow-123',
+            role_arn='arn:aws:iam::123456789012:role/OmicsRole',
+            output_uri='s3://output-bucket/results/',
+            batch_run_settings=_build_batch_run_settings(),
+            # scratch_storage_mode intentionally omitted -> defaults to LOCAL
+        )
+
+    assert 'error' not in result, f'Unexpected error: {result}'
+    call_kwargs = mock_client.start_run_batch.call_args.kwargs
+    assert call_kwargs['defaultRunSetting']['scratchStorageMode'] == 'LOCAL'
+
+
+@pytest.mark.asyncio
+async def test_start_run_batch_scratch_storage_misconfigured_default_rejected():
+    """A misconfigured (invalid) MCP default is rejected without calling the API.
+
+    Validates: Requirements Backward compatibility (misconfigured default rejection).
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run_batch.return_value = _build_start_run_batch_response()
+
+    with (
+        patch(
+            'awslabs.aws_healthomics_mcp_server.tools.run_batch.get_omics_client',
+            return_value=mock_client,
+        ),
+        patch(
+            'awslabs.aws_healthomics_mcp_server.tools.run_batch.DEFAULT_SCRATCH_STORAGE_MODE',
+            'INVALID',
+        ),
+    ):
+        result = await start_run_batch_wrapper.call(
+            ctx=mock_ctx,
+            workflow_id='workflow-123',
+            role_arn='arn:aws:iam::123456789012:role/OmicsRole',
+            output_uri='s3://output-bucket/results/',
+            batch_run_settings=_build_batch_run_settings(),
+            # scratch_storage_mode omitted -> resolves to the misconfigured default
+        )
+
+    # The request is rejected with an error and the API is never invoked.
+    assert 'error' in result
+    assert 'INVALID' in result['error']
+    mock_client.start_run_batch.assert_not_called()
+
+
+def test_start_run_batch_scratch_storage_mode_parameter_description():
+    """The parameter description documents LOCAL, SHARED, their meaning, and the LOCAL default.
+
+    Validates: Requirements Scratch storage mode parameter on the batch-run tool
+    (parameter documentation).
+    """
+    signature = _inspect.signature(_run_batch.start_run_batch)
+    field_info = signature.parameters['scratch_storage_mode'].default
+    description = field_info.description
+
+    assert description is not None
+    # Documents both allowed values.
+    assert 'LOCAL' in description
+    assert 'SHARED' in description
+    # Documents the meaning of each value.
+    assert 'ephemeral' in description.lower()
+    assert 'shared scratch storage' in description.lower()
+    # Documents that the MCP server default is LOCAL.
+    assert 'default' in description.lower()

--- a/src/aws-healthomics-mcp-server/tests/test_sdk_scratch_storage.py
+++ b/src/aws-healthomics-mcp-server/tests/test_sdk_scratch_storage.py
@@ -1,0 +1,119 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration / smoke tests for AWS SDK scratch storage mode support.
+
+These are low-iteration smoke tests (not property tests) that verify the
+external AWS SDK behavior required by this feature:
+
+- The installed boto3 / botocore versions meet the minimum that introduced the
+  ``scratchStorageMode`` parameter, and pyproject.toml declares that minimum.
+- A real ``omics`` boto3 client's StartRun and StartRunBatch operation models
+  accept ``scratchStorageMode`` (no network calls are made; the parameter is
+  verified against the client's input shape model).
+
+Validates: Requirements Minimum AWS SDK version
+"""
+
+import boto3
+import botocore
+import pathlib
+import re
+from packaging.version import Version
+
+
+# Minimum SDK version that introduced the scratchStorageMode parameter on the
+# HealthOmics StartRun / StartRunBatch request shapes.
+MINIMUM_SDK_VERSION = Version('1.43.36')
+
+# Repo root is the parent of the tests/ directory.
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYPROJECT_PATH = REPO_ROOT / 'pyproject.toml'
+
+
+def test_installed_boto3_version_meets_minimum():
+    """The installed boto3 version is >= 1.43.36."""
+    assert Version(boto3.__version__) >= MINIMUM_SDK_VERSION, (
+        f'Installed boto3 {boto3.__version__} is below the required minimum {MINIMUM_SDK_VERSION}'
+    )
+
+
+def test_installed_botocore_version_meets_minimum():
+    """The installed botocore version is >= 1.43.36."""
+    assert Version(botocore.__version__) >= MINIMUM_SDK_VERSION, (
+        f'Installed botocore {botocore.__version__} is below the required '
+        f'minimum {MINIMUM_SDK_VERSION}'
+    )
+
+
+def _declared_minimum(package):
+    """Return the declared minimum Version for a package from pyproject.toml."""
+    text = PYPROJECT_PATH.read_text(encoding='utf-8')
+    # Match a quoted dependency entry such as "boto3>=1.43.36".
+    match = re.search(rf'["\']{package}\s*>=\s*([0-9][0-9A-Za-z.\-]*)["\']', text)
+    if match:
+        return Version(match.group(1))
+    return None
+
+
+def test_pyproject_declares_boto3_minimum():
+    """pyproject.toml declares a boto3 minimum of at least 1.43.36."""
+    declared = _declared_minimum('boto3')
+
+    assert declared is not None, 'boto3 dependency constraint not found in pyproject.toml'
+    assert declared >= MINIMUM_SDK_VERSION, (
+        f'pyproject.toml declares boto3>={declared}, below required {MINIMUM_SDK_VERSION}'
+    )
+
+
+def test_pyproject_declares_botocore_minimum():
+    """pyproject.toml declares an explicit botocore minimum of at least 1.43.36."""
+    declared = _declared_minimum('botocore')
+
+    assert declared is not None, 'botocore dependency constraint not found in pyproject.toml'
+    assert declared >= MINIMUM_SDK_VERSION, (
+        f'pyproject.toml declares botocore>={declared}, below required {MINIMUM_SDK_VERSION}'
+    )
+
+
+def _omics_input_members(operation_name):
+    """Return the input shape members for an omics operation (no network calls)."""
+    client = boto3.client('omics', region_name='us-east-1')
+    operation_model = client.meta.service_model.operation_model(operation_name)
+    return operation_model.input_shape.members
+
+
+def test_start_run_accepts_scratch_storage_mode():
+    """The StartRun operation model accepts the scratchStorageMode parameter."""
+    members = _omics_input_members('StartRun')
+    assert 'scratchStorageMode' in members, (
+        'StartRun input shape does not declare scratchStorageMode; '
+        'the installed SDK does not support scratch storage mode'
+    )
+
+
+def test_start_run_batch_accepts_scratch_storage_mode():
+    """The StartRunBatch defaultRunSetting accepts the scratchStorageMode parameter."""
+    # For StartRunBatch the scratchStorageMode lives inside the defaultRunSetting
+    # structure (the per-batch default applied to every run), matching where the
+    # batch tool injects it.
+    members = _omics_input_members('StartRunBatch')
+    assert 'defaultRunSetting' in members, (
+        'StartRunBatch input shape does not declare defaultRunSetting'
+    )
+    default_run_setting_members = members['defaultRunSetting'].members
+    assert 'scratchStorageMode' in default_run_setting_members, (
+        'StartRunBatch defaultRunSetting does not declare scratchStorageMode; '
+        'the installed SDK does not support scratch storage mode'
+    )

--- a/src/aws-healthomics-mcp-server/tests/test_workflow_execution.py
+++ b/src/aws-healthomics-mcp-server/tests/test_workflow_execution.py
@@ -15,7 +15,11 @@
 """Unit tests for workflow execution tools."""
 
 import botocore.exceptions
+import copy as _copy
+import inspect as _inspect
 import pytest
+from awslabs.aws_healthomics_mcp_server.consts import DEFAULT_SCRATCH_STORAGE_MODE
+from awslabs.aws_healthomics_mcp_server.tools import workflow_execution as _workflow_execution
 from awslabs.aws_healthomics_mcp_server.tools.workflow_execution import (
     get_run,
     get_run_task,
@@ -24,6 +28,9 @@ from awslabs.aws_healthomics_mcp_server.tools.workflow_execution import (
     start_run,
 )
 from datetime import datetime, timedelta, timezone
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from tests.test_helpers import MCPToolTestWrapper
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -1041,6 +1048,7 @@ async def test_start_run_success():
             run_group_id=None,
             networking_mode=None,
             configuration_name=None,
+            scratch_storage_mode=None,
         )
 
     # Verify client was called correctly
@@ -1051,6 +1059,7 @@ async def test_start_run_success():
         outputUri='s3://my-bucket/outputs/',
         parameters={'param1': 'value1'},
         storageType='DYNAMIC',
+        scratchStorageMode='LOCAL',
     )
 
     # Verify result contains expected fields
@@ -1096,6 +1105,7 @@ async def test_start_run_null_response_fields():
             run_group_id=None,
             networking_mode=None,
             configuration_name=None,
+            scratch_storage_mode=None,
         )
 
     assert result['id'] == 'run-99999'
@@ -1140,6 +1150,7 @@ async def test_start_run_with_static_storage():
             run_group_id=None,
             networking_mode=None,
             configuration_name=None,
+            scratch_storage_mode=None,
         )
 
     # Verify client was called with static storage parameters
@@ -1151,6 +1162,7 @@ async def test_start_run_with_static_storage():
         parameters={'param1': 'value1'},
         storageType='STATIC',
         storageCapacity=1000,
+        scratchStorageMode='LOCAL',
     )
 
 
@@ -1213,6 +1225,7 @@ async def test_start_run_with_cache():
             cache_behavior='CACHE_ALWAYS',
             networking_mode=None,
             configuration_name=None,
+            scratch_storage_mode=None,
         )
 
     # Verify client was called with cache parameters
@@ -1247,6 +1260,7 @@ async def test_start_run_boto_error():
             cache_behavior=None,
             networking_mode=None,
             configuration_name=None,
+            scratch_storage_mode=None,
         )
 
     # Verify error was reported to context and returned
@@ -1289,6 +1303,7 @@ async def test_start_run_client_error():
             cache_behavior=None,
             networking_mode=None,
             configuration_name=None,
+            scratch_storage_mode=None,
         )
 
     # Verify error was reported to context and returned with the S3 error message
@@ -1632,6 +1647,7 @@ async def test_start_run_boto_error_new():
                 cache_behavior=None,
                 networking_mode=None,
                 configuration_name=None,
+                scratch_storage_mode=None,
             )
 
     # Verify error was reported to context and returned
@@ -1669,6 +1685,7 @@ async def test_start_run_unexpected_error_new():
                 cache_behavior=None,
                 networking_mode=None,
                 configuration_name=None,
+                scratch_storage_mode=None,
             )
 
     # Verify error was reported to context and returned
@@ -2017,3 +2034,582 @@ async def test_get_run_task_unexpected_error():
     # Verify error was reported to context
     mock_ctx.error.assert_called_once()
     assert 'Error getting task task-12345 for run run-12345' in mock_ctx.error.call_args[0][0]
+
+
+# Feature: local-temp-storage, Property: start_run forwards the effective scratch storage mode
+class TestStartRunForwardsEffectiveScratchStorageMode:
+    """start_run forwards the effective scratch storage mode to the HealthOmics API.
+
+    For any caller input where scratch_storage_mode is either a valid member of
+    SCRATCH_STORAGE_MODES or None, when start_run successfully starts a run, the
+    scratchStorageMode value passed to the HealthOmics start_run API equals the effective
+    mode - the caller-provided value when non-null, or LOCAL when the caller value is None.
+
+    Validates: Requirements 1.1, 1.2, 1.3, 1.4, 2.1, 2.4
+    """
+
+    _base_params = {
+        'workflow_id': 'wfl-12345',
+        'role_arn': 'arn:aws:iam::123456789012:role/HealthOmicsRole',
+        'name': 'test-run',
+        'output_uri': 's3://my-bucket/outputs/',
+        'parameters': {'param1': 'value1'},
+    }
+
+    @given(scratch_storage_mode=st.one_of(st.sampled_from(['LOCAL', 'SHARED']), st.none()))
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_start_run_forwards_effective_scratch_storage_mode(self, scratch_storage_mode):
+        """The scratchStorageMode kwarg passed to the API equals the effective mode."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = {
+            'id': 'run-12345',
+            'arn': 'arn:aws:omics:us-east-1:123456789012:run/run-12345',
+            'status': 'PENDING',
+            'name': 'test-run',
+            'workflowId': 'wfl-12345',
+            'uuid': 'uuid-abc-123',
+            'tags': {},
+        }
+
+        start_run_wrapper = MCPToolTestWrapper(start_run)
+
+        expected_mode = (
+            scratch_storage_mode
+            if scratch_storage_mode is not None
+            else DEFAULT_SCRATCH_STORAGE_MODE
+        )
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await start_run_wrapper.call(
+                ctx=mock_ctx,
+                **self._base_params,
+                scratch_storage_mode=scratch_storage_mode,
+            )
+
+        assert 'error' not in result, (
+            f'Unexpected error for scratch_storage_mode={scratch_storage_mode!r}: {result}'
+        )
+        mock_client.start_run.assert_called_once()
+        call_kwargs = mock_client.start_run.call_args.kwargs
+        assert 'scratchStorageMode' in call_kwargs, (
+            'scratchStorageMode should always be forwarded to the API'
+        )
+        assert call_kwargs['scratchStorageMode'] == expected_mode
+
+
+# Feature: local-temp-storage, Property: start_run response reports the effective scratch
+# storage mode
+class TestStartRunResponseReportsEffectiveScratchStorageMode:
+    """start_run reports the effective scratch storage mode in its response.
+
+    For any caller input where scratch_storage_mode is a valid member of
+    SCRATCH_STORAGE_MODES or None, when start_run succeeds, the scratchStorageMode field in
+    its response dictionary equals the effective mode that was passed to the HealthOmics
+    start_run API (the caller value when non-null, otherwise LOCAL).
+
+    Validates: Requirements Exposing the scratch storage mode in tool responses
+    """
+
+    _base_params = {
+        'workflow_id': 'wfl-12345',
+        'role_arn': 'arn:aws:iam::123456789012:role/HealthOmicsRole',
+        'name': 'test-run',
+        'output_uri': 's3://my-bucket/outputs/',
+        'parameters': {'param1': 'value1'},
+    }
+
+    @given(scratch_storage_mode=st.one_of(st.sampled_from(['LOCAL', 'SHARED']), st.none()))
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_start_run_response_reports_effective_scratch_storage_mode(
+        self, scratch_storage_mode
+    ):
+        """The response scratchStorageMode equals the effective mode and the API value."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = {
+            'id': 'run-12345',
+            'arn': 'arn:aws:omics:us-east-1:123456789012:run/run-12345',
+            'status': 'PENDING',
+            'name': 'test-run',
+            'workflowId': 'wfl-12345',
+            'uuid': 'uuid-abc-123',
+            'tags': {},
+        }
+
+        start_run_wrapper = MCPToolTestWrapper(start_run)
+
+        expected_mode = (
+            scratch_storage_mode
+            if scratch_storage_mode is not None
+            else DEFAULT_SCRATCH_STORAGE_MODE
+        )
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await start_run_wrapper.call(
+                ctx=mock_ctx,
+                **self._base_params,
+                scratch_storage_mode=scratch_storage_mode,
+            )
+
+        assert 'error' not in result, (
+            f'Unexpected error for scratch_storage_mode={scratch_storage_mode!r}: {result}'
+        )
+        # The response reports the effective mode.
+        assert result['scratchStorageMode'] == expected_mode
+        # And it matches the value forwarded to the HealthOmics API.
+        mock_client.start_run.assert_called_once()
+        call_kwargs = mock_client.start_run.call_args.kwargs
+        assert result['scratchStorageMode'] == call_kwargs['scratchStorageMode']
+
+
+# Feature: local-temp-storage, Property: start_run response preserves the pre-scratch-storage
+# schema
+class TestStartRunResponsePreservesPreScratchStorageSchema:
+    """start_run response preserves every legacy field plus the new scratchStorageMode.
+
+    For any valid caller input and HealthOmics start_run API response, when start_run
+    succeeds, every field present in the pre-scratch-storage response schema (id, arn,
+    status, name, workflowId, workflowVersionName, outputUri, runGroupId, tags, uuid,
+    networkingMode) is present with unchanged name, type, and value, in addition to the new
+    scratchStorageMode field.
+
+    Validates: Requirements Backward compatibility
+    """
+
+    # Safe, non-empty printable strings for ids/names/values.
+    _text = st.text(
+        alphabet=st.characters(min_codepoint=48, max_codepoint=122),
+        min_size=1,
+        max_size=20,
+    )
+
+    @given(
+        scratch_storage_mode=st.one_of(st.sampled_from(['LOCAL', 'SHARED']), st.none()),
+        run_id=_text,
+        arn=_text,
+        status=st.sampled_from(['PENDING', 'STARTING', 'RUNNING', 'COMPLETED']),
+        uuid=_text,
+        name=_text,
+        workflow_id=_text,
+        workflow_version_name=st.one_of(st.none(), _text),
+        run_group_id=st.one_of(st.none(), _text),
+        tags=st.one_of(
+            st.none(),
+            st.dictionaries(keys=_text, values=_text, max_size=3),
+        ),
+    )
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_start_run_response_preserves_legacy_schema(
+        self,
+        scratch_storage_mode,
+        run_id,
+        arn,
+        status,
+        uuid,
+        name,
+        workflow_id,
+        workflow_version_name,
+        run_group_id,
+        tags,
+    ):
+        """Every legacy field is present with unchanged name/type/value, plus the new field."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+
+        # Build the API response. tags is omitted entirely when None to exercise the
+        # response.get('tags', {}) default path.
+        api_response = {
+            'id': run_id,
+            'arn': arn,
+            'status': status,
+            'uuid': uuid,
+        }
+        if tags is not None:
+            api_response['tags'] = tags
+        mock_client.start_run.return_value = api_response
+
+        # output_uri already ends with '/' so ensure_s3_uri_ends_with_slash leaves it stable.
+        output_uri = 's3://my-bucket/outputs/'
+
+        # Expected legacy values: some derived from inputs, some from the API response.
+        expected_tags = tags if tags is not None else {}
+        expected = {
+            'id': run_id,
+            'arn': arn,
+            'status': status,
+            'name': name,
+            'workflowId': workflow_id,
+            'workflowVersionName': workflow_version_name,
+            'outputUri': output_uri,
+            'runGroupId': run_group_id,
+            'tags': expected_tags,
+            'uuid': uuid,
+            'networkingMode': 'RESTRICTED',  # defaults when networking_mode is None
+        }
+
+        call_params = {
+            'workflow_id': workflow_id,
+            'role_arn': 'arn:aws:iam::123456789012:role/HealthOmicsRole',
+            'name': name,
+            'output_uri': output_uri,
+            'parameters': {'param1': 'value1'},
+            'run_group_id': run_group_id,
+        }
+        if workflow_version_name is not None:
+            call_params['workflow_version_name'] = workflow_version_name
+
+        wrapper = MCPToolTestWrapper(start_run)
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await wrapper.call(
+                ctx=mock_ctx,
+                scratch_storage_mode=scratch_storage_mode,
+                **call_params,
+            )
+
+        assert 'error' not in result, (
+            f'Unexpected error for scratch_storage_mode={scratch_storage_mode!r}: {result}'
+        )
+
+        # Every legacy field is present with unchanged name, type, and value.
+        for field, expected_value in expected.items():
+            assert field in result, f'Legacy field {field!r} missing from response'
+            assert result[field] == expected_value, (
+                f'Legacy field {field!r} changed value: {result[field]!r} != {expected_value!r}'
+            )
+            assert type(result[field]) is type(expected_value), (
+                f'Legacy field {field!r} changed type: '
+                f'{type(result[field])} != {type(expected_value)}'
+            )
+
+        # The new scratchStorageMode field is also present.
+        assert 'scratchStorageMode' in result
+
+
+# ---------------------------------------------------------------------------
+# Scratch storage mode example tests (Feature: local-temp-storage)
+# ---------------------------------------------------------------------------
+def _build_start_run_response():
+    """Build a minimal successful start_run API response for example tests."""
+    return {
+        'id': 'run-scratch-1',
+        'arn': 'arn:aws:omics:us-east-1:123456789012:run/run-scratch-1',
+        'status': 'PENDING',
+        'name': 'scratch-run',
+        'workflowId': 'wfl-scratch',
+        'uuid': 'uuid-scratch-1',
+        'tags': {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_run_scratch_storage_mode_local_happy_path():
+    """LOCAL is forwarded to the API and echoed in the response.
+
+    Validates: Requirements Scratch storage mode parameter on the single-run tool,
+    Exposing the scratch storage mode in tool responses.
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run.return_value = _build_start_run_response()
+    wrapper = MCPToolTestWrapper(start_run)
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await wrapper.call(
+            mock_ctx,
+            workflow_id='wfl-scratch',
+            role_arn='arn:aws:iam::123456789012:role/HealthOmicsRole',
+            name='scratch-run',
+            output_uri='s3://my-bucket/outputs/',
+            parameters={'param1': 'value1'},
+            scratch_storage_mode='LOCAL',
+        )
+
+    # The HealthOmics API received scratchStorageMode=LOCAL
+    call_kwargs = mock_client.start_run.call_args.kwargs
+    assert call_kwargs['scratchStorageMode'] == 'LOCAL'
+    # And the tool echoes the effective mode back to the caller
+    assert result['scratchStorageMode'] == 'LOCAL'
+
+
+@pytest.mark.asyncio
+async def test_start_run_scratch_storage_mode_shared_happy_path():
+    """SHARED is forwarded to the API and echoed in the response.
+
+    Validates: Requirements Scratch storage mode parameter on the single-run tool,
+    Exposing the scratch storage mode in tool responses.
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run.return_value = _build_start_run_response()
+    wrapper = MCPToolTestWrapper(start_run)
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await wrapper.call(
+            mock_ctx,
+            workflow_id='wfl-scratch',
+            role_arn='arn:aws:iam::123456789012:role/HealthOmicsRole',
+            name='scratch-run',
+            output_uri='s3://my-bucket/outputs/',
+            parameters={'param1': 'value1'},
+            scratch_storage_mode='SHARED',
+        )
+
+    call_kwargs = mock_client.start_run.call_args.kwargs
+    assert call_kwargs['scratchStorageMode'] == 'SHARED'
+    assert result['scratchStorageMode'] == 'SHARED'
+
+
+@pytest.mark.asyncio
+async def test_start_run_scratch_storage_mode_omitted_defaults_to_local():
+    """Omitting scratch_storage_mode applies the MCP default LOCAL.
+
+    Validates: Requirements MCP server defaults to LOCAL scratch storage,
+    Backward compatibility.
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run.return_value = _build_start_run_response()
+    wrapper = MCPToolTestWrapper(start_run)
+
+    with patch(
+        'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+        return_value=mock_client,
+    ):
+        result = await wrapper.call(
+            mock_ctx,
+            workflow_id='wfl-scratch',
+            role_arn='arn:aws:iam::123456789012:role/HealthOmicsRole',
+            name='scratch-run',
+            output_uri='s3://my-bucket/outputs/',
+            parameters={'param1': 'value1'},
+            # scratch_storage_mode intentionally omitted -> defaults to LOCAL
+        )
+
+    call_kwargs = mock_client.start_run.call_args.kwargs
+    assert call_kwargs['scratchStorageMode'] == 'LOCAL'
+    assert result['scratchStorageMode'] == 'LOCAL'
+
+
+@pytest.mark.asyncio
+async def test_start_run_scratch_storage_misconfigured_default_rejected():
+    """A misconfigured (invalid) MCP default is rejected without calling the API.
+
+    Validates: Requirements Backward compatibility (misconfigured default rejection).
+    """
+    mock_ctx = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.start_run.return_value = _build_start_run_response()
+    wrapper = MCPToolTestWrapper(start_run)
+
+    with (
+        patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+            return_value=mock_client,
+        ),
+        patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.DEFAULT_SCRATCH_STORAGE_MODE',
+            'INVALID',
+        ),
+    ):
+        result = await wrapper.call(
+            mock_ctx,
+            workflow_id='wfl-scratch',
+            role_arn='arn:aws:iam::123456789012:role/HealthOmicsRole',
+            name='scratch-run',
+            output_uri='s3://my-bucket/outputs/',
+            parameters={'param1': 'value1'},
+            # scratch_storage_mode omitted -> resolves to the misconfigured default
+        )
+
+    # The request is rejected with an error and the API is never invoked
+    assert 'error' in result
+    assert 'INVALID' in result['error']
+    mock_client.start_run.assert_not_called()
+
+
+def test_start_run_scratch_storage_mode_parameter_description():
+    """The parameter description documents LOCAL, SHARED, their meaning, and the LOCAL default.
+
+    Validates: Requirements Scratch storage mode parameter on the single-run tool
+    (parameter documentation).
+    """
+    signature = _inspect.signature(_workflow_execution.start_run)
+    field_info = signature.parameters['scratch_storage_mode'].default
+    description = field_info.description
+
+    assert description is not None
+    assert 'LOCAL' in description
+    assert 'SHARED' in description
+    # Mentions the meaning of each value
+    assert 'ephemeral' in description.lower()
+    assert 'shared scratch storage' in description.lower()
+    # Mentions that the MCP server default is LOCAL
+    assert 'default' in description.lower()
+
+
+# Feature: local-temp-storage, Property: start_run rejects any invalid scratch storage mode
+# without calling the API
+class TestStartRunRejectsInvalidScratchStorageMode:
+    """start_run rejects any invalid scratch storage mode without calling the API.
+
+    For any non-null scratch_storage_mode value that is not an exact (case-sensitive) member of
+    SCRATCH_STORAGE_MODES -- including case variants, empty strings, and whitespace-only strings
+    -- start_run returns an error response that names the rejected value and lists all allowed
+    values, leaves caller-provided run inputs unchanged, and never calls the HealthOmics
+    start_run API.
+
+    **Validates: Requirements Scratch storage mode parameter on the single-run tool, MCP server
+    defaults to LOCAL scratch storage, Validation of the scratch storage mode value**
+    """
+
+    @given(
+        scratch_storage_mode=st.one_of(
+            # Arbitrary text that is not an exact valid mode.
+            st.text().filter(lambda value: value not in ('LOCAL', 'SHARED')),
+            # Explicit edge cases: case variants, surrounding whitespace, empty, whitespace-only.
+            st.sampled_from(
+                [
+                    'local',
+                    'Shared',
+                    'Local',
+                    'LOCAL ',
+                    ' LOCAL',
+                    '',
+                    '   ',
+                    '\t',
+                    '\n',
+                ]
+            ),
+        )
+    )
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_mode_without_calling_api(self, scratch_storage_mode):
+        """Invalid modes are rejected; API not called; caller inputs unchanged."""
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+
+        # Caller-provided run inputs that must be left unchanged.
+        parameters = {'param1': 'value1'}
+        original_parameters = _copy.deepcopy(parameters)
+
+        start_run_wrapper = MCPToolTestWrapper(start_run)
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await start_run_wrapper.call(
+                ctx=mock_ctx,
+                workflow_id='wfl-12345',
+                role_arn='arn:aws:iam::123456789012:role/HealthOmicsRole',
+                name='test-run',
+                output_uri='s3://my-bucket/outputs/',
+                parameters=parameters,
+                scratch_storage_mode=scratch_storage_mode,
+            )
+
+        # An error response is returned.
+        assert 'error' in result, f'Expected an error response, got: {result}'
+        error_message = result['error']
+
+        # The error names the rejected value and lists all allowed values.
+        assert str(scratch_storage_mode) in error_message
+        assert 'LOCAL' in error_message
+        assert 'SHARED' in error_message
+
+        # The HealthOmics start_run API was never called.
+        mock_client.start_run.assert_not_called()
+
+        # Caller-provided run inputs are left unchanged.
+        assert parameters == original_parameters
+
+
+# Feature: local-temp-storage, Property: get_run passes the scratch storage mode through
+# unchanged
+class TestGetRunPassesScratchStorageModeThrough:
+    """get_run passes the scratch storage mode through unchanged.
+
+    For any HealthOmics get_run API response, when the response contains a scratchStorageMode
+    field, the get_run tool result contains a scratchStorageMode field equal to that value
+    unchanged; and when the API response does not contain a scratchStorageMode field, the
+    get_run tool result does not contain a scratchStorageMode field at all.
+
+    Validates: Requirements Exposing the scratch storage mode in tool responses
+    """
+
+    @given(
+        # None is the sentinel meaning "scratchStorageMode is absent from the API response".
+        # Any other value (the documented LOCAL/SHARED modes plus arbitrary text) means the
+        # field is present and must pass through unchanged.
+        scratch_storage_mode=st.one_of(
+            st.none(),
+            st.sampled_from(['LOCAL', 'SHARED']),
+            st.text(),
+        ),
+    )
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_get_run_passes_scratch_storage_mode_through(self, scratch_storage_mode):
+        """get_run includes scratchStorageMode only when the API response contains it."""
+        creation_time = datetime.now(timezone.utc)
+
+        # Build the HealthOmics get_run API response with the fields get_run reads.
+        mock_response = {
+            'id': 'run-12345',
+            'arn': 'arn:aws:omics:us-east-1:123456789012:run/run-12345',
+            'name': 'test-run',
+            'status': 'COMPLETED',
+            'workflowId': 'wfl-12345',
+            'workflowType': 'WDL',
+            'creationTime': creation_time,
+            'outputUri': 's3://bucket/output/',
+            'roleArn': 'arn:aws:iam::123456789012:role/HealthOmicsRole',
+            'runOutputUri': 's3://bucket/run-output/',
+        }
+
+        # The sentinel None means the field is absent from the API response.
+        field_present = scratch_storage_mode is not None
+        if field_present:
+            mock_response['scratchStorageMode'] = scratch_storage_mode
+
+        mock_ctx = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.get_run.return_value = mock_response
+
+        with patch(
+            'awslabs.aws_healthomics_mcp_server.tools.workflow_execution.get_omics_client',
+            return_value=mock_client,
+        ):
+            result = await get_run(mock_ctx, run_id='run-12345')
+
+        assert 'error' not in result, f'Unexpected error response: {result}'
+
+        if field_present:
+            # When the API response contains scratchStorageMode, the result contains it
+            # unchanged.
+            assert 'scratchStorageMode' in result
+            assert result['scratchStorageMode'] == scratch_storage_mode
+        else:
+            # When the API response omits scratchStorageMode, the result omits it entirely.
+            assert 'scratchStorageMode' not in result

--- a/src/aws-healthomics-mcp-server/tests/test_workflow_execution_run_group.py
+++ b/src/aws-healthomics-mcp-server/tests/test_workflow_execution_run_group.py
@@ -75,6 +75,7 @@ class TestStartRunConditionallyIncludesRunGroupId:
                 run_group_id=run_group_id,
                 networking_mode=None,
                 configuration_name=None,
+                scratch_storage_mode=None,
             )
 
         mock_client.start_run.assert_called_once()
@@ -186,6 +187,7 @@ class TestStartRunWithRunGroupIdUnit:
                 run_group_id='12345',
                 networking_mode=None,
                 configuration_name=None,
+                scratch_storage_mode=None,
             )
 
         actual_params = mock_client.start_run.call_args[1]
@@ -226,6 +228,7 @@ class TestStartRunWithRunGroupIdUnit:
                 run_group_id=None,
                 networking_mode=None,
                 configuration_name=None,
+                scratch_storage_mode=None,
             )
 
         actual_params = mock_client.start_run.call_args[1]

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -54,6 +54,7 @@ version = "0.0.39"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
+    { name = "botocore" },
     { name = "coloredlogs" },
     { name = "cwltool", extra = ["deps"] },
     { name = "isodate" },
@@ -83,7 +84,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.42.78" },
+    { name = "boto3", specifier = ">=1.43.36" },
+    { name = "botocore", specifier = ">=1.43.36" },
     { name = "coloredlogs", specifier = ">=15.0" },
     { name = "cwltool", extras = ["deps"], specifier = ">=3.1.0" },
     { name = "isodate", specifier = ">=0.6.0" },
@@ -149,30 +151,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.78"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/2b/ebdad075934cf6bb78bf81fe31d83339bcd804ad6c856f7341376cbc88b6/boto3-1.42.78.tar.gz", hash = "sha256:cef2ebdb9be5c0e96822f8d3941ac4b816c90a5737a7ffb901d664c808964b63", size = 112789, upload-time = "2026-03-27T19:28:07.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/bb/1f6dade1f1e86858bef7bd332bc8106c445f2dbabec7b32ab5d7d118c9b6/boto3-1.42.78-py3-none-any.whl", hash = "sha256:480a34a077484a5ca60124dfd150ba3ea6517fc89963a679e45b30c6db614d26", size = 140556, upload-time = "2026-03-27T19:28:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.78"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/8e/cdb34c8ca71216d214e049ada2148ee08bcda12b1ac72af3a720dea300ff/botocore-1.42.78.tar.gz", hash = "sha256:61cbd49728e23f68cfd945406ab40044d49abed143362f7ffa4a4f4bd4311791", size = 15023592, upload-time = "2026-03-27T19:27:57.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/72/94bba1a375d45c685b00e051b56142359547837086a83861d76f6aec26f4/botocore-1.42.78-py3-none-any.whl", hash = "sha256:038ab63c7f898e8b5db58cb6a45e4da56c31dd984e7e995839a3540c735564ea", size = 14701729, upload-time = "2026-03-27T19:27:54.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
 ]
 
 [[package]]
@@ -2258,14 +2260,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Adds support for start-run and start-batch-run scratch storage mode

### Changes
- flags added to tools and passed to boto3
- validation of allowed values
- defaults to local scratch storage
- adds unit tests

> Please provide a summary of what's being changed

### User experience

Agents can now request scratch storage mode

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)
N
**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
