### PR TITLE
docs(aws-knowledge-mcp-server): remove recommend tool from README

### DIFF
--- a/src/aws-knowledge-mcp-server/README.md
+++ b/src/aws-knowledge-mcp-server/README.md
@@ -32,10 +32,9 @@ This MCP server is in general availability.
 
 1. `search_documentation`: Search across all AWS documentation, agent skills, and Strands Agents SDK docs with optional topic-based filtering for more targeted results
 2. `read_documentation`: Retrieve and convert AWS documentation and Strands Agents (strandsagents.com) pages to markdown
-3. `recommend`: Get content recommendations for AWS documentation pages
-4. `list_regions`: Retrieve a list of all AWS regions, including their identifiers and names
-5. `get_regional_availability`: Retrieve AWS regional availability information for Services, Features, SDK service APIs and CloudFormation resources
-6. `retrieve_skill`: Retrieve an AWS agent skill that provides domain-specific expertise, workflows, and step-by-step procedures for AWS tasks
+3. `list_regions`: Retrieve a list of all AWS regions, including their identifiers and names
+4. `get_regional_availability`: Retrieve AWS regional availability information for Services, Features, SDK service APIs and CloudFormation resources
+5. `retrieve_skill`: Retrieve an AWS agent skill that provides domain-specific expertise, workflows, and step-by-step procedures for AWS tasks
 
 ### Current knowledge sources
 


### PR DESCRIPTION
## Summary
- Removes the `recommend` tool from the AWS Knowledge MCP Server README as it is no longer available

## Test plan
- [x] Verify README renders correctly on GitHub

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).