### PR TITLE
fix(eks-mcp-server): treat blank insight id as absent

### DIFF
--- a/src/eks-mcp-server/awslabs/eks_mcp_server/insights_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/insights_handler.py
@@ -135,10 +135,8 @@ class InsightsHandler:
             # Always use the default EKS client
             eks_client = self.eks_client
 
-            # Determine operation mode based on whether insight_id is provided
-            detail_mode = insight_id is not None
-
-            if detail_mode:
+            # Determine operation mode based on whether a non-empty insight_id is provided
+            if insight_id and insight_id.strip():
                 # Get details for a specific insight
                 return await self._get_insight_detail(
                     ctx, eks_client, cluster_name, insight_id, next_token

--- a/src/eks-mcp-server/tests/test_insights_handler.py
+++ b/src/eks-mcp-server/tests/test_insights_handler.py
@@ -152,6 +152,40 @@ class TestInsightsHandler:
         assert 'Successfully retrieved 2 insights' in result.content[0].text
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize('insight_id', ['', '   '])
+    async def test_get_eks_insights_empty_insight_id_uses_list_mode(
+        self, mock_context, mock_mcp, insight_id
+    ):
+        """Test empty or whitespace-only insight_id values are treated as absent."""
+        # Create mock AWS client
+        mock_eks_client = MagicMock()
+
+        # Set up mock response for list mode
+        mock_eks_client.list_insights.return_value = {
+            'insights': [self._create_mock_insight_item(insight_id='insight-1')]
+        }
+
+        # Initialize the handler with our mock client
+        handler = InsightsHandler(mock_mcp)
+        handler.eks_client = mock_eks_client
+
+        # Call the implementation method with an empty/blank insight_id
+        result = await handler._get_eks_insights_impl(
+            mock_context, cluster_name='test-cluster', insight_id=insight_id
+        )
+
+        # Verify list mode was used instead of detail mode
+        mock_eks_client.list_insights.assert_called_once_with(clusterName='test-cluster')
+        mock_eks_client.describe_insight.assert_not_called()
+
+        # Verify the result
+        assert not result.isError
+        data = json.loads(result.content[1].text)
+        assert data['cluster_name'] == 'test-cluster'
+        assert len(data['insights']) == 1
+        assert data['detail_mode'] is False
+
+    @pytest.mark.asyncio
     async def test_get_eks_insights_detail_mode(self, mock_context, mock_mcp):
         """Test _get_eks_insights_impl in detail mode (with an insight_id)."""
         # Create mock AWS client


### PR DESCRIPTION
Fixes #4036

## Summary

### Changes

- Treat empty or whitespace-only `insight_id` values as absent in `get_eks_insights`.
- Add regression coverage confirming `""` and `"   "` use list mode instead of `DescribeInsight`.

### User experience

Before this change, MCP clients that serialize an unset optional `insight_id` as an empty string could not list EKS insights because the handler entered detail mode and called `DescribeInsight` with a blank id.

After this change, empty or whitespace-only `insight_id` values list insights, while non-empty insight ids continue to fetch insight details.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

N

**RFC issue number**:

N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
