### PR TITLE
fix(mysql-mcp-server): close read-only bypasses (CWE-184) and add security-model docs

### DIFF
--- a/src/mysql-mcp-server/CHANGELOG.md
+++ b/src/mysql-mcp-server/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.22
+
+### Security
+
+- **CWE-184** — extended the read-only-mode denylist to
+  close gaps reported by external security review. The previous
+  `MUTATING_KEYWORDS` set omitted `SET`, `CALL`, `PREPARE`, `EXECUTE`,
+  `DEALLOCATE`, `HANDLER`, `LOCK`, `LOCK TABLES`, `UNLOCK`,
+  `UNLOCK TABLES`, `FLUSH`, `RESET`, `KILL`, and `UNINSTALL`, so on the
+  RDS Data API path an LLM under prompt injection could fire these
+  statements against the operator's database under what the server
+  presented as a read-only call. All listed statements are now rejected
+  at the MCP layer.
+- Added an always-block list (`SECURITY_SENSITIVE_VARS`) that rejects
+  `SET sql_log_bin`, `SET foreign_key_checks`, and `SET unique_checks`
+  in both read-only and write modes. Flipping these variables disables
+  binary logging / referential integrity / uniqueness for the rest of
+  the session, and an LLM-driven flow should never be able to flip them
+  even when the operator has enabled writes via `--allow_write_query`.
+  Pattern handles the comma-separated multi-assignment form
+  (`SET @x = 1, sql_log_bin = 0`) and every MySQL scope modifier
+  permutation.
+- README adds a **Security model** section: the read-only mode is a
+  best-effort SQL-text safeguard, not a security boundary; operators
+  should connect with a least-privilege MySQL user / IAM role with only
+  `SELECT` granted at the database. Aligns the MySQL package with the
+  equivalent wording in the Postgres, MSSQL, and Oracle sibling
+  packages. `kiro_power/POWER.md` and the
+  `kiro_power/steering/aurora-mysql-mcp.md` steering file carry the
+  same caveat.
+- Existing stacked-queries detection in `SUSPICIOUS_PATTERNS` is now
+  pinned by `TestTransactionBypassCoverage`, which exercises the
+  canonical bypass payloads (`SELECT 1; COMMIT; INSERT …` and
+  variants) so a future change that relaxes the stacked-queries rule
+  has to update the tests deliberately.
+
 ## Unreleased
 
 ### Added

--- a/src/mysql-mcp-server/README.md
+++ b/src/mysql-mcp-server/README.md
@@ -143,6 +143,43 @@ The MCP server uses the AWS profile specified in the AWS_PROFILE environment var
 
 Make sure the AWS profile has permissions to access the RDS Data API, and the secret from AWS Secrets Manager. The MCP server creates a boto3 session using the specified profile to authenticate with AWS services. Your AWS IAM credentials remain on your local machine and are strictly used for accessing AWS services.
 
+## Security model
+
+> **The server's read-only mode is a best-effort SQL-text safeguard, not a security boundary.**
+
+When the MCP server runs without `--allow_write_query`, it inspects the SQL string for mutating keywords (`INSERT`, `UPDATE`, `DELETE`, `DROP`, `SET`, `CALL`, `PREPARE`, `EXECUTE`, `HANDLER`, `LOCK`, `FLUSH`, `RESET`, `KILL`, `INSTALL`, `UNINSTALL`, etc.) and rejects matches before they reach the database. This guard is defence in depth — it is not a guarantee. SQL grammars evolve, regular expressions have edge cases, and an LLM under prompt injection is a creative adversary.
+
+**The actual security boundary is the database role you connect with.** The Postgres, MSSQL, and Oracle sibling servers all carry the same caveat; this section aligns the MySQL package with that wording.
+
+### Recommended configuration
+
+Connect with a least-privilege MySQL user that has only the permissions your workload actually needs. For read-only workflows, grant `SELECT` (and `EXECUTE` on specific procedures, if any) at the database level:
+
+```sql
+-- Aurora MySQL / RDS MySQL / RDS MariaDB
+CREATE USER 'mcp_readonly'@'%' IDENTIFIED BY '...';
+GRANT SELECT ON your_database.* TO 'mcp_readonly'@'%';
+-- If the workflow legitimately needs specific stored procedures:
+GRANT EXECUTE ON PROCEDURE your_database.some_safe_proc TO 'mcp_readonly'@'%';
+FLUSH PRIVILEGES;
+```
+
+Or, for IAM authentication, attach a policy granting `rds-db:connect` for the dedicated read-only user only.
+
+With a least-privilege role in place, every mutating statement the regex might miss still fails at the database with `ERROR 1142 (42000): … command denied to user`. The server's regex serves as a fast, informative rejection at the MCP layer; the database role is the durable guarantee.
+
+### What the server-side regex does and does not catch
+
+| Catches | Does not catch |
+|---------|----------------|
+| Single mutating statements (`INSERT`, `UPDATE`, `DELETE`, DDL, GRANT/REVOKE, etc.) | Mutating logic inside an `EXECUTE` of a `PREPARE`'d statement whose body lives in a `@user_variable` (defence: `PREPARE`, `EXECUTE`, `DEALLOCATE` are themselves blocked) |
+| Stacked queries (`SELECT 1; INSERT …`, `SELECT 1; COMMIT; INSERT …`) | Mutating logic inside a stored procedure that this server isn't aware of (defence: `CALL` is blocked) |
+| Toggling integrity-control session variables (`SET sql_log_bin = 0`, `SET foreign_key_checks = 0`, `SET unique_checks = 0`) in **both** read-only and write modes | Quoted-identifier obfuscation of variable names |
+| MySQL conditional comment payloads (`/*!50000 INSERT … */`) | A trojaned UDF that has already been installed by a higher-privileged operator |
+| Multi-variable `SET` with the dangerous variable in any position (`SET @x = 1, sql_log_bin = 0`) | New mutating verbs introduced by future MySQL releases until added to the denylist |
+
+When in doubt, rely on the database role.
+
 ## Development setup
 
 This package ships the Amazon RDS global CA bundle inside the wheel so IAM

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.mysql_mcp_server"""
 
-__version__ = '1.0.21'
+__version__ = '1.0.22'
 __user_agent__ = f'awslabs/mcp/mysql_mcp_server/{__version__}'

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/mutable_sql_detector.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/mutable_sql_detector.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+import sqlparse
 
 
 MUTATING_KEYWORDS = {
@@ -44,9 +45,19 @@ MUTATING_KEYWORDS = {
     'ANALYZE',
 }
 
-# Compile regex pattern
+# Compile regex pattern.
+#
+# Keywords are sorted longest-first so that multi-word entries
+# (e.g. ``RENAME TABLE``, ``LOAD DATA``, ``CREATE FUNCTION``) match before
+# their single-word prefixes (``RENAME``, ``LOAD``, ``CREATE``). Python's
+# ``re`` uses leftmost-first alternation, not leftmost-longest, so without
+# this ordering the prefix can win the race and the longer keyword is
+# never reported. Iterating ``MUTATING_KEYWORDS`` directly would also be
+# non-deterministic across runs because Python ``set`` iteration order is
+# hash-seed dependent.
+_MUTATING_KEYWORDS_BY_LENGTH = sorted(MUTATING_KEYWORDS, key=len, reverse=True)
 MUTATING_PATTERN = re.compile(
-    r'(?i)\b(' + '|'.join(re.escape(k) for k in MUTATING_KEYWORDS) + r')\b'
+    r'(?i)\b(' + '|'.join(re.escape(k) for k in _MUTATING_KEYWORDS_BY_LENGTH) + r')\b'
 )
 
 SUSPICIOUS_PATTERNS = [
@@ -65,15 +76,58 @@ SUSPICIOUS_PATTERNS = [
     r'(?i)\binto\s+dumpfile\b',  # MySQL-specific file write
 ]
 
+# MySQL conditional comment marker (`/*!`). MySQL 5.0+ executes the contents
+# of these blocks while sqlparse strips them, so the detector would otherwise
+# never see what the database is going to run. We treat any presence of `/*!`
+# as a suspicious pattern in its own right; there is no benign reason for an
+# LLM-generated query to use a MySQL conditional comment through this server.
+MYSQL_CONDITIONAL_COMMENT_PATTERN = r'/\*!'
+
 
 def detect_mutating_keywords(sql_text: str) -> list[str]:
-    """Return a list of mutating keywords found in the SQL (excluding comments)."""
-    matches = MUTATING_PATTERN.findall(sql_text)
+    """Return a list of mutating keywords found in the SQL (excluding comments).
+
+    SQL inline comments (`/* ... */`, `-- ...`, `# ...`) are treated as
+    whitespace by the database parser but as opaque characters by Python
+    regex. To prevent bypasses such as `LOAD/**/DATA INFILE ...`, the SQL
+    is normalised with `sqlparse.format(strip_comments=True)` before the
+    keyword scan so a comment between adjacent keywords no longer hides
+    the multi-word match (e.g. `LOAD DATA`, `RENAME TABLE`).
+
+    MySQL conditional comments (`/*!50000 ... */`) are handled separately:
+    sqlparse strips them entirely, so a payload like
+    ``/*!50000 DELETE FROM users */`` would otherwise have its body
+    stripped before the regex runs and the function would return ``[]``.
+    Any presence of the ``/*!`` marker is therefore treated as a mutation
+    in its own right (MySQL 5.0+ executes the body server-side, so the
+    conservative answer for a readonly gate is "yes, this mutates").
+    A non-keyword sentinel is returned so callers' ``bool(matches)``
+    checks fire without misreporting a specific keyword.
+    """
+    if re.search(MYSQL_CONDITIONAL_COMMENT_PATTERN, sql_text):
+        # Defence in depth: keep this function correct in isolation, even
+        # when callers do not also invoke check_sql_injection_risk.
+        return ['MYSQL_CONDITIONAL_COMMENT']
+    sql_for_check = sqlparse.format(sql_text, strip_comments=True)
+    matches = MUTATING_PATTERN.findall(sql_for_check)
     return list({m.upper() for m in matches})
 
 
 def check_sql_injection_risk(sql: str) -> list[dict]:
-    """Check for potential SQL injection risks in sql query.
+    r"""Check for potential SQL injection risks in sql query.
+
+    Comment-based bypasses are mitigated in two stages:
+
+    1. MySQL conditional comments (``/*!50000 ... */``) are checked against
+       the raw SQL first. sqlparse would strip them before any pattern
+       gets a chance to match, so the check has to happen pre-strip.
+    2. The remaining suspicious patterns run against the comment-stripped
+       SQL so that ``INTO/**/OUTFILE``, ``INTO -- x\n DUMPFILE``, etc. all
+       normalise to their bare form and the existing regexes match.
+
+    Patterns are deliberately NOT applied to the raw SQL as a fallback,
+    to avoid false-positives on benign queries whose comment text happens
+    to contain forbidden keywords (e.g. ``-- export INTO OUTFILE later``).
 
     Args:
         sql: query string
@@ -82,8 +136,22 @@ def check_sql_injection_risk(sql: str) -> list[dict]:
         dictionaries containing detected security issue
     """
     issues = []
+
+    # Stage 1: reject MySQL conditional comments before sqlparse strips them.
+    if re.search(MYSQL_CONDITIONAL_COMMENT_PATTERN, sql):
+        issues.append(
+            {
+                'type': 'sql',
+                'message': f'Suspicious pattern in query: {sql}',
+                'severity': 'high',
+            }
+        )
+        return issues
+
+    # Stage 2: strip ordinary comments, then run the regex sweep.
+    sql_for_check = sqlparse.format(sql, strip_comments=True)
     for pattern in SUSPICIOUS_PATTERNS:
-        if re.search(pattern, sql):
+        if re.search(pattern, sql_for_check):
             issues.append(
                 {
                     'type': 'sql',

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/mutable_sql_detector.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/mutable_sql_detector.py
@@ -39,10 +39,45 @@ MUTATING_KEYWORDS = {
     'CREATE FUNCTION',
     'CREATE PROCEDURE',
     'INSTALL',
+    'UNINSTALL',
     # Storage-level
     'OPTIMIZE',
     'REPAIR',
     'ANALYZE',
+    # Session / server config — SET as a general keyword is rejected in
+    # read-only mode. Specific security-sensitive variables are also
+    # rejected in write mode via SECURITY_SENSITIVE_VAR_PATTERN below.
+    # Matches the Postgres sibling's model. The blanket SET block
+    # rejects benign forms (SET @var, SET NAMES, SET sql_mode) too;
+    # an LLM-driven read flow has SQL-native alternatives for all of
+    # them and the closed-by-construction shape is worth the trade-off.
+    'SET',
+    # Stored-program execution. CALL invokes a procedure that can
+    # INSERT/UPDATE/DELETE/GRANT inside its body — the readonly gate
+    # cannot see what's in the procedure, so the safe answer is to
+    # reject the call site.
+    'CALL',
+    # Dynamic SQL: PREPARE/EXECUTE/DEALLOCATE round-trips bypass the
+    # static keyword scan because the payload lives in a user variable.
+    # Each statement is rejected individually; even if PREPARE were
+    # missed, EXECUTE on its own is enough to fire the gate.
+    'PREPARE',
+    'EXECUTE',
+    'DEALLOCATE',
+    # Direct storage-engine access. HANDLER bypasses the SQL layer's
+    # transaction semantics entirely.
+    'HANDLER',
+    # Lock and admin state changes. LOCK / UNLOCK acquire write locks
+    # that survive the readonly transaction and affect concurrent
+    # workloads. FLUSH / RESET change server-wide state (privileges,
+    # binlog position, query log). KILL terminates other sessions.
+    'LOCK',
+    'LOCK TABLES',
+    'UNLOCK',
+    'UNLOCK TABLES',
+    'FLUSH',
+    'RESET',
+    'KILL',
 }
 
 # Compile regex pattern.
@@ -82,6 +117,71 @@ SUSPICIOUS_PATTERNS = [
 # as a suspicious pattern in its own right; there is no benign reason for an
 # LLM-generated query to use a MySQL conditional comment through this server.
 MYSQL_CONDITIONAL_COMMENT_PATTERN = r'/\*!'
+
+
+# Session variables that disable integrity / security controls. Setting
+# any of these silently changes what subsequent statements on the same
+# connection do, so they are rejected in BOTH read-only and write mode:
+#
+#   sql_log_bin = 0
+#       Disables binary logging for the session. A subsequent INSERT /
+#       UPDATE / DELETE will not appear in the binlog, defeating
+#       replication, point-in-time recovery, and audit pipelines that
+#       consume the binlog.
+#   foreign_key_checks = 0
+#       Skips referential-integrity validation. Subsequent writes can
+#       leave orphaned rows that violate declared FK constraints.
+#   unique_checks = 0
+#       Skips uniqueness validation on InnoDB inserts. Allows duplicate
+#       rows to be inserted past a UNIQUE index.
+#
+# These are session settings, so blocking the SET that toggles them is
+# the only practical defence against an LLM that has --allow_write_query
+# enabled. The Postgres sibling uses the same pattern for row_security
+# and session_replication_role; this is the MySQL analogue.
+SECURITY_SENSITIVE_VARS = {
+    'sql_log_bin',
+    'foreign_key_checks',
+    'unique_checks',
+}
+
+# Match SET ... <var> ... where <var> is one of SECURITY_SENSITIVE_VARS,
+# accepting the modifier permutations MySQL allows:
+#   SET sql_log_bin = 0
+#   SET SESSION sql_log_bin = 0
+#   SET LOCAL sql_log_bin = 0
+#   SET GLOBAL sql_log_bin = 0
+#   SET @@sql_log_bin = 0
+#   SET @@session.sql_log_bin = 0
+#   SET @@global.sql_log_bin = 0
+#   SET @@local.sql_log_bin = 0
+# The trailing \b prevents matches on prefixed identifiers (e.g.
+# sql_log_bin_extra). Quoted identifiers (`sql_log_bin`) are NOT
+# matched — a known regex limitation, mirroring the Postgres sibling.
+#
+# Multi-variable SET statements (MySQL allows comma-separated assignments
+# in a single SET — ``SET @x = 1, sql_log_bin = 0``) are handled by the
+# optional ``(?:.{0,500}?,\s*)?`` group: non-greedy, bounded to 500 chars
+# to prevent catastrophic backtracking, and ``re.DOTALL`` lets it span
+# newlines between assignments. The engine extends the wildcard as needed
+# to land on a security-sensitive variable in any position of the list,
+# so payloads like ``SET @x = 1, @y = 2, sql_log_bin = 0`` are caught.
+#
+# Known limitation: ``UPDATE t SET sql_log_bin = 0`` would false-positive
+# (the regex matches as if it were a session-variable SET). Real-world
+# risk is essentially zero — no realistic schema names a column after a
+# well-known MySQL session variable — and the cost is rejecting one
+# unusual query in write mode, not a security leak. Closing this would
+# require sqlparse tokenisation to distinguish statement-level SET from
+# UPDATE's SET clause; deemed not worth the complexity at this time.
+SECURITY_SENSITIVE_VAR_PATTERN = re.compile(
+    r'\bset\b\s+'
+    r'(?:.{0,500}?,\s*)?'  # optionally skip preceding assignments in the same SET
+    r'(?:(?:session|local|global)\s+)?'
+    r'(?:@@(?:session\.|local\.|global\.)?)?'
+    r'(' + '|'.join(re.escape(v) for v in SECURITY_SENSITIVE_VARS) + r')\b',
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 def detect_mutating_keywords(sql_text: str) -> list[str]:
@@ -125,6 +225,14 @@ def check_sql_injection_risk(sql: str) -> list[dict]:
        SQL so that ``INTO/**/OUTFILE``, ``INTO -- x\n DUMPFILE``, etc. all
        normalise to their bare form and the existing regexes match.
 
+    Stage 2 also includes a security-sensitive-variable check that
+    rejects ``SET sql_log_bin``, ``SET foreign_key_checks``, and
+    ``SET unique_checks`` regardless of read/write mode. These session
+    settings disable integrity / security controls and an LLM-driven
+    flow should never be able to flip them — even when the operator has
+    enabled writes via ``--allow_write_query``. Pattern mirrors the
+    Postgres sibling's ``SECURITY_SENSITIVE_GUCS`` design.
+
     Patterns are deliberately NOT applied to the raw SQL as a fallback,
     to avoid false-positives on benign queries whose comment text happens
     to contain forbidden keywords (e.g. ``-- export INTO OUTFILE later``).
@@ -150,6 +258,28 @@ def check_sql_injection_risk(sql: str) -> list[dict]:
 
     # Stage 2: strip ordinary comments, then run the regex sweep.
     sql_for_check = sqlparse.format(sql, strip_comments=True)
+
+    # Stage 2a: reject SET of security-sensitive session variables in
+    # both read and write mode. These disable integrity / security
+    # controls (binlog, FK checks, uniqueness) for the rest of the
+    # session, so an LLM should never be able to flip them — even when
+    # the operator has explicitly enabled writes.
+    var_match = SECURITY_SENSITIVE_VAR_PATTERN.search(sql_for_check)
+    if var_match:
+        issues.append(
+            {
+                'type': 'sql',
+                'message': (
+                    f'Security-sensitive SET rejected: {var_match.group(1)}. '
+                    'Changing this session setting disables an integrity or '
+                    'security control (binary logging / referential integrity / '
+                    'uniqueness) and is blocked regardless of read/write mode.'
+                ),
+                'severity': 'high',
+            }
+        )
+        return issues
+
     for pattern in SUSPICIOUS_PATTERNS:
         if re.search(pattern, sql_for_check):
             issues.append(

--- a/src/mysql-mcp-server/kiro_power/POWER.md
+++ b/src/mysql-mcp-server/kiro_power/POWER.md
@@ -92,7 +92,7 @@ Call mcp_mysql_run_query with:
 ```
 
 **Safety Guidelines:**
-- Read-only by default — writes require adding `--allow_write_query` to mcp.json and explicit user confirmation ("RUN IT")
+- Read-only by default — writes require adding `--allow_write_query` to mcp.json and explicit user confirmation ("RUN IT"). The read-only mode is a best-effort SQL-text safeguard, not a security boundary — operators should connect with a least-privilege MySQL user / IAM role with only `SELECT` granted (see the "Security model" section of the package README).
 - When writes are enabled, show the SQL and explain its impact before executing
 - Always use LIMIT on browsing queries
 - Run EXPLAIN ANALYZE plans before heavy queries

--- a/src/mysql-mcp-server/kiro_power/steering/aurora-mysql-mcp.md
+++ b/src/mysql-mcp-server/kiro_power/steering/aurora-mysql-mcp.md
@@ -33,7 +33,7 @@ Do not use for: speculative answers you can derive from code/docs only, or destr
 - Call get_database_connection_info to get all currently connections
 
 ## Tool usage policy (important)
-- Default mode is **read-only**; the server will reject any mutating SQL (INSERT/UPDATE/DELETE/DDL). If the user needs write operations, inform them the MCP server must be reconfigured with `--allow_write_query`.
+- Default mode is **read-only**; the server will reject any mutating SQL (INSERT/UPDATE/DELETE/DDL). If the user needs write operations, inform them the MCP server must be reconfigured with `--allow_write_query`. The read-only mode is a best-effort SQL-text safeguard, not a security boundary — for sensitive environments, operators should connect with a least-privilege MySQL user / IAM role with only `SELECT` granted (see the "Security model" section of the server README).
 - When writes **are** enabled, show the SQL and explain its impact before executing.
 - Dry-run first: when feasible, request an EXPLAIN plan before running heavy queries (>5s or large scans).
 - Bound queries: always include LIMIT 50 on browsing, and narrow with WHERE predicates.

--- a/src/mysql-mcp-server/pyproject.toml
+++ b/src/mysql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.mysql-mcp-server"
-version = "1.0.21"
+version = "1.0.20"
 description = "An AWS Labs Model Context Protocol (MCP) server for mysql"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic>=2.10.6",
     "asyncmy>=0.2.10",
     "aiorwlock>=1.5.0",
+    "sqlparse>=0.5.0",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/mysql-mcp-server/pyproject.toml
+++ b/src/mysql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.mysql-mcp-server"
-version = "1.0.20"
+version = "1.0.22"
 description = "An AWS Labs Model Context Protocol (MCP) server for mysql"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mysql-mcp-server/tests/test_mutable_sql_detector.py
+++ b/src/mysql-mcp-server/tests/test_mutable_sql_detector.py
@@ -16,11 +16,11 @@
 
 These pin two things at once:
 
-1. The reported bypass class
-   where SQL inline comments (``/* ... */``, ``-- ...``, ``#``) and MySQL
-   conditional comments (``/*!50000 ... */``) sneak forbidden keywords past
-   the regex-based detector because Python regex treats those tokens as
-   opaque characters while the MySQL parser treats them as whitespace.
+1. The reported bypass class where SQL inline comments
+   (``/* ... */``, ``-- ...``, ``#``) and MySQL conditional comments
+   (``/*!50000 ... */``) sneak forbidden keywords past the regex-based
+   detector because Python regex treats those tokens as opaque characters
+   while the MySQL parser treats them as whitespace.
 
 2. The benign-comment cases that real users have in real queries, so a
    future change to the detector cannot silently start blocking
@@ -30,7 +30,10 @@ The test cases include the reporter's verbatim payloads so a security
 reviewer can match them against the report 1:1.
 """
 
+import pytest
 from awslabs.mysql_mcp_server.mutable_sql_detector import (
+    MUTATING_KEYWORDS,
+    SECURITY_SENSITIVE_VARS,
     check_sql_injection_risk,
     detect_mutating_keywords,
 )
@@ -389,3 +392,416 @@ class TestCommentDoesNotReassembleIdentifiers:
         """
         sql = 'DR/**/OP TABLE users'
         assert 'DROP' not in detect_mutating_keywords(sql)
+
+
+# ---------------------------------------------------------------------------
+# Completeness of MUTATING_KEYWORDS
+#
+# These pin every entry in the set against a minimal payload so that:
+#   1. any future commit that removes a keyword fails CI loudly, and
+#   2. the security reviewer can match the test list against the ticket
+#      payload list 1:1 without having to read the regex.
+# ---------------------------------------------------------------------------
+
+
+# Mapping of every keyword in MUTATING_KEYWORDS to a minimal payload
+# that contains it as a top-level mutation. Listed by hand (not generated
+# from the set) so adding a keyword without thinking about the payload
+# fails the parametrize collection — that is the regression guard.
+_MUTATING_KEYWORD_PAYLOADS: dict[str, str] = {
+    # DML
+    'INSERT': "INSERT INTO t VALUES (1, 'x')",
+    'UPDATE': "UPDATE t SET name = 'x' WHERE id = 1",
+    'DELETE': 'DELETE FROM t WHERE id = 1',
+    'MERGE': 'MERGE INTO t USING s ON (t.id = s.id) WHEN MATCHED THEN UPDATE SET t.x = s.x',
+    'TRUNCATE': 'TRUNCATE TABLE t',
+    'REPLACE INTO': "REPLACE INTO t (id, name) VALUES (1, 'x')",
+    'LOAD DATA': "LOAD DATA INFILE '/etc/passwd' INTO TABLE t",
+    'LOAD XML': "LOAD XML INFILE '/etc/passwd' INTO TABLE t",
+    # DDL
+    'CREATE': 'CREATE TABLE t (id INT)',
+    'DROP': 'DROP TABLE t',
+    'ALTER': 'ALTER TABLE t ADD COLUMN x INT',
+    'RENAME': 'RENAME USER a TO b',
+    'RENAME TABLE': 'RENAME TABLE old_t TO new_t',
+    # Permissions
+    'GRANT': "GRANT SELECT ON t TO 'u'@'%'",
+    'REVOKE': "REVOKE SELECT ON t FROM 'u'@'%'",
+    # Extensions and functions
+    'CREATE FUNCTION': 'CREATE FUNCTION f() RETURNS INT RETURN 1',
+    'CREATE PROCEDURE': 'CREATE PROCEDURE p() BEGIN END',
+    'INSTALL': "INSTALL PLUGIN x SONAME 'x.so'",
+    'UNINSTALL': 'UNINSTALL PLUGIN x',
+    # Storage-level
+    'OPTIMIZE': 'OPTIMIZE TABLE t',
+    'REPAIR': 'REPAIR TABLE t',
+    'ANALYZE': 'ANALYZE TABLE t',
+    # Session / server config
+    'SET': "SET sql_mode = 'TRADITIONAL'",
+    # Stored-program execution
+    'CALL': 'CALL p()',
+    # Dynamic SQL
+    'PREPARE': "PREPARE s FROM 'SELECT 1'",
+    'EXECUTE': 'EXECUTE s',
+    'DEALLOCATE': 'DEALLOCATE PREPARE s',
+    # Direct storage-engine access
+    'HANDLER': 'HANDLER t OPEN',
+    # Lock and admin state
+    'LOCK': 'LOCK INSTANCE FOR BACKUP',
+    'LOCK TABLES': 'LOCK TABLES t WRITE',
+    'UNLOCK': 'UNLOCK INSTANCE',
+    'UNLOCK TABLES': 'UNLOCK TABLES',
+    'FLUSH': 'FLUSH PRIVILEGES',
+    'RESET': 'RESET MASTER',
+    'KILL': 'KILL 1',
+}
+
+
+def test_every_mutating_keyword_has_a_payload():
+    """The payload table must cover every entry in MUTATING_KEYWORDS.
+
+    Adding a keyword to MUTATING_KEYWORDS without adding a payload here
+    fails this test, forcing the author to think about how the new
+    keyword is exercised in a query.
+    """
+    missing = MUTATING_KEYWORDS - set(_MUTATING_KEYWORD_PAYLOADS.keys())
+    assert not missing, f'Missing test payloads for: {sorted(missing)}'
+
+
+@pytest.mark.parametrize(
+    'keyword,payload',
+    sorted(_MUTATING_KEYWORD_PAYLOADS.items()),
+)
+def test_mutating_keyword_is_detected(keyword, payload):
+    """Every keyword in MUTATING_KEYWORDS must be detected on its payload.
+
+    Mirrors the Postgres sibling's TestAllMutatingKeywords. Pins the set
+    against any future change that silently removes a keyword.
+    """
+    matches = detect_mutating_keywords(payload)
+    assert keyword in matches, (
+        f'Expected {keyword!r} in detect_mutating_keywords({payload!r}), got {matches!r}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ticket payloads — verbatim from the external security report
+#
+# Each test asserts the exact payload from the security report is
+# rejected by the readonly gate. A reviewer can match these 1:1 against
+# the report without reading the regex.
+# ---------------------------------------------------------------------------
+
+
+class TestReportedReadonlyBypassPayloads:
+    """Verbatim ticket payloads must each be reported as mutations."""
+
+    def test_set_global_general_log_is_detected(self):
+        """``SET GLOBAL general_log = 'ON'`` — server-config write."""
+        assert 'SET' in detect_mutating_keywords("SET GLOBAL general_log = 'ON'")
+
+    def test_set_sql_log_bin_is_detected_as_mutation(self):
+        """``SET sql_log_bin = 0`` — disables binlog for the session.
+
+        Caught by the SET keyword in MUTATING_KEYWORDS in readonly mode.
+        Also caught by SECURITY_SENSITIVE_VAR_PATTERN regardless of mode
+        — see TestSecuritySensitiveVarsAlwaysBlocked below.
+        """
+        assert 'SET' in detect_mutating_keywords('SET sql_log_bin = 0')
+
+    def test_call_some_proc_is_detected(self):
+        """``CALL some_proc()`` — stored proc body can mutate."""
+        assert 'CALL' in detect_mutating_keywords('CALL some_proc()')
+
+    def test_prepare_is_detected(self):
+        """``PREPARE s FROM @x`` — dynamic SQL setup."""
+        assert 'PREPARE' in detect_mutating_keywords('PREPARE s FROM @x')
+
+    def test_execute_is_detected(self):
+        """``EXECUTE s`` — dynamic SQL fire."""
+        assert 'EXECUTE' in detect_mutating_keywords('EXECUTE s')
+
+    def test_deallocate_is_detected(self):
+        """``DEALLOCATE PREPARE s`` — dynamic SQL teardown."""
+        assert 'DEALLOCATE' in detect_mutating_keywords('DEALLOCATE PREPARE s')
+
+    def test_handler_open_is_detected(self):
+        """``HANDLER t OPEN`` — direct storage-engine access."""
+        assert 'HANDLER' in detect_mutating_keywords('HANDLER t OPEN')
+
+    def test_flush_privileges_is_detected(self):
+        """``FLUSH PRIVILEGES`` — admin state change."""
+        assert 'FLUSH' in detect_mutating_keywords('FLUSH PRIVILEGES')
+
+    def test_reset_master_is_detected(self):
+        """``RESET MASTER`` — admin state change."""
+        assert 'RESET' in detect_mutating_keywords('RESET MASTER')
+
+    def test_lock_tables_write_is_detected(self):
+        """``LOCK TABLES t WRITE`` — write lock acquisition.
+
+        The longer phrase ``LOCK TABLES`` should win the regex race over
+        bare ``LOCK`` because of the length-descending sort. Either is
+        sufficient for the gate to fire; we assert the longer phrase
+        for log clarity.
+        """
+        assert 'LOCK TABLES' in detect_mutating_keywords('LOCK TABLES t WRITE')
+
+    def test_kill_is_detected(self):
+        """``KILL <id>`` — terminates other sessions."""
+        assert 'KILL' in detect_mutating_keywords('KILL 1')
+
+    def test_uninstall_plugin_is_detected(self):
+        """``UNINSTALL PLUGIN x`` — plugin lifecycle."""
+        assert 'UNINSTALL' in detect_mutating_keywords('UNINSTALL PLUGIN x')
+
+
+# ---------------------------------------------------------------------------
+# SET is blanket-blocked in readonly mode
+#
+# Pins the design choice that bare SET (without distinguishing user
+# vars from system vars) is rejected. This is the cost of the closed-
+# by-construction approach — a future change that allowlists SET @var
+# or SET NAMES must update these tests deliberately, with a CR linked
+# to the security review.
+# ---------------------------------------------------------------------------
+
+
+class TestSetVariantsAreBlocked:
+    """All SET forms are rejected in readonly mode by design."""
+
+    def test_set_user_variable_is_blocked(self):
+        """``SET @x = 1`` — benign in isolation, blocked by blanket rule."""
+        assert 'SET' in detect_mutating_keywords('SET @x = 1')
+
+    def test_set_names_is_blocked(self):
+        """``SET NAMES utf8mb4`` — character set, blocked by blanket rule."""
+        assert 'SET' in detect_mutating_keywords('SET NAMES utf8mb4')
+
+    def test_set_session_sql_mode_is_blocked(self):
+        """``SET SESSION sql_mode = 'TRADITIONAL'`` — session config."""
+        assert 'SET' in detect_mutating_keywords("SET SESSION sql_mode = 'TRADITIONAL'")
+
+    def test_set_global_is_blocked(self):
+        """``SET GLOBAL general_log = 'ON'`` — server-wide config."""
+        assert 'SET' in detect_mutating_keywords("SET GLOBAL general_log = 'ON'")
+
+    def test_set_with_double_at_prefix_is_blocked(self):
+        """``SET @@session.sql_mode = '...'`` — at-prefix syntax."""
+        assert 'SET' in detect_mutating_keywords("SET @@session.sql_mode = 'TRADITIONAL'")
+
+    def test_set_transaction_is_blocked(self):
+        """``SET TRANSACTION READ WRITE`` — would re-arm writes."""
+        assert 'SET' in detect_mutating_keywords('SET TRANSACTION READ WRITE')
+
+
+# ---------------------------------------------------------------------------
+# Security-sensitive variables are blocked in BOTH modes
+#
+# These run against check_sql_injection_risk, not detect_mutating_keywords,
+# because the always-block lives there. In readonly mode the SET keyword
+# fires first and these payloads are rejected by detect_mutating_keywords;
+# in write mode (with --allow_write_query) the keyword path is bypassed
+# and only this check stands between the LLM and the variable flip.
+# ---------------------------------------------------------------------------
+
+
+class TestSecuritySensitiveVarsAlwaysBlocked:
+    """SET of binlog / FK / uniqueness toggles is rejected in every mode."""
+
+    def test_set_sql_log_bin_zero_is_rejected(self):
+        """Reporter's payload: ``SET sql_log_bin = 0``."""
+        issues = check_sql_injection_risk('SET sql_log_bin = 0')
+        assert issues, 'Expected SET sql_log_bin = 0 to be flagged'
+        assert issues[0]['type'] == 'sql'
+        assert 'sql_log_bin' in issues[0]['message']
+
+    def test_set_session_sql_log_bin_is_rejected(self):
+        """``SET SESSION sql_log_bin = 0`` — explicit session modifier."""
+        assert check_sql_injection_risk('SET SESSION sql_log_bin = 0')
+
+    def test_set_global_sql_log_bin_is_rejected(self):
+        """``SET GLOBAL sql_log_bin = 0`` — global modifier (rare but valid)."""
+        assert check_sql_injection_risk('SET GLOBAL sql_log_bin = 0')
+
+    def test_set_at_at_sql_log_bin_is_rejected(self):
+        """``SET @@sql_log_bin = 0`` — at-prefix syntax."""
+        assert check_sql_injection_risk('SET @@sql_log_bin = 0')
+
+    def test_set_at_at_session_sql_log_bin_is_rejected(self):
+        """``SET @@session.sql_log_bin = 0`` — at-prefix with scope."""
+        assert check_sql_injection_risk('SET @@session.sql_log_bin = 0')
+
+    def test_set_at_at_global_sql_log_bin_is_rejected(self):
+        """``SET @@global.sql_log_bin = 0`` — at-prefix global."""
+        assert check_sql_injection_risk('SET @@global.sql_log_bin = 0')
+
+    def test_set_local_sql_log_bin_is_rejected(self):
+        """``SET LOCAL sql_log_bin = 0`` — LOCAL alias for SESSION."""
+        assert check_sql_injection_risk('SET LOCAL sql_log_bin = 0')
+
+    def test_set_foreign_key_checks_is_rejected(self):
+        """``SET foreign_key_checks = 0`` — FK bypass."""
+        issues = check_sql_injection_risk('SET foreign_key_checks = 0')
+        assert issues
+        assert 'foreign_key_checks' in issues[0]['message']
+
+    def test_set_unique_checks_is_rejected(self):
+        """``SET unique_checks = 0`` — uniqueness bypass."""
+        issues = check_sql_injection_risk('SET unique_checks = 0')
+        assert issues
+        assert 'unique_checks' in issues[0]['message']
+
+    def test_lowercase_set_is_rejected(self):
+        """Case-insensitive: lowercase ``set`` still fires."""
+        assert check_sql_injection_risk('set sql_log_bin = 0')
+
+    def test_security_sensitive_var_check_survives_block_comment(self):
+        """``SET /**/ sql_log_bin = 0`` — comment between SET and var.
+
+        sqlparse strips the comment before the regex sweep, so the
+        normalised form ``SET  sql_log_bin = 0`` matches the pattern.
+        """
+        assert check_sql_injection_risk('SET /**/ sql_log_bin = 0')
+
+    def test_prefix_match_does_not_false_positive(self):
+        r"""``SET sql_log_bin_extra = 0`` — \b prevents prefix collision.
+
+        There is no real MySQL variable named ``sql_log_bin_extra``,
+        but the principle matters: the pattern must require a word
+        boundary after the variable name so a longer identifier is
+        not flagged as the security-sensitive one.
+        """
+        # Note: the SET keyword itself still fires in readonly mode via
+        # MUTATING_KEYWORDS, so this test specifically asserts that
+        # check_sql_injection_risk does NOT flag the security-sensitive
+        # message — the readonly path uses detect_mutating_keywords.
+        issues = check_sql_injection_risk('SET sql_log_bin_extra = 0')
+        for issue in issues:
+            assert 'sql_log_bin' not in issue['message'], f'Prefix collision: {issue!r}'
+
+
+# ---------------------------------------------------------------------------
+# Multi-variable SET coverage
+#
+# MySQL allows comma-separated assignments in a single SET statement:
+#   SET @x = 1, sql_log_bin = 0
+# The previous pattern anchored on the first assignment slot only, so a
+# security-sensitive variable in any later position slipped through in
+# write mode. These tests pin the fix: the danger variable is detected
+# in any position of a multi-variable SET, with or without scope qualifiers,
+# across newlines, and even when earlier assignments contain commas
+# inside function call arguments.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiVariableSetCoverage:
+    """Security-sensitive vars must be detected in any position of a multi-var SET."""
+
+    def test_danger_var_in_position_two_is_rejected(self):
+        """``SET @x = 1, sql_log_bin = 0`` — reviewer's verbatim payload."""
+        issues = check_sql_injection_risk('SET @x = 1, sql_log_bin = 0')
+        assert issues, 'Multi-var SET with danger var in position 2 must be flagged'
+        assert 'sql_log_bin' in issues[0]['message']
+
+    def test_danger_var_in_position_three_is_rejected(self):
+        """``SET @x = 1, @y = 2, foreign_key_checks = 0``."""
+        issues = check_sql_injection_risk('SET @x = 1, @y = 2, foreign_key_checks = 0')
+        assert issues
+        assert 'foreign_key_checks' in issues[0]['message']
+
+    def test_danger_var_in_position_four_is_rejected(self):
+        """``SET @x = 1, @y = 2, @z = 3, unique_checks = 0``."""
+        issues = check_sql_injection_risk('SET @x = 1, @y = 2, @z = 3, unique_checks = 0')
+        assert issues
+        assert 'unique_checks' in issues[0]['message']
+
+    def test_danger_var_in_position_one_still_works(self):
+        """``SET sql_log_bin = 0, @x = 1`` — regression guard.
+
+        The new optional skip group must not break the position-1 case
+        that previously already worked correctly.
+        """
+        assert check_sql_injection_risk('SET sql_log_bin = 0, @x = 1')
+
+    def test_newline_between_assignments_is_handled(self):
+        r"""``SET @x = 1,\n sql_log_bin = 0`` — motivates re.DOTALL.
+
+        Without DOTALL, ``.`` does not match ``\n`` and the skip group
+        cannot span the newline. With DOTALL the payload is caught.
+        """
+        assert check_sql_injection_risk('SET @x = 1,\n sql_log_bin = 0')
+
+    def test_scope_qualifier_on_later_var_is_handled(self):
+        """``SET @x = 1, @@session.sql_log_bin = 0`` — scope on second var."""
+        assert check_sql_injection_risk('SET @x = 1, @@session.sql_log_bin = 0')
+
+    def test_function_call_comma_in_earlier_slot_is_handled(self):
+        """``SET @x = CONCAT('a', 'b'), sql_log_bin = 0``.
+
+        A naive comma-split would mis-tokenise the CONCAT call. The
+        regex approach handles this because the wildcard skip includes
+        the inner comma in its non-greedy span; the engine extends past
+        it until the security variable is reached.
+        """
+        assert check_sql_injection_risk("SET @x = CONCAT('a', 'b'), sql_log_bin = 0")
+
+    def test_long_preceding_assignment_within_bound_is_handled(self):
+        """A 100-char REPEAT() expression in slot 1 still leaves slot 2 detectable.
+
+        Pins that the 500-char wildcard bound is comfortable for
+        realistic payloads.
+        """
+        assert check_sql_injection_risk("SET @x = REPEAT('a', 100), sql_log_bin = 0")
+
+    def test_mixed_security_vars_in_one_statement_is_rejected(self):
+        """``SET sql_log_bin = 0, foreign_key_checks = 0`` — two danger vars.
+
+        Either match is sufficient to reject; we don't care which one
+        the regex reports first, only that the statement is rejected.
+        """
+        issues = check_sql_injection_risk('SET sql_log_bin = 0, foreign_key_checks = 0')
+        assert issues
+        # The reported variable is implementation-defined; assert one of them is named.
+        assert any(v in issues[0]['message'] for v in ('sql_log_bin', 'foreign_key_checks'))
+
+    def test_uppercase_set_with_multi_var_is_handled(self):
+        """Case-insensitive matching survives the multi-var path."""
+        assert check_sql_injection_risk('SET @X = 1, SQL_LOG_BIN = 0')
+
+
+class TestMultiVariableSetFalsePositiveBoundary:
+    """Pin the known false-positive limitation as deliberate, not accidental.
+
+    ``UPDATE t SET sql_log_bin = 0`` would match the regex (the parser
+    sees ``set sql_log_bin``). This is a deliberate trade-off: closing
+    it requires sqlparse tokenisation to distinguish statement-level
+    SET from UPDATE's SET clause. Real-world impact is rejecting one
+    weird query in write mode, not a security leak.
+
+    These tests document the boundary so a future "fix" that changes
+    the behaviour must update the tests deliberately.
+    """
+
+    def test_update_with_column_named_like_session_var_is_flagged(self):
+        """Documents the false positive: column named ``sql_log_bin``.
+
+        If a future change uses sqlparse to distinguish UPDATE-SET from
+        statement-level SET, this test must be updated to assert NO
+        match. Right now it asserts the false positive exists so the
+        trade-off is visible.
+        """
+        # No realistic schema names a column after a MySQL session
+        # variable; this test exists to make the boundary explicit.
+        assert check_sql_injection_risk('UPDATE t SET sql_log_bin = 0 WHERE id = 1')
+
+
+# ---------------------------------------------------------------------------
+# Security-sensitive vars set is well-formed
+# ---------------------------------------------------------------------------
+
+
+def test_security_sensitive_vars_is_non_empty():
+    """The set must have at least the three ticket-required entries."""
+    assert {'sql_log_bin', 'foreign_key_checks', 'unique_checks'} <= SECURITY_SENSITIVE_VARS
+

--- a/src/mysql-mcp-server/tests/test_mutable_sql_detector.py
+++ b/src/mysql-mcp-server/tests/test_mutable_sql_detector.py
@@ -1,0 +1,391 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for mutable_sql_detector.
+
+These pin two things at once:
+
+1. The reported bypass class
+   where SQL inline comments (``/* ... */``, ``-- ...``, ``#``) and MySQL
+   conditional comments (``/*!50000 ... */``) sneak forbidden keywords past
+   the regex-based detector because Python regex treats those tokens as
+   opaque characters while the MySQL parser treats them as whitespace.
+
+2. The benign-comment cases that real users have in real queries, so a
+   future change to the detector cannot silently start blocking
+   ``SELECT id /* primary key */ FROM users`` and similar.
+
+The test cases include the reporter's verbatim payloads so a security
+reviewer can match them against the report 1:1.
+"""
+
+from awslabs.mysql_mcp_server.mutable_sql_detector import (
+    check_sql_injection_risk,
+    detect_mutating_keywords,
+)
+
+
+# ---------------------------------------------------------------------------
+# Bypass class: comment-based evasion of the suspicious-pattern gate
+# ---------------------------------------------------------------------------
+
+
+class TestCommentBypassSuspiciousPatterns:
+    """Suspicious-pattern detection must survive ``/* */``, ``--``, ``#``."""
+
+    def test_into_outfile_with_block_comment_is_detected(self):
+        """Reporter's payload: SELECT * FROM mysql.user INTO/**/OUTFILE '/tmp/x'."""
+        sql = "SELECT * FROM mysql.user INTO/**/OUTFILE '/tmp/x'"
+        issues = check_sql_injection_risk(sql)
+        assert issues, f'Expected detector to flag {sql!r}'
+        assert issues[0]['type'] == 'sql'
+
+    def test_into_outfile_with_padded_block_comment_is_detected(self):
+        """Variant with whitespace surrounding the comment."""
+        sql = "SELECT password FROM users INTO /**/ OUTFILE '/tmp/p'"
+        assert check_sql_injection_risk(sql)
+
+    def test_into_dumpfile_with_block_comment_is_detected(self):
+        """DUMPFILE is the binary-write sibling of OUTFILE; same bypass shape."""
+        sql = "SELECT 1 INTO/**/DUMPFILE '/tmp/x'"
+        assert check_sql_injection_risk(sql)
+
+    def test_into_outfile_with_line_comment_is_detected(self):
+        """Line comment between INTO and OUTFILE; sqlparse normalises it."""
+        sql = "SELECT password FROM users INTO -- pivot\nOUTFILE '/tmp/p'"
+        assert check_sql_injection_risk(sql)
+
+    def test_into_outfile_with_hash_comment_is_detected(self):
+        """MySQL-specific ``#`` line comment; sqlparse strips it."""
+        sql = "SELECT password FROM users INTO # pivot\nOUTFILE '/tmp/p'"
+        assert check_sql_injection_risk(sql)
+
+    def test_load_file_function_call_still_detected(self):
+        """``load_file(...)`` is a single identifier; comment trick doesn't apply.
+
+        Included because the reporter explicitly notes this pattern was not
+        bypassable. We assert the existing behaviour didn't regress.
+        """
+        sql = "SELECT load_file('/etc/passwd')"
+        assert check_sql_injection_risk(sql)
+
+
+class TestMySQLConditionalCommentBypass:
+    """``/*!`` conditional comments execute on the server and must be rejected."""
+
+    def test_conditional_comment_with_into_outfile_is_rejected(self):
+        """``/*!50000 INTO OUTFILE ... */`` runs on MySQL 5.0+; reject pre-strip."""
+        sql = "SELECT 1 /*!50000 INTO OUTFILE '/tmp/x' */"
+        assert check_sql_injection_risk(sql)
+
+    def test_conditional_comment_with_insert_is_rejected(self):
+        """A conditional comment containing INSERT must be rejected."""
+        sql = 'SELECT 1 /*! INSERT INTO log VALUES (1) */'
+        assert check_sql_injection_risk(sql)
+
+    def test_conditional_comment_without_inner_payload_is_rejected(self):
+        """Even a no-op ``/*!*/`` is rejected; no benign caller emits one."""
+        sql = 'SELECT 1 /*!*/'
+        assert check_sql_injection_risk(sql)
+
+
+class TestMySQLConditionalCommentInMutationGate:
+    """``detect_mutating_keywords`` must catch ``/*!`` independently.
+
+    sqlparse strips conditional-comment bodies before the regex runs, so
+    without an explicit guard a payload like ``/*!50000 DELETE FROM users */``
+    would normalise to whitespace and ``MUTATING_PATTERN`` would find
+    nothing. The readonly gate would then let the query through to
+    ``check_sql_injection_risk``, which catches it — but only because the
+    two functions are coupled through the server's call order. This class
+    pins the behaviour that the function is correct in isolation, regardless
+    of who calls it next.
+    """
+
+    def test_conditional_comment_with_delete_is_reported_as_mutation(self):
+        """``/*!50000 DELETE */`` returns a non-empty list."""
+        sql = '/*!50000 DELETE FROM users */'
+        matches = detect_mutating_keywords(sql)
+        assert matches, f'Expected non-empty list, got {matches!r}'
+
+    def test_conditional_comment_with_drop_is_reported_as_mutation(self):
+        """``/*!50000 DROP */`` returns a non-empty list."""
+        sql = 'SELECT 1 /*!50000 DROP TABLE users */'
+        matches = detect_mutating_keywords(sql)
+        assert matches
+
+    def test_conditional_comment_marker_alone_is_reported_as_mutation(self):
+        """Bare ``/*!`` marker is sufficient to be reported."""
+        sql = 'SELECT 1 /*!*/'
+        matches = detect_mutating_keywords(sql)
+        assert matches
+
+    def test_mutation_sentinel_is_used_for_conditional_comments(self):
+        """The sentinel is a recognisable non-keyword for log clarity."""
+        matches = detect_mutating_keywords('/*!50000 DELETE FROM users */')
+        assert matches == ['MYSQL_CONDITIONAL_COMMENT']
+
+    def test_real_mutation_with_conditional_comment_still_flagged(self):
+        """A query with both a conditional comment and a real mutation is flagged.
+
+        Whether the guard or the keyword scan reports first, callers see a
+        non-empty list. The guard takes precedence in the current
+        implementation; this test pins that callers' ``bool(matches)``
+        check fires either way.
+        """
+        sql = 'INSERT INTO logs VALUES (1) /*! ignored */'
+        matches = detect_mutating_keywords(sql)
+        assert matches
+
+
+# ---------------------------------------------------------------------------
+# Bypass class: comment-based evasion of the readonly mutation gate
+# ---------------------------------------------------------------------------
+
+
+class TestCommentBypassMutatingKeywords:
+    """Multi-word mutating keywords must be detected even with ``/**/`` between words."""
+
+    def test_load_data_with_block_comment_is_detected(self):
+        """Reporter's payload: LOAD/**/DATA INFILE '/etc/passwd' INTO TABLE t."""
+        sql = "LOAD/**/DATA INFILE '/etc/passwd' INTO TABLE t"
+        matches = detect_mutating_keywords(sql)
+        assert 'LOAD DATA' in matches, f'Got {matches!r}'
+
+    def test_load_xml_with_block_comment_is_detected(self):
+        """LOAD XML is a sibling form of LOAD DATA and must also be caught."""
+        sql = "LOAD/**/XML INFILE '/etc/passwd' INTO TABLE t"
+        assert 'LOAD XML' in detect_mutating_keywords(sql)
+
+    def test_replace_into_with_block_comment_is_detected(self):
+        """REPLACE INTO is a mutation; the comment between words must not hide it."""
+        sql = "REPLACE/**/INTO users (id, name) VALUES (1, 'x')"
+        assert 'REPLACE INTO' in detect_mutating_keywords(sql)
+
+    def test_rename_table_with_block_comment_is_detected(self):
+        """RENAME TABLE is a mutation; the comment between words must not hide it."""
+        sql = 'RENAME/**/TABLE old_users TO users'
+        assert 'RENAME TABLE' in detect_mutating_keywords(sql)
+
+    def test_create_function_with_block_comment_is_detected(self):
+        """CREATE FUNCTION is a mutation; the comment between words must not hide it."""
+        sql = 'CREATE/**/FUNCTION foo() RETURNS INT RETURN 1'
+        assert 'CREATE FUNCTION' in detect_mutating_keywords(sql)
+
+
+# ---------------------------------------------------------------------------
+# Baselines: payloads the original detector already caught must still pass
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineDetections:
+    """Payloads the previous detector already caught must remain caught."""
+
+    def test_plain_into_outfile_is_detected(self):
+        """Bare INTO OUTFILE without comments was already caught and still is."""
+        sql = "SELECT * FROM mysql.user INTO OUTFILE '/tmp/x'"
+        assert check_sql_injection_risk(sql)
+
+    def test_plain_into_dumpfile_is_detected(self):
+        """Bare INTO DUMPFILE without comments was already caught and still is."""
+        sql = "SELECT 1 INTO DUMPFILE '/tmp/x'"
+        assert check_sql_injection_risk(sql)
+
+    def test_plain_load_data_infile_is_detected_in_readonly(self):
+        """Bare LOAD DATA INFILE is reported as a mutation in readonly mode."""
+        sql = "LOAD DATA INFILE '/etc/passwd' INTO TABLE t"
+        assert 'LOAD DATA' in detect_mutating_keywords(sql)
+
+    def test_union_select_is_detected(self):
+        """UNION SELECT is the canonical SQLi pivot and must remain blocked."""
+        sql = 'SELECT 1 UNION SELECT password FROM users'
+        assert check_sql_injection_risk(sql)
+
+    def test_drop_table_is_detected(self):
+        """DROP must remain blocked even outside readonly mode."""
+        sql = 'DROP TABLE users'
+        assert check_sql_injection_risk(sql)
+
+    def test_stacked_queries_are_detected(self):
+        """A semicolon-separated stacked query must be flagged."""
+        sql = 'SELECT 1; DROP TABLE users'
+        assert check_sql_injection_risk(sql)
+
+    def test_numeric_tautology_is_detected(self):
+        """OR 1=1 must remain blocked."""
+        sql = 'SELECT * FROM users WHERE id = 1 OR 1=1'
+        assert check_sql_injection_risk(sql)
+
+    def test_string_tautology_is_detected(self):
+        """OR '1'='1' must remain blocked."""
+        sql = "SELECT * FROM users WHERE name = '' OR 'x'='x'"
+        assert check_sql_injection_risk(sql)
+
+    def test_sleep_probe_is_detected(self):
+        """sleep() time-based SQLi probe must remain blocked."""
+        sql = 'SELECT * FROM users WHERE id = 1 AND sleep(5)'
+        assert check_sql_injection_risk(sql)
+
+    def test_benchmark_probe_is_detected(self):
+        """benchmark() time-based SQLi probe must remain blocked."""
+        sql = 'SELECT 1 FROM dual WHERE benchmark(1000000, MD5(1))'
+        assert check_sql_injection_risk(sql)
+
+
+class TestBaselineMutatingDetection:
+    """Mutating keyword detection on plain queries (no comments)."""
+
+    def test_insert_is_detected(self):
+        """Plain INSERT is reported as INSERT."""
+        assert 'INSERT' in detect_mutating_keywords("INSERT INTO users VALUES (1, 'x')")
+
+    def test_update_is_detected(self):
+        """Plain UPDATE is reported as UPDATE."""
+        assert 'UPDATE' in detect_mutating_keywords("UPDATE users SET name = 'x'")
+
+    def test_delete_is_detected(self):
+        """Plain DELETE is reported as DELETE."""
+        assert 'DELETE' in detect_mutating_keywords('DELETE FROM users WHERE id = 1')
+
+    def test_select_is_not_mutating(self):
+        """SELECT must not be reported as a mutation."""
+        assert detect_mutating_keywords('SELECT id FROM users') == []
+
+
+class TestMultiWordKeywordsPreferredOverPrefixes:
+    """Multi-word keywords must win over their single-word prefixes.
+
+    ``MUTATING_KEYWORDS`` is a Python set; without explicit length-sorting,
+    the alternation order is hash-seed dependent and ``RENAME`` can match
+    before ``RENAME TABLE`` is even tried. These tests pin the longer
+    phrase as the reported match so multi-word entries are not vestigial.
+
+    The readonly gate fires on either spelling (both ``RENAME`` and
+    ``RENAME TABLE`` are in the mutating set), so this is a labelling /
+    determinism fix, not a security fix.
+    """
+
+    def test_rename_table_wins_over_rename(self):
+        """RENAME TABLE must be reported in full, not as bare RENAME."""
+        assert 'RENAME TABLE' in detect_mutating_keywords('RENAME TABLE a TO b')
+
+    def test_create_function_wins_over_create(self):
+        """CREATE FUNCTION must be reported in full, not as bare CREATE."""
+        assert 'CREATE FUNCTION' in detect_mutating_keywords(
+            'CREATE FUNCTION foo() RETURNS INT RETURN 1'
+        )
+
+    def test_create_procedure_wins_over_create(self):
+        """CREATE PROCEDURE must be reported in full, not as bare CREATE."""
+        assert 'CREATE PROCEDURE' in detect_mutating_keywords('CREATE PROCEDURE bar() BEGIN END')
+
+    def test_load_data_wins_over_load_alone(self):
+        """LOAD DATA must be reported in full; bare LOAD isn't in the set."""
+        assert 'LOAD DATA' in detect_mutating_keywords(
+            "LOAD DATA INFILE '/etc/passwd' INTO TABLE t"
+        )
+
+    def test_replace_into_wins_over_replace(self):
+        """REPLACE INTO must be reported in full, not as bare REPLACE."""
+        assert 'REPLACE INTO' in detect_mutating_keywords(
+            "REPLACE INTO users (id, name) VALUES (1, 'x')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards: benign queries with comments must continue to pass
+# ---------------------------------------------------------------------------
+
+
+class TestBenignCommentsPass:
+    """Comments that genuinely appear in real queries must not be blocked.
+
+    These pin the design choice that the regex sweep runs against the
+    comment-stripped SQL only (not the raw SQL as a fallback). A future
+    change that re-introduces the raw-SQL fallback would fail these.
+    """
+
+    def test_select_with_block_comment_passes(self):
+        """A short ``/* ... */`` annotation between columns is benign."""
+        sql = 'SELECT id, /* primary key */ name FROM users'
+        assert check_sql_injection_risk(sql) == []
+
+    def test_select_with_line_comment_passes(self):
+        """A ``-- ...`` annotation at end-of-line is benign."""
+        sql = 'SELECT id FROM users -- get all users\nWHERE active = 1'
+        assert check_sql_injection_risk(sql) == []
+
+    def test_select_with_hash_comment_passes(self):
+        """A ``#`` annotation at end-of-line is benign in MySQL."""
+        sql = 'SELECT id FROM users # get all users\nWHERE active = 1'
+        assert check_sql_injection_risk(sql) == []
+
+    def test_multi_line_block_comment_header_passes(self):
+        """A leading ``/* ... */`` header is benign."""
+        sql = '/* monthly active users */\nSELECT COUNT(*) FROM events'
+        assert check_sql_injection_risk(sql) == []
+
+    def test_comment_text_containing_into_outfile_passes(self):
+        """Benign query whose comment happens to mention ``INTO OUTFILE``.
+
+        Regression test: V1 of the fix would have flagged this because it
+        ran the regex against the raw SQL too. V2 strips first and only
+        runs against the stripped form, which is the correct behaviour.
+        """
+        sql = 'SELECT id FROM users -- export INTO OUTFILE later'
+        assert check_sql_injection_risk(sql) == []
+
+    def test_comment_text_containing_load_data_passes(self):
+        """Benign query whose comment happens to mention ``LOAD DATA``."""
+        sql = 'SELECT id FROM users /* equivalent to LOAD DATA INFILE */'
+        assert check_sql_injection_risk(sql) == []
+
+    def test_explanatory_comments_in_cte_pass(self):
+        """A multi-line readonly CTE with comments must not be flagged."""
+        sql = """
+            /* monthly active users */
+            WITH active AS (
+                SELECT user_id FROM events
+                WHERE event_date >= NOW() - INTERVAL 30 DAY
+            )
+            SELECT COUNT(*) AS mau FROM active
+        """
+        assert check_sql_injection_risk(sql) == []
+
+
+class TestCommentDoesNotReassembleIdentifiers:
+    """Comments split inside an identifier do NOT yield a keyword.
+
+    ``INS/**/ERT`` is not an INSERT to the database (parsers don't treat
+    a comment as zero-width inside an identifier). After sqlparse strip
+    you get ``INS  ERT`` which still doesn't match any mutating keyword.
+    Pin this so a future "let's also strip inner whitespace" change
+    doesn't accidentally flag random identifiers that happen to look
+    like split keywords.
+    """
+
+    def test_split_insert_identifier_is_not_a_mutation(self):
+        """``INS/**/ERT`` must not be reported as INSERT."""
+        sql = 'INS/**/ERT INTO users VALUES (1)'
+        assert 'INSERT' not in detect_mutating_keywords(sql)
+
+    def test_split_drop_identifier_is_not_flagged_as_drop(self):
+        """``DR/**/OP`` must not be reported as DROP.
+
+        Note: this query DOES still get blocked because the database
+        would reject it as a syntax error, but our detector specifically
+        should not pretend to recognise a DROP.
+        """
+        sql = 'DR/**/OP TABLE users'
+        assert 'DROP' not in detect_mutating_keywords(sql)

--- a/src/mysql-mcp-server/tests/test_mutable_sql_detector.py
+++ b/src/mysql-mcp-server/tests/test_mutable_sql_detector.py
@@ -805,3 +805,73 @@ def test_security_sensitive_vars_is_non_empty():
     """The set must have at least the three ticket-required entries."""
     assert {'sql_log_bin', 'foreign_key_checks', 'unique_checks'} <= SECURITY_SENSITIVE_VARS
 
+
+# ---------------------------------------------------------------------------
+# Pin the existing stacked-queries protection against transaction-bypass
+# payloads.
+#
+# The initial assessment proposed adding a dedicated
+# detect_transaction_bypass_attempt function mirroring the Aurora-DSQL
+# sibling. On closer inspection the existing stacked-queries pattern
+# in SUSPICIOUS_PATTERNS already rejects every canonical bypass payload
+# the security report names, matching the Postgres sibling's design
+# choice. Rather than adding a new function with overlapping logic, we
+# pin the existing protection here so a future "let's relax stacked
+# queries" change has to update these tests deliberately.
+#
+# Each parametrised case exercises a real attack shape against
+# check_sql_injection_risk and asserts a rejection. detect_mutating_keywords
+# also fires on most of these because they contain mutating verbs after
+# the transaction-control keyword; we deliberately route through
+# check_sql_injection_risk to pin the SUSPICIOUS_PATTERNS layer
+# independently.
+# ---------------------------------------------------------------------------
+
+
+class TestTransactionBypassCoverage:
+    """Stacked-queries pattern must reject transaction-bypass payloads."""
+
+    @pytest.mark.parametrize(
+        'payload',
+        [
+            # Canonical: COMMIT mid-chain re-arms writes in a new transaction.
+            'SELECT 1; COMMIT; INSERT INTO t VALUES (1)',
+            # ROLLBACK variant — same shape.
+            'SELECT 1; ROLLBACK; INSERT INTO t VALUES (1)',
+            # SAVEPOINT manipulates nested transaction scope.
+            'SELECT 1; SAVEPOINT sp1',
+            # RELEASE SAVEPOINT — release of nested scope.
+            'SELECT 1; RELEASE SAVEPOINT sp1',
+            # START TRANSACTION re-arms a fresh writable transaction.
+            'SELECT 1; START TRANSACTION; INSERT INTO t VALUES (1)',
+            # BEGIN is a synonym for START TRANSACTION in MySQL.
+            'SELECT 1; BEGIN; INSERT INTO t VALUES (1)',
+            # Case-insensitive: lowercase variant must still fire.
+            'select 1; commit; insert into t values (1)',
+            # Comment between SELECT and COMMIT: sqlparse strip leaves the
+            # semicolon and the chained statement intact, so the stacked-
+            # queries pattern still matches.
+            'SELECT 1; /* annotation */ COMMIT; INSERT INTO t VALUES (1)',
+            # Whitespace variants: tab and newline as the post-semicolon
+            # separator both still leave a non-whitespace next char.
+            'SELECT 1;\tCOMMIT;\tINSERT INTO t VALUES (1)',
+            'SELECT 1;\nCOMMIT;\nINSERT INTO t VALUES (1)',
+        ],
+    )
+    def test_bypass_payload_is_rejected(self, payload):
+        """Every canonical bypass shape must be flagged by the injection check."""
+        issues = check_sql_injection_risk(payload)
+        assert issues, f'Bypass payload not rejected: {payload!r}'
+        assert issues[0]['type'] == 'sql'
+
+    def test_single_statement_with_commit_in_line_comment_is_benign(self):
+        """``SELECT 1 -- COMMIT`` is a comment, not a bypass — must pass.
+
+        Negative case: regression guard against an overzealous future
+        change that flags transaction-control keywords inside comments.
+        """
+        assert check_sql_injection_risk('SELECT 1 -- COMMIT') == []
+
+    def test_single_statement_with_commit_in_block_comment_is_benign(self):
+        """``SELECT 1 /* COMMIT */`` is a comment, not a bypass — must pass."""
+        assert check_sql_injection_risk('SELECT 1 /* COMMIT */') == []

--- a/src/mysql-mcp-server/uv.lock
+++ b/src/mysql-mcp-server/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-mysql-mcp-server"
-version = "1.0.21"
+version = "1.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },
@@ -113,6 +113,7 @@ dependencies = [
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
+    { name = "sqlparse" },
 ]
 
 [package.dev-dependencies]
@@ -136,6 +137,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "sqlparse", specifier = ">=0.5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1595,6 +1597,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
 ]
 
 [[package]]

--- a/src/mysql-mcp-server/uv.lock
+++ b/src/mysql-mcp-server/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-mysql-mcp-server"
-version = "1.0.20"
+version = "1.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },


### PR DESCRIPTION
## Summary

Closes two read-only-mode bypass classes in the `awslabs.mysql-mcp-server`
package and adds a "Security model" documentation section.

## What changed

### 1. Comment-bypass class (commit 1)

The detector matched regexes against the raw SQL while MySQL treats
`/* ... */`, `--`, and `#` as whitespace. Payloads like `INTO/**/OUTFILE`
and `LOAD/**/DATA INFILE` bypassed the read-only gate.

- `sqlparse.format(strip_comments=True)` normalises the SQL before regex
  matching in `detect_mutating_keywords` and `check_sql_injection_risk`.
- MySQL conditional comments (`/*! ... */`) are rejected against the raw
  SQL pre-strip, because their contents execute on MySQL 5.0+.
- `MUTATING_KEYWORDS` alternation is sorted longest-first so multi-word
  entries (`RENAME TABLE`, `LOAD DATA`, `CREATE FUNCTION`) match before
  their single-word prefixes deterministically.

### 2. Denylist extension and security-sensitive SET (CWE-184, commit 2)

Adds the mutating verbs the previous denylist missed and an always-block
on session variables that disable integrity controls.

- `MUTATING_KEYWORDS` adds `SET`, `CALL`, `PREPARE`, `EXECUTE`,
  `DEALLOCATE`, `HANDLER`, `LOCK`, `LOCK TABLES`, `UNLOCK`,
  `UNLOCK TABLES`, `FLUSH`, `RESET`, `KILL`, `UNINSTALL`.
- `SECURITY_SENSITIVE_VARS` (`sql_log_bin`, `foreign_key_checks`,
  `unique_checks`) is rejected in **both** read-only and write modes via
  a new `SECURITY_SENSITIVE_VAR_PATTERN` that handles every MySQL
  scope-modifier permutation (`SESSION`/`LOCAL`/`GLOBAL`, `@@`-prefix forms)
  and the comma-separated multi-assignment form (`SET @x = 1, sql_log_bin = 0`),
  with the dangerous variable detected in any position.

### 3. Security-model documentation and version bump (commit 3)

- `README.md` adds a "Security model" section: read-only mode is a
  best-effort SQL-text safeguard, not a security boundary. Operators
  should connect with a least-privilege MySQL user / IAM role granting
  only `SELECT`, with example SQL.
- `kiro_power/POWER.md` and `kiro_power/steering/aurora-mysql-mcp.md`
  carry the same caveat.
- `TestTransactionBypassCoverage` pins the existing stacked-queries
  `SUSPICIOUS_PATTERN` against ten canonical transaction-bypass payloads
  (`SELECT 1; COMMIT; INSERT ...` and variants) plus two negative cases.
- Version bump `1.0.21` -> `1.0.22`.

## Testing

- 137 new unit tests in `tests/test_mutable_sql_detector.py`. 100%
  line + branch coverage on `mutable_sql_detector.py`.
- End-to-end run against a live Aurora MySQL Serverless v2 cluster
  (RDS Data API path). Every payload from the reported bypass class
  rejected at the MCP layer before reaching the database; every
  benign comment-bearing query still passes; full backwards-compatibility
  with the existing Workout Planner demo confirmed (Express backend
  pointed at the test cluster, all four CRUD endpoints return seeded
  rows).

## Backwards compatibility

- New runtime dependency: `sqlparse>=0.5.0`.
- The blanket-SET block in read-only mode rejects `SET @var`,
  `SET NAMES`, and `SET sql_mode`. An LLM-driven read flow has
  SQL-native alternatives for all three. If an allowlist is needed
  later, it can be added without breaking the denylist contract.
- Known limitation: `UPDATE t SET sql_log_bin = 0` would
  false-positive on the always-block in write mode. Real-world risk
  is essentially zero (no schema names a column after a MySQL session
  variable). Documented as a deliberate trade-off in
  `TestMultiVariableSetFalsePositiveBoundary`. Closing it requires
  sqlparse tokenisation to distinguish statement-level SET from
  UPDATE's SET clause.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
