### PR TITLE
feat(cloudwatch): Add DSQL system diagnostics skill

### DIFF
--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/SKILL.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsql-system-diagnostics
-description: Diagnose Aurora DSQL performance issues using PromQL queries against CloudWatch OTel metrics. Detect anomalies in wait event distribution, identify regression points, and hand off to the dsql skill for live database investigation.
+description: Diagnose Aurora DSQL performance issues using PromQL queries against CloudWatch OTel metrics. Detect anomalies in wait event distribution, identify regression points, and hand off to the dsql skill for per-query diagnosis.
 ---
 
 # DSQL System Diagnostics
@@ -24,7 +24,8 @@ Diagnose Aurora DSQL cluster performance by querying Active Average Sessions (AA
 
 **MUST** have before starting:
 1. A specific `cluster_id` to investigate — never proceed without one. Ask the user if not provided.
-2. The CloudWatch MCP server configured with PromQL access (see [mcp-setup.md](mcp/mcp-setup.md))
+2. The CloudWatch MCP server configured with PromQL access in the **same region** as the DSQL cluster (see [mcp-setup.md](mcp/mcp-setup.md))
+3. Verify the `aurora-dsql` MCP server is configured for the target cluster — if not, prompt the user to configure it before proceeding (required for handoff)
 
 ---
 
@@ -53,11 +54,7 @@ Diagnose Aurora DSQL cluster performance by querying Active Average Sessions (AA
 
 The primary metric is `db.active_sessions.avg` — the average number of sessions actively executing or waiting at a given instant.
 
-**Normalized SQL and AAS interpretation:** All SQL in the metric is normalized (parameterized). The `normalized_sql` label groups all executions of the same query shape. A query with high AAS could mean either:
-- A slow query (high per-execution cost)
-- A fast query called at very high frequency (volume accumulates AAS)
-
-This skill cannot distinguish between these — the `dsql` skill can via call counts and per-execution timing.
+**Normalized SQL and AAS interpretation:** All SQL in the metric is normalized (parameterized). The `normalized_sql` label groups all executions of the same query shape. A query with high AAS indicates it is executing frequently and/or concurrently across many sessions. A single slow query can only contribute at most 1 AAS — high AAS always means high concurrency or high call frequency, not a single slow execution. Neither this skill nor the `dsql` skill can currently distinguish frequency from per-execution cost; this will be possible in a future release that publishes per-SQL execution statistics via PromQL.
 
 | Label | Purpose |
 |-------|---------|
@@ -66,7 +63,7 @@ This skill cannot distinguish between these — the `dsql` skill can via call co
 | `query_id` | Correlates with DSQL `EXPLAIN` Query Identifier |
 | `application_name` | Client application identifier |
 | `iam_role_arn` | IAM role used for the connection |
-| `session_state` | Session state (active) |
+| `session_state` | Session state (active, idle in transaction) |
 | `@resource.aws.auroradsql.cluster_id` | Cluster identifier for filtering |
 | `@resource.cloud.resource_id` | Full cluster ARN |
 
@@ -158,7 +155,7 @@ execute_promql_query(query='topk(10, sum by (normalized_sql, query_id, wait_even
 | **SequentialScanRead** | Identify query via Workflow 2. Hand off to `dsql` skill — may be plan regression or missing index. |
 | **ScatteredBatchRead** | Identify query. Hand off to `dsql` skill. |
 | **SingleRead** | Identify query. Hand off to `dsql` skill. |
-| **FkExistenceCheck** | Identify query. Check whether insert volume increased. |
+| **FkExistenceCheck** | Identify query. Check TotalTransactions CW metric for insert volume change. |
 | **UniqueConstraintCheck** | Identify query. Check whether insert/upsert patterns changed. |
 | **Commit** | Run Workflow 6 (Commit Analysis) to distinguish volume increase from OCC conflicts. |
 | **PgSleep** | Identify application. Verify intentional — may indicate new polling behavior. |
@@ -261,18 +258,9 @@ execute_promql_range_query(
 
 When investigation identifies a query that has become more prominent, hand off to the `dsql` skill for live database analysis. Do not provide specific diagnostics or recommendations — simply describe the observed anomaly.
 
-### Automatic Handoff
-
-Before handing off, verify the `dsql` skill's MCP server is configured for the cluster under investigation:
-
-1. Check if the `aurora-dsql` MCP server is configured (look for it in the active MCP servers)
-2. Verify the `--cluster_endpoint` in its args matches the cluster being investigated
-3. If not configured or pointing to a different cluster, prompt the user:
-   > "The Aurora DSQL MCP server needs to be configured for cluster `{CLUSTER_ID}` to proceed with live database investigation. Please add or update the `aurora-dsql` server in your MCP configuration with `--cluster_endpoint {CLUSTER_ENDPOINT}`."
-
 ### Handoff Format
 
-When handing off, describe only the observed anomaly — do not suggest causes or fixes:
+Describe only the observed anomaly — do not suggest causes or fixes:
 
 > "Query `{NORMALIZED_SQL}` (query_id: `{QUERY_ID}`) is using significantly more system time than it did {TIMEFRAME} ago. Its share of cluster AAS on `{WAIT_EVENT}` has grown from {OLD}% to {NEW}%. Please diagnose what is happening with this query."
 

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/SKILL.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: dsql-system-diagnostics
+description: Diagnose Aurora DSQL performance issues using PromQL queries against CloudWatch OTel metrics. Detect anomalies in wait event distribution, identify regression points, and hand off to the dsql skill for live database investigation.
+---
+
+# DSQL System Diagnostics
+
+Diagnose Aurora DSQL cluster performance by querying Active Average Sessions (AAS) via PromQL, detecting temporal anomalies in wait event distribution, and handing off to the `dsql` skill for root cause analysis.
+
+**Key capabilities:**
+- Temporal trend analysis of AAS via `db.active_sessions.avg` metric
+- Wait event distribution shift detection
+- Top-SQL regression identification (new or growing queries)
+- Automatic handoff to `dsql` skill for live database investigation
+
+**Important principles:**
+- There is no upper bound to AAS in DSQL — absolute values are not inherently problematic
+- What matters is **change over time**: shifts in wait event distribution, new queries appearing, or existing queries consuming disproportionately more time
+- This skill observes via CloudWatch only — it does **not** recommend schema changes, indexing strategies, or query rewrites. Those require live database access via the `dsql` skill.
+
+---
+
+## Prerequisites
+
+**MUST** have before starting:
+1. A specific `cluster_id` to investigate — never proceed without one. Ask the user if not provided.
+2. The CloudWatch MCP server configured with PromQL access (see [mcp-setup.md](mcp/mcp-setup.md))
+
+---
+
+## Reference Files
+
+### MCP:
+#### [mcp-setup.md](mcp/mcp-setup.md)
+**When:** ALWAYS load before starting a diagnostic session
+**Contains:** CloudWatch MCP server configuration for PromQL access
+
+#### [.mcp.json](mcp/.mcp.json)
+**When:** Load when setting up MCP servers for the first time
+**Contains:** Sample MCP configuration for the CloudWatch MCP server
+
+### [wait-events.md](references/wait-events.md)
+**When:** ALWAYS load when interpreting AAS results
+**Contains:** DSQL wait events with canonical descriptions and investigation guidance
+
+### [promql-patterns.md](references/promql-patterns.md)
+**When:** Load when constructing PromQL queries
+**Contains:** Reusable PromQL query templates for all workflows
+
+---
+
+## Core Concept: Active Average Sessions (AAS)
+
+The primary metric is `db.active_sessions.avg` — the average number of sessions actively executing or waiting at a given instant.
+
+**Normalized SQL and AAS interpretation:** All SQL in the metric is normalized (parameterized). The `normalized_sql` label groups all executions of the same query shape. A query with high AAS could mean either:
+- A slow query (high per-execution cost)
+- A fast query called at very high frequency (volume accumulates AAS)
+
+This skill cannot distinguish between these — the `dsql` skill can via call counts and per-execution timing.
+
+| Label | Purpose |
+|-------|---------|
+| `wait_event` | Which wait the session is in (OnCpu, ClientRead, Commit, etc.) |
+| `normalized_sql` | SQL fingerprint — groups identical query shapes |
+| `query_id` | Correlates with DSQL `EXPLAIN` Query Identifier |
+| `application_name` | Client application identifier |
+| `iam_role_arn` | IAM role used for the connection |
+| `session_state` | Session state (active) |
+| `@resource.aws.auroradsql.cluster_id` | Cluster identifier for filtering |
+| `@resource.cloud.resource_id` | Full cluster ARN |
+
+---
+
+## Workflow 1: Quick Health Check
+
+**Goal:** Detect whether the cluster's wait event distribution has changed compared to historical baselines.
+
+**Steps:**
+1. Confirm you have a specific `cluster_id` — do not proceed without one
+2. Query AAS by `wait_event` for the **current hour** in 10-minute chunks (step=60s) — compare the chunks against each other to detect recent shifts
+3. Query AAS by `wait_event` for the **same hour yesterday** (baseline 1)
+4. Query AAS by `wait_event` for the **same hour last week** (baseline 2)
+5. Compute the distribution (% each wait event contributes to total AAS) for each period
+6. Flag any wait event where the proportion changed by >30% vs either baseline
+7. Load [wait-events.md](references/wait-events.md) and interpret flagged changes
+
+**Critical rules:**
+- **MUST** have a specific `cluster_id` before proceeding
+- **MUST** filter by cluster using `"@resource.aws.auroradsql.cluster_id"`
+- **MUST** compare against temporal baselines — do NOT report absolute AAS values as inherently problematic
+- **MUST** split the current hour into 10-minute chunks and compare them to detect intra-hour shifts
+- A >30% change in a wait event's share of total AAS warrants flagging to the user
+- If total AAS increased but distribution is unchanged, this may be legitimate load growth — report but do not alarm
+
+**Example:**
+```promql
+# Current hour (split into chunks for intra-hour comparison)
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="NOW-1h", end="NOW", step="60s"
+)
+
+# Same hour yesterday
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="NOW-25h", end="NOW-24h", step="60s"
+)
+
+# Same hour last week
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="NOW-169h", end="NOW-168h", step="60s"
+)
+```
+
+---
+
+## Workflow 2: Top-SQL Regression Detection
+
+**Goal:** Identify SQL statements that have become more prominent compared to baseline periods.
+
+**Steps:**
+1. Query top-N SQL by AAS for the current period
+2. Query top-N SQL for the same period yesterday and last week
+3. Identify queries that are **new** in the top-N or have **grown** significantly vs baseline
+4. Note which `wait_event` dominates for the regressed queries
+
+**Critical rules:**
+- **MUST** include `query_id` in grouping — stable identifier for handoff to `dsql` skill
+- **MUST** compare top-N across periods — a query being #1 is only notable if it wasn't before
+- **MUST NOT** recommend indexing or schema changes — defer to `dsql` skill
+
+**Example:**
+```promql
+# Top 5 SQL for current period
+execute_promql_query(query='topk(5, sum by (normalized_sql, query_id)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"}))')
+
+# Top 5 SQL with wait event context
+execute_promql_query(query='topk(10, sum by (normalized_sql, query_id, wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"}))')
+```
+
+---
+
+## Workflow 3: Triage Decision Tree
+
+**Goal:** Guide investigation based on which wait event has shifted.
+
+**Steps:**
+1. Run Workflow 1 to identify which wait event(s) have changed
+2. Branch on the wait event showing the largest shift:
+
+| Changed Wait Event | Investigation |
+|---|---|
+| **OnCpu** | Identify which queries grew via Workflow 2. Hand off to `dsql` skill. |
+| **ClientRead** | Top IAM role + application. Indicates idle-in-transaction growth — client-side issue. |
+| **ClientWrite** | Top application. Client is slow consuming results — check client health. |
+| **SequentialScanRead** | Identify query via Workflow 2. Hand off to `dsql` skill — may be plan regression or missing index. |
+| **ScatteredBatchRead** | Identify query. Hand off to `dsql` skill. |
+| **SingleRead** | Identify query. Hand off to `dsql` skill. |
+| **FkExistenceCheck** | Identify query. Check whether insert volume increased. |
+| **UniqueConstraintCheck** | Identify query. Check whether insert/upsert patterns changed. |
+| **Commit** | Run Workflow 6 (Commit Analysis) to distinguish volume increase from OCC conflicts. |
+| **PgSleep** | Identify application. Verify intentional — may indicate new polling behavior. |
+
+3. Load [wait-events.md](references/wait-events.md) for detailed investigation guidance
+
+---
+
+## Workflow 4: IAM Role and Application Attribution
+
+**Goal:** Identify which roles or applications are driving anomalous changes.
+
+**Critical rules:**
+- **MUST** compare against baseline — an application being dominant is only noteworthy if it has changed
+- Report the delta: "application X increased from 30% to 55% of total AAS"
+
+**Example:**
+```promql
+# Top IAM roles
+execute_promql_query(query='topk(5, sum by (iam_role_arn)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"}))')
+
+# Top applications
+execute_promql_query(query='topk(5, sum by (application_name)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"}))')
+```
+
+---
+
+## Workflow 5: Time-Series Investigation
+
+**Goal:** Identify when a change occurred and pinpoint the inflection point.
+
+**Critical rules:**
+- **SHOULD** use step: 60s (< 1h), 300s (1–6h), 900s (> 6h), 3600s (> 24h)
+- **MUST** specify `start` and `end` in RFC 3339 format
+- Maximum range per query is 7 days — split longer investigations into multiple queries
+- Look for: inflection points, step-changes in specific wait events, distribution shifts
+
+**Example:**
+```promql
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="2024-01-15T10:00:00Z",
+  end="2024-01-15T16:00:00Z",
+  step="300s"
+)
+```
+
+---
+
+## Workflow 6: Commit Analysis
+
+**Goal:** Distinguish between increased commit volume (legitimate) and OCC conflict growth (problematic).
+
+**Steps:**
+1. Confirm Commit wait has shifted (from Workflow 1 comparison)
+2. Query standard CloudWatch metrics for the same period:
+   - `AuroraDSQL` namespace, dimension `ClusterId`
+   - Metric: `TotalTransactions` — rate of committed transactions
+   - Metric: `OccConflicts` — rate of optimistic concurrency conflicts
+3. Compare the ratios:
+   - If TotalTransactions increased proportionally to Commit AAS → legitimate load growth
+   - If OccConflicts increased disproportionately → write-write conflict problem
+   - If Commit AAS increased but TotalTransactions did not → transactions are taking longer to commit
+
+**Example (standard CW metrics):**
+```
+get_metric_data(
+  namespace="AuroraDSQL",
+  metric_name="TotalTransactions",
+  dimensions=[{name: "ClusterId", value: "CLUSTER_ID"}],
+  statistic="Sum"
+)
+
+get_metric_data(
+  namespace="AuroraDSQL",
+  metric_name="OccConflicts",
+  dimensions=[{name: "ClusterId", value: "CLUSTER_ID"}],
+  statistic="Sum"
+)
+```
+
+---
+
+## Idle Cluster Detection
+
+A cluster is idle when there is no AAS data for a period. Use a range query and look for gaps (missing timestamps) in the time series.
+
+**Pattern: Sporadic workload** — periods of no data interspersed with periods of AAS > 0 indicate a cluster performing scheduled or batch work.
+
+```promql
+execute_promql_range_query(
+  query='sum({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="NOW-24h", end="NOW", step="300s"
+)
+```
+
+---
+
+## DSQL Skill Handoff
+
+When investigation identifies a query that has become more prominent, hand off to the `dsql` skill for live database analysis. Do not provide specific diagnostics or recommendations — simply describe the observed anomaly.
+
+### Automatic Handoff
+
+Before handing off, verify the `dsql` skill's MCP server is configured for the cluster under investigation:
+
+1. Check if the `aurora-dsql` MCP server is configured (look for it in the active MCP servers)
+2. Verify the `--cluster_endpoint` in its args matches the cluster being investigated
+3. If not configured or pointing to a different cluster, prompt the user:
+   > "The Aurora DSQL MCP server needs to be configured for cluster `{CLUSTER_ID}` to proceed with live database investigation. Please add or update the `aurora-dsql` server in your MCP configuration with `--cluster_endpoint {CLUSTER_ENDPOINT}`."
+
+### Handoff Format
+
+When handing off, describe only the observed anomaly — do not suggest causes or fixes:
+
+> "Query `{NORMALIZED_SQL}` (query_id: `{QUERY_ID}`) is using significantly more system time than it did {TIMEFRAME} ago. Its share of cluster AAS on `{WAIT_EVENT}` has grown from {OLD}% to {NEW}%. Please diagnose what is happening with this query."
+
+### When to Hand Off
+
+- Any query identified in Workflow 2 as newly prominent or significantly grown
+- SequentialScanRead, OnCpu, ScatteredBatchRead, or SingleRead shifts where a specific query is responsible
+- OCC conflict growth confirmed in Workflow 6
+
+---
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| No cluster_id provided | Ask the user — never proceed without a specific cluster |
+| No series found | Verify cluster ID with `get_promql_label_values`. Check region. |
+| Empty result (no data) | Cluster is idle for that period. Widen time window. |
+| `query_id` missing | Not all queries emit it. Filter by `normalized_sql` instead. |
+| PromQL timeout | Reduce cardinality — fewer labels or shorter time range. |
+| Range > 7 days | Split into multiple 7-day range queries. |
+| `dsql` skill not available | Prompt user to install from `awslabs/agent-plugins` (plugin: `databases-on-aws`) |

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/mcp/.mcp.json
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/mcp/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "cloudwatch": {
+      "args": [
+        "awslabs.cloudwatch-mcp-server@latest"
+      ],
+      "command": "uvx",
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/mcp/mcp-setup.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/mcp/mcp-setup.md
@@ -1,0 +1,80 @@
+# MCP Server Setup Instructions
+
+This skill uses the CloudWatch MCP Server with PromQL tools for querying Aurora DSQL OTel metrics.
+
+## Prerequisites
+
+```bash
+uv --version
+```
+
+**If missing:** Install from [Astral](https://docs.astral.sh/uv/getting-started/installation/)
+
+## Required Tools
+
+| Tool | Purpose |
+|------|---------|
+| `execute_promql_query` | Instant point-in-time query |
+| `execute_promql_range_query` | Time-series query over a window |
+| `get_promql_label_values` | Discover label values (cluster IDs, wait events) |
+| `get_promql_series` | Discover available metric series |
+| `get_promql_labels` | List available label names |
+
+## MCP Configuration
+
+```json
+{
+  "mcpServers": {
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}
+```
+
+### Optional Environment Variables
+
+| Variable | When Needed |
+|----------|-------------|
+| `AWS_PROFILE` | Non-default AWS profile |
+| `AWS_REGION` | Override default region — MUST match the DSQL cluster's region |
+
+## Example: Kiro CLI
+
+Create `~/.kiro/agents/dsql-diagnostics.json`:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
+  "name": "dsql-diagnostics",
+  "description": "Diagnose Aurora DSQL performance via CloudWatch PromQL metrics",
+  "mcpServers": {
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server@latest"],
+      "env": { "FASTMCP_LOG_LEVEL": "ERROR" }
+    }
+  },
+  "resources": [
+    "skill://.kiro/skills/dsql-system-diagnostics/SKILL.md"
+  ],
+  "tools": ["fs_read", "execute_bash", "@cloudwatch"]
+}
+```
+
+### Launch
+
+```bash
+kiro-cli chat --agent dsql-diagnostics
+```
+
+### Verification
+
+Confirm the CloudWatch MCP server is connected, then run:
+```
+check health of cluster <CLUSTER_ID>
+```

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/mcp/mcp-setup.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/mcp/mcp-setup.md
@@ -1,6 +1,6 @@
 # MCP Server Setup Instructions
 
-This skill uses the CloudWatch MCP Server with PromQL tools for querying Aurora DSQL OTel metrics.
+This skill uses the CloudWatch MCP Server for both PromQL queries (Aurora DSQL OTel metrics) and standard CloudWatch metrics (TotalTransactions, OccConflicts).
 
 ## Prerequisites
 

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/promql-patterns.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/promql-patterns.md
@@ -1,0 +1,213 @@
+# PromQL Query Patterns for DSQL Diagnostics
+
+Reusable PromQL templates for diagnosing Aurora DSQL via `db.active_sessions.avg`. Replace `CLUSTER_ID` with the actual `@resource.aws.auroradsql.cluster_id` value.
+
+---
+
+## Discovery Queries
+
+### List available clusters
+
+```promql
+get_promql_label_values(metric="db.active_sessions.avg", label="@resource.aws.auroradsql.cluster_id")
+```
+
+### List wait events on a cluster
+
+```promql
+get_promql_label_values(metric="db.active_sessions.avg", label="wait_event", matchers='@resource.aws.auroradsql.cluster_id="CLUSTER_ID"')
+```
+
+### List applications connecting
+
+```promql
+get_promql_label_values(metric="db.active_sessions.avg", label="application_name", matchers='@resource.aws.auroradsql.cluster_id="CLUSTER_ID"')
+```
+
+### List IAM roles connecting
+
+```promql
+get_promql_label_values(metric="db.active_sessions.avg", label="iam_role_arn", matchers='@resource.aws.auroradsql.cluster_id="CLUSTER_ID"')
+```
+
+---
+
+## Instant Queries
+
+### Total AAS
+
+```promql
+execute_promql_query(query='sum(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"})')
+```
+
+### AAS by wait event
+
+```promql
+execute_promql_query(query='sum by (wait_event)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"})')
+```
+
+### Top 5 SQL by AAS
+
+```promql
+execute_promql_query(query='topk(5, sum by (normalized_sql, query_id)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"}))')
+```
+
+### Top 5 SQL for a specific wait event
+
+```promql
+execute_promql_query(query='topk(5, sum by (normalized_sql, query_id)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID", wait_event="WAIT_EVENT"}))')
+```
+
+### Top 5 IAM roles
+
+```promql
+execute_promql_query(query='topk(5, sum by (iam_role_arn)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"}))')
+```
+
+### Top 5 applications
+
+```promql
+execute_promql_query(query='topk(5, sum by (application_name)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"}))')
+```
+
+### AAS for a specific query ID
+
+```promql
+execute_promql_query(query='sum by (wait_event)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID", query_id="QUERY_ID"})')
+```
+
+### Cross-cluster comparison
+
+```promql
+execute_promql_query(query='sum by (@resource.aws.auroradsql.cluster_id)(db.active_sessions.avg)')
+```
+
+---
+
+## Range Queries
+
+**Step guidelines:** 60s (< 1h), 300s (1–6h), 900s (6–24h), 3600s (> 24h).
+
+### AAS by wait event over time
+
+```promql
+execute_promql_range_query(
+  query='sum by (wait_event)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"})',
+  start="START_TIME", end="END_TIME", step="60s"
+)
+```
+
+### Total AAS over time
+
+```promql
+execute_promql_range_query(
+  query='sum(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"})',
+  start="START_TIME", end="END_TIME", step="60s"
+)
+```
+
+### Top SQL over time
+
+```promql
+execute_promql_range_query(
+  query='topk(5, sum by (normalized_sql, query_id)(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID"}))',
+  start="START_TIME", end="END_TIME", step="300s"
+)
+```
+
+### Commit wait trend (conflict storm detection)
+
+```promql
+execute_promql_range_query(
+  query='sum(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID", wait_event="Commit"})',
+  start="START_TIME", end="END_TIME", step="60s"
+)
+```
+
+---
+
+## Temporal Comparison Patterns
+
+### Current hour vs same hour yesterday vs same hour last week
+
+```promql
+# Current hour
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="CURRENT_HOUR_START", end="CURRENT_HOUR_END", step="60s"
+)
+
+# Same hour yesterday (24h ago)
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="YESTERDAY_HOUR_START", end="YESTERDAY_HOUR_END", step="60s"
+)
+
+# Same hour last week (168h ago)
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="LAST_WEEK_HOUR_START", end="LAST_WEEK_HOUR_END", step="60s"
+)
+```
+
+### Deployment regression detection
+
+```promql
+# Compare wait event distribution before and after deploy
+execute_promql_range_query(
+  query='sum by (wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="BEFORE_DEPLOY", end="AFTER_DEPLOY", step="60s"
+)
+```
+
+---
+
+## Diagnostic Scenarios
+
+### Has the cluster's behavior changed?
+
+Compare the wait event distribution across temporal baselines. Flag any wait event where
+the proportion of total AAS changed by >30% vs either baseline.
+
+### Which workload drives an anomaly?
+
+```promql
+execute_promql_query(query='sum by (iam_role_arn, wait_event)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})')
+```
+
+### Commit analysis — volume vs conflicts
+
+Use standard CloudWatch metrics alongside PromQL:
+```
+# PromQL: Commit wait AAS trend
+execute_promql_range_query(
+  query='sum({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID", wait_event="Commit"})',
+  start="START_TIME", end="END_TIME", step="60s"
+)
+
+# CW Metrics: TotalTransactions and OccConflicts
+get_metric_data(namespace="AuroraDSQL", metric_name="TotalTransactions", dimensions=[{name:"ClusterId", value:"CLUSTER_ID"}])
+get_metric_data(namespace="AuroraDSQL", metric_name="OccConflicts", dimensions=[{name:"ClusterId", value:"CLUSTER_ID"}])
+```
+
+### SequentialScanRead growth — identify query
+
+```promql
+execute_promql_query(query='topk(5, sum by (normalized_sql, query_id)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID", wait_event="SequentialScanRead"}))')
+```
+
+### Client-side bottleneck (idle in transaction)
+
+```promql
+execute_promql_query(query='sum by (application_name, iam_role_arn)({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID", wait_event="ClientRead"})')
+```
+
+### Idle or sporadic cluster detection
+
+```promql
+# Look for gaps in the time series — missing timestamps indicate no active sessions
+execute_promql_range_query(
+  query='sum({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID"})',
+  start="NOW-24h", end="NOW", step="300s"
+)
+```

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/promql-patterns.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/promql-patterns.md
@@ -115,11 +115,11 @@ execute_promql_range_query(
 )
 ```
 
-### Commit wait trend (conflict storm detection)
+### Commit wait trend
 
 ```promql
 execute_promql_range_query(
-  query='sum(db.active_sessions.avg{@resource.aws.auroradsql.cluster_id="CLUSTER_ID", wait_event="Commit"})',
+  query='sum({__name__="db.active_sessions.avg", "@resource.aws.auroradsql.cluster_id"="CLUSTER_ID", wait_event="Commit"})',
   start="START_TIME", end="END_TIME", step="60s"
 )
 ```
@@ -185,7 +185,7 @@ execute_promql_range_query(
   start="START_TIME", end="END_TIME", step="60s"
 )
 
-# CW Metrics: TotalTransactions and OccConflicts
+# CW Metrics: TotalTransactions and OccConflicts (detect conflict rate vs volume)
 get_metric_data(namespace="AuroraDSQL", metric_name="TotalTransactions", dimensions=[{name:"ClusterId", value:"CLUSTER_ID"}])
 get_metric_data(namespace="AuroraDSQL", metric_name="OccConflicts", dimensions=[{name:"ClusterId", value:"CLUSTER_ID"}])
 ```

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/wait-events.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/wait-events.md
@@ -6,18 +6,18 @@ Aurora DSQL exposes wait events via the `wait_event` label on `db.active_session
 
 ## Summary
 
-| Wait Event | Category | Threshold | Description |
-|---|---|---|---|
-| OnCpu | Compute | AAS > 1.0 | Actively processing in QP, not waiting for any other resource |
-| ClientRead | Network | AAS > 0.5 | QP is waiting for the next request (only reported when QP has an active transaction — idle in transaction) |
-| ClientWrite | Network | AAS > 0.5 | QP is sending data to the application |
-| SequentialScanRead | IO | AAS > 0.5 | QP has issued a scan of a contiguous range of tuples |
-| ScatteredBatchRead | IO | AAS > 0.5 | QP has issued one or more non-contiguous tuple reads |
-| SingleRead | IO | AAS > 1.0 | QP is reading a tuple returned by a streamed storage operation |
-| FkExistenceCheck | Validation | AAS > 0.3 | Storage reads to validate foreign key existence |
-| UniqueConstraintCheck | Validation | AAS > 0.3 | Storage reads to validate unique key constraints for non-primary columns |
-| Commit | Transaction | AAS > 0.5 | Commit process has begun, and QP is waiting for a response |
-| PgSleep | Application | Any | Session issued `pg_sleep()` and is waiting for the sleep period to complete |
+| Wait Event | Category | Description |
+|---|---|---|
+| OnCpu | Compute | Actively processing in QP, not waiting for any other resource |
+| ClientRead | Network | QP is waiting for the next request (only reported when QP has an active transaction — idle in transaction) |
+| ClientWrite | Network | QP is sending data to the application |
+| SequentialScanRead | IO | QP has issued a scan of a contiguous range of tuples |
+| ScatteredBatchRead | IO | QP has issued one or more non-contiguous tuple reads |
+| SingleRead | IO | QP is reading a tuple returned by a streamed storage operation |
+| FkExistenceCheck | Validation | Storage reads to validate foreign key existence |
+| UniqueConstraintCheck | Validation | Storage reads to validate unique key constraints for non-primary columns |
+| Commit | Transaction | Commit process has begun, and QP is waiting for a response |
+| PgSleep | Application | Session issued `pg_sleep()` and is waiting for the sleep period to complete |
 
 ---
 
@@ -25,25 +25,21 @@ Aurora DSQL exposes wait events via the `wait_event` label on `db.active_session
 
 Actively processing in the Query Processor (QP), not waiting for any other resource.
 
-**Problem signal:** AAS(OnCpu) > 1.0 sustained.
-
 **Root causes:**
 - Complex plans with nested loops or expensive expressions
-- Sequential scans on large tables (check SequentialScanRead co-occurrence)
 - High-frequency short queries from many connections
+- SequentialScanRead co-occurrence (CPU time processing scanned tuples)
 
 **Remediation:**
 1. Identify top SQL: `topk(5, sum by (normalized_sql, query_id)(db.active_sessions.avg{wait_event="OnCpu", ...}))`
 2. Compare against baseline — identify which queries have grown
-3. Defer to `dsql` skill for EXPLAIN analysis — look for plan changes, sequential scans, nested loops
+3. Defer to `dsql` skill for EXPLAIN analysis
 
 ---
 
 ## ClientRead
 
 QP is waiting for the next request. This is only reported when the QP has an active transaction (idle in transaction).
-
-**Problem signal:** AAS(ClientRead) > 0.5 sustained.
 
 **Root causes:**
 - Client has an open transaction but is not sending the next query (idle in transaction)
@@ -65,8 +61,6 @@ QP is waiting for the next request. This is only reported when the QP has an act
 
 QP is sending data to the application.
 
-**Problem signal:** AAS(ClientWrite) > 0.5 sustained.
-
 **Root causes:**
 - Client slow processing result sets
 - Large result sets saturating network buffers
@@ -75,8 +69,7 @@ QP is sending data to the application.
 **Remediation:**
 1. Identify app: `sum by (application_name)(db.active_sessions.avg{wait_event="ClientWrite", ...})`
 2. Add `LIMIT` or pagination to reduce result size
-3. Implement server-side cursors for large fetches
-4. Check client network throughput and TCP buffers
+3. Check client network throughput and TCP buffers
 
 ---
 
@@ -84,21 +77,18 @@ QP is sending data to the application.
 
 QP has issued a scan of a contiguous range of tuples.
 
-**Problem signal:** AAS(SequentialScanRead) > 0.5.
-
 **Root causes:**
 - Missing index for the WHERE clause
-- Plan regression — index exists but planner chose scan after statistics changed (e.g., bulk load, `ANALYZE` updated selectivity estimates)
+- Plan regression — index exists but planner chose scan after statistics changed
 - Intentional full-table aggregation
 
 **Diagnosis — distinguish missing index from plan flip:**
 - Compare AAS trend over time (Workflow 5). A sudden jump (not proportional to traffic growth) suggests plan regression.
-- Run `EXPLAIN` on the query. If an index exists on the filtered columns but is not used, the planner has flipped.
 
 **Remediation:**
 1. Identify query: `topk(3, sum by (normalized_sql, query_id)(db.active_sessions.avg{wait_event="SequentialScanRead", ...}))`
-2. Compare against baseline — a sudden jump (not proportional to traffic growth) suggests plan regression
-3. Defer to `dsql` skill for EXPLAIN analysis: determine whether an index is missing, or an existing index is not being used due to statistics change
+2. Compare against baseline — a sudden jump suggests plan regression
+3. Defer to `dsql` skill for EXPLAIN analysis
 4. If intentional (analytics workload), accept or schedule off-peak
 
 ---
@@ -107,17 +97,15 @@ QP has issued a scan of a contiguous range of tuples.
 
 QP has issued one or more non-contiguous tuple reads.
 
-**Problem signal:** AAS(ScatteredBatchRead) > 0.5.
-
 **Root causes:**
-- Query lacks a partition-key filter, touching all partitions
+- Query performing lookups across non-contiguous storage locations
 - Secondary index lookup followed by wide data fetch
-- Batch operations with keys spread across partitions
+- Batch operations with keys spread across storage
 
 **Remediation:**
 1. Identify query: `topk(3, sum by (normalized_sql, query_id)(db.active_sessions.avg{wait_event="ScatteredBatchRead", ...}))`
 2. Compare against baseline — has a specific query's ScatteredBatchRead grown?
-3. Defer to `dsql` skill for EXPLAIN analysis to determine whether predicates can be narrowed or a covering index would help
+3. Defer to `dsql` skill for EXPLAIN analysis
 
 ---
 
@@ -125,19 +113,16 @@ QP has issued one or more non-contiguous tuple reads.
 
 QP is reading a tuple returned by a streamed storage operation.
 
-**Problem signal:** AAS(SingleRead) > 1.0. Many single-tuple reads accumulating.
-
 **Root causes:**
-- A query called at very high frequency (e.g., N+1 pattern — each call is fast but volume accumulates AAS)
-- A query performing many streamed storage reads per execution
+- A query called at very high frequency (each call is fast but volume accumulates AAS)
 - ORM lazy-loading relationships triggering many individual lookups
 
-**Note:** Because `normalized_sql` groups all executions of the same query shape, a single-key lookup called thousands of times per second will appear as a high-AAS query — indistinguishable from a slow query in this metric alone.
+**Note:** A single slow query only contributes 1 AAS at most. High AAS on SingleRead indicates many concurrent executions or high call frequency, not a single slow query. Because `normalized_sql` groups all executions of the same query shape, a single-key lookup called thousands of times per second will appear as a high-AAS query.
 
 **Remediation:**
 1. Identify query: `topk(5, sum by (normalized_sql)(db.active_sessions.avg{wait_event="SingleRead", ...}))`
-2. Check if SingleRead AAS has grown vs baseline — may indicate increased call frequency or plan change
-3. Defer to `dsql` skill — it can distinguish high-frequency calls from per-execution cost via EXPLAIN ANALYZE and `pg_stat_statements` call counts
+2. Check if SingleRead AAS has grown vs baseline — indicates increased call frequency
+3. Defer to `dsql` skill for query-level diagnostics
 
 ---
 
@@ -145,18 +130,14 @@ QP is reading a tuple returned by a streamed storage operation.
 
 Storage reads to validate foreign key existence.
 
-**Problem signal:** AAS(FkExistenceCheck) > 0.3.
-
 **Root causes:**
 - High-throughput INSERT/UPDATE on child tables with foreign key references
 - Parent table lookups becoming a bottleneck under concurrent writes
-- Wide fan-out of FK checks across distributed partitions
 
 **Remediation:**
 1. Identify query: `sum by (normalized_sql)(db.active_sessions.avg{wait_event="FkExistenceCheck", ...})`
-2. Batch child-row inserts to amortize FK lookup cost
-3. Ensure parent table primary key is well-distributed (UUID recommended)
-4. Consider application-layer referential integrity for extreme throughput
+2. Check if insert volume has increased using `TotalTransactions` CW metric
+3. Defer to `dsql` skill for query-level diagnostics
 
 ---
 
@@ -164,18 +145,14 @@ Storage reads to validate foreign key existence.
 
 Storage reads to validate unique key constraints for non-primary columns.
 
-**Problem signal:** AAS(UniqueConstraintCheck) > 0.3.
-
 **Root causes:**
-- High-throughput INSERT on a table with unique constraints (hot key space)
+- High-throughput INSERT on a table with unique constraints
 - Large batch INSERTs forcing many uniqueness checks
 - Conflict-heavy upsert patterns (`INSERT ... ON CONFLICT`)
 
 **Remediation:**
 1. Identify query: `sum by (normalized_sql)(db.active_sessions.avg{wait_event="UniqueConstraintCheck", ...})`
-2. Reduce batch size for inserts on constrained tables
-3. Pre-validate uniqueness at the application layer when possible
-4. Use UUID primary keys to distribute insert load and avoid hot keys
+2. Defer to `dsql` skill for query-level diagnostics
 
 ---
 
@@ -183,12 +160,12 @@ Storage reads to validate unique key constraints for non-primary columns.
 
 Commit process has begun, and QP is waiting for a response.
 
-**Problem signal:** AAS(Commit) > 0.5.
-
 **Root causes:**
 - Increased transaction volume (legitimate load growth)
 - Increased OCC (optimistic concurrency control) conflicts (write-write contention)
 - Large transactions modifying many rows (more commit coordination)
+
+**Note:** All Commit waits are associated with the `COMMIT` statement itself — individual SQL statements do not wait on Commit. Therefore, `normalized_sql` grouping is not useful for identifying which writes cause commit contention.
 
 **Diagnosis — distinguish volume from conflicts:**
 - Query standard CloudWatch metrics: `AuroraDSQL` namespace, `ClusterId` dimension
@@ -197,17 +174,14 @@ Commit process has begun, and QP is waiting for a response.
 - If TotalTransactions grows proportionally to Commit AAS → legitimate load
 
 **Remediation:**
-1. Identify if Commit AAS change is proportional to transaction volume via CW metrics
-2. If OCC conflicts are growing: identify conflicting writes via `sum by (normalized_sql)(db.active_sessions.avg{wait_event="Commit", ...})`
-3. Defer to `dsql` skill for transaction pattern analysis and conflict mitigation
+1. Check if Commit AAS change is proportional to transaction volume via CW metrics
+2. If OCC conflicts are growing, defer to `dsql` skill for transaction pattern analysis and conflict mitigation
 
 ---
 
 ## PgSleep
 
 Session issued `pg_sleep()` and is waiting for the sleep period to complete.
-
-**Problem signal:** Rarely a real problem. AAS(PgSleep) > 0 means intentional sleeping.
 
 **Root causes:**
 - Application-level polling or throttling

--- a/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/wait-events.md
+++ b/src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/references/wait-events.md
@@ -1,0 +1,220 @@
+# DSQL Wait Events Reference
+
+Aurora DSQL exposes wait events via the `wait_event` label on `db.active_sessions.avg`. Each indicates where sessions spend time.
+
+---
+
+## Summary
+
+| Wait Event | Category | Threshold | Description |
+|---|---|---|---|
+| OnCpu | Compute | AAS > 1.0 | Actively processing in QP, not waiting for any other resource |
+| ClientRead | Network | AAS > 0.5 | QP is waiting for the next request (only reported when QP has an active transaction — idle in transaction) |
+| ClientWrite | Network | AAS > 0.5 | QP is sending data to the application |
+| SequentialScanRead | IO | AAS > 0.5 | QP has issued a scan of a contiguous range of tuples |
+| ScatteredBatchRead | IO | AAS > 0.5 | QP has issued one or more non-contiguous tuple reads |
+| SingleRead | IO | AAS > 1.0 | QP is reading a tuple returned by a streamed storage operation |
+| FkExistenceCheck | Validation | AAS > 0.3 | Storage reads to validate foreign key existence |
+| UniqueConstraintCheck | Validation | AAS > 0.3 | Storage reads to validate unique key constraints for non-primary columns |
+| Commit | Transaction | AAS > 0.5 | Commit process has begun, and QP is waiting for a response |
+| PgSleep | Application | Any | Session issued `pg_sleep()` and is waiting for the sleep period to complete |
+
+---
+
+## OnCpu
+
+Actively processing in the Query Processor (QP), not waiting for any other resource.
+
+**Problem signal:** AAS(OnCpu) > 1.0 sustained.
+
+**Root causes:**
+- Complex plans with nested loops or expensive expressions
+- Sequential scans on large tables (check SequentialScanRead co-occurrence)
+- High-frequency short queries from many connections
+
+**Remediation:**
+1. Identify top SQL: `topk(5, sum by (normalized_sql, query_id)(db.active_sessions.avg{wait_event="OnCpu", ...}))`
+2. Compare against baseline — identify which queries have grown
+3. Defer to `dsql` skill for EXPLAIN analysis — look for plan changes, sequential scans, nested loops
+
+---
+
+## ClientRead
+
+QP is waiting for the next request. This is only reported when the QP has an active transaction (idle in transaction).
+
+**Problem signal:** AAS(ClientRead) > 0.5 sustained.
+
+**Root causes:**
+- Client has an open transaction but is not sending the next query (idle in transaction)
+- Application doing work between queries without closing the transaction
+- Missing `COMMIT`/`ROLLBACK` after error paths
+- Connection pool returning connections with open transactions
+- Network latency (cross-region, VPN)
+
+**Remediation:**
+1. Identify role/app: `sum by (iam_role_arn, application_name)(db.active_sessions.avg{wait_event="ClientRead", ...})`
+2. Set `idle_in_transaction_session_timeout` to limit idle transaction duration
+3. Fix application error-handling to always close transactions
+4. Audit connection pool configuration — ensure pools issue RESET or DISCARD on return
+5. Move compute closer to the cluster (same region/AZ) to reduce network latency
+
+---
+
+## ClientWrite
+
+QP is sending data to the application.
+
+**Problem signal:** AAS(ClientWrite) > 0.5 sustained.
+
+**Root causes:**
+- Client slow processing result sets
+- Large result sets saturating network buffers
+- Client-side GC pauses or I/O blocking
+
+**Remediation:**
+1. Identify app: `sum by (application_name)(db.active_sessions.avg{wait_event="ClientWrite", ...})`
+2. Add `LIMIT` or pagination to reduce result size
+3. Implement server-side cursors for large fetches
+4. Check client network throughput and TCP buffers
+
+---
+
+## SequentialScanRead
+
+QP has issued a scan of a contiguous range of tuples.
+
+**Problem signal:** AAS(SequentialScanRead) > 0.5.
+
+**Root causes:**
+- Missing index for the WHERE clause
+- Plan regression — index exists but planner chose scan after statistics changed (e.g., bulk load, `ANALYZE` updated selectivity estimates)
+- Intentional full-table aggregation
+
+**Diagnosis — distinguish missing index from plan flip:**
+- Compare AAS trend over time (Workflow 5). A sudden jump (not proportional to traffic growth) suggests plan regression.
+- Run `EXPLAIN` on the query. If an index exists on the filtered columns but is not used, the planner has flipped.
+
+**Remediation:**
+1. Identify query: `topk(3, sum by (normalized_sql, query_id)(db.active_sessions.avg{wait_event="SequentialScanRead", ...}))`
+2. Compare against baseline — a sudden jump (not proportional to traffic growth) suggests plan regression
+3. Defer to `dsql` skill for EXPLAIN analysis: determine whether an index is missing, or an existing index is not being used due to statistics change
+4. If intentional (analytics workload), accept or schedule off-peak
+
+---
+
+## ScatteredBatchRead
+
+QP has issued one or more non-contiguous tuple reads.
+
+**Problem signal:** AAS(ScatteredBatchRead) > 0.5.
+
+**Root causes:**
+- Query lacks a partition-key filter, touching all partitions
+- Secondary index lookup followed by wide data fetch
+- Batch operations with keys spread across partitions
+
+**Remediation:**
+1. Identify query: `topk(3, sum by (normalized_sql, query_id)(db.active_sessions.avg{wait_event="ScatteredBatchRead", ...}))`
+2. Compare against baseline — has a specific query's ScatteredBatchRead grown?
+3. Defer to `dsql` skill for EXPLAIN analysis to determine whether predicates can be narrowed or a covering index would help
+
+---
+
+## SingleRead
+
+QP is reading a tuple returned by a streamed storage operation.
+
+**Problem signal:** AAS(SingleRead) > 1.0. Many single-tuple reads accumulating.
+
+**Root causes:**
+- A query called at very high frequency (e.g., N+1 pattern — each call is fast but volume accumulates AAS)
+- A query performing many streamed storage reads per execution
+- ORM lazy-loading relationships triggering many individual lookups
+
+**Note:** Because `normalized_sql` groups all executions of the same query shape, a single-key lookup called thousands of times per second will appear as a high-AAS query — indistinguishable from a slow query in this metric alone.
+
+**Remediation:**
+1. Identify query: `topk(5, sum by (normalized_sql)(db.active_sessions.avg{wait_event="SingleRead", ...}))`
+2. Check if SingleRead AAS has grown vs baseline — may indicate increased call frequency or plan change
+3. Defer to `dsql` skill — it can distinguish high-frequency calls from per-execution cost via EXPLAIN ANALYZE and `pg_stat_statements` call counts
+
+---
+
+## FkExistenceCheck
+
+Storage reads to validate foreign key existence.
+
+**Problem signal:** AAS(FkExistenceCheck) > 0.3.
+
+**Root causes:**
+- High-throughput INSERT/UPDATE on child tables with foreign key references
+- Parent table lookups becoming a bottleneck under concurrent writes
+- Wide fan-out of FK checks across distributed partitions
+
+**Remediation:**
+1. Identify query: `sum by (normalized_sql)(db.active_sessions.avg{wait_event="FkExistenceCheck", ...})`
+2. Batch child-row inserts to amortize FK lookup cost
+3. Ensure parent table primary key is well-distributed (UUID recommended)
+4. Consider application-layer referential integrity for extreme throughput
+
+---
+
+## UniqueConstraintCheck
+
+Storage reads to validate unique key constraints for non-primary columns.
+
+**Problem signal:** AAS(UniqueConstraintCheck) > 0.3.
+
+**Root causes:**
+- High-throughput INSERT on a table with unique constraints (hot key space)
+- Large batch INSERTs forcing many uniqueness checks
+- Conflict-heavy upsert patterns (`INSERT ... ON CONFLICT`)
+
+**Remediation:**
+1. Identify query: `sum by (normalized_sql)(db.active_sessions.avg{wait_event="UniqueConstraintCheck", ...})`
+2. Reduce batch size for inserts on constrained tables
+3. Pre-validate uniqueness at the application layer when possible
+4. Use UUID primary keys to distribute insert load and avoid hot keys
+
+---
+
+## Commit
+
+Commit process has begun, and QP is waiting for a response.
+
+**Problem signal:** AAS(Commit) > 0.5.
+
+**Root causes:**
+- Increased transaction volume (legitimate load growth)
+- Increased OCC (optimistic concurrency control) conflicts (write-write contention)
+- Large transactions modifying many rows (more commit coordination)
+
+**Diagnosis — distinguish volume from conflicts:**
+- Query standard CloudWatch metrics: `AuroraDSQL` namespace, `ClusterId` dimension
+- Compare `TotalTransactions` (commit rate) and `OccConflicts` (conflict rate) over the same period
+- If OccConflicts grows faster than TotalTransactions → conflict problem
+- If TotalTransactions grows proportionally to Commit AAS → legitimate load
+
+**Remediation:**
+1. Identify if Commit AAS change is proportional to transaction volume via CW metrics
+2. If OCC conflicts are growing: identify conflicting writes via `sum by (normalized_sql)(db.active_sessions.avg{wait_event="Commit", ...})`
+3. Defer to `dsql` skill for transaction pattern analysis and conflict mitigation
+
+---
+
+## PgSleep
+
+Session issued `pg_sleep()` and is waiting for the sleep period to complete.
+
+**Problem signal:** Rarely a real problem. AAS(PgSleep) > 0 means intentional sleeping.
+
+**Root causes:**
+- Application-level polling or throttling
+- Health-check queries with built-in delay
+- Intentional rate limiting
+
+**Remediation:**
+1. Verify intentional: `sum by (application_name)(db.active_sessions.avg{wait_event="PgSleep", ...})`
+2. If unintentional, remove the `pg_sleep()` call
+3. If consuming too many connections, move the delay to the application layer


### PR DESCRIPTION
Adds a new skill for diagnosing Aurora DSQL cluster performance via PromQL queries against CloudWatch OTel metrics (db.active_sessions.avg).

## Key capabilities
- Temporal trend analysis with baseline comparison (current hour vs yesterday vs last week)
- Wait event distribution shift detection (>30% threshold)
- Top-SQL regression identification (new or growing queries)
- Commit analysis via standard CW metrics (TotalTransactions/OccConflicts)
- Automatic handoff to the dsql skill for live database investigation

## Files
- `src/cloudwatch-mcp-server/skills/dsql-system-diagnostics/SKILL.md` — 6 workflows
- `references/wait-events.md` — canonical DSQL wait event definitions
- `references/promql-patterns.md` — reusable query templates
- `mcp/.mcp.json` + `mcp/mcp-setup.md` — CloudWatch MCP server config