### PR TITLE
fix(redshift-mcp-server): serialize the per-cluster:database session

### DIFF
--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -24,44 +24,6 @@ QUERY_TIMEOUT = 3600
 QUERY_POLL_INTERVAL = 1
 SESSION_KEEPALIVE = 600
 
-# Best practices
-
-CLIENT_BEST_PRACTICES = """
-## AWS Client Best Practices
-
-### Authentication and Configuration
-
-- Default AWS credentials chain (IAM roles, ~/.aws/credentials, etc.).
-- AWS_PROFILE environment variable (if set).
-- Region configuration (in order of precedence):
-  - AWS_REGION environment variable (highest priority)
-  - AWS_DEFAULT_REGION environment variable
-  - Region specified in AWS profile configuration
-
-### Error Handling
-
-- Always print out AWS client errors in full to help diagnose configuration issues.
-- For region-related errors, suggest checking AWS_REGION, AWS_DEFAULT_REGION, or AWS profile configuration.
-- For credential errors, suggest verifying AWS credentials setup and permissions.
-"""
-
-REDSHIFT_BEST_PRACTICES = """
-## Amazon Redshift Best Practices
-
-### Query Guidelines
-
-- Always specify the database and schema when referencing objects to avoid ambiguity.
-- Leverage distribution in WHERE and JOIN predicates and sort keys in ORDER BY for optimal query performance.
-- Use LIMIT clauses for exploratory queries to avoid large result sets.
-- Analyze table to update table statistics if it is not updated or too off before making a decision on the query structure.
-- Prefer explicitly specifying columns in SELECT over "*" for better performance.
-
-### Connection Guidelines
-
-- We are use the Redshift API and Redshift Data API.
-- Leverage IAM authentication when possible instead of secrets (database passwords).
-"""
-
 # SQL queries
 
 SVV_REDSHIFT_DATABASES_QUERY = """

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -113,8 +113,27 @@ class RedshiftSessionManager:
             app_name: Application name to set in sessions.
         """
         self._sessions = {}  # {cluster:database -> session_info}
+        self._locks: dict[str, asyncio.Lock] = {}  # {cluster:database -> asyncio.Lock}
         self._session_keepalive = session_keepalive
         self._app_name = app_name
+
+    def lock(self, cluster_identifier: str, database_name: str) -> asyncio.Lock:
+        """Get or create the per cluster:database lock that serializes session use.
+
+        Args:
+            cluster_identifier: The cluster identifier to lock on.
+            database_name: The database name to lock on.
+
+        Returns:
+            The asyncio.Lock for the cluster:database, created lazily on first use.
+        """
+        key = f'{cluster_identifier}:{database_name}'
+        # No await between the get and set, so lazy creation is race-free on the event loop.
+        existing = self._locks.get(key)
+        if existing is None:
+            existing = asyncio.Lock()
+            self._locks[key] = existing
+        return existing
 
     async def session(
         self, cluster_identifier: str, database_name: str, cluster_info: dict
@@ -251,37 +270,13 @@ async def _execute_protected_statement(
             f'Cluster {cluster_identifier} not found. Please use list_clusters to get valid cluster identifiers.'
         )
 
-    # Get session (creates if needed, sets app name automatically)
-    session_id = await session_manager.session(cluster_identifier, database_name, cluster_info)
+    # Serialize work on the shared per cluster:database session.
+    async with session_manager.lock(cluster_identifier, database_name):
+        session_id = await session_manager.session(cluster_identifier, database_name, cluster_info)
 
-    if allow_read_write:
-        # Read-write: run the single guarded statement directly (autocommit). No
-        # transaction wrapper, so non-transactional statements (e.g. VACUUM,
-        # CREATE DATABASE, ALTER TABLE APPEND) are not broken. Any error propagates.
-        user_query_id = await _execute_statement(
-            cluster_info=cluster_info,
-            cluster_identifier=cluster_identifier,
-            database_name=database_name,
-            sql=sql,
-            parameters=parameters,
-            session_id=session_id,
-        )
-    else:
-        # Read-only: BEGIN READ ONLY ... ROLLBACK. The engine rejects data writes
-        # the deny-list does not enumerate; ROLLBACK discards anything uncommitted.
-        await _execute_statement(
-            cluster_info=cluster_info,
-            cluster_identifier=cluster_identifier,
-            database_name=database_name,
-            sql='BEGIN READ ONLY;',
-            session_id=session_id,
-        )
-
-        # Execute user SQL with parameters, ensuring the transaction is always closed.
-        user_query_id = None
-        user_sql_error = None
-
-        try:
+        if allow_read_write:
+            # Read-write: run the single guarded statement directly (autocommit). No
+            # transaction wrapper. Any error propagates.
             user_query_id = await _execute_statement(
                 cluster_info=cluster_info,
                 cluster_identifier=cluster_identifier,
@@ -290,35 +285,61 @@ async def _execute_protected_statement(
                 parameters=parameters,
                 session_id=session_id,
             )
-        except Exception as e:
-            user_sql_error = e
-            logger.error(f'User SQL execution failed: {e}')
-
-        # Always close the read-only transaction, discarding everything with ROLLBACK.
-        try:
+        else:
+            # Read-only: BEGIN READ ONLY ... ROLLBACK. The engine rejects data writes
+            # the deny-list does not enumerate; ROLLBACK discards anything uncommitted.
             await _execute_statement(
                 cluster_info=cluster_info,
                 cluster_identifier=cluster_identifier,
                 database_name=database_name,
-                sql='ROLLBACK;',
+                sql='BEGIN READ ONLY;',
                 session_id=session_id,
             )
-        except Exception as close_error:
-            logger.error(f'ROLLBACK statement execution failed: {close_error}')
-            if user_sql_error:
-                # Both failed - raise combined error
-                raise Exception(
-                    f'User SQL failed: {user_sql_error}; ROLLBACK statement failed: {close_error}'
+
+            # Execute user SQL with parameters, ensuring the transaction is always closed.
+            user_query_id = None
+            user_sql_error: Exception | None = None
+
+            try:
+                user_query_id = await _execute_statement(
+                    cluster_info=cluster_info,
+                    cluster_identifier=cluster_identifier,
+                    database_name=database_name,
+                    sql=sql,
+                    parameters=parameters,
+                    session_id=session_id,
                 )
-            else:
-                # Only the close statement failed
-                raise close_error
+            except Exception as e:
+                user_sql_error = e
+                logger.error(f'User SQL execution failed: {e}')
+            finally:
+                # Always close the read-only transaction with ROLLBACK, even on
+                # CancelledError / BaseException.
+                try:
+                    await _execute_statement(
+                        cluster_info=cluster_info,
+                        cluster_identifier=cluster_identifier,
+                        database_name=database_name,
+                        sql='ROLLBACK;',
+                        session_id=session_id,
+                    )
+                except Exception as close_error:
+                    logger.error(f'ROLLBACK statement execution failed: {close_error}')
+                    if user_sql_error is not None:
+                        # Both failed - raise combined error
+                        raise Exception(
+                            f'User SQL failed: {user_sql_error}; '
+                            f'ROLLBACK statement failed: {close_error}'
+                        ) from close_error
+                    raise
 
-        # If user SQL failed but the ROLLBACK succeeded, raise the user SQL error.
-        if user_sql_error:
-            raise user_sql_error
+            # If user SQL failed but the ROLLBACK succeeded, raise the user SQL error.
+            if user_sql_error is not None:
+                raise user_sql_error
 
-    # Get results from user query (shared by both modes)
+    # Get results from user query (shared by both modes); runs outside the lock.
+    # describe_statement / get_statement_result are keyed by query_id, not session-bound,
+    # so the lock is not held during the (potentially unbounded) results wait.
     data_client = client_manager.redshift_data_client()
     assert user_query_id is not None, 'user_query_id should not be None at this point'
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -17,9 +17,7 @@
 import os
 import sys
 from awslabs.redshift_mcp_server.consts import (
-    CLIENT_BEST_PRACTICES,
     DEFAULT_LOG_LEVEL,
-    REDSHIFT_BEST_PRACTICES,
 )
 from awslabs.redshift_mcp_server.models import (
     QueryResult,
@@ -52,7 +50,7 @@ logger.add(
 
 mcp = FastMCP(
     'awslabs.redshift-mcp-server',
-    instructions=f"""
+    instructions="""
 # Amazon Redshift MCP Server.
 
 This MCP server provides comprehensive access to Amazon Redshift clusters and serverless workgroups.
@@ -89,8 +87,44 @@ This tool uses the Redshift Data API to run queries and return results.
 2. Use the list_clusters tool to discover available Redshift instances.
 3. Note the cluster identifiers for use with other tools (coming in future milestones).
 
-{CLIENT_BEST_PRACTICES}
-{REDSHIFT_BEST_PRACTICES}
+## Session Management and Concurrency
+
+The server reuses one Redshift Data API session per `cluster:database`:
+- Queries to the same `cluster:database` are serialized (parallel calls queue; a long-running query blocks later ones to that target).
+- Queries to different targets run concurrently on independent sessions.
+- Each read-only query runs isolated in its own transaction.
+
+## AWS Client Best Practices
+
+### Authentication and Configuration
+
+- Default AWS credentials chain (IAM roles, ~/.aws/credentials, etc.).
+- AWS_PROFILE environment variable (if set).
+- Region configuration (in order of precedence):
+  - AWS_REGION environment variable (highest priority)
+  - AWS_DEFAULT_REGION environment variable
+  - Region specified in AWS profile configuration
+
+### Error Handling
+
+- Always print out AWS client errors in full to help diagnose configuration issues.
+- For region-related errors, suggest checking AWS_REGION, AWS_DEFAULT_REGION, or AWS profile configuration.
+- For credential errors, suggest verifying AWS credentials setup and permissions.
+
+## Amazon Redshift Best Practices
+
+### Query Guidelines
+
+- Always specify the database and schema when referencing objects to avoid ambiguity.
+- Leverage distribution in WHERE and JOIN predicates and sort keys in ORDER BY for optimal query performance.
+- Use LIMIT clauses for exploratory queries to avoid large result sets.
+- Analyze table to update table statistics if it is not updated or too off before making a decision on the query structure.
+- Prefer explicitly specifying columns in SELECT over "*" for better performance.
+
+### Connection Guidelines
+
+- We use the Redshift API and Redshift Data API.
+- Leverage IAM authentication when possible instead of secrets (database passwords).
 """,
     dependencies=['boto3', 'loguru', 'pydantic', 'sqlglot'],
 )

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -14,6 +14,7 @@
 
 """Tests for the redshift module."""
 
+import asyncio
 import pytest
 import time
 from awslabs.redshift_mcp_server.redshift import (
@@ -29,6 +30,7 @@ from awslabs.redshift_mcp_server.redshift import (
     execute_query,
 )
 from botocore.config import Config
+from types import SimpleNamespace
 
 
 class TestRedshiftClientManagerRedshiftClient:
@@ -256,6 +258,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement
         mock_execute_statement = mocker.patch(
@@ -299,6 +302,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement
         mock_execute_statement = mocker.patch(
@@ -343,6 +347,7 @@ class TestExecuteProtectedStatement:
 
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         mock_execute_statement = mocker.patch(
             'awslabs.redshift_mcp_server.redshift._execute_statement'
@@ -373,6 +378,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement
         mock_execute_statement = mocker.patch(
@@ -417,6 +423,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement
         mock_execute_statement = mocker.patch(
@@ -454,6 +461,7 @@ class TestExecuteProtectedStatement:
         ]
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         mock_execute_statement = mocker.patch(
             'awslabs.redshift_mcp_server.redshift._execute_statement'
@@ -495,6 +503,7 @@ class TestExecuteProtectedStatement:
         ]
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         mock_execute_statement = mocker.patch(
             'awslabs.redshift_mcp_server.redshift._execute_statement'
@@ -555,6 +564,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement to fail for user SQL, succeed for BEGIN and ROLLBACK
         mock_execute_statement = mocker.patch(
@@ -598,6 +608,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement to succeed for user SQL, fail for ROLLBACK
         mock_execute_statement = mocker.patch(
@@ -634,6 +645,7 @@ class TestExecuteProtectedStatement:
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
 
         # Mock _execute_statement to fail for both user SQL and ROLLBACK
         mock_execute_statement = mocker.patch(
@@ -929,6 +941,28 @@ class TestRedshiftSessionManager:
         mock_data_client.execute_statement.assert_called_once()
         # Verify the expired session was deleted and replaced (covers lines 141-142)
         assert session_manager._sessions[session_key]['session_id'] == 'new-session-id'
+
+    def test_lock_per_key_identity(self):
+        """Test that lock() returns the same Lock for the same key and distinct Locks for distinct keys."""
+        session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
+
+        # First access lazily creates the lock and returns an asyncio.Lock
+        lock_a1 = session_manager.lock('cluster-a', 'db-1')
+        assert isinstance(lock_a1, asyncio.Lock)
+
+        # Same key returns the exact same instance
+        lock_a1_again = session_manager.lock('cluster-a', 'db-1')
+        assert lock_a1_again is lock_a1
+
+        # Different database on same cluster returns a distinct lock
+        lock_a2 = session_manager.lock('cluster-a', 'db-2')
+        assert isinstance(lock_a2, asyncio.Lock)
+        assert lock_a2 is not lock_a1
+
+        # Different cluster returns a distinct lock
+        lock_b1 = session_manager.lock('cluster-b', 'db-1')
+        assert isinstance(lock_b1, asyncio.Lock)
+        assert lock_b1 is not lock_a1
 
 
 class TestDiscoverFunctions:
@@ -1413,3 +1447,504 @@ class TestExecuteQuery:
 
         with pytest.raises(Exception, match='Query execution failed'):
             await execute_query('test-cluster', 'dev', 'SELECT * FROM nonexistent')
+
+
+# Shared fakes and parametrization for the TestConcurrency tests below.
+_CONCURRENCY_CLUSTER_TYPES = pytest.mark.parametrize(
+    'cluster_type',
+    ['provisioned', 'serverless'],
+    ids=['provisioned', 'serverless'],
+)
+
+
+def _cluster_info(cluster_type='provisioned'):
+    """Build the cluster_info shared by the concurrency tests."""
+    return {
+        'identifier': 'test-cluster',
+        'type': cluster_type,
+        'status': 'available',
+    }
+
+
+def _make_counting_session_fake(prefix='session'):
+    """Counting async fake for `_create_session_with_app_name`; exposes `.count`."""
+    counter = SimpleNamespace(count=0)
+
+    async def fake_create_session(self, cluster_identifier, database_name, ci):
+        counter.count += 1
+        await asyncio.sleep(0)  # interleave point
+        return f'{prefix}-{counter.count}'
+
+    return fake_create_session, counter
+
+
+def _make_yielding_execute_statement_fake():
+    """Async fake for `_execute_statement` that yields then returns a unique id."""
+    counter = SimpleNamespace(count=0)
+
+    async def fake_execute_statement(
+        cluster_info, cluster_identifier, database_name, sql, **kwargs
+    ):
+        counter.count += 1
+        await asyncio.sleep(0)  # interleave point
+        return f'stmt-{counter.count}'
+
+    return fake_execute_statement
+
+
+def _make_recording_execute_statement_fake(owner_var=None):
+    """Recording async fake for `_execute_statement`; returns (fake, log)."""
+    log: list[tuple] = []
+
+    async def fake_execute_statement(
+        cluster_info, cluster_identifier, database_name, sql, **kwargs
+    ):
+        owner = owner_var.get('unknown') if owner_var is not None else None
+        log.append((owner, sql))
+        await asyncio.sleep(0)  # interleave point
+        return f'stmt-{len(log)}'
+
+    return fake_execute_statement, log
+
+
+class TestConcurrency:
+    """Concurrency tests for the per-cluster:database session lock."""
+
+    @pytest.mark.asyncio
+    @_CONCURRENCY_CLUSTER_TYPES
+    async def test_cold_start_creates_exactly_one_session(self, mocker, cluster_type):
+        """Concurrent cold-start calls create exactly one session (zero orphans)."""
+        import awslabs.redshift_mcp_server.redshift as redshift_module
+
+        N = 6
+        cluster_info = _cluster_info(cluster_type)
+
+        # Real manager (not a Mock) so the actual session() get-or-create race runs.
+        manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app')
+        mocker.patch.object(redshift_module, 'session_manager', manager)
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[cluster_info],
+        )
+
+        fake_create_session, session_counter = _make_counting_session_fake()
+        mocker.patch.object(
+            RedshiftSessionManager,
+            '_create_session_with_app_name',
+            fake_create_session,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=_make_yielding_execute_statement_fake(),
+        )
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': True,
+        }
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'stringValue': 'hello'}]],
+            'ColumnMetadata': [{'name': 'col1'}],
+        }
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_data_client,
+        )
+
+        results = await asyncio.gather(
+            *[
+                _execute_protected_statement(
+                    'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+                )
+                for _ in range(N)
+            ]
+        )
+
+        assert len(results) == N
+
+        assert session_counter.count == 1, (
+            f'Expected 1 session created, got {session_counter.count} '
+            f'({session_counter.count - 1} orphaned)'
+        )
+        assert len(manager._sessions) == 1, (
+            f'Expected 1 cached session, got {len(manager._sessions)}'
+        )
+
+    @pytest.mark.asyncio
+    @_CONCURRENCY_CLUSTER_TYPES
+    async def test_success_under_race_all_calls_return_correct_results(self, mocker, cluster_type):
+        """Concurrent cold-start calls all succeed with correct results."""
+        import awslabs.redshift_mcp_server.redshift as redshift_module
+
+        N = 6
+        cluster_info = _cluster_info(cluster_type)
+
+        # Real manager (not a Mock) so the actual session() get-or-create race runs.
+        manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app')
+        mocker.patch.object(redshift_module, 'session_manager', manager)
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[cluster_info],
+        )
+
+        fake_create_session, session_counter = _make_counting_session_fake()
+        mocker.patch.object(
+            RedshiftSessionManager,
+            '_create_session_with_app_name',
+            fake_create_session,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=_make_yielding_execute_statement_fake(),
+        )
+
+        expected_result = {
+            'Records': [[{'stringValue': 'result-ok'}]],
+            'ColumnMetadata': [{'name': 'col1'}],
+        }
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': True,
+        }
+        mock_data_client.get_statement_result.return_value = expected_result
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_data_client,
+        )
+
+        # return_exceptions=True to inspect failures instead of aborting on the first.
+        results = await asyncio.gather(
+            *[
+                _execute_protected_statement(
+                    'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+                )
+                for _ in range(N)
+            ],
+            return_exceptions=True,
+        )
+
+        exceptions = [r for r in results if isinstance(r, BaseException)]
+        assert exceptions == [], (
+            f'Expected zero exceptions from concurrent cold-start calls, '
+            f'got {len(exceptions)}: {exceptions}'
+        )
+
+        ok_results = [r for r in results if not isinstance(r, BaseException)]
+        assert len(ok_results) == N, f'Expected {N} results, got {len(ok_results)}'
+        for i, (result_response, query_id) in enumerate(ok_results):
+            assert result_response == expected_result, (
+                f'Result {i} has unexpected payload: {result_response}'
+            )
+            assert query_id is not None, (
+                f'Result {i} has None query_id (statement was not executed)'
+            )
+
+    @pytest.mark.asyncio
+    async def test_mutual_exclusion_begin_rollback_contiguous(self, mocker):
+        """Each call's BEGIN..ROLLBACK block stays contiguous under concurrency."""
+        import awslabs.redshift_mcp_server.redshift as redshift_module
+        import contextvars
+
+        current_owner: contextvars.ContextVar[str] = contextvars.ContextVar('current_owner')
+
+        cluster_info = _cluster_info('provisioned')
+
+        # Pre-warm the cache so session-acquire doesn't serialize the two calls.
+        manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app')
+        manager._sessions['test-cluster:test-db'] = {
+            'session_id': 'warm-session-id',
+            'created_at': time.time(),
+        }
+        mocker.patch.object(redshift_module, 'session_manager', manager)
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[cluster_info],
+        )
+
+        fake_execute_statement, statement_log = _make_recording_execute_statement_fake(
+            owner_var=current_owner
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=fake_execute_statement,
+        )
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': False,
+        }
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [],
+            'ColumnMetadata': [],
+        }
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_data_client,
+        )
+
+        async def call_with_owner(owner: str, sql: str):
+            current_owner.set(owner)
+            return await _execute_protected_statement(
+                'test-cluster', 'test-db', sql, allow_read_write=False
+            )
+
+        await asyncio.gather(
+            call_with_owner('A', 'CREATE TABLE test_tbl (id INT)'),
+            call_with_owner('B', 'SELECT 1'),
+        )
+
+        owners_in_order = [owner for owner, _ in statement_log]
+
+        def is_contiguous(owners: list[str], target: str) -> bool:
+            """Check that all occurrences of `target` are contiguous in the list."""
+            indices = [i for i, o in enumerate(owners) if o == target]
+            if not indices:
+                return True
+            return indices[-1] - indices[0] == len(indices) - 1
+
+        a_contiguous = is_contiguous(owners_in_order, 'A')
+        b_contiguous = is_contiguous(owners_in_order, 'B')
+
+        log_repr = [f'{owner}:{sql}' for owner, sql in statement_log]
+
+        assert a_contiguous and b_contiguous, (
+            f'Mutual-exclusion invariant violated: statements interleave.\n'
+            f'Global statement order: {log_repr}\n'
+            f'A contiguous: {a_contiguous}, B contiguous: {b_contiguous}\n'
+            f"Expected: each call's BEGIN..ROLLBACK block is contiguous "
+            f"(no other call's statements between BEGIN and ROLLBACK)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_still_issues_rollback(self, mocker):
+        """A CancelledError during user SQL still issues ROLLBACK."""
+        recorded_statements: list[str] = []
+
+        async def fake_execute_statement(
+            cluster_info, cluster_identifier, database_name, sql, **kwargs
+        ):
+            recorded_statements.append(sql)
+            if sql == 'SELECT 1':
+                raise asyncio.CancelledError()
+            return f'stmt-id-for-{sql}'
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[
+                {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+            ],
+        )
+
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = asyncio.Lock()
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=fake_execute_statement,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await _execute_protected_statement(
+                'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+            )
+
+        assert 'ROLLBACK;' in recorded_statements, (
+            f'ROLLBACK was not issued. Recorded statements: {recorded_statements}'
+        )
+
+    @pytest.mark.asyncio
+    @_CONCURRENCY_CLUSTER_TYPES
+    async def test_warm_concurrent_selects_no_extra_sessions(self, mocker, cluster_type):
+        """Concurrent SELECTs on a warm cache create no extra sessions."""
+        import awslabs.redshift_mcp_server.redshift as redshift_module
+
+        N = 6
+        cluster_info = _cluster_info(cluster_type)
+
+        # Real manager (not a Mock) so the actual session() get-or-create path runs.
+        manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app')
+        mocker.patch.object(redshift_module, 'session_manager', manager)
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[cluster_info],
+        )
+
+        fake_create_session, session_counter = _make_counting_session_fake()
+        mocker.patch.object(
+            RedshiftSessionManager,
+            '_create_session_with_app_name',
+            fake_create_session,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=_make_yielding_execute_statement_fake(),
+        )
+
+        expected_result = {
+            'Records': [[{'stringValue': 'hello'}]],
+            'ColumnMetadata': [{'name': 'col1'}],
+        }
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': True,
+        }
+        mock_data_client.get_statement_result.return_value = expected_result
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_data_client,
+        )
+
+        warmup_result = await _execute_protected_statement(
+            'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+        )
+        assert warmup_result is not None, 'Warm-up call must succeed'
+        assert session_counter.count == 1, (
+            f'Warm-up must create exactly 1 session, got {session_counter.count}'
+        )
+        assert 'test-cluster:test-db' in manager._sessions, (
+            'Warm-up must populate the session cache'
+        )
+
+        results = await asyncio.gather(
+            *[
+                _execute_protected_statement(
+                    'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+                )
+                for _ in range(N)
+            ]
+        )
+
+        assert len(results) == N, f'Expected {N} results, got {len(results)}'
+        for i, (result_response, query_id) in enumerate(results):
+            assert result_response == expected_result, f'Result {i} mismatch: {result_response}'
+
+        assert session_counter.count == 1, (
+            f'Expected 1 session created (warm-up only), got {session_counter.count} '
+            f'({session_counter.count - 1} extra sessions created during concurrent reads)'
+        )
+        assert len(manager._sessions) == 1, (
+            f'Expected 1 cached session, got {len(manager._sessions)}'
+        )
+
+    @pytest.mark.asyncio
+    async def test_lock_not_held_during_describe_statement(self, mocker):
+        """describe_statement / get_statement_result run outside the per-key lock."""
+        mock_discover_clusters = mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters'
+        )
+        mock_discover_clusters.return_value = [
+            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        ]
+
+        # Real Lock so we can inspect .locked().
+        real_lock = asyncio.Lock()
+        mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
+        mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
+        mock_session_manager.lock.return_value = real_lock
+
+        fake_execute_statement, _ = _make_recording_execute_statement_fake()
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=fake_execute_statement,
+        )
+
+        lock_held_during_describe = None
+
+        def describe_side_effect(Id):
+            nonlocal lock_held_during_describe
+            lock_held_during_describe = real_lock.locked()
+            return {'Status': 'FINISHED', 'HasResultSet': False}
+
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.side_effect = describe_side_effect
+        mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
+        mock_client_manager.redshift_data_client.return_value = mock_data_client
+
+        await _execute_protected_statement(
+            'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+        )
+
+        assert lock_held_during_describe is False, (
+            'describe_statement must run OUTSIDE the lock (lock should not be held)'
+        )
+
+    @pytest.mark.asyncio
+    async def test_expired_session_concurrent_creates_one_fresh(self, mocker):
+        """Concurrent calls on an expired entry create exactly one fresh session."""
+        import awslabs.redshift_mcp_server.redshift as redshift_module
+
+        N = 6
+        cluster_info = _cluster_info('provisioned')
+
+        # Real manager with a short keepalive so we can force session expiry.
+        manager = RedshiftSessionManager(session_keepalive=500, app_name='test-app')
+        mocker.patch.object(redshift_module, 'session_manager', manager)
+
+        session_key = 'test-cluster:test-db'
+        manager._sessions[session_key] = {
+            'session_id': 'expired-session-id',
+            'created_at': time.time() - 600,  # 600s ago > 500s keepalive -> expired
+        }
+
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.discover_clusters',
+            return_value=[cluster_info],
+        )
+
+        fake_create_session, session_counter = _make_counting_session_fake('fresh-session')
+        mocker.patch.object(
+            RedshiftSessionManager,
+            '_create_session_with_app_name',
+            fake_create_session,
+        )
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift._execute_statement',
+            side_effect=_make_yielding_execute_statement_fake(),
+        )
+
+        expected_result = {
+            'Records': [[{'stringValue': 'hello'}]],
+            'ColumnMetadata': [{'name': 'col1'}],
+        }
+        mock_data_client = mocker.Mock()
+        mock_data_client.describe_statement.return_value = {
+            'Status': 'FINISHED',
+            'HasResultSet': True,
+        }
+        mock_data_client.get_statement_result.return_value = expected_result
+        mocker.patch(
+            'awslabs.redshift_mcp_server.redshift.client_manager.redshift_data_client',
+            return_value=mock_data_client,
+        )
+
+        results = await asyncio.gather(
+            *[
+                _execute_protected_statement(
+                    'test-cluster', 'test-db', 'SELECT 1', allow_read_write=False
+                )
+                for _ in range(N)
+            ],
+            return_exceptions=True,
+        )
+
+        exceptions = [r for r in results if isinstance(r, BaseException)]
+        assert exceptions == [], f'Expected zero exceptions, got {len(exceptions)}: {exceptions}'
+
+        assert session_counter.count == 1, (
+            f'Expected exactly 1 fresh session created after expiry, got {session_counter.count}'
+        )
+        assert len(manager._sessions) == 1, (
+            f'Expected 1 cached session, got {len(manager._sessions)}'
+        )
+        assert manager._sessions[session_key]['session_id'] == 'fresh-session-1', (
+            f'Expected fresh session in cache, got {manager._sessions[session_key]["session_id"]}'
+        )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes <!-- add the tracking issue number here (e.g. #1234), or remove this line if there isn't one -->

## Summary

### Changes

- Serialize all work on the shared per-`cluster:database` Redshift Data API session with a per-key `asyncio.Lock`, held across session acquisition **and** the full `BEGIN READ ONLY` / `<user sql>` / `ROLLBACK` sequence. The result fetch (keyed by `query_id`) stays **outside** the lock.
- Move the read-only `ROLLBACK` into a `finally` block so the transaction is always closed, including when a request is cancelled (`asyncio.CancelledError`).
- Together these harden concurrent `execute_query` calls against the same `cluster:database`, which previously could interleave on the single shared session. This addresses:
  - a session-creation race under concurrent cold starts that could create and leak extra server-side sessions and surface intermittent errors;
  - read-only execution under concurrency — each query now owns its session and transaction for the full `BEGIN`/SQL/`ROLLBACK` sequence, so it is properly isolated;
  - transaction cleanup on cancellation, so a cancelled query no longer leaves an open transaction on the reused session.
- Add a `TestConcurrency` unit suite covering these behaviors plus warm-session preservation; update existing tests for the new lock.
- Document the behavior in the FastMCP server instructions (new **Session Management and Concurrency** section), inline the previously-referenced best-practices text into the instructions, and remove the now-unused `CLIENT_BEST_PRACTICES` / `REDSHIFT_BEST_PRACTICES` constants.

Validated end-to-end against live provisioned and serverless Redshift clusters: concurrent cold start creates exactly one session (no leaks), concurrent calls complete reliably with isolated read-only transactions, and the transaction is always rolled back on cancellation.

### User experience

**Before:** concurrent `execute_query` calls to the same `cluster:database` could interleave on the shared session — creating and leaking extra sessions, surfacing intermittent errors, and (on cancellation) leaving an open transaction on the shared session.

**After:** those calls are serialized on the shared session, so exactly one session is created (no leaks), concurrent calls complete reliably, each query's read-only transaction is isolated, and a cancelled query always closes its transaction. Calls to **different** `cluster:database` targets still run concurrently. The trade-off — now documented in the tool instructions — is that parallel calls to the **same** `cluster:database` queue and run one at a time rather than simultaneously.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N** — no API or tool-signature changes; behavior is more correct. Same-`cluster:database` queries are now serialized (a behavioral/performance trade-off) that could be noticeable under heavy same-target parallelism.

**RFC issue number**: N/A

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

---

## Feature E2E

Targets: redshift-cluster-analytics (provisioned), redshift-cluster-marketing (provisioned), redshift-workgroup-etl (serverless)
Tool: Redshift MCP Server (list_clusters, list_databases, list_schemas, execute_query)

| # | Scenario (from unit tests) | Result |
|---|---|---|
| 1 | Cold-start execute_query on provisioned analytics:dev creates session and returns rows | ✅ SELECT 1 → [1], query_id returned |
| 2 | Warm-cache reuse: 2nd query on same analytics:dev succeeds via reused session | ✅ SELECT 2 → [2] |
| 3 | Sequential queries on same cluster:db (per-key lock serialization, no corruption) | ✅ current_user/current_database() → IAM:sergkono / dev |
| 4 | Independent lock/session for different cluster — marketing:dev | ✅ SELECT 1 → [1] |
| 5 | Independent lock/session for serverless workgroup — etl:dev | ✅ SELECT 1 → [1] |
| 6 | Independent lock/session for different database on same cluster — analytics:sample_data_dev | ✅ SELECT 1 → [1] |
| 7 | Read-only enforcement: write inside BEGIN READ ONLY txn is rejected | ✅ CREATE TABLE … → ERROR: transaction is read-only |
| 8 | Error propagation: invalid relation surfaces clean error | ✅ SELECT * FROM __no_such_table__ → relation … does not exist |
| 9 | finally-ROLLBACK keeps the session usable after a failed user SQL (would hang on stale txn otherwise) | ✅ Next SELECT 42 on same analytics:dev → [42] |
| 10 | Session still usable for discovery tools after errors (same code path: list_schemas) | ✅ Returned information_schema, pg_catalog, public |


## Full E2E


Targets exercised:
- Provisioned: redshift-cluster-analytics (also confirmed redshift-cluster-marketing discoverable)
- Serverless: redshift-workgroup-etl
- Database used for schema exploration on both: sample_data_dev (TICKIT sample schema)

### Per-tool results (one line each)

| Tool | Result |
|---|---|
| list_clusters | ✅ Returned 2 provisioned + 1 serverless workgroup with full metadata (type, status, endpoint, port, VPC, node_type, encryption). |
| list_databases | ✅ Listed dev + sample_data_dev on both provisioned and serverless; isolation level surfaced as Snapshot Isolation. |
| list_schemas | ✅ Returned information_schema, pg_catalog, public, tickit on both cluster types with schema_acl populated. |
| list_tables | ✅ Returned all 7 TICKIT tables (category, date, event, listing, sales, users, venue) on both cluster types as TABLE type. |
| list_columns | ✅ Returned 18 columns of tickit.users on both cluster types with full type metadata (precision/scale, nullability, max length). |
| execute_query | ✅ Successful SELECTs on both cluster types; param binding works in all list_* tools via Data API. |

### Policy / guard behavior (covered scenarios)

| Scenario | Probe | Outcome |
|---|---|---|
| Basic read | SELECT … FROM tickit.users WHERE state='CA' LIMIT 3 (provisioned) | ✅ 3 rows, query_id returned |
| Basic read | SELECT COUNT(*), MIN(saletime)… (serverless) | ✅ 172,456 rows aggregated |
| Read-only protection — DDL/maintenance | TRUNCATE, GRANT, UNLOAD | ✅ All rejected by guard: Statement type not allowed in read-only mode: <KW> |
| Transaction-breaker protection | BEGIN, COMMIT, ROLLBACK (also tested across both cluster types) | ✅ All rejected by guard — cannot smuggle past the BEGIN READ ONLY … ROLLBACK wrapper |
| Engine backstop (write not in deny-list) | INSERT INTO tickit.users … (provisioned) | ✅ Guard allowed it through, engine rejected: ERROR: transaction is read-only |
| Engine backstop (DDL not in deny-list) | CREATE TABLE tickit.should_not_exist … (serverless) | ✅ Same backstop: ERROR: transaction is read-only |
| Multi-statement protection | SELECT 1; SELECT 2 | ✅ Rejected: Only a single SQL statement is allowed |
| Unparseable SQL (fail-closed) | SELECT FROM WHERE | ✅ Rejected: SQL could not be parsed |
| Failed user SQL — engine error | SELECT * FROM tickit.no_such_table_xyz (serverless) | ✅ Surfaced engine error: relation "tickit.no_such_table_xyz" does not exist |
| Session recovery after failure | Follow-up SELECT current_user, current_database() on provisioned (after INSERT failure) and SELECT … FROM tickit.users on serverless (after CREATE failure) |  ✅ Both succeeded — confirms the finally-block ROLLBACK cleanly closed the failed transaction and the cached per cluster:database session is reusable |
| Guard false-positive check | SELECT 1 AS commit_as_alias, 'BEGIN; ROLLBACK;' AS payload_literal | ✅ Allowed — deny-listed words used only as alias and string literal are not flagged (matches TestNoFalsePositives unit tests) |

### Notes
- Identity confirmed: current_user = IAM:xyz — IAM auth is in use, no DB password required.
- The schema-exploration tools (list_databases/list_schemas/list_tables/list_columns) all run through the same _execute_protected_statement wrapper and therefore inherit the same read-only 
protection — verified end-to-end since they returned results on both cluster types without writing anything.
- Read-only deny-list rejections fire before any Data API call (guard short-circuits), while engine-level rejections (INSERT/CREATE) fire after Data API submission inside the BEGIN READ ONLY 
transaction. Both pathways were observed.
