### PR TITLE
fix(valkey-mcp-server): use absolute URL for ELASTICACHECONNECT.md link

### DIFF
--- a/src/valkey-mcp-server/README.md
+++ b/src/valkey-mcp-server/README.md
@@ -56,7 +56,7 @@ This MCP server provides 12 purpose-built tools for AI agents working with Valke
    - **Bedrock** (default): Requires AWS credentials — `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, or an IAM role. Without credentials, semantic search will fail with a `NoCredentialsError`.
    - **OpenAI**: Requires `OPENAI_API_KEY`
    - **Ollama**: Requires a running Ollama instance (no credentials needed)
-5. For Amazon ElastiCache/MemoryDB connection instructions, see [ELASTICACHECONNECT.md](ELASTICACHECONNECT.md).
+5. For Amazon ElastiCache/MemoryDB connection instructions, see [ELASTICACHECONNECT.md](https://github.com/awslabs/mcp/blob/main/src/valkey-mcp-server/ELASTICACHECONNECT.md).
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

Fixes the Docusaurus build failure introduced in PR #4024.

## Problem

The relative link `[ELASTICACHECONNECT.md](ELASTICACHECONNECT.md)` in the valkey-mcp-server README causes a broken link error during the Docusaurus build. This is because the README is imported as an MDX component by `docusaurus/docs/servers/valkey-mcp-server.md`, and Docusaurus resolves relative `.md` links against the **importing page's location** (`docs/servers/`), not the source file's actual location (`src/valkey-mcp-server/`).

## Fix

Changed the link to use the absolute GitHub URL, matching the pattern used by other servers in the repo (aurora-dsql, aws-api, memcached, etc.).

## Note

If a Docusaurus-rendered version of the ElastiCache connection guide is desired, a corresponding wrapper page (e.g. `docusaurus/docs/servers/valkey-mcp-server-elasticache-connect.md`) must be created with an MDX import of `ELASTICACHECONNECT.md`, and the sidebar configured to include it. The README link can then use a relative doc path to that page.

## Verification

- Ran `npx docusaurus build` locally — build passes with no broken link errors.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).