### PR TITLE
feat(aurora-dsql): add EF Core .NET ORM adapter guidance

### DIFF
--- a/src/aurora-dsql-mcp-server/CHANGELOG.md
+++ b/src/aurora-dsql-mcp-server/CHANGELOG.md
@@ -25,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- DSQL skill and Kiro Power guidance for the `Amazon.AuroraDsql.EntityFrameworkCore` (EF Core) adapter: C# / .NET connectivity section, EF Core adapter entry, and updated adapter count
 - `dsql_lint` tool: validates SQL for Aurora DSQL compatibility via the `dsql-lint` binary, with optional auto-fix
 - Initial project setup

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/auth-connectivity.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/auth-connectivity.md
@@ -6,7 +6,7 @@ Part of [DSQL Development Guide](../development-guide.md).
 
 ## Database Connectivity Tools
 
-DSQL has many tools for connecting including 10 database drivers, 4, ORM libraries, and 3 specialized adapters
+DSQL has many tools for connecting including 12 database drivers, 4 ORM libraries, and 4 specialized adapters
 across various languages as listed in the [programming guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/aws-sdks.html). PREFER using connectors, drivers, ORM libraries, and adapters.
 
 ### Database Drivers
@@ -43,11 +43,12 @@ Standalone libraries that provide object-relational mapping functionality:
 
 Specific extensions that make existing ORMs work with Aurora DSQL:
 
-| Programming Language | ORM/Framework | Repository                                                                           |
-| -------------------- | ------------- | ------------------------------------------------------------------------------------ |
-| **Java**             | Hibernate     | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-hibernate/)   |
-| **Python**           | Django        | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-django/)         |
-| **Python**           | SQLAlchemy    | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-sqlalchemy/) |
+| Programming Language | ORM/Framework | Repository                                                                                          |
+| -------------------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| **C# (.NET)**        | EF Core       | [Aurora DSQL EF Core Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet/ef-core) |
+| **Java**             | Hibernate     | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-hibernate/)                  |
+| **Python**           | Django        | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-django/)                        |
+| **Python**           | SQLAlchemy    | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-sqlalchemy/)                |
 
 ---
 

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/language.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/language.md
@@ -142,6 +142,19 @@ PREFER using JDBC with the [DSQL JDBC Connector](https://docs.aws.amazon.com/aur
 - Wrap JDBC connection, configure max lifetime < 1 hour
 - See [aurora-dsql-samples/java/pgjdbc_hikaricp](https://github.com/aws-samples/aurora-dsql-samples/tree/main/java/pgjdbc_hikaricp)
 
+### C# / .NET
+
+PREFER using the [Amazon.AuroraDsql.Npgsql](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet) connector for automatic IAM auth:
+
+- Wraps Npgsql with IAM token generation and refresh
+- Register via `AddDsqlDataSource(host)`
+
+#### EF Core
+
+- Adapter: [Amazon.AuroraDsql.EntityFrameworkCore](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet/ef-core) (requires .NET 8.0+, EF Core 9.0.7+, `Amazon.AuroraDsql.Npgsql` 1.1.0+)
+- Configure with `options.UseDsql(sp)` in `AddDbContext`
+- Use `Guid` keys (store-generated `gen_random_uuid()`) and `DsqlExecutionStrategy` for OCC retry — see the [EF Core adapter README](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet/ef-core) for framework gotchas
+
 ### Rust
 
 **SQLx** (async)

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/onboarding.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/onboarding.md
@@ -364,7 +364,7 @@ Let them know you're ready to help with more:
 2. **Distributed:** Active-active writes across multiple regions
 3. **Strong Consistency:** Immediate read-your-writes across all regions
 4. **IAM Authentication:** No password management, automatic token rotation
-5. **PostgreSQL Compatible:** Supports 10 [Database Drivers](./auth/connectivity-tools.md#database-drivers), 4 [ORMs](./auth/connectivity-tools.md#object-relational-mapping-orm-libraries), and 3 [Adapters/Dialects](./auth/connectivity-tools.md#aurora-dsql-adapters-and-dialects) as listed.
+5. **PostgreSQL Compatible:** Supports 12 [Database Drivers](./auth/connectivity-tools.md#database-drivers), 4 [ORMs](./auth/connectivity-tools.md#object-relational-mapping-orm-libraries), and 4 [Adapters/Dialects](./auth/connectivity-tools.md#aurora-dsql-adapters-and-dialects) as listed.
 
 **For detailed patterns, see [`./development-guide.md`](./development-guide.md)**
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/auth/connectivity-tools.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/auth/connectivity-tools.md
@@ -6,7 +6,7 @@ Part of [DSQL Development Guide](../development-guide.md).
 
 ## Database Connectivity Tools
 
-DSQL has many tools for connecting including 10 database drivers, 4, ORM libraries, and 3 specialized adapters
+DSQL has many tools for connecting including 12 database drivers, 4 ORM libraries, and 4 specialized adapters
 across various languages as listed in the [programming guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/aws-sdks.html). PREFER using connectors, drivers, ORM libraries, and adapters.
 
 ### Database Drivers
@@ -43,11 +43,12 @@ Standalone libraries that provide object-relational mapping functionality:
 
 Specific extensions that make existing ORMs work with Aurora DSQL:
 
-| Programming Language | ORM/Framework | Repository                                                                           |
-| -------------------- | ------------- | ------------------------------------------------------------------------------------ |
-| **Java**             | Hibernate     | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-hibernate/)   |
-| **Python**           | Django        | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-django/)         |
-| **Python**           | SQLAlchemy    | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-sqlalchemy/) |
+| Programming Language | ORM/Framework | Repository                                                                                          |
+| -------------------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| **C# (.NET)**        | EF Core       | [Aurora DSQL EF Core Adapter](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet/ef-core) |
+| **Java**             | Hibernate     | [Aurora DSQL Hibernate Adapter](https://github.com/awslabs/aurora-dsql-hibernate/)                  |
+| **Python**           | Django        | [Aurora DSQL Django Adapter](https://github.com/awslabs/aurora-dsql-django/)                        |
+| **Python**           | SQLAlchemy    | [Aurora DSQL SQLAlchemy Adapter](https://github.com/awslabs/aurora-dsql-sqlalchemy/)                |
 
 ---
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/language.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/language.md
@@ -142,6 +142,19 @@ PREFER using JDBC with the [DSQL JDBC Connector](https://docs.aws.amazon.com/aur
 - Wrap JDBC connection, configure max lifetime < 1 hour
 - See [aurora-dsql-samples/java/pgjdbc_hikaricp](https://github.com/aws-samples/aurora-dsql-samples/tree/main/java/pgjdbc_hikaricp)
 
+### C# / .NET
+
+PREFER using the [Amazon.AuroraDsql.Npgsql](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet) connector for automatic IAM auth:
+
+- Wraps Npgsql with IAM token generation and refresh
+- Register via `AddDsqlDataSource(host)`
+
+#### EF Core
+
+- Adapter: [Amazon.AuroraDsql.EntityFrameworkCore](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet/ef-core) (requires .NET 8.0+, EF Core 9.0.7+, `Amazon.AuroraDsql.Npgsql` 1.1.0+)
+- Configure with `options.UseDsql(sp)` in `AddDbContext`
+- Use `Guid` keys (store-generated `gen_random_uuid()`) and `DsqlExecutionStrategy` for OCC retry — see the [EF Core adapter README](https://github.com/awslabs/aurora-dsql-orms/tree/main/dotnet/ef-core) for framework gotchas
+
 ### Rust
 
 **SQLx** (async)

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/onboarding.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/onboarding.md
@@ -364,7 +364,7 @@ Let them know you're ready to help with more:
 2. **Distributed:** Active-active writes across multiple regions
 3. **Strong Consistency:** Immediate read-your-writes across all regions
 4. **IAM Authentication:** No password management, automatic token rotation
-5. **PostgreSQL Compatible:** Supports 10 [Database Drivers](./auth/connectivity-tools.md#database-drivers), 4 [ORMs](./auth/connectivity-tools.md#object-relational-mapping-orm-libraries), and 3 [Adapters/Dialects](./auth/connectivity-tools.md#aurora-dsql-adapters-and-dialects) as listed.
+5. **PostgreSQL Compatible:** Supports 12 [Database Drivers](./auth/connectivity-tools.md#database-drivers), 4 [ORMs](./auth/connectivity-tools.md#object-relational-mapping-orm-libraries), and 4 [Adapters/Dialects](./auth/connectivity-tools.md#aurora-dsql-adapters-and-dialects) as listed.
 
 **For detailed patterns, see [`./development-guide.md`](./development-guide.md)**
 


### PR DESCRIPTION
## What

Mirrors the EF Core (`Amazon.AuroraDsql.EntityFrameworkCore`) adapter guidance into the Aurora DSQL MCP server skill and Kiro Power.

Companion to awslabs/agent-plugins#208 (canonical, edited first).

## Changes

| File | Change |
|---|---|
| `references/auth/connectivity-tools.md` | EF Core (.NET) adapter row; adapter count 3 → 4 |
| `references/language.md` | New `C# / .NET` section (Npgsql connector + EF Core subsection) |
| `references/onboarding.md` | Capability counts updated (12 drivers, 4 adapters) |
| `kiro_power/steering/{auth-connectivity,language,onboarding}.md` | Byte-identical mirror of the three reference files |
| `CHANGELOG.md` | `Added` entry under `Unreleased` |

`kiro_power/steering/*.md` kept byte-identical to `skills/dsql-skill/references/*.md` (verified via `diff`).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
