### PR TITLE
fix(eks-mcp-server): treat empty insight_id as list mode

### DIFF
--- a/src/eks-mcp-server/awslabs/eks_mcp_server/insights_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/insights_handler.py
@@ -136,9 +136,7 @@ class InsightsHandler:
             eks_client = self.eks_client
 
             # Determine operation mode based on whether insight_id is provided
-            detail_mode = insight_id is not None
-
-            if detail_mode:
+            if insight_id and insight_id.strip():
                 # Get details for a specific insight
                 return await self._get_insight_detail(
                     ctx, eks_client, cluster_name, insight_id, next_token

--- a/src/eks-mcp-server/tests/test_insights_handler.py
+++ b/src/eks-mcp-server/tests/test_insights_handler.py
@@ -152,6 +152,33 @@ class TestInsightsHandler:
         assert 'Successfully retrieved 2 insights' in result.content[0].text
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize('insight_id', ['', '   '])
+    async def test_get_eks_insights_empty_insight_id_uses_list_mode(
+        self, mock_context, mock_mcp, insight_id
+    ):
+        """Test empty insight IDs are treated as not provided."""
+        mock_eks_client = MagicMock()
+        mock_eks_client.list_insights.return_value = {
+            'insights': [
+                self._create_mock_insight_item(insight_id='insight-1', category='CONFIGURATION')
+            ]
+        }
+
+        handler = InsightsHandler(mock_mcp)
+        handler.eks_client = mock_eks_client
+
+        result = await handler._get_eks_insights_impl(
+            mock_context, cluster_name='test-cluster', insight_id=insight_id
+        )
+
+        mock_eks_client.list_insights.assert_called_once_with(clusterName='test-cluster')
+        mock_eks_client.describe_insight.assert_not_called()
+        assert not result.isError
+
+        data = json.loads(result.content[1].text)
+        assert data['detail_mode'] is False
+
+    @pytest.mark.asyncio
     async def test_get_eks_insights_detail_mode(self, mock_context, mock_mcp):
         """Test _get_eks_insights_impl in detail mode (with an insight_id)."""
         # Create mock AWS client


### PR DESCRIPTION
## Description

Fixes the EKS MCP server's insight mode selection so empty or whitespace-only insight_id values are treated as not provided. Some MCP clients serialize unset optional arguments as an empty string instead of null; before this change, get_eks_insights would enter detail mode and call DescribeInsight with an empty ID.

This keeps real insight IDs on the detail path and routes empty values through the existing list-insights path.

## Testing

From src/eks-mcp-server:

- uv run pytest tests/test_insights_handler.py -q
- uv run ruff check awslabs tests
- uv run ruff format --check awslabs tests
- uv run pyright

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).