### PR TITLE
fix(eks): treat blank insight_id as list mode in get_eks_insights

### DIFF
--- a/src/eks-mcp-server/awslabs/eks_mcp_server/insights_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/insights_handler.py
@@ -135,13 +135,14 @@ class InsightsHandler:
             # Always use the default EKS client
             eks_client = self.eks_client
 
-            # Determine operation mode based on whether insight_id is provided
-            detail_mode = insight_id is not None
+            # Treat empty or whitespace-only insight_id as unset (list mode).
+            normalized_insight_id = insight_id.strip() if insight_id else None
+            detail_mode = bool(normalized_insight_id)
 
             if detail_mode:
                 # Get details for a specific insight
                 return await self._get_insight_detail(
-                    ctx, eks_client, cluster_name, insight_id, next_token
+                    ctx, eks_client, cluster_name, normalized_insight_id, next_token
                 )
             else:
                 # List all insights with optional category filter

--- a/src/eks-mcp-server/tests/test_insights_handler.py
+++ b/src/eks-mcp-server/tests/test_insights_handler.py
@@ -105,6 +105,34 @@ class TestInsightsHandler:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize('insight_id', ['', '   '])
+    async def test_get_eks_insights_list_mode_for_blank_insight_id(
+        self, mock_context, mock_mcp, insight_id
+    ):
+        """Blank insight_id values should list insights instead of entering detail mode."""
+        mock_eks_client = MagicMock()
+        mock_eks_client.list_insights.return_value = {
+            'insights': [
+                self._create_mock_insight_item(insight_id='insight-1', category='CONFIGURATION'),
+            ]
+        }
+
+        handler = InsightsHandler(mock_mcp)
+        handler.eks_client = mock_eks_client
+
+        result = await handler._get_eks_insights_impl(
+            mock_context, cluster_name='test-cluster', insight_id=insight_id
+        )
+
+        mock_eks_client.list_insights.assert_called_once_with(clusterName='test-cluster')
+        mock_eks_client.describe_insight.assert_not_called()
+
+        assert not result.isError
+        data = json.loads(result.content[1].text)
+        assert data['detail_mode'] is False
+        assert len(data['insights']) == 1
+
+    @pytest.mark.asyncio
     async def test_get_eks_insights_list_mode(self, mock_context, mock_mcp):
         """Test _get_eks_insights_impl in list mode (without an insight_id)."""
         # Create mock AWS client


### PR DESCRIPTION
Fixes #4036

## Summary

This fixes `get_eks_insights` so empty or whitespace-only `insight_id` values are treated as unset and use list mode instead of calling `DescribeInsight` with an empty id.

## Motivation

Some MCP clients serialize unset optional string parameters as `""` instead of JSON `null`. The handler previously used `insight_id is not None`, so those clients could never list insights and always hit `DescribeInsight` authorization errors.

## Changes

- Normalize `insight_id` with `strip()` before choosing list vs detail mode
- Pass the normalized id to `_get_insight_detail` when detail mode is selected
- Add parametrized regression tests for `""` and `"   "`

## Tests

From `src/eks-mcp-server`:

```bash
uv run --frozen pytest tests/test_insights_handler.py -v
uv run --frozen ruff check awslabs/eks_mcp_server/insights_handler.py tests/test_insights_handler.py
```

All 14 tests passed locally.

## Notes

This aligns `insight_id` handling with the existing truthy checks already used for `category` and `next_token` in the same handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).