### PR TITLE
fix(aws-transform-mcp-server): parallelize SigV4 region discovery probe

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/consts.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/consts.py
@@ -63,3 +63,17 @@ FES_REGIONS: List[str] = [
 
 # ── Fan-out timeout for profile discovery (seconds per region) ──────────
 PROFILE_DISCOVERY_TIMEOUT_SECONDS: float = 5.0
+
+
+def regions_for_profile_discovery() -> List[str]:
+    """Return regions to probe during credential/profile discovery.
+
+    When ``AWS_REGION`` is set to a supported FES region, probe only that
+    region to avoid serializing slow boto3 client builds across all regions.
+    """
+    import os
+
+    env_region = (os.environ.get('AWS_REGION') or '').strip()
+    if env_region in FES_REGIONS:
+        return [env_region]
+    return list(FES_REGIONS)

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/server.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/server.py
@@ -32,8 +32,8 @@ from awslabs.aws_transform_mcp_server.config_store import (
     set_sigv4_regions,
 )
 from awslabs.aws_transform_mcp_server.consts import (
-    FES_REGIONS,
     PROFILE_DISCOVERY_TIMEOUT_SECONDS,
+    regions_for_profile_discovery,
 )
 from awslabs.aws_transform_mcp_server.tools.adaptive_poll import AdaptivePollHandler
 from awslabs.aws_transform_mcp_server.tools.artifact import ArtifactHandler
@@ -245,10 +245,13 @@ async def _discover_sigv4_regions() -> list[str]:
             logger.info('Region discovery: {} succeeded', region)
             return region
         except Exception as exc:
-            logger.info('Region discovery failed for {}: {}', region, exc)
+            logger.info('Region discovery failed for {}: {!r}', region, exc)
             return None
 
-    results = await asyncio.gather(*[_call_region(r) for r in FES_REGIONS])
+    probe_regions = regions_for_profile_discovery()
+    if len(probe_regions) == 1:
+        logger.info('Region discovery: probing configured AWS_REGION {} only', probe_regions[0])
+    results = await asyncio.gather(*[_call_region(r) for r in probe_regions])
     return [r for r in results if r is not None]
 
 

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
@@ -206,10 +206,14 @@ async def call_fes_direct_sigv4(
     if region is None:
         session = AwsHelper.create_session()
         region = AwsHelper.resolve_region(session)
-    client = _create_sigv4_client(
-        endpoint, region=region, max_retries=max_retries, timeout=timeout_seconds
-    )
-    return await asyncio.to_thread(_call_boto3, client, operation, body or {})
+
+    def _create_and_call() -> Any:
+        client = _create_sigv4_client(
+            endpoint, region=region, max_retries=max_retries, timeout=timeout_seconds
+        )
+        return _call_boto3(client, operation, body or {})
+
+    return await asyncio.to_thread(_create_and_call)
 
 
 async def call_fes_direct_cookie(

--- a/src/aws-transform-mcp-server/tests/test_credential_auth.py
+++ b/src/aws-transform-mcp-server/tests/test_credential_auth.py
@@ -306,6 +306,70 @@ class TestProbeSigv4Fes:
         mock_set.assert_called_once_with(False)
 
 
+# ── regions_for_profile_discovery / _discover_sigv4_regions ──────────────
+
+
+class TestRegionsForProfileDiscovery:
+    def test_uses_aws_region_when_supported(self, monkeypatch):
+        from awslabs.aws_transform_mcp_server.consts import regions_for_profile_discovery
+
+        monkeypatch.setenv('AWS_REGION', 'eu-central-1')
+        assert regions_for_profile_discovery() == ['eu-central-1']
+
+    def test_falls_back_to_all_regions_when_unset(self, monkeypatch):
+        from awslabs.aws_transform_mcp_server.consts import FES_REGIONS, regions_for_profile_discovery
+
+        monkeypatch.delenv('AWS_REGION', raising=False)
+        assert regions_for_profile_discovery() == list(FES_REGIONS)
+
+    def test_falls_back_when_aws_region_not_supported(self, monkeypatch):
+        from awslabs.aws_transform_mcp_server.consts import FES_REGIONS, regions_for_profile_discovery
+
+        monkeypatch.setenv('AWS_REGION', 'us-west-2')
+        assert regions_for_profile_discovery() == list(FES_REGIONS)
+
+
+class TestDiscoverSigv4Regions:
+    @pytest.mark.asyncio
+    async def test_probes_only_configured_aws_region(self, monkeypatch):
+        from awslabs.aws_transform_mcp_server.server import _discover_sigv4_regions
+
+        monkeypatch.setenv('AWS_REGION', 'us-east-1')
+
+        with patch(f'{_SERVER_MOD}.call_fes_direct_sigv4', new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = {'workspaces': []}
+            regions = await _discover_sigv4_regions()
+
+        assert regions == ['us-east-1']
+        assert mock_call.call_count == 1
+        assert mock_call.call_args[1]['region'] == 'us-east-1'
+
+    @pytest.mark.asyncio
+    async def test_client_creation_runs_in_worker_thread(self):
+        from awslabs.aws_transform_mcp_server.transform_api_client import call_fes_direct_sigv4
+
+        async def _run_worker(fn):
+            return fn()
+
+        with (
+            patch(f'{_FES_MOD}.asyncio.to_thread', side_effect=_run_worker) as mock_to_thread,
+            patch(f'{_FES_MOD}._create_sigv4_client') as mock_create,
+            patch(f'{_FES_MOD}._call_boto3', return_value={'items': []}) as mock_call,
+        ):
+            mock_create.return_value = MagicMock()
+
+            result = await call_fes_direct_sigv4(
+                'https://api.transform.us-east-1.on.aws/',
+                'ListWorkspaces',
+                region='us-east-1',
+            )
+
+        assert result == {'items': []}
+        mock_to_thread.assert_awaited_once()
+        mock_create.assert_called_once()
+        mock_call.assert_called_once()
+
+
 # ── _startup clears stale config ─────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #4059

## Summary

Fix the AWS Transform MCP server SigV4 credential probe so it no longer times out on hosts network-distant from the profile region.

## Motivation

Startup region discovery fans out `ListWorkspaces` across all FES regions. `_create_sigv4_client` builds the boto3 client synchronously (~1.9s) before the awaited HTTP call, which serializes `asyncio.gather` on the event loop. The per-region 7s timeout expires before the real region responds, so IAM auth is incorrectly marked unavailable.

## Changes

- Add `regions_for_profile_discovery()` to probe only `AWS_REGION` when it is a supported FES region
- Use that helper in `_discover_sigv4_regions` and log timeout failures with `repr` for easier diagnosis
- Move SigV4 client creation and the boto3 call into `asyncio.to_thread` so multi-region fallback probes run in parallel
- Add regression tests for region selection and worker-thread execution

## Tests

From `src/aws-transform-mcp-server`:

```bash
PYTHONPATH=. python3 -m pytest tests/test_credential_auth.py tests/test_transform_api_client.py -q
```

Result: 43 passed.

## Notes

This implements the issue's recommended fixes #1 (honor `AWS_REGION`) and #2 (avoid blocking client creation on the event loop). When `AWS_REGION` is unset or not a supported FES region, the server still fans out to all regions, but probes now run concurrently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).