### PR TITLE
fix(postgres): allow username-only secrets for PG_WIRE_IAM_PROTOCOL

### DIFF
--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/psycopg_pool_connection.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/connection/psycopg_pool_connection.py
@@ -33,8 +33,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 def get_credentials_from_secret(
-    secret_arn: str, region: str, is_test: bool = False
-) -> Tuple[str, str]:
+    secret_arn: str, region: str, is_test: bool = False, require_password: bool = True
+) -> Tuple[str, Optional[str]]:
     """Fetch database (username, password) from AWS Secrets Manager.
 
     The secret payload is expected to be JSON with ``username``/``user``/
@@ -50,13 +50,17 @@ def get_credentials_from_secret(
         region: AWS region of the secret.
         is_test: If True, return deterministic test credentials instead of
             hitting AWS. Intended for unit tests only.
+        require_password: If False, a secret without a password field is
+            accepted (IAM auth generates its own token and only needs the
+            username).
 
     Returns:
-        ``(username, password)`` tuple.
+        ``(username, password)`` tuple. ``password`` is ``None`` when the
+        secret has no password field and ``require_password`` is False.
 
     Raises:
-        ValueError: If the secret is missing, malformed, or lacks
-            username/password fields.
+        ValueError: If the secret is missing, malformed, lacks a username,
+            or lacks a password while ``require_password`` is True.
     """
     if is_test:
         return 'test_user', 'test_password'
@@ -88,7 +92,7 @@ def get_credentials_from_secret(
                 f'Secret does not contain username. Available keys: {", ".join(secret.keys())}'
             )
 
-        if not password:
+        if require_password and not password:
             logger.error('Password not found in secret')
             raise ValueError(
                 f'Secret does not contain password. Available keys: {", ".join(secret.keys())}'
@@ -346,7 +350,7 @@ class PsycopgPoolConnection(AbstractDBConnection):
 
     def _get_credentials_from_secret(
         self, secret_arn: str, region: str, is_test: bool = False
-    ) -> Tuple[str, str]:
+    ) -> Tuple[str, Optional[str]]:
         """Get database credentials from AWS Secrets Manager.
 
         Instance-method wrapper around the module-level

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -839,7 +839,7 @@ def internal_create_connection(
         #      clusters, which never have a Secrets Manager secret.
         if effective_secret_arn:
             iam_username, _ = get_credentials_from_secret(
-                secret_arn=effective_secret_arn, region=region
+                secret_arn=effective_secret_arn, region=region, require_password=False
             )
         elif metadata_master_username:
             iam_username = metadata_master_username
@@ -1028,7 +1028,9 @@ def validate_table_name(table_name: str | None) -> bool:
     return True
 
 
-def validate_secret_arn_at_startup(secret_arn: str, region: str) -> None:
+def validate_secret_arn_at_startup(
+    secret_arn: str, region: str, require_password: bool = True
+) -> None:
     """Verify the configured Secrets Manager ARN is readable at startup.
 
     Calls Secrets Manager once with GetSecretValue against the given ARN.
@@ -1043,12 +1045,14 @@ def validate_secret_arn_at_startup(secret_arn: str, region: str) -> None:
     Args:
         secret_arn: The ARN from --secret_arn.
         region: AWS region for Secrets Manager.
+        require_password: If False, accept secrets without a password field
+            (IAM auth only reads the username from the secret).
 
     Raises:
         SystemExit: If the secret cannot be read. Exit code 1.
     """
     try:
-        get_credentials_from_secret(secret_arn, region)
+        get_credentials_from_secret(secret_arn, region, require_password=require_password)
     except Exception as e:
         logger.error(
             f'MCP server cannot start: unable to read Secrets Manager ARN '
@@ -1174,15 +1178,19 @@ def main():
     # before any query is attempted. The probe is skipped only when no
     # ARNs are configured at all — the cluster's managed secret will be
     # discovered (and validated) lazily on the first connection attempt.
+    # IAM auth generates its own token, so its secrets only need a username.
+    require_password = args.connection_method != ConnectionMethod.PG_WIRE_IAM_PROTOCOL.name
     for target, arn in configured_secret_arns.items():
         try:
-            validate_secret_arn_at_startup(arn, args.region)
+            validate_secret_arn_at_startup(arn, args.region, require_password=require_password)
         except SystemExit:
             logger.error(f'Configured --secret_arn entry for target {target!r} is unreadable.')
             raise
     if configured_default_secret_arn:
         try:
-            validate_secret_arn_at_startup(configured_default_secret_arn, args.region)
+            validate_secret_arn_at_startup(
+                configured_default_secret_arn, args.region, require_password=require_password
+            )
         except SystemExit:
             logger.error('Configured default --secret_arn is unreadable.')
             raise

--- a/src/postgres-mcp-server/tests/test_psycopg_connector.py
+++ b/src/postgres-mcp-server/tests/test_psycopg_connector.py
@@ -17,7 +17,10 @@ import concurrent.futures
 import pytest
 import threading
 import time
-from awslabs.postgres_mcp_server.connection.psycopg_pool_connection import PsycopgPoolConnection
+from awslabs.postgres_mcp_server.connection.psycopg_pool_connection import (
+    PsycopgPoolConnection,
+    get_credentials_from_secret,
+)
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -669,6 +672,20 @@ class TestPsycopgConnector:
 
             with pytest.raises(ValueError, match='Secret does not contain password'):
                 conn._get_credentials_from_secret('arn:secret', 'us-east-1', is_test=False)
+
+    def test_get_credentials_from_secret_password_not_required(self):
+        """Test username-only secret is accepted when password is not required."""
+        with patch('boto3.Session') as mock_session:
+            mock_client = MagicMock()
+            mock_session.return_value.client.return_value = mock_client
+            mock_client.get_secret_value.return_value = {'SecretString': '{"username": "db_user"}'}
+
+            user, password = get_credentials_from_secret(
+                'arn:secret', 'us-east-1', require_password=False
+            )
+
+            assert user == 'db_user'
+            assert password is None
 
     def test_get_credentials_from_secret_no_secret_string(self):
         """Test error when secret doesn't contain SecretString."""

--- a/src/postgres-mcp-server/tests/test_server.py
+++ b/src/postgres-mcp-server/tests/test_server.py
@@ -725,7 +725,10 @@ def test_main_with_valid_parameters(monkeypatch, capsys):
     # Stub the startup Secrets Manager probe so main() doesn't exit(1).
     monkeypatch.setattr(
         'awslabs.postgres_mcp_server.server.get_credentials_from_secret',
-        lambda secret_arn, region, is_test=False: ('test_user', 'test_password'),
+        lambda secret_arn, region, is_test=False, require_password=True: (
+            'test_user',
+            'test_password',
+        ),
     )
 
     # Mock the connection so main can complete successfully
@@ -778,7 +781,10 @@ def test_main_with_invalid_parameters(monkeypatch, capsys):
     # Stub the startup Secrets Manager probe so main() doesn't exit(1).
     monkeypatch.setattr(
         'awslabs.postgres_mcp_server.server.get_credentials_from_secret',
-        lambda secret_arn, region, is_test=False: ('test_user', 'test_password'),
+        lambda secret_arn, region, is_test=False, require_password=True: (
+            'test_user',
+            'test_password',
+        ),
     )
 
     # This test of main() will succeed in parsing parameters.
@@ -849,7 +855,10 @@ def test_main_with_psycopg_parameters(monkeypatch, capsys):
     # Stub the startup Secrets Manager probe so main() doesn't exit(1).
     monkeypatch.setattr(
         'awslabs.postgres_mcp_server.server.get_credentials_from_secret',
-        lambda secret_arn, region, is_test=False: ('test_user', 'test_password'),
+        lambda secret_arn, region, is_test=False, require_password=True: (
+            'test_user',
+            'test_password',
+        ),
     )
 
     # The key fix: patch the PsycopgPoolConnection.__init__ to set is_test=True
@@ -1007,7 +1016,7 @@ def test_main_exits_when_secret_arn_unreadable(monkeypatch, capsys):
 
     monkeypatch.setattr('awslabs.postgres_mcp_server.server.mcp.run', _fail_if_called)
 
-    def _raise_access_denied(secret_arn, region, is_test=False):
+    def _raise_access_denied(secret_arn, region, is_test=False, require_password=True):
         raise ValueError(
             'Failed to retrieve credentials from Secrets Manager: AccessDeniedException'
         )
@@ -1048,7 +1057,7 @@ def test_main_verifies_secret_before_mcp_run(monkeypatch, capsys):
     def _record_run():
         call_order.append('mcp.run')
 
-    def _record_secret(secret_arn, region, is_test=False):
+    def _record_secret(secret_arn, region, is_test=False, require_password=True):
         call_order.append('get_credentials_from_secret')
         return ('test_user', 'test_password')
 
@@ -1082,7 +1091,7 @@ def test_main_skips_secret_probe_when_arg_omitted(monkeypatch, capsys):
 
     secret_probe_calls = {'count': 0}
 
-    def _record_secret(secret_arn, region, is_test=False):
+    def _record_secret(secret_arn, region, is_test=False, require_password=True):
         secret_probe_calls['count'] += 1
         return ('test_user', 'test_password')
 
@@ -1132,7 +1141,10 @@ def test_main_parses_per_target_and_default_secret_arn(monkeypatch, capsys):
     monkeypatch.setattr('awslabs.postgres_mcp_server.server.mcp.run', lambda: None)
     monkeypatch.setattr(
         'awslabs.postgres_mcp_server.server.get_credentials_from_secret',
-        lambda secret_arn, region, is_test=False: ('test_user', 'test_password'),
+        lambda secret_arn, region, is_test=False, require_password=True: (
+            'test_user',
+            'test_password',
+        ),
     )
 
     main()
@@ -1261,7 +1273,7 @@ def test_main_skips_empty_bare_secret_arn(monkeypatch, capsys):
 
     secret_probe_calls = {'count': 0}
 
-    def _record_secret(secret_arn, region, is_test=False):
+    def _record_secret(secret_arn, region, is_test=False, require_password=True):
         secret_probe_calls['count'] += 1
         return ('test_user', 'test_password')
 


### PR DESCRIPTION
Fixes #4047

## Summary

### Changes

`get_credentials_from_secret` gains a `require_password` flag (default `True`, so existing behavior is unchanged). The two IAM-auth paths opt out of it:

* `internal_create_connection` — reads only the username from the secret (the password is a generated IAM token)
* `validate_secret_arn_at_startup` — skips the password requirement when the operator declared `--connection_method PG_WIRE_IAM_PROTOCOL`

Non-IAM connection methods still require a password in the secret, at both startup validation and pool initialization.

### User experience

Before: with `PG_WIRE_IAM_PROTOCOL`, a secret containing only `{"username": "..."}` fails startup validation (`Secret does not contain password`), forcing operators to store a sentinel password that is never used and reads like a real credential in security reviews.

After: a username-only secret boots the server on the IAM path. Secrets for non-IAM methods behave exactly as before.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N): N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
