### PR TITLE
chore: exclude *.drawio from license header check

### DIFF
--- a/.github/workflows/check-license-header.json
+++ b/.github/workflows/check-license-header.json
@@ -22,6 +22,7 @@
       "**/*.cs",
       "**/*.properties",
       "**/*.xml",
+      "**/*.drawio",
       "**/dist/**"
     ],
     "include": [
@@ -78,6 +79,7 @@
       "**/*.template",
       "**/*.properties",
       "**/*.xml",
+      "**/*.drawio",
       "**/dist/**",
       "**/skills/*/scripts",
       "**/skills/*/references",


### PR DESCRIPTION
## Summary

The `Check License Header` workflow ([viperproject/check-license-header](https://github.com/viperproject/check-license-header)) runs in `strict: true` mode. In strict mode, every file must be matched by either an `include` glob (checked for a header) or an `exclude` glob (skipped). A file matching **neither** produces `Config does not cover the file`, and warnings are treated as errors.

The raw `*.drawio` diagram source (`src/roda-mcp-server/docs/architecture.drawio`) matched no glob, failing the check:

```
##[warning]Config does not cover the file 'src/roda-mcp-server/docs/architecture.drawio'
##[error]0 error(s) and 1 warning(s) found. Warnings are treated as errors.
```

(Ref: https://github.com/awslabs/mcp/actions/runs/28818019848/job/85462321252)

## Change

`.drawio` is an XML-based format, so this follows the existing convention already used for `*.xml`, `*.template`, and `*.properties`:

- Added `**/*.drawio` to the **first block's `exclude`** — no Python-style license header is expected on diagram sources.
- Added `**/*.drawio` to the **third block's `include`** — so strict mode acknowledges the file and stops warning.

The rendered `architecture.drawio.png` was already covered by the existing `**/*.png` include.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)