### PR TITLE
fix(aws-api-mcp-server): resolve Windows launch failures on aws-api-m…

### DIFF
--- a/src/aws-api-mcp-server/CONTRIBUTING.md
+++ b/src/aws-api-mcp-server/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Add the following code to your MCP client configuration (e.g., for Kiro, edit `~
         "--directory",
         "<your_working_directory>/mcp/src/aws-api-mcp-server",
         "run",
+        "--no-sync",
         "awslabs.aws-api-mcp-server"
       ],
       "env": {

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/__init__.py
@@ -14,6 +14,6 @@
 
 """Core functionality for the AWS API MCP server."""
 
-from . import aws, common, data, metadata, parser
+from . import aws, common, metadata, parser
 
-__all__ = ['aws', 'common', 'data', 'metadata', 'parser']
+__all__ = ['aws', 'common', 'metadata', 'parser']

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/agent_scripts/manager.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/agent_scripts/manager.py
@@ -49,7 +49,7 @@ class AgentScriptsManager:
 
             for script_directory in self.scripts_dirs:
                 for file_path in script_directory.glob('*.script.md'):
-                    with open(file_path, 'r') as f:
+                    with file_path.open('r') as f:
                         metadata, script = frontmatter.parse(f.read())
                         script_name = file_path.stem.removesuffix('.script')
                         description = metadata.get('description')


### PR DESCRIPTION
cp-server (#4018)

Fix 3 bugs preventing server startup on Windows:
1. Remove non-package 'data' module from core import in __init__.py
2. Use Path.open() for long path support exceeding Windows MAX_PATH
3. Add --no-sync to uv run to prevent concurrent sync race condition

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
