### PR TITLE
fix: roda-mcp update project script

### DIFF
--- a/src/roda-mcp-server/pyproject.toml
+++ b/src/roda-mcp-server/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 ]
 
 [project.scripts]
-roda-mcp-server = "awslabs.roda_mcp_server.server:main"
+awslabs.roda-mcp-server = "awslabs.roda_mcp_server.server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/roda-mcp-server/pyproject.toml
+++ b/src/roda-mcp-server/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 ]
 
 [project.scripts]
-awslabs.roda-mcp-server = "awslabs.roda_mcp_server.server:main"
+"awslabs.roda-mcp-server" = "awslabs.roda_mcp_server.server:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Update project script for roda-mcp-server

### User experience

> Users can use the MCP server directly with the following config, instead of having to specify executables in args:

```
{
  "mcpServers": {
    "awslabs.roda-mcp-server": {
      "command": "uvx",
      "args": [
        "awslabs.roda-mcp-server@latest", 
      ],
      "env": {
        "FASTMCP_LOG_LEVEL": "ERROR"
      },
      "disabled": false,
      "autoApprove": []
    }
  }
}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
