### PR TITLE
fix(iam-mcp-server): make managed-policy denylist case-insensitive

### DIFF
--- a/src/iam-mcp-server/awslabs/iam_mcp_server/server.py
+++ b/src/iam-mcp-server/awslabs/iam_mcp_server/server.py
@@ -43,20 +43,27 @@ from pydantic import Field
 from typing import Any, Dict, List, Optional, Union
 
 
-# Policy ARNs that are too dangerous to attach via MCP
+# Policy ARNs that are too dangerous to attach via MCP.
+# Stored lowercased because IAM resolves managed-policy ARNs case-insensitively,
+# so the denylist check must be case-insensitive too (see _check_denied_policy_arn).
 DENIED_POLICY_ARNS = {
-    'arn:aws:iam::aws:policy/AdministratorAccess',
-    'arn:aws:iam::aws:policy/IAMFullAccess',
-    'arn:aws:iam::aws:policy/PowerUserAccess',
+    'arn:aws:iam::aws:policy/administratoraccess',
+    'arn:aws:iam::aws:policy/iamfullaccess',
+    'arn:aws:iam::aws:policy/poweruseraccess',
 }
 
 
 def _check_denied_policy_arn(policy_arn: str) -> None:
-    """Reject policy ARNs on the denylist."""
-    normalized = policy_arn.strip()
+    """Reject policy ARNs on the denylist.
+
+    The comparison is case-insensitive: IAM resolves managed-policy ARNs without
+    regard to case, so a case variant such as 'arn:aws:iam::aws:policy/administratoraccess'
+    would otherwise bypass the denylist and still attach the canonical policy.
+    """
+    normalized = policy_arn.strip().lower()
     if normalized in DENIED_POLICY_ARNS:
         raise IamValidationError(
-            f'Policy {normalized} is on the denylist and cannot be attached via MCP. '
+            f'Policy {policy_arn.strip()} is on the denylist and cannot be attached via MCP. '
             'Use the AWS Console for high-privilege policy changes.'
         )
 

--- a/src/iam-mcp-server/tests/test_server.py
+++ b/src/iam-mcp-server/tests/test_server.py
@@ -1541,6 +1541,30 @@ async def test_attach_user_policy_denied_arn():
 
 
 @pytest.mark.asyncio
+async def test_attach_user_policy_denied_arn_case_insensitive():
+    """Denied ARNs must be rejected regardless of case.
+
+    IAM resolves managed-policy ARNs case-insensitively, so case variants of a
+    denied ARN must not bypass the denylist (bug bounty P468271457).
+    """
+    from awslabs.iam_mcp_server.server import attach_user_policy
+
+    Context.initialize(readonly=False, require_confirmation=False)
+
+    for arn in [
+        'arn:aws:iam::aws:policy/administratoraccess',
+        'arn:aws:iam::aws:policy/ADMINISTRATORACCESS',
+        'arn:aws:iam::aws:policy/AdMiNiStRaToRaCcEsS',
+        'arn:aws:iam::aws:policy/iamfullaccess',
+        'arn:aws:iam::aws:policy/PowerUserACCESS',
+        '  arn:aws:iam::aws:policy/administratoraccess  ',
+    ]:
+        with pytest.raises(IamValidationError) as exc_info:
+            await attach_user_policy(user_name='test-user', policy_arn=arn, confirmed=True)
+        assert 'denylist' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_attach_group_policy_denied_arn():
     """Test that attach_group_policy rejects denied policy ARNs."""
     from awslabs.iam_mcp_server.server import attach_group_policy
@@ -1551,6 +1575,22 @@ async def test_attach_group_policy_denied_arn():
         await attach_group_policy(
             group_name='test-group',
             policy_arn='arn:aws:iam::aws:policy/AdministratorAccess',
+            confirmed=True,
+        )
+    assert 'denylist' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_attach_group_policy_denied_arn_case_insensitive():
+    """Denied ARNs must be rejected on groups regardless of case (bug bounty P468271457)."""
+    from awslabs.iam_mcp_server.server import attach_group_policy
+
+    Context.initialize(readonly=False, require_confirmation=False)
+
+    with pytest.raises(IamValidationError) as exc_info:
+        await attach_group_policy(
+            group_name='test-group',
+            policy_arn='arn:aws:iam::aws:policy/administratoraccess',
             confirmed=True,
         )
     assert 'denylist' in str(exc_info.value)


### PR DESCRIPTION
## Summary

The `DENIED_POLICY_ARNS` guardrail in the IAM MCP server compared policy ARNs using case-sensitive set membership. IAM resolves managed-policy ARNs without regard to case, so a case variant of a denied ARN passed the check while IAM still attached the canonical high-privilege policy (e.g. `AdministratorAccess`). This made the denylist ineffective as a guardrail.

## Changes

- `_check_denied_policy_arn` normalizes the input with `.strip().lower()`, and `DENIED_POLICY_ARNS` entries are stored lowercased, so the comparison matches IAM's own case-insensitive resolution.
- The error message still echoes the original (stripped) ARN for clarity.
- Applies to both `attach_user_policy` and `attach_group_policy`.

## Tests

- Added `test_attach_user_policy_denied_arn_case_insensitive` and `test_attach_group_policy_denied_arn_case_insensitive` covering lower-case, upper-case, mixed-case, and whitespace-padded variants.
- Existing denylist tests (canonical ARNs) still pass.

## Verification

`./run_tests.sh` passes fully:
- `ruff check` — all checks passed
- `ruff format --check` — all files formatted
- `pyright` — 0 errors, 0 warnings
- `pytest` — 169 passed, 97% coverage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).