### PR TITLE
feat(redshift-mcp-server): add MCP directory requirements

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -111,6 +111,10 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 - `FASTMCP_LOG_LEVEL`: Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
 - `LOG_FILE`: Path to log file (optional, logs to stdout if not specified)
 
+## Support
+
+If you need help or want to report problems, please open an issue in the [AWS Labs MCP repository](https://github.com/awslabs/mcp/issues).
+
 ## Basic Usage
 
 ### Discovery Workflow
@@ -126,6 +130,15 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 - "List databases in cluster 'my-redshift-cluster'"
 - "What tables are in the 'public' schema of database 'analytics'?"
 - "Execute: SELECT COUNT(*) FROM users WHERE created_date > '2024-01-01'"
+
+### Prompt Examples
+
+Here are a few concrete prompts that work well with the Redshift MCP tools:
+
+- "List all available Redshift clusters and workgroups in my account."
+- "Show me the databases available in the analytics cluster."
+- "What tables are in the public schema of the analytics database?"
+- "Run a safe query to show the latest 10 rows from the sales table."
 
 ### Advanced Examples
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -37,6 +37,7 @@ from awslabs.redshift_mcp_server.redshift import (
 )
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -126,11 +127,16 @@ The server reuses one Redshift Data API session per `cluster:database`:
 - We use the Redshift API and Redshift Data API.
 - Leverage IAM authentication when possible instead of secrets (database passwords).
 """,
+    website_url='https://github.com/awslabs/mcp/tree/main/src/redshift-mcp-server',
+    icons=[{'src': 'icon.svg', 'mimeType': 'image/svg+xml', 'sizes': ['256x256']}],
     dependencies=['boto3', 'loguru', 'pydantic', 'sqlglot'],
 )
 
 
-@mcp.tool(name='list_clusters')
+@mcp.tool(
+    name='list_clusters',
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
 async def list_clusters_tool(ctx: Context) -> list[RedshiftCluster]:
     """List all available Amazon Redshift clusters and serverless workgroups.
 
@@ -195,7 +201,10 @@ async def list_clusters_tool(ctx: Context) -> list[RedshiftCluster]:
         raise
 
 
-@mcp.tool(name='list_databases')
+@mcp.tool(
+    name='list_databases',
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
 async def list_databases_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -274,7 +283,10 @@ async def list_databases_tool(
         raise
 
 
-@mcp.tool(name='list_schemas')
+@mcp.tool(
+    name='list_schemas',
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
 async def list_schemas_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -361,7 +373,10 @@ async def list_schemas_tool(
         raise
 
 
-@mcp.tool(name='list_tables')
+@mcp.tool(
+    name='list_tables',
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
 async def list_tables_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -456,7 +471,10 @@ async def list_tables_tool(
         raise
 
 
-@mcp.tool(name='list_columns')
+@mcp.tool(
+    name='list_columns',
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
 async def list_columns_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -565,7 +583,10 @@ async def list_columns_tool(
         raise
 
 
-@mcp.tool(name='execute_query')
+@mcp.tool(
+    name='execute_query',
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
 async def execute_query_tool(
     ctx: Context,
     cluster_identifier: str = Field(

--- a/src/redshift-mcp-server/icon.svg
+++ b/src/redshift-mcp-server/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Amazon Redshift MCP Server icon">
+  <rect width="256" height="256" rx="48" fill="#232F3E"/>
+  <path d="M64 80h128c17.7 0 32 14.3 32 32v32c0 17.7-14.3 32-32 32H64c-17.7 0-32-14.3-32-32v-32c0-17.7 14.3-32 32-32z" fill="#FF9900"/>
+  <path d="M76 96h104v16H76zm0 32h80v16H76z" fill="#FFFFFF"/>
+  <path d="M80 156h96c11.1 0 20 8.9 20 20v20H60v-20c0-11.1 8.9-20 20-20z" fill="#3B48CC"/>
+</svg>

--- a/src/redshift-mcp-server/manifest.json
+++ b/src/redshift-mcp-server/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "awslabs.redshift-mcp-server",
+  "version": "0.0.27",
+  "description": "MCP server for discovering and querying Amazon Redshift clusters and serverless workgroups.",
+  "support": "https://github.com/awslabs/mcp/issues",
+  "icon": "icon.svg"
+}

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -14,6 +14,7 @@
 
 """Tests for the Redshift MCP Server tools."""
 
+import json
 import pytest
 from awslabs.redshift_mcp_server.models import (
     QueryResult,
@@ -30,8 +31,42 @@ from awslabs.redshift_mcp_server.server import (
     list_databases_tool,
     list_schemas_tool,
     list_tables_tool,
+    mcp,
 )
 from mcp.server.fastmcp import Context
+from pathlib import Path
+
+
+class TestDirectoryMetadata:
+    """Tests for MCP directory metadata and annotations."""
+
+    def test_server_tools_have_read_only_annotations(self):
+        """Read-only discovery tools should expose MCP annotations."""
+        tool_manager = mcp._tool_manager
+
+        for tool_name in [
+            'list_clusters',
+            'list_databases',
+            'list_schemas',
+            'list_tables',
+            'list_columns',
+        ]:
+            tool = tool_manager._tools[tool_name]
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True
+
+        execute_tool = tool_manager._tools['execute_query']
+        assert execute_tool.annotations is not None
+        assert execute_tool.annotations.readOnlyHint is True
+
+    def test_directory_assets_are_present(self):
+        """The server package should include the icon and support manifest metadata."""
+        package_root = Path(__file__).resolve().parents[1]
+
+        assert (package_root / 'icon.svg').exists()
+
+        manifest = json.loads((package_root / 'manifest.json').read_text(encoding='utf-8'))
+        assert manifest['support'] == 'https://github.com/awslabs/mcp/issues'
 
 
 class TestListClustersTool:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

Fixes #2484

## Summary

### Changes

This PR updates the Redshift MCP server to satisfy the MCP Directory review requirements from Issue #2484.

Changes include:
- Added `ToolAnnotations(readOnlyHint=True)` to all read-only discovery and query tools.
- Added MCP server metadata (`website_url` and `icons`) to the `FastMCP` configuration.
- Added a package `icon.svg`.
- Added a `manifest.json` with support information and icon metadata.
- Expanded the README with prompt examples and a support section.
- Added regression tests to verify tool annotations and directory metadata.

### User experience

**Before**
- MCP tools did not advertise read-only behavior.
- The server lacked MCP directory metadata.
- No prompt examples were provided in the README.
- No support metadata or package icon was included.

**After**
- MCP clients can recognize read-only tools through annotations.
- The server includes metadata required for the MCP Directory.
- Users have example prompts to get started quickly.
- The package includes support information and an icon.
- Regression tests help ensure these requirements remain satisfied.

## Checklist

- [x] I have reviewed the contributing guidelines
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? (Y/N)

N

**RFC issue number**:

N/A

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).