### PR TITLE
fix(openapi-mcp-server): DNS-pin spec fetches to prevent rebinding SSRF

### DIFF
--- a/src/openapi-mcp-server/CHANGELOG.md
+++ b/src/openapi-mcp-server/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- **Fixed DNS-rebinding TOCTOU SSRF in spec fetching** ([CWE-350](https://cwe.mitre.org/data/definitions/350.html) / [CWE-367](https://cwe.mitre.org/data/definitions/367.html)): `spec_url` was validated via DNS resolution and then re-fetched via a second, independent resolution, allowing a rebinding host to pass validation with a public IP and be fetched from an internal/metadata IP. Spec URLs are now fetched by connecting only to the IP(s) that passed validation (DNS resolved once; `Host`/SNI preserved), redirects are refused, and response bodies are capped at 10 MiB. The primary spec URL is now validated too (previously unchecked).
+
+### Changed
+- Spec URL loading is DNS-pinned end to end; the previous README note about deploying behind an egress proxy for "full DNS pinning" no longer applies.
+
 ## [1.1.0] - 2026-05-31
 
 ### Added

--- a/src/openapi-mcp-server/README.md
+++ b/src/openapi-mcp-server/README.md
@@ -329,17 +329,17 @@ The server validates all URLs in `additional_specs` entries before fetching:
 
 **Credential isolation**: Additional specs never inherit the primary API's credentials. Each entry must declare its own `auth_type`/`auth_token` or defaults to no auth.
 
+**DNS pinning (rebinding protection)**: Spec URLs are validated **and fetched against the same resolved IP** — the loader connects only to the address(es) that passed validation, never re-resolving the hostname at fetch time. This closes the DNS-rebinding TOCTOU window where a hostname could resolve to a public IP during validation and to an internal/metadata IP during the fetch. This applies to both the primary spec URL and every `additional_specs` entry. Redirects are not followed (a `30x` toward an internal host is rejected), and spec bodies are capped at 10 MiB.
+
 **Path traversal protection**: `spec_path` is canonicalized, restricted to spec file extensions (`.json`, `.yaml`, `.yml`), and checked against a best-effort system directory blocklist. For production deployments, use `--allowed-spec-dirs` to explicitly restrict allowed paths.
 
 **Escape hatches** for development/internal use:
 
 | Flag | Env Var | Effect |
 |------|---------|--------|
-| `--allow-insecure-http` | `ALLOW_INSECURE_HTTP=true` | Permits `http://` URLs |
+| `--allow-insecure-http` | `ALLOW_INSECURE_HTTP=true` | Permits `http://` URLs (still DNS-pinned) |
 | `--allow-private-networks` | `ALLOW_PRIVATE_NETWORKS=true` | Permits private/loopback IPs |
 | `--allowed-spec-dirs` | `ALLOWED_SPEC_DIRS=/path1:/path2` | Restricts `spec_path` to listed directories |
-
-> **Note**: DNS validation confirms hostnames resolve to public IPs at check time. For environments requiring full DNS pinning, deploy behind an egress proxy or use `spec_path` with local files.
 
 To report security issues, see the [Contributing Guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md#security-issue-notifications).
 

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/server.py
@@ -92,7 +92,17 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
         logger.debug(
             f'Loading OpenAPI spec from URL: {config.api_spec_url} or path: {config.api_spec_path}'
         )
-        openapi_spec = load_openapi_spec(url=config.api_spec_url, path=config.api_spec_path)
+
+        # For a URL, load_openapi_spec validates + DNS-pins internally: it
+        # resolves once and fetches by connecting only to that pinned IP, so
+        # there is no un-pinned fetch path for the primary spec either. Pass the
+        # SSRF flags through so the operator's --allow-* opt-ins are honored.
+        openapi_spec = load_openapi_spec(
+            url=config.api_spec_url,
+            path=config.api_spec_path,
+            allow_http=config.allow_insecure_http,
+            allow_private_networks=config.allow_private_networks,
+        )
 
         # Validate the OpenAPI spec
         if not validate_openapi_spec(openapi_spec):
@@ -300,9 +310,12 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
                     spec_url = entry.get('spec_url', '')
                     spec_path = entry.get('spec_path', '')
 
+                    # Capture the validated result so the fetch connects to the
+                    # pinned IP(s) — never re-resolving the hostname at fetch time.
+                    spec_validated_url = None
                     if spec_url:
                         try:
-                            await validate_url_for_spec(
+                            spec_validated_url = await validate_url_for_spec(
                                 spec_url,
                                 allow_http=config.allow_insecure_http,
                                 allow_private_networks=config.allow_private_networks,
@@ -326,7 +339,13 @@ async def create_mcp_server_async(config: Config) -> FastMCP:
 
                     logger.info(f'Loading additional spec: {extra_name}')
                     try:
-                        extra_spec = load_openapi_spec(url=spec_url, path=spec_path)
+                        # Load using the pinned IPs from validation (no re-resolution).
+                        extra_spec = load_openapi_spec(
+                            validated_url=spec_validated_url,
+                            path=spec_path,
+                            allow_http=config.allow_insecure_http,
+                            allow_private_networks=config.allow_private_networks,
+                        )
                     except Exception as e:
                         logger.warning(f'Failed to load additional spec {extra_name}: {e}')
                         continue

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -285,9 +285,6 @@ def load_openapi_spec(
         httpx.TimeoutException: If there's a timeout when fetching the spec
 
     """
-    # Existing branch logic should return a parsed spec dict or raise.
-    # Keep this explicit terminal raise to avoid implicit None fall-through.
-    raise ValueError('Either url/validated_url or path must be provided')
     if not url and not path and validated_url is None:
         logger.error('Neither URL/validated_url nor path provided')
         raise ValueError('Either url/validated_url or path must be provided')
@@ -406,3 +403,7 @@ def load_openapi_spec(
         except Exception as e:
             logger.error(f'Failed to load OpenAPI spec from file: {path} - Error: {e}')
             raise
+
+    # All real branches above return or raise; this terminal raise only guards
+    # against an implicit None fall-through (satisfies the no-fall-through linter).
+    raise ValueError('Either url/validated_url or path must be provided')

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -193,7 +193,11 @@ def _pinned_fetch(
                                     f'Spec too large: {content_length} bytes (max {max_size})'
                                 )
                         except ValueError:
-                            pass
+                            # Ignore malformed Content-Length; enforce max_size while streaming below.
+                            logger.debug(
+                                'Ignoring invalid Content-Length header value: %s',
+                                content_length,
+                            )
 
                     # ...and enforce the cap while streaming regardless.
                     chunks = []

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -281,6 +281,9 @@ def load_openapi_spec(
         httpx.TimeoutException: If there's a timeout when fetching the spec
 
     """
+    # Existing branch logic should return a parsed spec dict or raise.
+    # Keep this explicit terminal raise to avoid implicit None fall-through.
+    raise ValueError('Either url/validated_url or path must be provided')
     if not url and not path and validated_url is None:
         logger.error('Neither URL/validated_url nor path provided')
         raise ValueError('Either url/validated_url or path must be provided')

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/utils/openapi.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utilities for working with OpenAPI specifications."""
 
+import asyncio
 import httpx
 import json
 import tempfile
@@ -20,8 +21,21 @@ import time
 from awslabs.openapi_mcp_server import logger
 from awslabs.openapi_mcp_server.utils.cache_provider import cached
 from awslabs.openapi_mcp_server.utils.openapi_validator import validate_openapi_spec
+from fastmcp.server.auth.ssrf import (
+    SSRFError,
+    SSRFFetchError,
+    ValidatedURL,
+    format_ip_for_url,
+)
 from pathlib import Path
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+
+# Upper bound on a fetched spec body. The old loader read response bodies
+# unbounded; a 10 MiB cap comfortably fits real-world OpenAPI documents while
+# preventing a hostile endpoint from exhausting memory.
+MAX_SPEC_BYTES = 10 * 1024 * 1024
 
 
 def extract_api_name_from_spec(spec: Dict[str, Any]) -> Optional[str]:
@@ -63,66 +77,233 @@ except ImportError:
     logger.warning('Prance library not found. Reference resolution will be limited.')
 
 
-@cached(ttl_seconds=3600)  # Cache OpenAPI specs for 1 hour
-def load_openapi_spec(url: str = '', path: str = '') -> Dict[str, Any]:
-    """Load an OpenAPI specification from a URL or file path.
+def _validate_url_sync(
+    url: str,
+    *,
+    allow_http: bool,
+    allow_private_networks: bool,
+) -> ValidatedURL:
+    """Validate + DNS-pin a spec URL from synchronous code.
 
-    If prance is available, it will be used to resolve references in the OpenAPI spec.
-    Otherwise, falls back to basic JSON/YAML parsing.
+    ``validate_url_for_spec`` is async, but ``load_openapi_spec`` is synchronous
+    and may be invoked either from a plain sync context or from within an
+    already-running event loop (e.g. ``create_mcp_server_async``). Calling
+    ``asyncio.run`` inside a running loop raises ``RuntimeError``; when a loop is
+    already running we drive the coroutine to completion on a short-lived worker
+    thread instead of touching the live loop.
+    """
+    # Imported lazily to avoid a module import cycle at load time.
+    from awslabs.openapi_mcp_server.utils.url_validator import validate_url_for_spec
+
+    async def _run() -> ValidatedURL:
+        return await validate_url_for_spec(
+            url,
+            allow_http=allow_http,
+            allow_private_networks=allow_private_networks,
+        )
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop in this thread: safe to drive one directly.
+        return asyncio.run(_run())
+
+    # A loop is already running here; run the coroutine on a separate thread.
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(_run())).result()
+
+
+def _pinned_fetch(
+    validated_url: ValidatedURL,
+    *,
+    allow_http: bool,
+    max_size: int = MAX_SPEC_BYTES,
+    timeout: float = 10.0,
+) -> bytes:
+    """Fetch a spec body, connecting ONLY to the IPs validation already pinned.
+
+    This mirrors fastmcp's ``ssrf_safe_fetch`` but consumes the resolved IPs from
+    ``validated_url`` rather than re-resolving DNS (so there is no second,
+    unchecked ``getaddrinfo`` that a rebinding server could exploit). It also
+    supports http:// when the operator explicitly opted in, and caps the body at
+    a spec-appropriate size. Redirects are disabled and rejected explicitly.
 
     Args:
-        url: URL to the OpenAPI specification
-        path: Path to the OpenAPI specification file
+        validated_url: The result of SSRF validation, carrying pinned IPs.
+        allow_http: Whether http:// is permitted (mirrors the validation flag).
+        max_size: Maximum accepted response body size in bytes.
+        timeout: Per-operation timeout in seconds.
+
+    Returns:
+        The raw response body as bytes.
+
+    Raises:
+        SSRFError: If the scheme is disallowed.
+        SSRFFetchError: On redirect, oversized body, or exhausted pinned IPs.
+        httpx.HTTPError: On transient network/HTTP errors (retryable upstream).
+
+    """
+    scheme = urlparse(validated_url.original_url).scheme or 'https'
+    if scheme not in ('https', 'http'):
+        raise SSRFError(f"URL scheme '{scheme}' not allowed")
+    if scheme == 'http' and not allow_http:
+        # Defensive: validation should already have rejected this.
+        raise SSRFError('http:// URL requires allow_insecure_http')
+
+    last_error: Optional[Exception] = None
+    for pinned_ip in validated_url.resolved_ips:
+        pinned_url = (
+            f'{scheme}://{format_ip_for_url(pinned_ip)}:{validated_url.port}{validated_url.path}'
+        )
+        # Keep Host + (for TLS) SNI bound to the validated hostname while we dial
+        # the pinned IP directly, so vhost routing and certificate validation
+        # still work against the real host.
+        headers = {'Host': validated_url.hostname}
+        extensions = {'sni_hostname': validated_url.hostname} if scheme == 'https' else {}
+
+        logger.debug(
+            f'Fetching spec {validated_url.original_url} pinned to {pinned_ip} ({pinned_url})'
+        )
+        try:
+            with httpx.Client(
+                timeout=httpx.Timeout(timeout),
+                follow_redirects=False,
+                verify=True,
+            ) as client:
+                with client.stream(
+                    'GET', pinned_url, headers=headers, extensions=extensions
+                ) as response:
+                    # Following a 30x is a classic SSRF bypass (redirect to an
+                    # internal host); reject rather than follow.
+                    if 300 <= response.status_code < 400:
+                        raise SSRFFetchError(
+                            f'Refusing to follow redirect (HTTP {response.status_code}) '
+                            f'for {validated_url.original_url}'
+                        )
+                    response.raise_for_status()
+
+                    # Reject oversized bodies up front when advertised...
+                    content_length = response.headers.get('content-length')
+                    if content_length:
+                        try:
+                            if int(content_length) > max_size:
+                                raise SSRFFetchError(
+                                    f'Spec too large: {content_length} bytes (max {max_size})'
+                                )
+                        except ValueError:
+                            pass
+
+                    # ...and enforce the cap while streaming regardless.
+                    chunks = []
+                    total = 0
+                    for chunk in response.iter_bytes():
+                        total += len(chunk)
+                        if total > max_size:
+                            raise SSRFFetchError(f'Spec too large: exceeded {max_size} bytes')
+                        chunks.append(chunk)
+                    return b''.join(chunks)
+        except (httpx.TimeoutException, httpx.TransportError) as e:
+            # Transient / per-IP connection error: try the next pinned IP.
+            last_error = e
+            continue
+
+    if last_error is not None:
+        raise last_error
+    raise SSRFFetchError(f'No resolved IPs available for {validated_url.original_url}')
+
+
+def _parse_spec_bytes(content: bytes) -> Dict[str, Any]:
+    """Parse fetched spec bytes into a dict.
+
+    Uses prance for ``$ref`` resolution when available, falling back to basic
+    JSON (then YAML) parsing.
+    """
+    if PRANCE_AVAILABLE:
+        logger.info('Using prance for reference resolution')
+        with tempfile.NamedTemporaryFile(suffix='.yaml', delete=False) as temp_file:
+            temp_path = temp_file.name
+            temp_file.write(content)
+        try:
+            parser = ResolvingParser(temp_path)
+            spec = parser.specification
+            Path(temp_path).unlink(missing_ok=True)
+            return spec
+        except Exception as e:
+            logger.warning(f'Failed to parse with prance: {e}. Falling back to basic parsing.')
+            Path(temp_path).unlink(missing_ok=True)
+
+    # Basic parsing without reference resolution: JSON first, then YAML.
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        if yaml is None:
+            raise
+        return yaml.safe_load(content)
+
+
+@cached(ttl_seconds=3600)  # Cache OpenAPI specs for 1 hour
+def load_openapi_spec(
+    url: str = '',
+    path: str = '',
+    validated_url: Optional[ValidatedURL] = None,
+    allow_http: bool = False,
+    allow_private_networks: bool = False,
+) -> Dict[str, Any]:
+    """Load an OpenAPI specification from a URL or file path.
+
+    URL fetches are always DNS-pinned: the spec is retrieved by connecting only
+    to the IP address(es) that SSRF validation approved, never by re-resolving
+    the hostname at fetch time. Callers that have already validated a URL should
+    pass the resulting ``validated_url``; a bare ``url`` is validated and pinned
+    in-function so there is no code path that fetches a spec un-pinned.
+
+    If prance is available, it will be used to resolve references in the OpenAPI
+    spec. Otherwise, falls back to basic JSON/YAML parsing.
+
+    Args:
+        url: URL to the OpenAPI specification (validated + pinned in-function).
+        path: Path to the OpenAPI specification file.
+        validated_url: A pre-validated, DNS-pinned URL from ``validate_url_for_spec``.
+        allow_http: Permit http:// when validating a bare ``url``.
+        allow_private_networks: Permit private/loopback IPs when validating a bare ``url``.
 
     Returns:
         Dict[str, Any]: The parsed OpenAPI specification
 
     Raises:
-        ValueError: If neither url nor path are provided
+        ValueError: If neither url/validated_url nor path are provided
+        SSRFError: If a bare url fails security validation
+        SSRFFetchError: If the pinned fetch is unsafe (redirect, oversized, etc.)
         FileNotFoundError: If the file at path does not exist
         httpx.HTTPError: If there's an HTTP error when fetching the spec
         httpx.TimeoutException: If there's a timeout when fetching the spec
 
     """
-    if not url and not path:
-        logger.error('Neither URL nor path provided')
-        raise ValueError('Either url or path must be provided')
+    if not url and not path and validated_url is None:
+        logger.error('Neither URL/validated_url nor path provided')
+        raise ValueError('Either url/validated_url or path must be provided')
 
-    # Load from URL
-    if url:
-        logger.info(f'Fetching OpenAPI spec from URL: {url}')
+    # Load from URL (DNS-pinned; no re-resolution at fetch time)
+    if validated_url is not None or url:
+        # If only a raw url was given, validate + pin here so there is NO code
+        # path that fetches a spec without SSRF-safe DNS pinning.
+        if validated_url is None:
+            validated_url = _validate_url_sync(
+                url,
+                allow_http=allow_http,
+                allow_private_networks=allow_private_networks,
+            )
+
+        logger.info(f'Fetching OpenAPI spec from URL: {validated_url.original_url}')
         last_exception = None
 
         # Use retry logic for network resilience
         for attempt in range(3):
             try:
-                response = httpx.get(url, timeout=10.0)
-                response.raise_for_status()
-
-                if PRANCE_AVAILABLE:
-                    logger.info('Using prance for reference resolution')
-                    # Use prance for reference resolution if available
-                    with tempfile.NamedTemporaryFile(suffix='.yaml', delete=False) as temp_file:
-                        temp_path = temp_file.name
-                        temp_file.write(response.content)
-
-                    try:
-                        parser = ResolvingParser(temp_path)
-                        spec = parser.specification
-
-                        # Clean up the temporary file
-                        Path(temp_path).unlink(missing_ok=True)
-                    except Exception as e:
-                        logger.warning(
-                            f'Failed to parse with prance: {e}. Falling back to basic parsing.'
-                        )
-                        # Clean up the temporary file
-                        Path(temp_path).unlink(missing_ok=True)
-                        # Fall back to basic parsing
-                        spec = response.json()
-                else:
-                    # Basic parsing without reference resolution
-                    spec = response.json()
+                content = _pinned_fetch(validated_url, allow_http=allow_http)
+                spec = _parse_spec_bytes(content)
 
                 # Validate the spec
                 if validate_openapi_spec(spec):
@@ -131,6 +312,9 @@ def load_openapi_spec(url: str = '', path: str = '') -> Dict[str, Any]:
                     logger.error('Invalid OpenAPI specification')
                     raise ValueError('Invalid OpenAPI specification')
 
+            except (SSRFError, SSRFFetchError):
+                # Security failures must not be retried away.
+                raise
             except (httpx.TimeoutException, httpx.HTTPError) as e:
                 last_exception = e
                 if attempt < 2:  # Don't log on the last attempt

--- a/src/openapi-mcp-server/tests/test_new_features.py
+++ b/src/openapi-mcp-server/tests/test_new_features.py
@@ -120,7 +120,8 @@ async def _create_server(config, spec=None, extra_spec=None):
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if extra_spec and url != config.api_spec_url:
                 return extra_spec
             return spec
@@ -472,7 +473,8 @@ async def test_additional_specs_load_failure_skipped():
         patch('awslabs.openapi_mcp_server.server.HttpClientFactory.create_client') as mock_client,
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if url == 'http://x':
                 raise ValueError('bad spec')
             return PETSTORE_SPEC
@@ -533,7 +535,8 @@ async def test_additional_specs_validation_failure_continues():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             return PETSTORE_SPEC if url != 'https://payments.example.com/spec' else EXTRA_SPEC
 
         def validate_side_effect(spec):

--- a/src/openapi-mcp-server/tests/test_server.py
+++ b/src/openapi-mcp-server/tests/test_server.py
@@ -71,7 +71,10 @@ def test_create_mcp_server_basic(
     assert result == mock_server
     mock_fastmcp.assert_called_once()
     mock_load_spec.assert_called_once_with(
-        url=mock_config.api_spec_url, path=mock_config.api_spec_path
+        url=mock_config.api_spec_url,
+        path=mock_config.api_spec_path,
+        allow_http=mock_config.allow_insecure_http,
+        allow_private_networks=mock_config.allow_private_networks,
     )
     mock_validate.assert_called_once()
     mock_create_client.assert_called_once()

--- a/src/openapi-mcp-server/tests/test_server_part1.py
+++ b/src/openapi-mcp-server/tests/test_server_part1.py
@@ -71,7 +71,10 @@ def test_create_mcp_server_basic(
     assert result == mock_server
     mock_fastmcp.assert_called_once()
     mock_load_spec.assert_called_once_with(
-        url=mock_config.api_spec_url, path=mock_config.api_spec_path
+        url=mock_config.api_spec_url,
+        path=mock_config.api_spec_path,
+        allow_http=mock_config.allow_insecure_http,
+        allow_private_networks=mock_config.allow_private_networks,
     )
     mock_validate.assert_called_once()
     mock_create_client.assert_called_once()

--- a/src/openapi-mcp-server/tests/test_ssrf_protection.py
+++ b/src/openapi-mcp-server/tests/test_ssrf_protection.py
@@ -940,3 +940,138 @@ def test_load_openapi_spec_bare_url_is_validated_and_blocks_private():
     ):
         with pytest.raises(SSRFError, match='blocked IP'):
             load_openapi_spec(url='https://internal-primary.example.com/openapi.json')
+
+
+def test_pinned_fetch_rejects_disallowed_scheme():
+    """A non-http(s) scheme on the validated URL is rejected."""
+    vurl = _validated(original_url='ftp://spec.example.com/openapi.json')
+    with pytest.raises(SSRFError, match='not allowed'):
+        _pinned_fetch(vurl, allow_http=False)
+
+
+def test_pinned_fetch_tries_next_ip_on_transient_error():
+    """A transient error on the first pinned IP falls through to the next."""
+    capture = {}
+    good = _FakeStreamResponse(chunks=(b'{"ok": true}',))
+
+    class _FlakyClient:
+        _calls = {'n': 0}
+
+        def __init__(self, *args, **kwargs):
+            capture['client_kwargs'] = kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def stream(self, method, url, headers=None, extensions=None):
+            capture.setdefault('urls', []).append(url)
+            type(self)._calls['n'] += 1
+            if type(self)._calls['n'] == 1:
+                raise httpx.ConnectError('connection refused')
+            return good
+
+    vurl = _validated(resolved_ips=['93.184.216.34', '198.51.100.7'])
+    with patch('httpx.Client', _FlakyClient):
+        body = _pinned_fetch(vurl, allow_http=False)
+
+    assert body == b'{"ok": true}'
+    # Both pinned IPs were attempted, in order.
+    assert capture['urls'] == [
+        'https://93.184.216.34:443/openapi.json',
+        'https://198.51.100.7:443/openapi.json',
+    ]
+
+
+def test_pinned_fetch_raises_last_error_when_all_ips_fail():
+    """When every pinned IP errors transiently, the last error is raised."""
+
+    class _AlwaysFailClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def stream(self, *args, **kwargs):
+            raise httpx.ConnectError('down')
+
+    vurl = _validated(resolved_ips=['93.184.216.34', '198.51.100.7'])
+    with patch('httpx.Client', _AlwaysFailClient):
+        with pytest.raises(httpx.ConnectError, match='down'):
+            _pinned_fetch(vurl, allow_http=False)
+
+
+def test_pinned_fetch_no_resolved_ips():
+    """A ValidatedURL with no IPs surfaces a clear SSRFFetchError."""
+    vurl = _validated(resolved_ips=[])
+    with pytest.raises(SSRFFetchError, match='No resolved IPs'):
+        _pinned_fetch(vurl, allow_http=False)
+
+
+def test_validate_url_sync_bridges_from_running_loop():
+    """_validate_url_sync works when called from inside a running event loop.
+
+    load_openapi_spec is synchronous but is invoked from create_mcp_server_async;
+    the async validator must be driven without touching the live loop.
+    """
+    from awslabs.openapi_mcp_server.utils.openapi import _validate_url_sync
+
+    async def _drive():
+        # Calling the sync helper from within this running loop must not raise
+        # "asyncio.run() cannot be called from a running event loop".
+        return _validate_url_sync(
+            'https://spec.example.com/openapi.json',
+            allow_http=False,
+            allow_private_networks=False,
+        )
+
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    ):
+        import asyncio
+
+        result = asyncio.run(_drive())
+
+    assert result.hostname == 'spec.example.com'
+    assert result.resolved_ips == ['93.184.216.34']
+
+
+def test_load_openapi_spec_does_not_retry_ssrf_failures():
+    """An SSRFFetchError from the fetch is raised immediately, not retried away."""
+    with (
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            return_value=['93.184.216.34'],
+        ),
+        patch(
+            'awslabs.openapi_mcp_server.utils.openapi._pinned_fetch',
+            side_effect=SSRFFetchError('redirect refused'),
+        ) as mock_fetch,
+    ):
+        with pytest.raises(SSRFFetchError, match='redirect refused'):
+            load_openapi_spec(url='https://no-retry.example.com/openapi.json')
+
+    # Exactly one attempt — security failures must not be retried.
+    assert mock_fetch.call_count == 1
+
+
+def test_pinned_fetch_http_opt_in_uses_no_sni():
+    """An opted-in http:// fetch dials the pinned IP with no TLS SNI extension."""
+    capture = {}
+    response = _FakeStreamResponse(chunks=(b'{}',))
+    vurl = _validated(original_url='http://spec.example.com/openapi.json', port=80)
+    with patch('httpx.Client', _make_fake_client(capture, response)):
+        _pinned_fetch(vurl, allow_http=True)
+
+    req = capture['requests'][0]
+    assert req['url'] == 'http://93.184.216.34:80/openapi.json'
+    assert req['headers']['Host'] == 'spec.example.com'
+    # No SNI extension for plaintext http.
+    assert req['extensions'] == {}

--- a/src/openapi-mcp-server/tests/test_ssrf_protection.py
+++ b/src/openapi-mcp-server/tests/test_ssrf_protection.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 """Tests for SSRF protection in multi-spec configuration."""
 
+import httpx
 import json
 import pytest
 from awslabs.openapi_mcp_server.api.config import Config
 from awslabs.openapi_mcp_server.server import create_mcp_server_async
+from awslabs.openapi_mcp_server.utils.openapi import _pinned_fetch, load_openapi_spec
 from awslabs.openapi_mcp_server.utils.url_validator import (
     validate_spec_path,
     validate_url_for_spec,
 )
-from fastmcp.server.auth.ssrf import SSRFError
+from fastmcp.server.auth.ssrf import SSRFError, SSRFFetchError, ValidatedURL
 from unittest.mock import MagicMock, patch
 
 
@@ -286,7 +288,8 @@ async def test_additional_specs_do_not_inherit_primary_auth():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'partner' in url:
                 return EXTRA_SPEC
             return PETSTORE_SPEC
@@ -337,7 +340,8 @@ async def test_additional_specs_per_entry_auth():
         patch('awslabs.openapi_mcp_server.auth.register.register_provider_by_type'),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'partner' in url:
                 return EXTRA_SPEC
             return PETSTORE_SPEC
@@ -520,7 +524,8 @@ async def test_additional_spec_load_failure_is_skipped():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'broken' in url:
                 raise RuntimeError('Connection refused')
             return PETSTORE_SPEC
@@ -600,7 +605,8 @@ async def test_additional_spec_api_key_query_warns():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'partner' in url:
                 return EXTRA_SPEC
             return PETSTORE_SPEC
@@ -644,7 +650,8 @@ async def test_additional_spec_api_key_cookie_is_passed():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'partner' in url:
                 return EXTRA_SPEC
             return PETSTORE_SPEC
@@ -686,7 +693,8 @@ async def test_additional_spec_basic_auth():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'partner' in url:
                 return EXTRA_SPEC
             return PETSTORE_SPEC
@@ -728,7 +736,8 @@ async def test_additional_spec_unrecognized_auth_type_warns():
         ),
     ):
 
-        def load_side_effect(url='', path=''):
+        def load_side_effect(url='', path='', validated_url=None, **kwargs):
+            url = url or (validated_url.original_url if validated_url else '')
             if 'partner' in url:
                 return EXTRA_SPEC
             return PETSTORE_SPEC
@@ -746,3 +755,188 @@ async def test_additional_spec_unrecognized_auth_type_warns():
         extra_kwargs = extra_call.kwargs if extra_call.kwargs else {}
         assert extra_kwargs.get('auth') is None
         assert not (extra_kwargs.get('headers') or {})
+
+
+# --- DNS-pinned fetch: rebinding / redirect / size cap ---
+#
+# These directly exercise the TOCTOU SSRF fix: the spec is fetched by connecting
+# ONLY to the IP(s) validation pinned, so a hostname that rebinds between the
+# validation lookup and the fetch can never steer the connection.
+
+
+class _FakeStreamResponse:
+    """Minimal stand-in for an httpx streaming response."""
+
+    def __init__(self, status_code=200, headers=None, chunks=(b'{}',)):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError('error', request=None, response=None)
+
+    def iter_bytes(self):
+        yield from self._chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _make_fake_client(capture, response):
+    """Build a fake httpx.Client class that records the URL it was asked to dial."""
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            capture['client_kwargs'] = kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def stream(self, method, url, headers=None, extensions=None):
+            capture.setdefault('requests', []).append(
+                {'method': method, 'url': url, 'headers': headers, 'extensions': extensions}
+            )
+            return response
+
+    return _FakeClient
+
+
+def _validated(**overrides):
+    defaults = {
+        'original_url': 'https://spec.example.com/openapi.json',
+        'hostname': 'spec.example.com',
+        'port': 443,
+        'path': '/openapi.json',
+        'resolved_ips': ['93.184.216.34'],
+    }
+    defaults.update(overrides)
+    return ValidatedURL(**defaults)
+
+
+def test_pinned_fetch_connects_to_pinned_ip_with_host_and_sni():
+    """The fetch dials the pinned IP literal, keeping Host + SNI = validated host."""
+    capture = {}
+    response = _FakeStreamResponse(chunks=(b'{"ok": true}',))
+    with patch('httpx.Client', _make_fake_client(capture, response)):
+        body = _pinned_fetch(_validated(), allow_http=False)
+
+    assert body == b'{"ok": true}'
+    req = capture['requests'][0]
+    # Connection target is the pinned IP literal, not the hostname.
+    assert req['url'] == 'https://93.184.216.34:443/openapi.json'
+    assert req['headers']['Host'] == 'spec.example.com'
+    assert req['extensions']['sni_hostname'] == 'spec.example.com'
+    # Redirects are disabled on the client.
+    assert capture['client_kwargs'].get('follow_redirects') is False
+
+
+def test_pinned_fetch_refuses_redirect_to_metadata():
+    """A 302 toward the metadata IP is rejected, not followed (redirect bypass)."""
+    capture = {}
+    response = _FakeStreamResponse(
+        status_code=302, headers={'location': 'http://169.254.169.254/latest/meta-data/'}
+    )
+    with patch('httpx.Client', _make_fake_client(capture, response)):
+        with pytest.raises(SSRFFetchError, match='redirect'):
+            _pinned_fetch(_validated(), allow_http=False)
+
+    # We only ever dialed the pinned public IP; the redirect target was never used.
+    assert capture['requests'][0]['url'] == 'https://93.184.216.34:443/openapi.json'
+
+
+def test_pinned_fetch_rejects_oversized_body_streaming():
+    """A body exceeding the size cap is rejected while streaming."""
+    capture = {}
+    response = _FakeStreamResponse(chunks=(b'x' * 50, b'y' * 50))
+    with patch('httpx.Client', _make_fake_client(capture, response)):
+        with pytest.raises(SSRFFetchError, match='too large'):
+            _pinned_fetch(_validated(), allow_http=False, max_size=10)
+
+
+def test_pinned_fetch_rejects_oversized_body_content_length():
+    """A body advertising an oversized Content-Length is rejected up front."""
+    capture = {}
+    response = _FakeStreamResponse(headers={'content-length': '999999'}, chunks=(b'{}',))
+    with patch('httpx.Client', _make_fake_client(capture, response)):
+        with pytest.raises(SSRFFetchError, match='too large'):
+            _pinned_fetch(_validated(), allow_http=False, max_size=10)
+
+
+def test_pinned_fetch_http_requires_opt_in():
+    """An http:// pinned URL is refused unless allow_http is set."""
+    vurl = _validated(original_url='http://spec.example.com/openapi.json', port=80)
+    with pytest.raises(SSRFError, match='allow_insecure_http'):
+        _pinned_fetch(vurl, allow_http=False)
+
+
+@pytest.mark.asyncio
+async def test_validate_url_rejects_mixed_public_and_private_ips():
+    """A hostname resolving to a mix of public + private IPs is rejected at validation."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34', '169.254.169.254'],
+    ):
+        with pytest.raises(SSRFError, match='blocked IP'):
+            await validate_url_for_spec('https://rebind.example.com/spec.json')
+
+
+def test_load_openapi_spec_rebinding_never_hits_metadata_ip():
+    """Rebinding PoC: validation resolves once to a public IP; the fetch is pinned to it.
+
+    Simulates an authoritative DNS that would answer 93.184.216.34 first (passing
+    the SSRF check) and 169.254.169.254 on any later lookup. Because the fetch
+    connects to the IP validation pinned — and never re-resolves — the metadata
+    IP is unreachable, and DNS is queried exactly once.
+    """
+    resolve_calls = {'n': 0}
+
+    def rebinding_resolve(hostname, port=443):
+        resolve_calls['n'] += 1
+        # First answer public (passes), any subsequent answer is the metadata IP.
+        return ['93.184.216.34'] if resolve_calls['n'] == 1 else ['169.254.169.254']
+
+    capture = {}
+    response = _FakeStreamResponse(chunks=(b'{"openapi": "3.0.0"}',))
+
+    with (
+        patch(
+            'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+            side_effect=rebinding_resolve,
+        ),
+        patch('httpx.Client', _make_fake_client(capture, response)),
+        patch(
+            'awslabs.openapi_mcp_server.utils.openapi._parse_spec_bytes',
+            return_value=PETSTORE_SPEC,
+        ),
+        patch(
+            'awslabs.openapi_mcp_server.utils.openapi.validate_openapi_spec',
+            return_value=True,
+        ),
+    ):
+        # Unique host avoids the 1-hour spec cache colliding with other tests.
+        spec = load_openapi_spec(url='https://rebind-poc.example.com/openapi.json')
+
+    assert spec == PETSTORE_SPEC
+    # DNS was resolved exactly once — the single source of truth for the target.
+    assert resolve_calls['n'] == 1
+    # Every connection went to the pinned public IP; the metadata IP was never dialed.
+    dialed = [r['url'] for r in capture['requests']]
+    assert dialed == ['https://93.184.216.34:443/openapi.json']
+    assert all('169.254.169.254' not in url for url in dialed)
+
+
+def test_load_openapi_spec_bare_url_is_validated_and_blocks_private():
+    """The primary-spec path (bare url) is now validated: a private IP is blocked."""
+    with patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['10.0.0.5'],
+    ):
+        with pytest.raises(SSRFError, match='blocked IP'):
+            load_openapi_spec(url='https://internal-primary.example.com/openapi.json')

--- a/src/openapi-mcp-server/tests/test_ssrf_protection.py
+++ b/src/openapi-mcp-server/tests/test_ssrf_protection.py
@@ -1043,6 +1043,45 @@ def test_validate_url_sync_bridges_from_running_loop():
     assert result.resolved_ips == ['93.184.216.34']
 
 
+def test_parse_spec_bytes_uses_prance_when_available():
+    """When prance is available, its resolved specification is returned."""
+    from awslabs.openapi_mcp_server.utils import openapi as openapi_mod
+
+    resolved = {'openapi': '3.0.0', 'info': {'title': 'Resolved', 'version': '1'}}
+    with (
+        patch.object(openapi_mod, 'PRANCE_AVAILABLE', True),
+        patch.object(openapi_mod, 'ResolvingParser') as mock_parser,
+    ):
+        mock_parser.return_value.specification = resolved
+        result = openapi_mod._parse_spec_bytes(b'{"openapi": "3.0.0"}')
+
+    assert result == resolved
+
+
+def test_parse_spec_bytes_falls_back_to_json_when_prance_fails():
+    """A prance failure falls back to basic JSON parsing."""
+    from awslabs.openapi_mcp_server.utils import openapi as openapi_mod
+
+    with (
+        patch.object(openapi_mod, 'PRANCE_AVAILABLE', True),
+        patch.object(openapi_mod, 'ResolvingParser', side_effect=Exception('prance boom')),
+    ):
+        result = openapi_mod._parse_spec_bytes(b'{"openapi": "3.0.0", "x": 1}')
+
+    assert result == {'openapi': '3.0.0', 'x': 1}
+
+
+def test_parse_spec_bytes_falls_back_to_yaml_when_not_json():
+    """Non-JSON content is parsed as YAML."""
+    from awslabs.openapi_mcp_server.utils import openapi as openapi_mod
+
+    yaml_body = b'openapi: "3.0.0"\ninfo:\n  title: YAML API\n  version: "1"\n'
+    with patch.object(openapi_mod, 'PRANCE_AVAILABLE', False):
+        result = openapi_mod._parse_spec_bytes(yaml_body)
+
+    assert result['info']['title'] == 'YAML API'
+
+
 def test_load_openapi_spec_does_not_retry_ssrf_failures():
     """An SSRFFetchError from the fetch is raised immediately, not retried away."""
     with (

--- a/src/openapi-mcp-server/tests/utils/test_openapi.py
+++ b/src/openapi-mcp-server/tests/utils/test_openapi.py
@@ -141,9 +141,11 @@ class TestOpenAPIUtils:
     @patch('json.loads', return_value={'openapi': '3.0.0'})
     def test_path_invalid_validation(self, mock_json, mock_file, mock_exists):
         """Test invalid OpenAPI spec from file."""
-        # Override the validation function to return False
+        # Override the validation function to return False. Patch the name in the
+        # module where it is used (openapi.py binds it at import time), not where
+        # it is defined, or the mock never takes effect.
         with patch(
-            'awslabs.openapi_mcp_server.utils.openapi_validator.validate_openapi_spec',
+            'awslabs.openapi_mcp_server.utils.openapi.validate_openapi_spec',
             return_value=False,
         ):
             with pytest.raises(ValueError, match='Invalid OpenAPI specification'):

--- a/src/openapi-mcp-server/tests/utils/test_openapi.py
+++ b/src/openapi-mcp-server/tests/utils/test_openapi.py
@@ -56,40 +56,48 @@ class TestOpenAPIUtils:
 
     def test_no_args(self):
         """Test that the function raises ValueError when no arguments are provided."""
-        with pytest.raises(ValueError, match='Either url or path must be provided'):
+        with pytest.raises(ValueError, match='Either url/validated_url or path must be provided'):
             load_openapi_spec()
 
-    @patch('httpx.get')
-    def test_url_http_error(self, mock_get):
-        """Test HTTP error handling."""
-        # Create mock response that raises HTTPError
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = httpx.HTTPError('HTTP Error')
-        mock_get.return_value = mock_response
+    @patch('awslabs.openapi_mcp_server.utils.openapi.time.sleep')
+    @patch('awslabs.openapi_mcp_server.utils.openapi._pinned_fetch')
+    @patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    )
+    def test_url_http_error(self, mock_resolve, mock_fetch, mock_sleep):
+        """Test HTTP error handling on the DNS-pinned fetch path."""
+        # The pinned fetch raises HTTPError; validation resolves to a public IP.
+        mock_fetch.side_effect = httpx.HTTPError('HTTP Error')
 
         # Test the exception is propagated correctly
         with pytest.raises(httpx.HTTPError, match='HTTP Error'):
             load_openapi_spec(url='https://example.com/api.json')
 
-    @patch('httpx.get')
-    def test_url_timeout(self, mock_get):
-        """Test timeout exception handling."""
+    @patch('awslabs.openapi_mcp_server.utils.openapi.time.sleep')
+    @patch('awslabs.openapi_mcp_server.utils.openapi._pinned_fetch')
+    @patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    )
+    def test_url_timeout(self, mock_resolve, mock_fetch, mock_sleep):
+        """Test timeout exception handling on the DNS-pinned fetch path."""
         # Setup the mock to raise TimeoutException
-        mock_get.side_effect = httpx.TimeoutException('Timeout Error')
+        mock_fetch.side_effect = httpx.TimeoutException('Timeout Error')
 
         # Test the exception is propagated correctly
         with pytest.raises(httpx.TimeoutException, match='Timeout Error'):
             load_openapi_spec(url='https://example.com/api.json')
 
-    @patch('httpx.get')
-    def test_url_invalid_spec(self, mock_get):
+    @patch('awslabs.openapi_mcp_server.utils.openapi._pinned_fetch')
+    @patch(
+        'awslabs.openapi_mcp_server.utils.url_validator.resolve_hostname',
+        return_value=['93.184.216.34'],
+    )
+    def test_url_invalid_spec(self, mock_resolve, mock_fetch):
         """Test invalid OpenAPI spec validation."""
-        # Setup mock response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.content = b'{"invalid": "spec"}'  # Return bytes content
-        mock_response.json.return_value = {'invalid': 'spec'}
-        mock_get.return_value = mock_response
+        # The fetch returns a well-formed but non-OpenAPI body.
+        mock_fetch.return_value = b'{"invalid": "spec"}'
 
         # Mock the validate_openapi_spec function directly
         with patch(


### PR DESCRIPTION
Fixes

## Summary

Closes a DNS-rebinding TOCTOU SSRF in the `openapi-mcp-server` spec loader (CWE-350 / CWE-367 / CWE-918).

### Changes

The multi-spec (`additional_specs`) path validated `spec_url` via `validate_url_for_spec()` and then **discarded** the result, re-fetching with `httpx.get(url)` — a *second, fresh* DNS resolution. A rebinding authoritative DNS can answer a public IP during validation (passing the SSRF check) and `169.254.169.254` (or any internal IP) at fetch time. The **primary** spec URL was not SSRF-validated at all.

The fix fetches the spec by connecting **only to the IP(s) validation already pinned**, never re-resolving the hostname:

- **`utils/openapi.py`**
  - `_pinned_fetch()` — dials the pinned IP literal with `Host` + `sni_hostname` set to the validated hostname; `follow_redirects=False` with explicit 30x rejection; a 10 MiB streamed size cap (the old loader read bodies unbounded).
  - `_validate_url_sync()` — bridges the async validator into the sync loader, safe even when called from inside the running event loop.
  - `load_openapi_spec()` — new `validated_url` param; a bare `url` is validated + pinned **in-function**, so there is no code path that fetches a spec un-pinned. `SSRFError`/`SSRFFetchError` are re-raised immediately (not retried away).
- **`server.py`** — threads the `ValidatedURL` from validation into `load_openapi_spec()` for additional specs; the primary spec is validated + pinned by the loader with the `--allow-insecure-http` / `--allow-private-networks` flags passed through.

> **Why not reuse `fastmcp.server.auth.ssrf.ssrf_safe_fetch`?** In the pinned `fastmcp==3.3.1` it re-resolves DNS internally (ignoring pre-computed IPs), is HTTPS-only (breaks `--allow-insecure-http`), caps bodies at 5 KB, and is async (would `RuntimeError` inside the sync loader called from the running loop). We reuse its primitives (`ValidatedURL`, `format_ip_for_url`, error types) instead.

### User experience

- **Before:** A spec URL whose hostname rebinds between validation and fetch could steer the server into fetching internal/metadata endpoints; the primary spec URL bypassed SSRF checks entirely; response bodies were read unbounded.
- **After:** The spec is fetched only from the exact IP that passed validation (DNS resolved once). Redirects to internal hosts are refused, oversized bodies are rejected, and the primary spec path is validated too. The `--allow-insecure-http` / `--allow-private-networks` opt-ins are preserved.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
