### PR TITLE
fix(billing-cost-management): serialize SQLite session access

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -25,6 +25,7 @@ Security model:
 - Query validation to prevent harmful operations
 """
 
+import asyncio
 import atexit
 import json
 import os
@@ -52,6 +53,11 @@ BUSY_TIMEOUT_MS = int(
 
 # Session database path singleton
 _SESSION_DB_PATH = None
+
+# SQLite allows concurrent readers in WAL mode, but writes are still serialized.
+# Keep the queueing inside this process so concurrent MCP tool calls do not race
+# each other into "database is locked" errors.
+_SQLITE_LOCK = asyncio.Lock()
 
 
 def should_convert_to_sql(response_size: int) -> bool:
@@ -471,6 +477,16 @@ async def convert_response_if_needed(
 async def convert_api_response_to_table(
     ctx: Context, response: Dict[str, Any], operation_name: str, **metadata
 ) -> Dict[str, Any]:
+    """Convert a large API response to a SQLite table with serialized DB access."""
+    async with _SQLITE_LOCK:
+        return await _convert_api_response_to_table_unlocked(
+            ctx, response, operation_name, **metadata
+        )
+
+
+async def _convert_api_response_to_table_unlocked(
+    ctx: Context, response: Dict[str, Any], operation_name: str, **metadata
+) -> Dict[str, Any]:
     """Convert a large API response to a SQLite table.
 
     This function stores API response data in a SQLite table for easier querying
@@ -760,6 +776,7 @@ async def convert_api_response_to_table(
         register_table_in_schema_info(
             cursor, table_name, operation_name, json.dumps(metadata), rows_inserted
         )
+        conn.commit()
 
         await ctx.info(f'Converted {rows_inserted} rows to SQL table: {table_name}')
 
@@ -989,6 +1006,18 @@ async def convert_api_response_to_table(
 
 
 async def execute_session_sql(
+    ctx: Context,
+    query: str,
+    schema: Optional[List[str]] = None,
+    data: Optional[List[List[Any]]] = None,
+    table_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Execute SQL query on the session database with serialized DB access."""
+    async with _SQLITE_LOCK:
+        return await _execute_session_sql_unlocked(ctx, query, schema, data, table_name)
+
+
+async def _execute_session_sql_unlocked(
     ctx: Context,
     query: str,
     schema: Optional[List[str]] = None,

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
@@ -24,12 +24,14 @@ This module contains unit tests for the sql_utils.py module, including:
 - API response conversion to database tables
 """
 
+import asyncio
 import os
 import pytest
 import sqlite3
 import sys
 import tempfile
 import uuid
+from awslabs.billing_cost_management_mcp_server.utilities import sql_utils
 from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
     convert_api_response_to_table,
     convert_response_if_needed,
@@ -61,6 +63,94 @@ def temp_db_path():
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = os.path.join(temp_dir, 'test_session.db')
         yield db_path
+
+
+@pytest.mark.asyncio
+class TestSqliteLocking:
+    """Tests for serialized SQLite access."""
+
+    async def test_convert_api_response_to_table_uses_sqlite_lock(self, mock_context):
+        """Test response conversion acquires the SQLite operation lock."""
+        mock_lock = MagicMock()
+        mock_lock.__aenter__ = AsyncMock()
+        mock_lock.__aexit__ = AsyncMock(return_value=None)
+        expected = {'status': 'success'}
+
+        with (
+            patch.object(sql_utils, '_SQLITE_LOCK', mock_lock),
+            patch.object(
+                sql_utils,
+                '_convert_api_response_to_table_unlocked',
+                AsyncMock(return_value=expected),
+            ) as mock_unlocked,
+        ):
+            result = await sql_utils.convert_api_response_to_table(
+                mock_context, {'data': 'value'}, 'test_operation', source='unit-test'
+            )
+
+        assert result == expected
+        mock_lock.__aenter__.assert_awaited_once()
+        mock_lock.__aexit__.assert_awaited_once()
+        mock_unlocked.assert_awaited_once_with(
+            mock_context, {'data': 'value'}, 'test_operation', source='unit-test'
+        )
+
+    async def test_execute_session_sql_uses_sqlite_lock(self, mock_context):
+        """Test session SQL acquires the SQLite operation lock."""
+        mock_lock = MagicMock()
+        mock_lock.__aenter__ = AsyncMock()
+        mock_lock.__aexit__ = AsyncMock(return_value=None)
+        expected = {'status': 'success'}
+
+        with (
+            patch.object(sql_utils, '_SQLITE_LOCK', mock_lock),
+            patch.object(
+                sql_utils, '_execute_session_sql_unlocked', AsyncMock(return_value=expected)
+            ) as mock_unlocked,
+        ):
+            result = await sql_utils.execute_session_sql(
+                mock_context, 'SELECT * FROM test_table'
+            )
+
+        assert result == expected
+        mock_lock.__aenter__.assert_awaited_once()
+        mock_lock.__aexit__.assert_awaited_once()
+        mock_unlocked.assert_awaited_once_with(
+            mock_context, 'SELECT * FROM test_table', None, None, None
+        )
+
+    async def test_convert_api_response_to_table_serializes_concurrent_calls(
+        self, mock_context
+    ):
+        """Test concurrent response conversions enter the SQLite section one at a time."""
+        active_calls = 0
+        max_active_calls = 0
+
+        async def slow_unlocked(*args, **kwargs):
+            nonlocal active_calls, max_active_calls
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+            await asyncio.sleep(0.01)
+            active_calls -= 1
+            return {'status': 'success'}
+
+        with patch.object(
+            sql_utils,
+            '_convert_api_response_to_table_unlocked',
+            side_effect=slow_unlocked,
+        ) as mock_unlocked:
+            results = await asyncio.gather(
+                *[
+                    sql_utils.convert_api_response_to_table(
+                        mock_context, {'data': i}, 'test_operation'
+                    )
+                    for i in range(20)
+                ]
+            )
+
+        assert all(result == {'status': 'success'} for result in results)
+        assert mock_unlocked.await_count == 20
+        assert max_active_calls == 1
 
 
 class TestShouldConvertToSql:
@@ -1261,6 +1351,37 @@ class TestConvertApiResponseToTableSpecificTypes:
         assert result['row_count'] == 3
         assert 'table_name' in result
         assert 'sample_queries' in result
+        assert mock_connection.commit.call_count >= 3
+
+    @patch('sqlite3.connect')
+    @patch('awslabs.billing_cost_management_mcp_server.utilities.sql_utils.get_session_db_path')
+    async def test_convert_response_commits_schema_info_registration(
+        self, mock_get_path, mock_connect, mock_context
+    ):
+        """Test schema_info registration is committed before the connection closes."""
+        mock_get_path.return_value = '/mock/path/session.db'
+        events = []
+
+        mock_cursor = MagicMock()
+        mock_cursor.description = [('tag_value',)]
+        mock_cursor.fetchall.return_value = [('Environment',)]
+
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value = mock_cursor
+        mock_connection.commit.side_effect = lambda: events.append('commit')
+        mock_connect.return_value = mock_connection
+
+        with patch.object(
+            sql_utils,
+            'register_table_in_schema_info',
+            side_effect=lambda *args, **kwargs: events.append('register'),
+        ):
+            result = await convert_api_response_to_table(
+                mock_context, {'Tags': ['Environment']}, 'cost_explorer_get_tags'
+            )
+
+        assert result['status'] == 'success'
+        assert events[-2:] == ['register', 'commit']
 
     @patch('sqlite3.connect')
     @patch('awslabs.billing_cost_management_mcp_server.utilities.sql_utils.get_session_db_path')


### PR DESCRIPTION
## Summary
- Serialize billing-cost-management session SQLite access with a process-local asyncio lock.
- Keep AWS API calls concurrent while queueing only local SQLite operations.
- Commit schema_info registration after response offload metadata is written.

## Tests
- uv run pytest tests/utilities/test_sql_utils.py -q
- uv run ruff check awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py tests/utilities/test_sql_utils.py


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
