### PR TITLE
fix(redshift-mcp-server): correct serverless db name, map SHOW output by column name, drop execution_time_ms

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -398,7 +398,7 @@ execute_query(cluster_identifier: str, database_name: str, sql: str) -> QueryRes
 
 - Column names and data types
 - Result rows with proper type conversion
-- Row count and execution time
+- Row count
 - Query ID for reference
 
 ### review_cluster

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
@@ -16,7 +16,40 @@
 
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, TypeVar
+
+
+RedshiftDataModelT = TypeVar('RedshiftDataModelT', bound='RedshiftDataModel')
+
+
+class RedshiftDataModel(BaseModel):
+    """Base for models built from a Redshift Data API result set.
+
+    Subclasses declare their fields named to match the SHOW result columns.
+    `from_redshift_response` maps result columns to those fields by name, so
+    parsing is independent of column order; unknown columns are ignored.
+    """
+
+    @staticmethod
+    def cell_value(cell: dict) -> Any:
+        """Unwrap a single Redshift Data API result cell to a Python scalar."""
+        if cell.get('isNull'):
+            return None
+        for key in ('stringValue', 'longValue', 'doubleValue', 'booleanValue'):
+            if key in cell:
+                return cell[key]
+        return str(cell)
+
+    @classmethod
+    def from_redshift_response(
+        cls: type[RedshiftDataModelT], results_response: dict
+    ) -> list[RedshiftDataModelT]:
+        """Build a list of model instances from a Data API result set."""
+        names = [col.get('name') for col in results_response.get('ColumnMetadata', [])]
+        return [
+            cls.model_validate({name: cls.cell_value(cell) for name, cell in zip(names, record)})
+            for record in results_response.get('Records', [])
+        ]
 
 
 class RedshiftCluster(BaseModel):
@@ -40,7 +73,7 @@ class RedshiftCluster(BaseModel):
     )
 
 
-class RedshiftDatabase(BaseModel):
+class RedshiftDatabase(RedshiftDataModel):
     """Information about a database in a Redshift cluster."""
 
     database_name: str = Field(..., description='The name of the database')
@@ -51,14 +84,14 @@ class RedshiftDatabase(BaseModel):
     database_acl: Optional[str] = Field(
         None, description='Access control information (for internal use)'
     )
-    database_options: Optional[str] = Field(None, description='The properties of the database')
+    parameters: Optional[str] = Field(None, description='The properties of the database')
     database_isolation_level: Optional[str] = Field(
         None,
         description='The isolation level of the database (Snapshot Isolation or Serializable)',
     )
 
 
-class RedshiftSchema(BaseModel):
+class RedshiftSchema(RedshiftDataModel):
     """Information about a schema in a Redshift database."""
 
     database_name: str = Field(..., description='The name of the database where the schema exists')
@@ -78,7 +111,7 @@ class RedshiftSchema(BaseModel):
     )
 
 
-class RedshiftTable(BaseModel):
+class RedshiftTable(RedshiftDataModel):
     """Information about a table in a Redshift database."""
 
     database_name: str = Field(..., description='The name of the database where the table exists')
@@ -94,7 +127,7 @@ class RedshiftTable(BaseModel):
     remarks: Optional[str] = Field(None, description='Remarks about the table')
 
 
-class RedshiftColumn(BaseModel):
+class RedshiftColumn(RedshiftDataModel):
     """Information about a column in a Redshift table."""
 
     database_name: str = Field(..., description='The name of the database')
@@ -123,7 +156,4 @@ class QueryResult(BaseModel):
     columns: list[str] = Field(..., description='List of column names in the result set')
     rows: list[list] = Field(..., description='List of rows, where each row is a list of values')
     row_count: int = Field(..., description='Number of rows returned')
-    execution_time_ms: Optional[int] = Field(
-        None, description='Query execution time in milliseconds'
-    )
     query_id: str = Field(..., description='Unique identifier for the query execution')

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -32,6 +32,14 @@ from awslabs.redshift_mcp_server.consts import (
     SESSION_KEEPALIVE,
     TABLES_SQL,
 )
+from awslabs.redshift_mcp_server.models import (
+    RedshiftCluster,
+    RedshiftColumn,
+    RedshiftDatabase,
+    RedshiftDataModel,
+    RedshiftSchema,
+    RedshiftTable,
+)
 from awslabs.redshift_mcp_server.sql_guard import assert_executable
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -147,14 +155,14 @@ class RedshiftSessionManager:
         return existing
 
     async def session(
-        self, cluster_identifier: str, database_name: str, cluster_info: dict
+        self, cluster_identifier: str, database_name: str, cluster_info: RedshiftCluster
     ) -> str:
         """Get or create a session for the given cluster and database.
 
         Args:
             cluster_identifier: The cluster identifier to get session for.
             database_name: The database name to get session for.
-            cluster_info: Cluster information dictionary from discover_clusters.
+            cluster_info: Cluster information model from discover_clusters.
 
         Returns:
             Session ID for use in ExecuteStatement calls.
@@ -182,14 +190,14 @@ class RedshiftSessionManager:
         return session_id
 
     async def _create_session_with_app_name(
-        self, cluster_identifier: str, database_name: str, cluster_info: dict
+        self, cluster_identifier: str, database_name: str, cluster_info: RedshiftCluster
     ) -> str:
         """Create a new session by executing SET application_name.
 
         Args:
             cluster_identifier: The cluster identifier.
             database_name: The database name.
-            cluster_info: Cluster information dictionary.
+            cluster_info: Cluster information model.
 
         Returns:
             Session ID from the ExecuteStatement response.
@@ -272,7 +280,7 @@ async def _execute_protected_statement(
     clusters = await discover_clusters()
     cluster_info = None
     for cluster in clusters:
-        if cluster['identifier'] == cluster_identifier:
+        if cluster.identifier == cluster_identifier:
             cluster_info = cluster
             break
 
@@ -364,7 +372,7 @@ async def _execute_protected_statement(
 
 
 async def _execute_statement(
-    cluster_info: dict,
+    cluster_info: RedshiftCluster,
     cluster_identifier: str,
     database_name: str,
     sql: str,
@@ -377,7 +385,7 @@ async def _execute_statement(
     """Execute a single statement with optional session support and parameters.
 
     Args:
-        cluster_info: Cluster information dictionary.
+        cluster_info: Cluster information model.
         cluster_identifier: The cluster identifier.
         database_name: The database name.
         sql: The SQL statement to execute.
@@ -398,12 +406,12 @@ async def _execute_statement(
     # Add database and cluster/workgroup identifier only if not using session
     if not session_id:
         request_params['Database'] = database_name
-        if cluster_info['type'] == 'provisioned':
+        if cluster_info.type == 'provisioned':
             request_params['ClusterIdentifier'] = cluster_identifier
-        elif cluster_info['type'] == 'serverless':
+        elif cluster_info.type == 'serverless':
             request_params['WorkgroupName'] = cluster_identifier
         else:
-            raise Exception(f'Unknown cluster type: {cluster_info["type"]}')
+            raise Exception(f'Unknown cluster type: {cluster_info.type}')
 
     # Add parameters if provided
     if parameters:
@@ -446,7 +454,7 @@ async def _execute_statement(
     return statement_id
 
 
-async def discover_clusters() -> list[dict]:
+async def discover_clusters() -> list[RedshiftCluster]:
     """Discover all Redshift clusters and serverless workgroups.
 
     Discovery is best-effort for each type: if either provisioned or serverless
@@ -454,7 +462,7 @@ async def discover_clusters() -> list[dict]:
     if both fail (i.e., no clusters could be discovered at all).
 
     Returns:
-        List of cluster information dictionaries.
+        List of RedshiftCluster models.
 
     Raises:
         Exception: If both provisioned and serverless discovery fail.
@@ -488,7 +496,7 @@ async def discover_clusters() -> list[dict]:
                     'encrypted': cluster.get('Encrypted'),
                     'tags': {tag['Key']: tag['Value'] for tag in cluster.get('Tags', [])},
                 }
-                clusters.append(cluster_info)
+                clusters.append(RedshiftCluster(**cluster_info))
 
         logger.info(f'Found {len(clusters)} provisioned clusters')
 
@@ -516,14 +524,10 @@ async def discover_clusters() -> list[dict]:
                     'identifier': workgroup['workgroupName'],
                     'type': 'serverless',
                     'status': workgroup['status'],
-                    'database_name': next(
-                        (
-                            p['parameterValue']
-                            for p in workgroup_detail.get('configParameters', [])
-                            if p.get('parameterKey') == 'default_database'
-                        ),
-                        'dev',
-                    ),
+                    # Serverless always exposes the built-in 'dev' database. Reporting the
+                    # namespace's configured default would require redshift-serverless:GetNamespace;
+                    # callers can pass an explicit database_name to the other tools instead.
+                    'database_name': 'dev',
                     'endpoint': workgroup_detail.get('endpoint', {}).get('address'),
                     'port': workgroup_detail.get('endpoint', {}).get('port'),
                     'vpc_id': (workgroup_detail.get('subnetIds') or [None])[
@@ -537,9 +541,9 @@ async def discover_clusters() -> list[dict]:
                     'encrypted': True,  # Serverless is always encrypted
                     'tags': {tag['key']: tag['value'] for tag in workgroup_detail.get('tags', [])},
                 }
-                clusters.append(cluster_info)
+                clusters.append(RedshiftCluster(**cluster_info))
 
-        serverless_count = len([c for c in clusters if c['type'] == 'serverless'])
+        serverless_count = len([c for c in clusters if c.type == 'serverless'])
         logger.info(f'Found {serverless_count} serverless workgroups')
 
     except ClientError as e:
@@ -562,7 +566,9 @@ async def discover_clusters() -> list[dict]:
     return clusters
 
 
-async def discover_databases(cluster_identifier: str, database_name: str = 'dev') -> list[dict]:
+async def discover_databases(
+    cluster_identifier: str, database_name: str = 'dev'
+) -> list[RedshiftDatabase]:
     """Discover databases in a Redshift cluster using the Data API.
 
     Args:
@@ -570,33 +576,18 @@ async def discover_databases(cluster_identifier: str, database_name: str = 'dev'
         database_name: The database to connect to for querying system views.
 
     Returns:
-        List of database information dictionaries.
+        List of RedshiftDatabase models.
     """
     try:
         logger.info(f'Discovering databases in cluster {cluster_identifier}')
 
-        # Execute the query using the common function
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=database_name,
             sql=DATABASES_SQL,
         )
 
-        databases = []
-        records = results_response.get('Records', [])
-
-        for record in records:
-            # Extract values from the record
-            database_info = {
-                'database_name': record[0].get('stringValue'),
-                'database_owner': record[1].get('longValue'),
-                'database_type': record[2].get('stringValue'),
-                'database_acl': record[3].get('stringValue'),
-                'database_options': record[4].get('stringValue'),
-                'database_isolation_level': record[5].get('stringValue'),
-            }
-            databases.append(database_info)
-
+        databases = RedshiftDatabase.from_redshift_response(results_response)
         logger.info(f'Found {len(databases)} databases in cluster {cluster_identifier}')
         return databases
 
@@ -605,7 +596,9 @@ async def discover_databases(cluster_identifier: str, database_name: str = 'dev'
         raise
 
 
-async def discover_schemas(cluster_identifier: str, schema_database_name: str) -> list[dict]:
+async def discover_schemas(
+    cluster_identifier: str, schema_database_name: str
+) -> list[RedshiftSchema]:
     """Discover schemas in a Redshift database using the Data API.
 
     Args:
@@ -613,36 +606,20 @@ async def discover_schemas(cluster_identifier: str, schema_database_name: str) -
         schema_database_name: The database name to filter schemas for. Also used to connect to.
 
     Returns:
-        List of schema information dictionaries.
+        List of RedshiftSchema models.
     """
     try:
         logger.info(
             f'Discovering schemas in database {schema_database_name} in cluster {cluster_identifier}'
         )
 
-        # Execute the query using the common function
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=schema_database_name,
             sql=SCHEMAS_SQL.format(database=_sql_identifier(schema_database_name)),
         )
 
-        schemas = []
-        records = results_response.get('Records', [])
-
-        for record in records:
-            # Extract values from the record
-            schema_info = {
-                'database_name': record[0].get('stringValue'),
-                'schema_name': record[1].get('stringValue'),
-                'schema_owner': record[2].get('longValue'),
-                'schema_type': record[3].get('stringValue'),
-                'schema_acl': record[4].get('stringValue'),
-                'source_database': record[5].get('stringValue'),
-                'schema_option': record[6].get('stringValue'),
-            }
-            schemas.append(schema_info)
-
+        schemas = RedshiftSchema.from_redshift_response(results_response)
         logger.info(
             f'Found {len(schemas)} schemas in database {schema_database_name} in cluster {cluster_identifier}'
         )
@@ -657,7 +634,7 @@ async def discover_schemas(cluster_identifier: str, schema_database_name: str) -
 
 async def discover_tables(
     cluster_identifier: str, table_database_name: str, table_schema_name: str
-) -> list[dict]:
+) -> list[RedshiftTable]:
     """Discover tables in a Redshift schema using the Data API.
 
     Args:
@@ -666,14 +643,13 @@ async def discover_tables(
         table_schema_name: The schema name to filter tables for.
 
     Returns:
-        List of table information dictionaries.
+        List of RedshiftTable models.
     """
     try:
         logger.info(
             f'Discovering tables in schema {table_schema_name} in database {table_database_name} in cluster {cluster_identifier}'
         )
 
-        # Execute the query using the common function
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=table_database_name,
@@ -683,22 +659,7 @@ async def discover_tables(
             ),
         )
 
-        tables = []
-        records = results_response.get('Records', [])
-
-        for record in records:
-            # Extract values from the record. SHOW TABLES returns table_type
-            # before table_acl.
-            table_info = {
-                'database_name': record[0].get('stringValue'),
-                'schema_name': record[1].get('stringValue'),
-                'table_name': record[2].get('stringValue'),
-                'table_type': record[3].get('stringValue'),
-                'table_acl': record[4].get('stringValue'),
-                'remarks': record[5].get('stringValue'),
-            }
-            tables.append(table_info)
-
+        tables = RedshiftTable.from_redshift_response(results_response)
         logger.info(
             f'Found {len(tables)} tables in schema {table_schema_name} in database {table_database_name} in cluster {cluster_identifier}'
         )
@@ -716,7 +677,7 @@ async def discover_columns(
     column_database_name: str,
     column_schema_name: str,
     column_table_name: str,
-) -> list[dict]:
+) -> list[RedshiftColumn]:
     """Discover columns in a Redshift table using the Data API.
 
     Args:
@@ -726,14 +687,13 @@ async def discover_columns(
         column_table_name: The table name to filter columns for.
 
     Returns:
-        List of column information dictionaries.
+        List of RedshiftColumn models.
     """
     try:
         logger.info(
             f'Discovering columns in table {column_table_name} in schema {column_schema_name} in database {column_database_name} in cluster {cluster_identifier}'
         )
 
-        # Execute the query using the common function
         results_response, _ = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
             database_name=column_database_name,
@@ -744,27 +704,7 @@ async def discover_columns(
             ),
         )
 
-        columns = []
-        records = results_response.get('Records', [])
-
-        for record in records:
-            # Extract values from the record
-            column_info = {
-                'database_name': record[0].get('stringValue'),
-                'schema_name': record[1].get('stringValue'),
-                'table_name': record[2].get('stringValue'),
-                'column_name': record[3].get('stringValue'),
-                'ordinal_position': record[4].get('longValue'),
-                'column_default': record[5].get('stringValue'),
-                'is_nullable': record[6].get('stringValue'),
-                'data_type': record[7].get('stringValue'),
-                'character_maximum_length': record[8].get('longValue'),
-                'numeric_precision': record[9].get('longValue'),
-                'numeric_scale': record[10].get('longValue'),
-                'remarks': record[11].get('stringValue'),
-            }
-            columns.append(column_info)
-
+        columns = RedshiftColumn.from_redshift_response(results_response)
         logger.info(
             f'Found {len(columns)} columns in table {column_table_name} in schema {column_schema_name} in database {column_database_name} in cluster {cluster_identifier}'
         )
@@ -795,11 +735,6 @@ async def execute_query(
         logger.info(f'Executing query on cluster {cluster_identifier} in database {database_name}')
         logger.debug(f'SQL: {sql}')
 
-        # Record start time for execution time calculation
-        import time
-
-        start_time = time.time()
-
         # Execute the query using the common function
         results_response, query_id = await _execute_protected_statement(
             cluster_identifier=cluster_identifier,
@@ -808,50 +743,23 @@ async def execute_query(
             allow_read_write=allow_read_write,
         )
 
-        # Calculate execution time
-        end_time = time.time()
-        execution_time_ms = int((end_time - start_time) * 1000)
-
         # Extract column names
-        columns = []
-        column_metadata = results_response.get('ColumnMetadata', [])
-        for col_meta in column_metadata:
-            columns.append(col_meta.get('name'))
+        columns = [col.get('name') for col in results_response.get('ColumnMetadata', [])]
 
         # Extract rows
-        rows = []
-        records = results_response.get('Records', [])
-
-        for record in records:
-            row = []
-            for field in record:
-                # Extract the actual value from the field based on its type
-                if 'stringValue' in field:
-                    row.append(field['stringValue'])
-                elif 'longValue' in field:
-                    row.append(field['longValue'])
-                elif 'doubleValue' in field:
-                    row.append(field['doubleValue'])
-                elif 'booleanValue' in field:
-                    row.append(field['booleanValue'])
-                elif 'isNull' in field and field['isNull']:
-                    row.append(None)
-                else:
-                    # Fallback for unknown field types
-                    row.append(str(field))
-            rows.append(row)
+        rows = [
+            [RedshiftDataModel.cell_value(cell) for cell in record]
+            for record in results_response.get('Records', [])
+        ]
 
         query_result = {
             'columns': columns,
             'rows': rows,
             'row_count': len(rows),
-            'execution_time_ms': execution_time_ms,
             'query_id': query_id,
         }
 
-        logger.info(
-            f'Query executed successfully: {query_id}, returned {len(rows)} rows in {execution_time_ms}ms'
-        )
+        logger.info(f'Query executed successfully: {query_id}, returned {len(rows)} rows')
         return query_result
 
     except Exception as e:

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/review/executor.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/review/executor.py
@@ -51,7 +51,7 @@ async def review_cluster(
     clusters = await discover_clusters_func()
     cluster_info = None
     for cluster in clusters:
-        if cluster['identifier'] == cluster_identifier:
+        if cluster.identifier == cluster_identifier:
             cluster_info = cluster
             break
 
@@ -60,7 +60,7 @@ async def review_cluster(
             f'Cluster {cluster_identifier} not found. Please use list_clusters to get valid cluster identifiers.'
         )
 
-    is_serverless = cluster_info.get('type') == 'serverless'
+    is_serverless = cluster_info.type == 'serverless'
 
     # Stage 1: Select queries, filtering by cluster type scope
     queries = [

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -185,13 +185,7 @@ async def list_clusters_tool(ctx: Context) -> list[RedshiftCluster]:
     """
     try:
         logger.info('Discovering Redshift clusters and serverless workgroups')
-        clusters_data = await discover_clusters()
-
-        # Convert to RedshiftCluster models
-        clusters = []
-        for cluster_data in clusters_data:
-            cluster = RedshiftCluster(**cluster_data)
-            clusters.append(cluster)
+        clusters = await discover_clusters()
 
         logger.info(f'Successfully retrieved {len(clusters)} clusters')
         return clusters
@@ -241,7 +235,7 @@ async def list_databases_tool(
     - database_owner: The database owner user ID.
     - database_type: The type of database (local or shared).
     - database_acl: Access control information (for internal use).
-    - database_options: The properties of the database.
+    - parameters: The properties of the database.
     - database_isolation_level: The isolation level (Snapshot Isolation or Serializable).
 
     ## Usage Tips
@@ -250,6 +244,7 @@ async def list_databases_tool(
     2. Ensure the cluster status is 'available' before querying databases.
     3. Use the default database name unless you know a specific database exists.
     4. Note database types to understand if they are local or shared from datashares.
+    5. Shared (datashare) databases appear only if the connecting principal has been granted access to the consumer database (e.g. GRANT USAGE ON DATABASE <db> TO <principal>); otherwise they are omitted even though the datashare exists.
 
     ## Interpretation Best Practices
 
@@ -260,15 +255,9 @@ async def list_databases_tool(
     """
     try:
         logger.info(f'Discovering databases on cluster: {cluster_identifier}')
-        databases_data = await discover_databases(
+        databases = await discover_databases(
             cluster_identifier=cluster_identifier, database_name=database_name
         )
-
-        # Convert to RedshiftDatabase models
-        databases = []
-        for database_data in databases_data:
-            database = RedshiftDatabase(**database_data)
-            databases.append(database)
 
         logger.info(
             f'Successfully retrieved {len(databases)} databases from cluster {cluster_identifier}'
@@ -332,6 +321,7 @@ async def list_schemas_tool(
     3. Ensure the cluster status is 'available' before querying schemas.
     4. Note schema types to understand if they are local, external, or shared.
     5. External schemas connect to external data sources like S3 or other databases.
+    6. Schemas in a shared (datashare) database appear only if the connecting principal has been granted access to the consumer database (e.g. GRANT USAGE ON DATABASE <db> TO <principal>); otherwise they are omitted even though the datashare exists.
 
     ## Interpretation Best Practices
 
@@ -345,15 +335,9 @@ async def list_schemas_tool(
         logger.info(
             f'Discovering schemas in database {schema_database_name} on cluster {cluster_identifier}'
         )
-        schemas_data = await discover_schemas(
+        schemas = await discover_schemas(
             cluster_identifier=cluster_identifier, schema_database_name=schema_database_name
         )
-
-        # Convert to RedshiftSchema models
-        schemas = []
-        for schema_data in schemas_data:
-            schema = RedshiftSchema(**schema_data)
-            schemas.append(schema)
 
         logger.info(
             f'Successfully retrieved {len(schemas)} schemas from database {schema_database_name} on cluster {cluster_identifier}'
@@ -438,17 +422,11 @@ async def list_tables_tool(
         logger.info(
             f'Discovering tables in schema {table_schema_name} in database {table_database_name} on cluster {cluster_identifier}'
         )
-        tables_data = await discover_tables(
+        tables = await discover_tables(
             cluster_identifier=cluster_identifier,
             table_database_name=table_database_name,
             table_schema_name=table_schema_name,
         )
-
-        # Convert to RedshiftTable models
-        tables = []
-        for table_data in tables_data:
-            table = RedshiftTable(**table_data)
-            tables.append(table)
 
         logger.info(
             f'Successfully retrieved {len(tables)} tables from schema {table_schema_name} in database {table_database_name} on cluster {cluster_identifier}'
@@ -546,18 +524,12 @@ async def list_columns_tool(
         logger.info(
             f'Discovering columns in table {column_table_name} in schema {column_schema_name} in database {column_database_name} on cluster {cluster_identifier}'
         )
-        columns_data = await discover_columns(
+        columns = await discover_columns(
             cluster_identifier=cluster_identifier,
             column_database_name=column_database_name,
             column_schema_name=column_schema_name,
             column_table_name=column_table_name,
         )
-
-        # Convert to RedshiftColumn models
-        columns = []
-        for column_data in columns_data:
-            column = RedshiftColumn(**column_data)
-            columns.append(column)
 
         logger.info(
             f'Successfully retrieved {len(columns)} columns from table {column_table_name} in schema {column_schema_name} in database {column_database_name} on cluster {cluster_identifier}'
@@ -615,7 +587,6 @@ async def execute_query_tool(
     - columns: List of column names in the result set.
     - rows: List of rows, where each row is a list of values.
     - row_count: Number of rows returned.
-    - execution_time_ms: Query execution time in milliseconds.
     - query_id: Unique identifier for the query execution.
 
     ## Usage Tips
@@ -652,7 +623,7 @@ async def execute_query_tool(
         query_result = QueryResult(**query_result_data)
 
         logger.info(
-            f'Successfully executed query on cluster {cluster_identifier}: {query_result.row_count} rows returned in {query_result.execution_time_ms}ms'
+            f'Successfully executed query on cluster {cluster_identifier}: {query_result.row_count} rows returned'
         )
         return query_result
 

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -18,6 +18,7 @@ import asyncio
 import pytest
 import sqlglot
 import time
+from awslabs.redshift_mcp_server.models import RedshiftCluster
 from awslabs.redshift_mcp_server.redshift import (
     RedshiftClientManager,
     RedshiftSessionManager,
@@ -35,6 +36,13 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from sqlglot import exp
 from types import SimpleNamespace
+
+
+def _fake_cluster(identifier='test-cluster', type='provisioned', status='available'):
+    """Build a RedshiftCluster for mocking discover_clusters() return values."""
+    return RedshiftCluster.model_validate(
+        {'identifier': identifier, 'type': type, 'status': status, 'database_name': 'dev'}
+    )
 
 
 class TestRedshiftClientManagerRedshiftClient:
@@ -255,9 +263,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -299,9 +305,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -345,9 +349,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
@@ -375,9 +377,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -420,9 +420,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -460,9 +458,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
         mock_session_manager.lock.return_value = asyncio.Lock()
@@ -502,9 +498,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
         mock_session_manager.session = mocker.AsyncMock(return_value='test-session-123')
         mock_session_manager.lock.return_value = asyncio.Lock()
@@ -545,8 +539,8 @@ class TestExecuteProtectedStatement:
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
         mock_discover_clusters.return_value = [
-            {'identifier': 'other-cluster', 'type': 'provisioned'},
-            {'identifier': 'another-cluster', 'type': 'serverless'},
+            _fake_cluster(identifier='other-cluster'),
+            _fake_cluster(identifier='another-cluster', type='serverless'),
         ]
 
         with pytest.raises(Exception, match='Cluster target-cluster not found'):
@@ -561,9 +555,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -605,9 +597,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -642,9 +632,7 @@ class TestExecuteProtectedStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Mock session manager
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -694,7 +682,7 @@ class TestExecuteStatement:
             return_value=mock_client,
         )
 
-        cluster_info = {'type': 'provisioned'}
+        cluster_info = _fake_cluster()
         with pytest.raises(Exception, match='Statement failed: SQL syntax error'):
             await _execute_statement(cluster_info, 'cluster', 'db', 'SELECT 1')
 
@@ -704,9 +692,7 @@ class TestExecuteStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         mock_client = mocker.Mock()
         mock_client.execute_statement.return_value = {'Id': 'stmt-123'}
@@ -717,7 +703,7 @@ class TestExecuteStatement:
             return_value=mock_client,
         )
 
-        cluster_info = {'type': 'provisioned'}
+        cluster_info = _fake_cluster()
         # Use small timeout and poll interval to trigger timeout quickly
         with pytest.raises(Exception, match='Statement timed out after'):
             await _execute_statement(
@@ -736,15 +722,13 @@ class TestExecuteStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'unknown-type'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster(type='unknown-type')]
 
         mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
         mock_data_client = mocker.Mock()
         mock_client_manager.redshift_data_client.return_value = mock_data_client
 
-        cluster_info = {'type': 'unknown-type', 'identifier': 'test-cluster'}
+        cluster_info = _fake_cluster(type='unknown-type')
 
         # This should trigger the unknown cluster type error (lines 324, 331)
         with pytest.raises(Exception, match='Unknown cluster type: unknown-type'):
@@ -756,9 +740,7 @@ class TestExecuteStatement:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         mock_client = mocker.Mock()
         mock_client.execute_statement.return_value = {'Id': 'stmt-123'}
@@ -767,7 +749,7 @@ class TestExecuteStatement:
         mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
         mock_client_manager.redshift_data_client.return_value = mock_client
 
-        cluster_info = {'type': 'provisioned', 'identifier': 'test-cluster'}
+        cluster_info = _fake_cluster()
         parameters = [{'name': 'param1', 'value': 'value1'}]
 
         # This should cover line 335 (parameters path)
@@ -790,7 +772,7 @@ class TestExecuteStatement:
         mock_client_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.client_manager')
         mock_client_manager.redshift_data_client.return_value = mock_client
 
-        cluster_info = {'type': 'provisioned', 'identifier': 'test-cluster'}
+        cluster_info = _fake_cluster()
 
         # This should cover line 339 (session_id path)
         await _execute_statement(
@@ -813,7 +795,7 @@ class TestRedshiftSessionManager:
     async def test_session_creation_provisioned(self, mocker):
         """Test session creation for provisioned cluster."""
         session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
-        cluster_info = {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        cluster_info = _fake_cluster()
 
         mock_response = {'SessionId': 'test-session-123', 'Id': 'statement-456'}
 
@@ -840,11 +822,7 @@ class TestRedshiftSessionManager:
     async def test_session_creation_serverless(self, mocker):
         """Test session creation for serverless workgroup."""
         session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
-        cluster_info = {
-            'identifier': 'test-workgroup',
-            'type': 'serverless',
-            'status': 'available',
-        }
+        cluster_info = _fake_cluster(identifier='test-workgroup', type='serverless')
 
         mock_response = {'SessionId': 'test-session-456', 'Id': 'statement-789'}
 
@@ -869,7 +847,7 @@ class TestRedshiftSessionManager:
     async def test_session_reuse(self, mocker):
         """Test that existing sessions are reused."""
         session_manager = RedshiftSessionManager(session_keepalive=600, app_name='test-app/1.0')
-        cluster_info = {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
+        cluster_info = _fake_cluster()
 
         mock_response = {'SessionId': 'test-session-123', 'Id': 'statement-456'}
 
@@ -935,7 +913,7 @@ class TestRedshiftSessionManager:
         }
         mock_client_manager.redshift_data_client.return_value = mock_data_client
 
-        cluster_info = {'type': 'provisioned', 'identifier': 'test-cluster'}
+        cluster_info = _fake_cluster()
 
         # This should clean up the expired session and create a new one
         session_id = await session_manager.session('test-cluster', 'dev', cluster_info)
@@ -1037,27 +1015,27 @@ class TestDiscoverFunctions:
 
         # Verify full cluster (with all fields)
         cluster = result[0]
-        assert cluster['identifier'] == 'test-cluster'
-        assert cluster['type'] == 'provisioned'
-        assert cluster['status'] == 'available'
-        assert cluster['database_name'] == 'dev'
-        assert cluster['endpoint'] == 'test.redshift.amazonaws.com'
-        assert cluster['port'] == 5439
-        assert cluster['node_type'] == 'dc2.large'
-        assert cluster['number_of_nodes'] == 2
-        assert cluster['tags'] == {'env': 'test'}
+        assert cluster.identifier == 'test-cluster'
+        assert cluster.type == 'provisioned'
+        assert cluster.status == 'available'
+        assert cluster.database_name == 'dev'
+        assert cluster.endpoint == 'test.redshift.amazonaws.com'
+        assert cluster.port == 5439
+        assert cluster.node_type == 'dc2.large'
+        assert cluster.number_of_nodes == 2
+        assert cluster.tags == {'env': 'test'}
 
         # Verify minimal cluster (with defaults applied)
         minimal = result[1]
-        assert minimal['identifier'] == 'minimal-cluster'
-        assert minimal['type'] == 'provisioned'
-        assert minimal['status'] == 'available'
-        assert minimal['database_name'] == 'dev'  # Should default to 'dev', not KeyError
-        assert minimal['endpoint'] == 'minimal.redshift.amazonaws.com'
-        assert minimal['port'] == 5439
-        assert minimal['node_type'] == 'ra3.xlplus'
-        assert minimal['number_of_nodes'] == 1
-        assert minimal['tags'] == {}
+        assert minimal.identifier == 'minimal-cluster'
+        assert minimal.type == 'provisioned'
+        assert minimal.status == 'available'
+        assert minimal.database_name == 'dev'  # default to 'dev'
+        assert minimal.endpoint == 'minimal.redshift.amazonaws.com'
+        assert minimal.port == 5439
+        assert minimal.node_type == 'ra3.xlplus'
+        assert minimal.number_of_nodes == 1
+        assert minimal.tags == {}
 
     @pytest.mark.asyncio
     async def test_discover_clusters_provisioned_error(self, mocker):
@@ -1084,12 +1062,15 @@ class TestDiscoverFunctions:
 
     @pytest.mark.asyncio
     async def test_discover_clusters_serverless(self, mocker):
-        """Test discover_clusters function with serverless workgroups."""
+        """Test discover_clusters with serverless workgroups.
+
+        The serverless database_name is always reported as the built-in 'dev';
+        """
         # Mock redshift client (empty response)
         mock_redshift_client = mocker.Mock()
         mock_redshift_client.get_paginator.return_value.paginate.return_value = [{'Clusters': []}]
 
-        # Mock serverless client
+        # Mock serverless client with one workgroup
         mock_serverless_client = mocker.Mock()
         mock_serverless_client.get_paginator.return_value.paginate.return_value = [
             {
@@ -1104,9 +1085,6 @@ class TestDiscoverFunctions:
         ]
         mock_serverless_client.get_workgroup.return_value = {
             'workgroup': {
-                'configParameters': [
-                    {'parameterKey': 'default_database', 'parameterValue': 'analytics'}
-                ],
                 'endpoint': {'address': 'test.serverless.amazonaws.com', 'port': 5439},
                 'subnetIds': ['subnet-123'],
                 'publiclyAccessible': True,
@@ -1127,17 +1105,18 @@ class TestDiscoverFunctions:
         result = await discover_clusters()
 
         assert len(result) == 1
+
         workgroup = result[0]
-        assert workgroup['identifier'] == 'test-workgroup'
-        assert workgroup['type'] == 'serverless'
-        assert workgroup['status'] == 'AVAILABLE'
-        assert workgroup['database_name'] == 'analytics'
-        assert workgroup['endpoint'] == 'test.serverless.amazonaws.com'
-        assert workgroup['port'] == 5439
-        assert workgroup['node_type'] is None
-        assert workgroup['number_of_nodes'] is None
-        assert workgroup['encrypted'] is True
-        assert workgroup['tags'] == {'team': 'data'}
+        assert workgroup.identifier == 'test-workgroup'
+        assert workgroup.type == 'serverless'
+        assert workgroup.status == 'AVAILABLE'
+        assert workgroup.database_name == 'dev'
+        assert workgroup.endpoint == 'test.serverless.amazonaws.com'
+        assert workgroup.port == 5439
+        assert workgroup.node_type is None
+        assert workgroup.number_of_nodes is None
+        assert workgroup.encrypted is True
+        assert workgroup.tags == {'team': 'data'}
 
     @pytest.mark.asyncio
     async def test_discover_clusters_serverless_empty_subnet_ids(self, mocker):
@@ -1177,7 +1156,7 @@ class TestDiscoverFunctions:
         result = await discover_clusters()
 
         assert len(result) == 1
-        assert result[0]['vpc_id'] is None
+        assert result[0].vpc_id is None
 
     @pytest.mark.asyncio
     async def test_discover_clusters_serverless_error(self, mocker):
@@ -1282,8 +1261,8 @@ class TestDiscoverFunctions:
         result = await discover_clusters()
 
         assert len(result) == 1
-        assert result[0]['identifier'] == 'my-workgroup'
-        assert result[0]['type'] == 'serverless'
+        assert result[0].identifier == 'my-workgroup'
+        assert result[0].type == 'serverless'
 
     @pytest.mark.asyncio
     async def test_discover_clusters_serverless_access_denied_provisioned_succeeds(self, mocker):
@@ -1330,8 +1309,8 @@ class TestDiscoverFunctions:
         result = await discover_clusters()
 
         assert len(result) == 1
-        assert result[0]['identifier'] == 'my-cluster'
-        assert result[0]['type'] == 'provisioned'
+        assert result[0].identifier == 'my-cluster'
+        assert result[0].type == 'provisioned'
 
     @pytest.mark.asyncio
     async def test_discover_clusters_non_access_denied_provisioned_bubbles_up(self, mocker):
@@ -1425,18 +1404,27 @@ class TestDiscoverFunctions:
         mock_execute_protected = mocker.patch(
             'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
         )
+        # Verify column order is handled correctly.
         mock_execute_protected.return_value = (
             {
+                'ColumnMetadata': [
+                    {'name': 'database_type'},
+                    {'name': 'database_name'},
+                    {'name': 'database_isolation_level'},
+                    {'name': 'database_owner'},
+                    {'name': 'parameters'},
+                    {'name': 'database_acl'},
+                ],
                 'Records': [
                     [
-                        {'stringValue': 'dev'},
-                        {'longValue': 100},
                         {'stringValue': 'local'},
-                        {'stringValue': 'user=admin'},
-                        {'stringValue': 'encoding=utf8'},
+                        {'stringValue': 'dev'},
                         {'stringValue': 'Snapshot Isolation'},
+                        {'longValue': 100},
+                        {'stringValue': 'encoding=utf8'},
+                        {'stringValue': 'user=admin'},
                     ]
-                ]
+                ],
             },
             'query-123',
         )
@@ -1444,9 +1432,11 @@ class TestDiscoverFunctions:
         result = await discover_databases('test-cluster', 'dev')
 
         assert len(result) == 1
-        assert result[0]['database_name'] == 'dev'
-        assert result[0]['database_owner'] == 100
-        assert result[0]['database_type'] == 'local'
+        assert result[0].database_name == 'dev'
+        assert result[0].database_owner == 100
+        assert result[0].database_type == 'local'
+        assert result[0].parameters == 'encoding=utf8'
+        assert result[0].database_isolation_level == 'Snapshot Isolation'
 
         # SHOW DATABASES takes no bind parameters.
         sql = mock_execute_protected.call_args[1]['sql']
@@ -1473,6 +1463,15 @@ class TestDiscoverFunctions:
         )
         mock_execute_protected.return_value = (
             {
+                'ColumnMetadata': [
+                    {'name': 'database_name'},
+                    {'name': 'schema_name'},
+                    {'name': 'schema_owner'},
+                    {'name': 'schema_type'},
+                    {'name': 'schema_acl'},
+                    {'name': 'source_database'},
+                    {'name': 'schema_option'},
+                ],
                 'Records': [
                     [
                         {'stringValue': 'dev'},
@@ -1483,7 +1482,7 @@ class TestDiscoverFunctions:
                         {'stringValue': None},
                         {'stringValue': None},
                     ]
-                ]
+                ],
             },
             'query-456',
         )
@@ -1491,9 +1490,9 @@ class TestDiscoverFunctions:
         result = await discover_schemas('test-cluster', 'dev')
 
         assert len(result) == 1
-        assert result[0]['database_name'] == 'dev'
-        assert result[0]['schema_name'] == 'public'
-        assert result[0]['schema_owner'] == 100
+        assert result[0].database_name == 'dev'
+        assert result[0].schema_name == 'public'
+        assert result[0].schema_owner == 100
 
         # The database is embedded as a quoted identifier (no bind params).
         mock_execute_protected.assert_called_once()
@@ -1527,10 +1526,16 @@ class TestDiscoverFunctions:
         mock_execute_protected = mocker.patch(
             'awslabs.redshift_mcp_server.redshift._execute_protected_statement'
         )
-        # SHOW TABLES column order: database_name, schema_name, table_name,
-        # table_type, table_acl, remarks (table_type precedes table_acl).
         mock_execute_protected.return_value = (
             {
+                'ColumnMetadata': [
+                    {'name': 'database_name'},
+                    {'name': 'schema_name'},
+                    {'name': 'table_name'},
+                    {'name': 'table_type'},
+                    {'name': 'table_acl'},
+                    {'name': 'remarks'},
+                ],
                 'Records': [
                     [
                         {'stringValue': 'dev'},
@@ -1540,7 +1545,7 @@ class TestDiscoverFunctions:
                         {'stringValue': 'user=admin'},
                         {'stringValue': 'User data table'},
                     ]
-                ]
+                ],
             },
             'query-789',
         )
@@ -1548,13 +1553,13 @@ class TestDiscoverFunctions:
         result = await discover_tables('test-cluster', 'dev', 'public')
 
         assert len(result) == 1
-        assert result[0]['database_name'] == 'dev'
-        assert result[0]['schema_name'] == 'public'
-        assert result[0]['table_name'] == 'users'
-        # Positional remap is correct: type and acl are not swapped.
-        assert result[0]['table_type'] == 'TABLE'
-        assert result[0]['table_acl'] == 'user=admin'
-        assert result[0]['remarks'] == 'User data table'
+        assert result[0].database_name == 'dev'
+        assert result[0].schema_name == 'public'
+        assert result[0].table_name == 'users'
+        # type and acl are mapped by column name, not swapped by position.
+        assert result[0].table_type == 'TABLE'
+        assert result[0].table_acl == 'user=admin'
+        assert result[0].remarks == 'User data table'
 
         # db.schema is embedded as quoted identifiers (no bind params).
         mock_execute_protected.assert_called_once()
@@ -1590,6 +1595,20 @@ class TestDiscoverFunctions:
         )
         mock_execute_protected.return_value = (
             {
+                'ColumnMetadata': [
+                    {'name': 'database_name'},
+                    {'name': 'schema_name'},
+                    {'name': 'table_name'},
+                    {'name': 'column_name'},
+                    {'name': 'ordinal_position'},
+                    {'name': 'column_default'},
+                    {'name': 'is_nullable'},
+                    {'name': 'data_type'},
+                    {'name': 'character_maximum_length'},
+                    {'name': 'numeric_precision'},
+                    {'name': 'numeric_scale'},
+                    {'name': 'remarks'},
+                ],
                 'Records': [
                     [
                         {'stringValue': 'dev'},
@@ -1605,7 +1624,7 @@ class TestDiscoverFunctions:
                         {'longValue': 0},
                         {'stringValue': 'Primary key'},
                     ]
-                ]
+                ],
             },
             'query-101',
         )
@@ -1613,12 +1632,12 @@ class TestDiscoverFunctions:
         result = await discover_columns('test-cluster', 'dev', 'public', 'users')
 
         assert len(result) == 1
-        assert result[0]['database_name'] == 'dev'
-        assert result[0]['schema_name'] == 'public'
-        assert result[0]['table_name'] == 'users'
-        assert result[0]['column_name'] == 'id'
-        assert result[0]['ordinal_position'] == 1
-        assert result[0]['data_type'] == 'integer'
+        assert result[0].database_name == 'dev'
+        assert result[0].schema_name == 'public'
+        assert result[0].table_name == 'users'
+        assert result[0].column_name == 'id'
+        assert result[0].ordinal_position == 1
+        assert result[0].data_type == 'integer'
 
         # db.schema.table is embedded as quoted identifiers (no bind params).
         mock_execute_protected.assert_called_once()
@@ -1680,10 +1699,6 @@ class TestExecuteQuery:
             'query-123',
         )
 
-        # Mock time for execution time calculation
-        mock_time = mocker.patch('time.time')
-        mock_time.side_effect = [1000.0, 1000.123]  # start_time, end_time
-
         result = await execute_query(
             'test-cluster',
             'dev',
@@ -1695,7 +1710,6 @@ class TestExecuteQuery:
             [1, 'Test User', 95.5, True, None, "{'unknownType': 'fallback'}"]
         ]
         assert result['row_count'] == 1
-        assert result['execution_time_ms'] == 123
         assert result['query_id'] == 'query-123'
 
     @pytest.mark.asyncio
@@ -1709,9 +1723,6 @@ class TestExecuteQuery:
             {'Records': [], 'ColumnMetadata': []},
             'set-query-123',
         )
-
-        mock_time = mocker.patch('time.time')
-        mock_time.side_effect = [1000.0, 1000.05]  # start_time, end_time
 
         result = await execute_query(
             'test-cluster',
@@ -1747,11 +1758,7 @@ _CONCURRENCY_CLUSTER_TYPES = pytest.mark.parametrize(
 
 def _cluster_info(cluster_type='provisioned'):
     """Build the cluster_info shared by the concurrency tests."""
-    return {
-        'identifier': 'test-cluster',
-        'type': cluster_type,
-        'status': 'available',
-    }
+    return _fake_cluster(type=cluster_type)
 
 
 def _make_counting_session_fake(prefix='session'):
@@ -2024,9 +2031,7 @@ class TestConcurrency:
 
         mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters',
-            return_value=[
-                {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-            ],
+            return_value=[_fake_cluster()],
         )
 
         mock_session_manager = mocker.patch('awslabs.redshift_mcp_server.redshift.session_manager')
@@ -2129,9 +2134,7 @@ class TestConcurrency:
         mock_discover_clusters = mocker.patch(
             'awslabs.redshift_mcp_server.redshift.discover_clusters'
         )
-        mock_discover_clusters.return_value = [
-            {'identifier': 'test-cluster', 'type': 'provisioned', 'status': 'available'}
-        ]
+        mock_discover_clusters.return_value = [_fake_cluster()]
 
         # Real Lock so we can inspect .locked().
         real_lock = asyncio.Lock()

--- a/src/redshift-mcp-server/tests/test_review_executor.py
+++ b/src/redshift-mcp-server/tests/test_review_executor.py
@@ -15,6 +15,7 @@
 """Tests for review cluster executor."""
 
 import pytest
+from awslabs.redshift_mcp_server.models import RedshiftCluster
 from awslabs.redshift_mcp_server.review.definitions import (
     RECOMMENDATIONS,
     SIGNAL_EVALUATION_SQL,
@@ -40,9 +41,21 @@ def _make_empty_response() -> dict:
     return {'rows': [], 'columns': ['count', 'rec_id'], 'row_count': 0}
 
 
+def _cluster(identifier='test-cluster', cluster_type='provisioned'):
+    """Build a RedshiftCluster model for discover_clusters mocks."""
+    return RedshiftCluster.model_validate(
+        {
+            'identifier': identifier,
+            'type': cluster_type,
+            'status': 'available',
+            'database_name': 'dev',
+        }
+    )
+
+
 def _make_discover_clusters(cluster_type='provisioned'):
     """Build a mock discover_clusters returning a single cluster."""
-    return AsyncMock(return_value=[{'identifier': 'test-cluster', 'type': cluster_type}])
+    return AsyncMock(return_value=[_cluster(cluster_type=cluster_type)])
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +72,7 @@ class TestServerlessExclusion:
         execute_query_func = AsyncMock(side_effect=lambda *a, **kw: _make_empty_response())
         discover_clusters_func = AsyncMock(
             return_value=[
-                {'identifier': 'test-cluster', 'type': 'serverless'},
+                _cluster(cluster_type='serverless'),
             ]
         )
 
@@ -79,7 +92,7 @@ class TestServerlessExclusion:
         execute_query_func = AsyncMock(side_effect=lambda *a, **kw: _make_empty_response())
         discover_clusters_func = AsyncMock(
             return_value=[
-                {'identifier': 'test-cluster', 'type': 'provisioned'},
+                _cluster(),
             ]
         )
 
@@ -98,7 +111,7 @@ class TestServerlessExclusion:
         execute_query_func = AsyncMock(side_effect=lambda *a, **kw: _make_empty_response())
         discover_clusters_func = AsyncMock(
             return_value=[
-                {'identifier': 'test-cluster', 'type': 'provisioned'},
+                _cluster(),
             ]
         )
 
@@ -202,7 +215,7 @@ class TestErrorPropagation:
         execute_query_func = AsyncMock()
         discover_clusters_func = AsyncMock(
             return_value=[
-                {'identifier': 'other-cluster', 'type': 'provisioned'},
+                _cluster(identifier='other-cluster'),
             ]
         )
 

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -37,6 +37,7 @@ from awslabs.redshift_mcp_server.server import (
     list_tables_tool,
     review_cluster_tool,
 )
+from datetime import datetime
 from mcp.server.fastmcp import Context
 
 
@@ -50,38 +51,38 @@ class TestListClustersTool:
             'awslabs.redshift_mcp_server.server.discover_clusters'
         )
         mock_discover_clusters.return_value = [
-            {
-                'identifier': 'test-cluster',
-                'type': 'provisioned',
-                'status': 'available',
-                'database_name': 'dev',
-                'endpoint': 'test-cluster.abc123.us-east-1.redshift.amazonaws.com',
-                'port': 5439,
-                'vpc_id': 'vpc-12345',
-                'node_type': 'dc2.large',
-                'number_of_nodes': 2,
-                'creation_time': '2023-01-01T00:00:00Z',
-                'master_username': 'testuser',
-                'publicly_accessible': False,
-                'encrypted': True,
-                'tags': {'Environment': 'test'},
-            },
-            {
-                'identifier': 'test-workgroup',
-                'type': 'serverless',
-                'status': 'AVAILABLE',
-                'database_name': 'dev',
-                'endpoint': 'test-workgroup.123456.us-east-1.redshift-serverless.amazonaws.com',
-                'port': 5439,
-                'vpc_id': 'subnet-12345',
-                'node_type': None,
-                'number_of_nodes': None,
-                'creation_time': '2023-01-01T00:00:00Z',
-                'master_username': None,
-                'publicly_accessible': False,
-                'encrypted': True,
-                'tags': {},
-            },
+            RedshiftCluster(
+                identifier='test-cluster',
+                type='provisioned',
+                status='available',
+                database_name='dev',
+                endpoint='test-cluster.abc123.us-east-1.redshift.amazonaws.com',
+                port=5439,
+                vpc_id='vpc-12345',
+                node_type='dc2.large',
+                number_of_nodes=2,
+                creation_time=datetime(2023, 1, 1),
+                master_username='testuser',
+                publicly_accessible=False,
+                encrypted=True,
+                tags={'Environment': 'test'},
+            ),
+            RedshiftCluster(
+                identifier='test-workgroup',
+                type='serverless',
+                status='AVAILABLE',
+                database_name='dev',
+                endpoint='test-workgroup.123456.us-east-1.redshift-serverless.amazonaws.com',
+                port=5439,
+                vpc_id='subnet-12345',
+                node_type=None,
+                number_of_nodes=None,
+                creation_time=datetime(2023, 1, 1),
+                master_username=None,
+                publicly_accessible=False,
+                encrypted=True,
+                tags={},
+            ),
         ]
 
         result = await list_clusters_tool(Context())
@@ -145,22 +146,22 @@ class TestListDatabasesTool:
             'awslabs.redshift_mcp_server.server.discover_databases'
         )
         mock_discover_databases.return_value = [
-            {
-                'database_name': 'dev',
-                'database_owner': 100,
-                'database_type': 'local',
-                'database_acl': 'user=admin',
-                'database_options': 'encoding=utf8',
-                'database_isolation_level': 'Snapshot Isolation',
-            },
-            {
-                'database_name': 'test',
-                'database_owner': 101,
-                'database_type': 'shared',
-                'database_acl': 'user=readonly',
-                'database_options': 'encoding=utf8',
-                'database_isolation_level': 'Serializable',
-            },
+            RedshiftDatabase(
+                database_name='dev',
+                database_owner=100,
+                database_type='local',
+                database_acl='user=admin',
+                parameters='encoding=utf8',
+                database_isolation_level='Snapshot Isolation',
+            ),
+            RedshiftDatabase(
+                database_name='test',
+                database_owner=101,
+                database_type='shared',
+                database_acl='user=readonly',
+                parameters='encoding=utf8',
+                database_isolation_level='Serializable',
+            ),
         ]
 
         result = await list_databases_tool(Context(), 'test-cluster', 'dev')
@@ -220,24 +221,24 @@ class TestListSchemasTool:
         """Test successful schema discovery."""
         mock_discover_schemas = mocker.patch('awslabs.redshift_mcp_server.server.discover_schemas')
         mock_discover_schemas.return_value = [
-            {
-                'database_name': 'dev',
-                'schema_name': 'public',
-                'schema_owner': 100,
-                'schema_type': 'local',
-                'schema_acl': 'user=admin',
-                'source_database': None,
-                'schema_option': None,
-            },
-            {
-                'database_name': 'dev',
-                'schema_name': 'external_schema',
-                'schema_owner': 100,
-                'schema_type': 'external',
-                'schema_acl': 'user=admin',
-                'source_database': 's3_source',
-                'schema_option': 'IAM_ROLE arn:aws:iam::123456789012:role/RedshiftRole',
-            },
+            RedshiftSchema(
+                database_name='dev',
+                schema_name='public',
+                schema_owner=100,
+                schema_type='local',
+                schema_acl='user=admin',
+                source_database=None,
+                schema_option=None,
+            ),
+            RedshiftSchema(
+                database_name='dev',
+                schema_name='external_schema',
+                schema_owner=100,
+                schema_type='external',
+                schema_acl='user=admin',
+                source_database='s3_source',
+                schema_option='IAM_ROLE arn:aws:iam::123456789012:role/RedshiftRole',
+            ),
         ]
 
         result = await list_schemas_tool(Context(), 'test-cluster', 'dev')
@@ -295,22 +296,22 @@ class TestListTablesTool:
         """Test successful table discovery."""
         mock_discover_tables = mocker.patch('awslabs.redshift_mcp_server.server.discover_tables')
         mock_discover_tables.return_value = [
-            {
-                'database_name': 'dev',
-                'schema_name': 'public',
-                'table_name': 'users',
-                'table_acl': 'user=admin',
-                'table_type': 'TABLE',
-                'remarks': 'User data table',
-            },
-            {
-                'database_name': 'dev',
-                'schema_name': 'public',
-                'table_name': 'user_view',
-                'table_acl': 'user=admin',
-                'table_type': 'VIEW',
-                'remarks': 'User view',
-            },
+            RedshiftTable(
+                database_name='dev',
+                schema_name='public',
+                table_name='users',
+                table_acl='user=admin',
+                table_type='TABLE',
+                remarks='User data table',
+            ),
+            RedshiftTable(
+                database_name='dev',
+                schema_name='public',
+                table_name='user_view',
+                table_acl='user=admin',
+                table_type='VIEW',
+                remarks='User view',
+            ),
         ]
 
         result = await list_tables_tool(Context(), 'test-cluster', 'dev', 'public')
@@ -368,34 +369,34 @@ class TestListColumnsTool:
         """Test successful column discovery."""
         mock_discover_columns = mocker.patch('awslabs.redshift_mcp_server.server.discover_columns')
         mock_discover_columns.return_value = [
-            {
-                'database_name': 'dev',
-                'schema_name': 'public',
-                'table_name': 'users',
-                'column_name': 'id',
-                'ordinal_position': 1,
-                'column_default': None,
-                'is_nullable': 'NO',
-                'data_type': 'integer',
-                'character_maximum_length': None,
-                'numeric_precision': None,
-                'numeric_scale': None,
-                'remarks': 'Primary key',
-            },
-            {
-                'database_name': 'dev',
-                'schema_name': 'public',
-                'table_name': 'users',
-                'column_name': 'name',
-                'ordinal_position': 2,
-                'column_default': None,
-                'is_nullable': 'YES',
-                'data_type': 'varchar',
-                'character_maximum_length': 255,
-                'numeric_precision': None,
-                'numeric_scale': None,
-                'remarks': 'User name',
-            },
+            RedshiftColumn(
+                database_name='dev',
+                schema_name='public',
+                table_name='users',
+                column_name='id',
+                ordinal_position=1,
+                column_default=None,
+                is_nullable='NO',
+                data_type='integer',
+                character_maximum_length=None,
+                numeric_precision=None,
+                numeric_scale=None,
+                remarks='Primary key',
+            ),
+            RedshiftColumn(
+                database_name='dev',
+                schema_name='public',
+                table_name='users',
+                column_name='name',
+                ordinal_position=2,
+                column_default=None,
+                is_nullable='YES',
+                data_type='varchar',
+                character_maximum_length=255,
+                numeric_precision=None,
+                numeric_scale=None,
+                remarks='User name',
+            ),
         ]
 
         result = await list_columns_tool(Context(), 'test-cluster', 'dev', 'public', 'users')
@@ -463,7 +464,6 @@ class TestExecuteQueryTool:
                 [2, 'Max', 42, False, None],
             ],
             'row_count': 2,
-            'execution_time_ms': 123,
             'query_id': 'query-123',
         }
 
@@ -483,7 +483,6 @@ class TestExecuteQueryTool:
         assert result.rows[0] == [1, 'Sergey', 54, True, 95.5]
         assert result.rows[1] == [2, 'Max', 42, False, None]
         assert result.row_count == 2
-        assert result.execution_time_ms == 123
         assert result.query_id == 'query-123'
 
     @pytest.mark.asyncio
@@ -494,7 +493,6 @@ class TestExecuteQueryTool:
             'columns': ['count'],
             'rows': [],
             'row_count': 0,
-            'execution_time_ms': 45,
             'query_id': 'query-456',
         }
 
@@ -512,7 +510,6 @@ class TestExecuteQueryTool:
         assert result.columns == ['count']
         assert len(result.rows) == 0
         assert result.row_count == 0
-        assert result.execution_time_ms == 45
         assert result.query_id == 'query-456'
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes three issues in the redshift-mcp-server discovery/query tools and clarifies datashare behavior in the docs.

### Changes

- Serverless `list_clusters` reported a bogus database_name (e.g. `true`) because it read an arbitrary config parameter; report the built-in `dev` database instead. Every serverless workgroup exposes `dev` and can always connect to it. Callers can still pass an explicit database_name to the other tools.
- SHOW output is now parsed by column name. Introduces a small `RedshiftDataModel` base whose `from_redshift_response` builds models by matching result columns to model fields by name (via the result-set column metadata), so the discovery tools (`list_databases`, `list_schemas`, `list_tables`, `list_columns`) are resilient to column reordering or additional columns instead of relying on fixed positions. The discovery models inherit it; `execute_query` shares the same value decoder. 
- Removed `execution_time_ms` from query results. It reported server-side wall time including session/queue overhead, so it could be wildly larger than the actual query time and was misleading. Clients can time tool calls directly. `QueryResult` now returns `columns`, `rows`, `row_count`, and `query_id`.
- Docs: clarified that discovery reflects the privileges of the principal the server connects as — datashare (shared) databases and their schemas appear only when that principal has been granted access to the consumer database.


### User experience

<details>

```
% kiro-cli chat \
    --model claude-opus-4.8 \
    --no-interactive \
    --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
'Use Redshift MCP Server to run end-to-end (integration) tests covering the scenarios for the changes introduced in the current branch only. Get the test scenario ideas from the unit tests under the project directory. Provide a short testing summary, one line per scenario.'
```
...

> All six scenarios pass against live clusters. Here's the testing summary.

## Integration Test Summary — branch redshift-mcp-show-fixes (commit 08ddc5a1)

Tested live via the Redshift MCP Server against us-east-1 (serverless workgroup redshift-cluster-serverless + provisioned test-drive-consumer-personal). Scenarios derived from the branch's changed unit tests.

| # | Scenario (unit test) | Result |
|---|---|---|
| 1 | Serverless db name fix — list_clusters reports database_name="dev" for serverless, not a bogus config value (test_discover_clusters_serverless) | ✅ Both serverless workgroups returned "dev"; provisioned +
serverless all returned as typed models |
| 2 | parameters field rename + column-name mapping — list_databases exposes parameters (was database_options) (test_discover_databases) | ✅ parameters field present; connecting to serverless dev succeeded (
validates the 'dev' connect fix) |
| 3 | Schema discovery mapping — list_schemas maps all 7 fields by column name (test_discover_schemas) | ✅ tickit/public/information_schema returned with correct owner (long), type, acl |
| 4 | Table type/acl not swapped — list_tables maps table_type vs table_acl by name, not position (test_discover_tables) | ✅ 7 tables; table_type="TABLE" and table_acl=ACL string correctly assigned (the exact
regression fixed) |
| 5 | Column discovery mapping — list_columns maps 12 fields incl. mixed null/long/string (test_discover_columns) | ✅ All 10 sales columns returned with correct ordinal, data_type, precision/scale, nullable |
| 6 | Cell decoder + drop execution_time_ms — execute_query decodes string/long/double/bool/null and omits execution_time_ms (test_execute_query_success) | ✅ Row [1,"lbl",728.0,true,null] decoded correctly; result
had only columns/rows/row_count/query_id — no execution_time_ms |
| + | Datashare visibility (doc change) — shared DBs appear for granted principals | ✅ Consumer cluster showed sample_data_dev as shared with populated datashare parameters JSON |

All branch-introduced behaviors verified end-to-end with no failures.




```
% kiro-cli chat \
    --model claude-opus-4.8 \
    --no-interactive \
    --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
'Use Redshift MCP Server to run a complete set of end-to-end (integration) tests covering all its tools. Check both provisioned and serverless clusters, including the database schema exploration in both. Check the SQL read-only protection, transaction breaker protection, failed user SQL behavior. Get the test scenario ideas from the unit tests under the project directory. Provide a short testing summary, one line per tool.'
```

...

> All tests passed. Here's the end-to-end testing summary.

## Redshift MCP Server — E2E Test Summary

Environment: us-east-1 · provisioned = redshift-cluster-1 · serverless = redshift-cluster-serverless · sample dataset sample_data_dev.tickit

Per-tool results (one line each):

- **list_clusters** — ✅ Returned all 6 resources (4 provisioned, 2 serverless) with correct type/status/config.
- **list_databases** — ✅ Worked on both cluster types; listed local + auto-mounted catalog DBs (sample_data_dev present on both).
- **list_schemas** — ✅ Explored sample_data_dev on both; returned tickit/public/information_schema (+tpcds/tpch on provisioned)^[[O with ACLs.
- **list_tables** — ✅ Listed all 7 tickit tables on both cluster types identically.
- **list_columns** — ✅ Returned all 10 tickit.sales columns with types/precision/nullability, identical across both.
- **execute_query** — ✅ Valid SELECTs succeeded on both (provisioned aggregate: 344,912 rows / $221.5M; serverless top-3 recent sales) and all protection paths held (see below).
- **review_cluster** — ✅ Provisioned: 11 signals → 11 findings + recommendations; Serverless: 8 signals (provisioned-only diagnostics correctly skipped, ServerlessScaling added) → 0 findings (healthy).

Safety / negative-path checks (all behaved correctly):

| Scenario | Input | Result |
|---|---|---|
| Read-only guard (deny-list) | TRUNCATE tickit.sales | Rejected: Statement type not allowed in read-only mode: TRUNCATE |
| Read-only guard (DCL) | GRANT SELECT … TO PUBLIC | Rejected: …not allowed…: GRANT |
| Multi-statement guard | SELECT 1; SELECT 2 | Rejected: Only a single SQL statement is allowed |
| Transaction breaker (provisioned) | CREATE TABLE … | Passed guard, blocked by engine: transaction is read-only |
| Transaction breaker (serverless) | INSERT INTO tickit.sales … | Blocked by engine: transaction is read-only |
| No side effects | SELECT … FROM mcp_e2e_should_not_exist | relation … does not exist — confirms the CREATE was rolled back |
| Failed user SQL (unparseable) | SELECT FROM WHERE | Fails closed: SQL could not be parsed |
| Failed user SQL (bad relation) | SELECT * FROM tickit.no_such_table_xyz | Engine error surfaced cleanly: relation … does not exist |

All 7 tools function correctly across both provisioned and serverless clusters. The two-layer write protection is verified end-to-end: the AST deny-list stops transaction-control/DDL-egress statements before
execution, and the BEGIN READ ONLY transaction backstop rejects ordinary writes (CREATE/INSERT) that intentionally pass the guard — with no residual side effects. Failed-query behavior (both parse-time and engine-
time) returns clear errors without leaking internals.

</details>

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) - Yes, minor. `execution_time_ms` is removed from `execute_query` results; consumers that read that field should drop it (all other fields are unchanged).


**RFC issue number**:

Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
