### PR TITLE
fix(aws-location-mcp-server): read route distance/duration from Summary.Overview

### DIFF
--- a/src/aws-location-mcp-server/awslabs/aws_location_server/server.py
+++ b/src/aws-location-mcp-server/awslabs/aws_location_server/server.py
@@ -737,9 +737,9 @@ async def calculate_route(
         if not routes:
             return {'error': 'No route found'}
         route = routes[0]
-        summary_overview = route.get('Summary', {}).get('Overview', {})
-        distance_meters = summary_overview.get('Distance', None)
-        duration_seconds = summary_overview.get('Duration', None)
+        summary = route.get('Summary', {})
+        distance_meters = summary.get('Distance', None)
+        duration_seconds = summary.get('Duration', None)
         turn_by_turn = []
         for leg in route.get('Legs', []):
             vehicle_leg_details = leg.get('VehicleLegDetails', {})

--- a/src/aws-location-mcp-server/awslabs/aws_location_server/server.py
+++ b/src/aws-location-mcp-server/awslabs/aws_location_server/server.py
@@ -737,8 +737,9 @@ async def calculate_route(
         if not routes:
             return {'error': 'No route found'}
         route = routes[0]
-        distance_meters = route.get('Distance', None)
-        duration_seconds = route.get('DurationSeconds', None)
+        summary_overview = route.get('Summary', {}).get('Overview', {})
+        distance_meters = summary_overview.get('Distance', None)
+        duration_seconds = summary_overview.get('Duration', None)
         turn_by_turn = []
         for leg in route.get('Legs', []):
             vehicle_leg_details = leg.get('VehicleLegDetails', {})

--- a/src/aws-location-mcp-server/tests/test_server.py
+++ b/src/aws-location-mcp-server/tests/test_server.py
@@ -676,10 +676,8 @@ async def test_calculate_route(mock_boto3_client, mock_context):
         'Routes': [
             {
                 'Summary': {
-                    'Overview': {
-                        'Distance': 100.0,
-                        'Duration': 300,
-                    },
+                    'Distance': 100.0,
+                    'Duration': 300,
                 },
                 'Legs': [
                     {
@@ -805,7 +803,7 @@ async def test_calculate_route_raw_mode(mock_boto3_client, mock_context):
     # function processes the response correctly.
 
     # Create a mock response with the expected structure
-    mock_response = {'Routes': [{'Summary': {'Overview': {'Distance': 100.0, 'Duration': 300}}}]}
+    mock_response = {'Routes': [{'Summary': {'Distance': 100.0, 'Duration': 300}}]}
 
     # Create a mock for the calculate_route function
     with patch('awslabs.aws_location_server.server.GeoRoutesClient') as mock_geo_client:
@@ -972,10 +970,8 @@ async def test_calculate_route_with_leg_geometry(mock_boto3_client, mock_context
         'Routes': [
             {
                 'Summary': {
-                    'Overview': {
-                        'Distance': 100.0,
-                        'Duration': 300,
-                    },
+                    'Distance': 100.0,
+                    'Duration': 300,
                 },
                 'Legs': [
                     {

--- a/src/aws-location-mcp-server/tests/test_server.py
+++ b/src/aws-location-mcp-server/tests/test_server.py
@@ -675,8 +675,12 @@ async def test_calculate_route(mock_boto3_client, mock_context):
     mock_response = {
         'Routes': [
             {
-                'Distance': 100.0,
-                'DurationSeconds': 300,
+                'Summary': {
+                    'Overview': {
+                        'Distance': 100.0,
+                        'Duration': 300,
+                    },
+                },
                 'Legs': [
                     {
                         'Distance': 100.0,
@@ -801,7 +805,7 @@ async def test_calculate_route_raw_mode(mock_boto3_client, mock_context):
     # function processes the response correctly.
 
     # Create a mock response with the expected structure
-    mock_response = {'Routes': [{'Distance': 100.0, 'DurationSeconds': 300}]}
+    mock_response = {'Routes': [{'Summary': {'Overview': {'Distance': 100.0, 'Duration': 300}}}]}
 
     # Create a mock for the calculate_route function
     with patch('awslabs.aws_location_server.server.GeoRoutesClient') as mock_geo_client:
@@ -967,8 +971,12 @@ async def test_calculate_route_with_leg_geometry(mock_boto3_client, mock_context
     mock_response = {
         'Routes': [
             {
-                'Distance': 100.0,
-                'DurationSeconds': 300,
+                'Summary': {
+                    'Overview': {
+                        'Distance': 100.0,
+                        'Duration': 300,
+                    },
+                },
                 'Legs': [
                     {
                         'Distance': 100.0,


### PR DESCRIPTION
## Summary

The `calculate_route` tool always returns `null` for the top-level `distance_meters` and `duration_seconds` fields, despite per-step values in `turn_by_turn` being populated correctly. The root cause is reading from non-existent keys at the route top level instead of the nested `Summary.Overview` path where the `calculate_routes` API actually returns them.

## Changes

**`server.py`** — Read `Distance` and `Duration` from `route['Summary']['Overview']` instead of `route['Distance']` / `route['DurationSeconds']` (2 lines changed).

**`test_server.py`** — Update three test mock responses (`test_calculate_route`, `test_calculate_route_raw_mode`, `test_calculate_route_with_leg_geometry`) to use the correct `Summary.Overview` structure matching the real API response.

## Root Cause

The `calculate_routes` API response nests route-level totals under `Summary.Overview.Distance` and `Summary.Overview.Duration`. The code was reading `route.get('Distance')` and `route.get('DurationSeconds')` at the top level, which don't exist.

Note: The `optimize_waypoints` API does return `Distance` and `DurationSeconds` at the route top level, so that function is correct and unchanged.

## Fixes

Fixes #3493

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
