### PR TITLE
fix(amazon-bedrock-agentcore): preserve non-ASCII text in browser_evaluate

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/browser/observation.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/browser/observation.py
@@ -328,7 +328,7 @@ class ObservationTools:
             if isinstance(result, (str, int, float, bool)):
                 return f'Result: {result}'
 
-            return f'Result:\n{json.dumps(result, indent=2, default=str)}'
+            return f'Result:\n{json.dumps(result, indent=2, default=str, ensure_ascii=False)}'
 
         except Exception as e:
             error_msg = f'Error evaluating JavaScript: {e}'


### PR DESCRIPTION
## Summary

`browser_evaluate` returns non-ASCII text (CJK characters, emoji, accented characters) as `\uXXXX` escape sequences, making the output unreadable for non-Latin scripts. This is the same class of bug fixed in `bedrock-kb-retrieval` (PR #3821).

## Change

Add `ensure_ascii=False` to the `json.dumps()` call in `observation.py`:

```python
# Before:
return f'Result:\n{json.dumps(result, indent=2, default=str)}'

# After:
return f'Result:\n{json.dumps(result, indent=2, default=str, ensure_ascii=False)}'
```

Scalar strings already return verbatim — only structured object/array results were affected.

## Fixes

Fixes #3994

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
