### PR TITLE
chore(aws-api-mcp-server): upgrade AWS CLI to v1.45.48

### DIFF
--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "requests>=2.32.4",
     "python-frontmatter>=1.1.0",
     "fastmcp>=3.0.1",
-    "awscli==1.45.47",
+    "awscli==1.45.48",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.45.47"
+version = "1.45.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -89,9 +89,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/09/36cc214a1b30254a081c8458f20140805116cea0b2b51cb5cb264685c8ce/awscli-1.45.47.tar.gz", hash = "sha256:bb1b9955e07416edbdb32874454224178c31e35a5e427530a31b530d948787f4", size = 1903358, upload-time = "2026-07-13T19:32:08.299Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ab/0e29bde135965c4124152128b057f8f5d998fd21e905ab24128150957683/awscli-1.45.48.tar.gz", hash = "sha256:afebfe62868c65246d69e885596a06d3f5525d394e01ddb91e939e3970f8d8fd", size = 1903196, upload-time = "2026-07-14T19:29:53.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/dd/60628b455bb6af44c062dfd4dc194b7c3e2d71406c1a8979c258dff6a489/awscli-1.45.47-py3-none-any.whl", hash = "sha256:5315a0d552c11c74f92c2dcb79896d2154931bc292899e43415065a9ac31afe2", size = 4667086, upload-time = "2026-07-13T19:32:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/cdf4093cad40f6bbf30a4158544659210b8812a236da4709033f13ccfcdc/awscli-1.45.48-py3-none-any.whl", hash = "sha256:b35b6dedde63faed516e7ad35caddb9afffa01c57f3f4f23b112f70d20e96376", size = 4667090, upload-time = "2026-07-14T19:29:50.059Z" },
 ]
 
 [[package]]
@@ -169,7 +169,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "awscli", specifier = "==1.45.47" },
+    { name = "awscli", specifier = "==1.45.48" },
     { name = "boto3", specifier = ">=1.41.0" },
     { name = "botocore", extras = ["crt"], specifier = ">=1.41.0" },
     { name = "fastmcp", specifier = ">=3.0.1" },
@@ -230,16 +230,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.43.47"
+version = "1.43.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/2c/279bf51f68e85a12323996aa4a7f2a163da84dad949ee751caa318928ce1/botocore-1.43.47.tar.gz", hash = "sha256:9e04d8da7f9cff8a911b14284829f78b74e1ce785444833199837decb5ecc17a", size = 15696311, upload-time = "2026-07-13T19:32:01.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/69/76c5576654c0982351a821c544042ccd7a25a060776453a3c15e0486e47e/botocore-1.43.48.tar.gz", hash = "sha256:4f60c1072fb529610359cdb6df92c59615d739df3b0a124091d3bbd28f7ea00c", size = 15700978, upload-time = "2026-07-14T19:29:45.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/c0/6a8f824d613c5e5b8755ce99e3cf83fd1db135f5df02da7ed5bf106abdfd/botocore-1.43.47-py3-none-any.whl", hash = "sha256:4d16559a3a1866fa7b9e651dd1422c1a033497e069f8a73cae5eebafe70ff39c", size = 15382537, upload-time = "2026-07-13T19:31:56.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/28d40443ed912260d55cf7a5d377378fc43e384627fd57b632472cbea7bf/botocore-1.43.48-py3-none-any.whl", hash = "sha256:cc9b4e925c1913d662194507f4f9b37aa744dcd2361af31c013672eafe824490", size = 15385380, upload-time = "2026-07-14T19:29:41.826Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
# AWS CLI Version Upgrade

This PR upgrades the AWS CLI version in the aws-api-mcp-server package.

## Changes
* Updated AWS CLI from **v1.45.47** to **v1.45.48**

## Checklist
- [ ] Dependencies have been upgraded
- [ ] Lock file has been updated
- [ ] Tests pass with new versions

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).