### PR TITLE
fix(eks-mcp-server): handle null optional fields in get_k8s_events

### DIFF
--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
@@ -1103,13 +1103,13 @@ class K8sHandler:
             cleaned_events = [self.cleanup_resource_response(event) for event in events]
             event_items = [
                 EventItem(
-                    first_timestamp=event['first_timestamp'],
-                    last_timestamp=event['last_timestamp'],
-                    count=event['count'],
-                    message=event['message'],
-                    reason=event['reason'],
-                    reporting_component=event['reporting_component'],
-                    type=event['type'],
+                    first_timestamp=event.get('first_timestamp'),
+                    last_timestamp=event.get('last_timestamp'),
+                    count=event.get('count'),
+                    message=event.get('message', ''),
+                    reason=event.get('reason'),
+                    reporting_component=event.get('reporting_component'),
+                    type=event.get('type'),
                 )
                 for event in cleaned_events
             ]

--- a/src/eks-mcp-server/tests/test_k8s_handler.py
+++ b/src/eks-mcp-server/tests/test_k8s_handler.py
@@ -1591,6 +1591,84 @@ metadata:
             assert data['events'][1]['message'] == 'Container started'
 
     @pytest.mark.asyncio
+    async def test_get_k8s_events_with_null_fields(
+        self, mock_context, mock_mcp, mock_client_cache
+    ):
+        """Test get_k8s_events when events carry null optional fields.
+
+        Modern events.k8s.io/v1 events leave the legacy fields (firstTimestamp,
+        lastTimestamp, count, reason, type, ...) set to None. cleanup_resource_response
+        strips null-valued keys, so the handler must not assume those keys are present.
+        Regression test for a KeyError raised when subscripting the dropped keys.
+        """
+        # Initialize the K8s handler
+        with patch(
+            'awslabs.eks_mcp_server.k8s_handler.K8sClientCache', return_value=mock_client_cache
+        ):
+            handler = K8sHandler(mock_mcp, allow_sensitive_data_access=True)
+
+        # Mock get_client with two events: one whose optional fields are all None
+        # (e.g. an events.k8s.io/v1 event with no legacy fields), and one where only
+        # some fields are null. cleanup_resource_response strips the null keys in both.
+        mock_k8s_apis = MagicMock()
+        mock_k8s_apis.get_events.return_value = [
+            {
+                'first_timestamp': None,
+                'last_timestamp': None,
+                'count': None,
+                'message': 'Something happened',
+                'reason': None,
+                'reporting_component': None,
+                'type': None,
+            },
+            {
+                'first_timestamp': '2023-01-01T00:00:00Z',
+                'last_timestamp': None,
+                'count': 3,
+                'message': 'Partly populated',
+                'reason': None,
+                'reporting_component': 'kubelet',
+                'type': 'Warning',
+            },
+        ]
+
+        with patch.object(handler, 'get_client', return_value=mock_k8s_apis):
+            result = await handler.get_k8s_events(
+                mock_context,
+                cluster_name='test-cluster',
+                kind='Pod',
+                name='test-pod',
+                namespace='test-namespace',
+            )
+
+            # The tool must succeed rather than raising KeyError on the dropped keys
+            assert not result.isError
+
+            data = json.loads(result.content[1].text)
+            assert data['count'] == 2
+            assert len(data['events']) == 2
+
+            # All-null optional fields come back as None; the message is preserved
+            all_null = data['events'][0]
+            assert all_null['message'] == 'Something happened'
+            assert all_null['first_timestamp'] is None
+            assert all_null['last_timestamp'] is None
+            assert all_null['count'] is None
+            assert all_null['reason'] is None
+            assert all_null['reporting_component'] is None
+            assert all_null['type'] is None
+
+            # Mixed event: present fields kept, null fields returned as None
+            mixed = data['events'][1]
+            assert mixed['message'] == 'Partly populated'
+            assert mixed['first_timestamp'] == '2023-01-01T00:00:00Z'
+            assert mixed['count'] == 3
+            assert mixed['reporting_component'] == 'kubelet'
+            assert mixed['type'] == 'Warning'
+            assert mixed['last_timestamp'] is None
+            assert mixed['reason'] is None
+
+    @pytest.mark.asyncio
     async def test_get_k8s_events_empty(self, mock_context, mock_mcp, mock_client_cache):
         """Test get_k8s_events method with no events found."""
         # Initialize the K8s handler


### PR DESCRIPTION
Fixes

## Summary

### Changes

`get_k8s_events` could fail with a `KeyError` and return an error instead of the events.

The cause: each event is first passed through `cleanup_resource_response`, which removes every key whose value is `None`. The code then read those same keys directly, for example `event['first_timestamp']`. When an event has a null field, that key is already gone, so the direct lookup raises `KeyError`.

The fix changes those lookups to use `.get()`, which returns `None` for a missing key instead of raising. The `EventItem` model already declares these fields as `Optional`, so `None` is a valid value. `message` keeps a safe `''` default.

This also matches how the handler already reads other cleaned responses. The `list_k8s_resources` summary path uses `item_dict.get(...)` on the same kind of cleaned dict. The events path was the only spot still using direct key access.

A regression test is added. It covers one event with all optional fields null, and one event that is only partly populated.

### User experience

Before: if any returned event has a null legacy field, the whole call fails with `Failed to get events for <kind> <ns>/<name>: 'first_timestamp'` and returns no events. This is common on modern clusters, where `events.k8s.io/v1` events often leave `firstTimestamp`, `lastTimestamp`, and `count` null.

After: the call succeeds and returns all events. Missing fields are reported as null.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
