### PR TITLE
feat(billing-cost-management-mcp-server): add read-only invoice-units and procurement-preferences tools

### DIFF
--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -65,6 +65,8 @@ MCP server for accessing AWS Billing and Cost Management capabilities.
 ### AWS Invoicing
 
 - **Invoice summaries**: List invoice-level details (invoice ID, type, billing period, issued/due dates, issuing entity, and amounts with discount/tax/fee breakdowns across base, tax, and payment currencies) for an account or a single invoice, filtered by month or date range
+- **Invoice units**: List and retrieve invoice unit definitions (groups of accounts that receive a separate invoice, with their receiver account and linked-account rules), filtered by name, receiver, or member account; and fetch invoice receiver profiles (legal name, address, tax registration number) for a set of accounts
+- **Procurement portal preferences**: List and retrieve procurement portal connections (SAP Business Network, Coupa) and e-invoice delivery / purchase-order retrieval settings
 
 ### Specialized Cost Optimization Prompts
 
@@ -298,6 +300,11 @@ AWS Billing Conductor:
 
 AWS Invoicing:
 - invoicing:ListInvoiceSummaries
+- invoicing:ListInvoiceUnits
+- invoicing:GetInvoiceUnit
+- invoicing:BatchGetInvoiceProfile
+- invoicing:ListProcurementPortalPreferences
+- invoicing:GetProcurementPortalPreference
 
 #### Configuration
 
@@ -394,4 +401,6 @@ The server currently supports the following AWS services
     - list_cost_category_definitions
 
 12. **AWS Invoicing**
-    - list_invoice_summaries
+    - `invoicing` tool: list_invoice_summaries
+    - `invoice-units` tool: list_invoice_units, get_invoice_unit, batch_get_invoice_profile
+    - `procurement-preferences` tool: list_procurement_portal_preferences, get_procurement_portal_preference

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -61,7 +61,13 @@ from awslabs.billing_cost_management_mcp_server.tools.cost_optimization_hub_tool
 from awslabs.billing_cost_management_mcp_server.tools.free_tier_usage_tools import (
     free_tier_usage_server,
 )
+from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+    invoice_units_server,
+)
 from awslabs.billing_cost_management_mcp_server.tools.invoicing_tools import invoicing_server
+from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_tools import (
+    procurement_preferences_server,
+)
 from awslabs.billing_cost_management_mcp_server.tools.recommendation_details_tools import (
     recommendation_details_server,
 )
@@ -214,6 +220,8 @@ async def setup():
     await mcp.import_server(cost_allocation_tags_server)
     await mcp.import_server(cost_category_server)
     await mcp.import_server(invoicing_server)
+    await mcp.import_server(invoice_units_server)
+    await mcp.import_server(procurement_preferences_server)
 
     await register_prompts()
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_operations.py
@@ -16,7 +16,7 @@
 
 This module contains the read-only operation handlers for the ``invoice-units``
 tool (AWS Invoice Configuration). Each operation performs the AWS API call,
-normalizes epoch/``datetime`` timestamps to ISO 8601 strings for the agent, and
+normalizes ``datetime`` timestamps to ISO 8601 strings for the agent, and
 returns a standardized response envelope.
 """
 
@@ -27,10 +27,9 @@ from ..utilities.aws_service_base import (
     paginate_aws_response,
 )
 from ..utilities.time_utils import (
-    timestamp_to_utc_iso_string,
+    normalize_datetimes_to_iso,
     utc_datetime_string_to_epoch_seconds,
 )
-from datetime import datetime
 from fastmcp import Context
 from typing import Any, Dict, List, Optional
 
@@ -46,31 +45,6 @@ def _create_invoicing_client() -> Any:
         boto3.client: AWS Invoicing client.
     """
     return create_aws_client('invoicing')
-
-
-def _normalize_timestamps(obj: Any) -> Any:
-    """Recursively convert ``datetime`` values to ISO 8601 UTC strings.
-
-    boto3 returns Python ``datetime`` objects for AWS timestamp fields (for
-    example ``LastModified``). These are not JSON-serializable, so we walk the
-    response and convert every ``datetime`` to a human-readable ISO 8601 string
-    while leaving all other values untouched. Walking the structure (rather than
-    normalizing named fields) keeps this correct as the API adds nested
-    timestamp fields.
-
-    Args:
-        obj: An arbitrary value from an AWS response (dict, list, or scalar).
-
-    Returns:
-        The value with any ``datetime`` instances converted to ISO 8601 strings.
-    """
-    if isinstance(obj, dict):
-        return {key: _normalize_timestamps(value) for key, value in obj.items()}
-    if isinstance(obj, list):
-        return [_normalize_timestamps(item) for item in obj]
-    if isinstance(obj, datetime):
-        return timestamp_to_utc_iso_string(obj)
-    return obj
 
 
 async def list_invoice_units(
@@ -89,21 +63,22 @@ async def list_invoice_units(
     Retrieves the invoice units (groups of accounts that receive a separate
     invoice) visible to the management account. All filters are optional and
     combine as an AND across filter types; within a single filter the list
-    values are an OR (match any).
+    values are an OR (match any). Account IDs are AWS account IDs (12 digits).
 
     Args:
         ctx: The MCP context object.
         names: Return only invoice units whose name matches one of these values.
-        invoice_receivers: Return only invoice units whose receiver account is
-            one of these 12-digit account IDs.
-        accounts: Return only invoice units that contain one of these member
-            account IDs.
-        bill_source_accounts: Return only invoice units with one of these bill
-            source account IDs.
+        invoice_receivers: Return only invoice units whose receiver is one of
+            these AWS account IDs (12 digits).
+        accounts: Return only invoice units that reference one of these AWS
+            account IDs anywhere — as the receiver, a linked (member) account,
+            or a bill-source account (a global search across all three roles).
+        bill_source_accounts: Return only invoice units with one of these AWS
+            account IDs as a bill-source account.
         as_of: Return the invoice unit definitions as they existed at this
             UTC instant (``YYYY-MM-DD`` or ``YYYY-MM-DDTHH:MM:SS``). Defaults to
             the current definitions when omitted.
-        max_results: Maximum number of results per page (1-100).
+        max_results: Maximum number of results per page (1-500).
         next_token: Pagination token from a previous response to resume from.
         max_pages: Maximum number of pages to auto-paginate through. Defaults to
             all pages.
@@ -152,7 +127,7 @@ async def list_invoice_units(
             max_pages=max_pages,
         )
 
-        normalized = _normalize_timestamps(units)
+        normalized = normalize_datetimes_to_iso(units)
 
         await ctx.info(f'Successfully listed {len(normalized)} invoice units')
 
@@ -202,7 +177,7 @@ async def get_invoice_unit(
 
         await ctx.info(f'Successfully retrieved invoice unit: {invoice_unit_arn}')
 
-        return format_response('success', {'invoice_unit': _normalize_timestamps(response)})
+        return format_response('success', {'invoice_unit': normalize_datetimes_to_iso(response)})
 
     except Exception as e:
         return await handle_aws_error(ctx, e, 'GetInvoiceUnit', 'Invoicing')
@@ -212,17 +187,19 @@ async def batch_get_invoice_profile(
     ctx: Context,
     account_ids: List[str],
 ) -> Dict[str, Any]:
-    """Retrieve invoice receiver profiles for a set of linked accounts.
+    """Retrieve invoice receiver profiles for a set of accounts.
 
     Returns high-level invoice receiver information (legal name, address,
     email, issuer, tax registration number) for each requested account. The
-    accounts must be linked accounts under the requester's management account
-    organization.
+    accounts must belong to the requester's organization; both linked accounts
+    and the payer (management) account are valid — for example, when selecting
+    the payer as an invoice unit receiver.
 
     Args:
         ctx: The MCP context object.
-        account_ids: The 12-digit account IDs to retrieve invoice profiles for
-            (required, non-empty).
+        account_ids: The AWS account IDs (12 digits) to retrieve invoice
+            profiles for (required, non-empty). Linked accounts and the payer
+            account are both valid.
 
     Returns:
         Dict containing ``profiles``, or a standardized error response.
@@ -238,7 +215,7 @@ async def batch_get_invoice_profile(
         response = client.batch_get_invoice_profile(AccountIds=account_ids)
         response.pop('ResponseMetadata', None)
 
-        profiles = _normalize_timestamps(response.get('Profiles', []))
+        profiles = normalize_datetimes_to_iso(response.get('Profiles', []))
 
         await ctx.info(f'Successfully retrieved {len(profiles)} invoice profiles')
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_operations.py
@@ -1,0 +1,248 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Invoice Unit operations for the AWS Billing and Cost Management MCP server.
+
+This module contains the read-only operation handlers for the ``invoice-units``
+tool (AWS Invoice Configuration). Each operation performs the AWS API call,
+normalizes epoch/``datetime`` timestamps to ISO 8601 strings for the agent, and
+returns a standardized response envelope.
+"""
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from ..utilities.time_utils import (
+    timestamp_to_utc_iso_string,
+    utc_datetime_string_to_epoch_seconds,
+)
+from datetime import datetime
+from fastmcp import Context
+from typing import Any, Dict, List, Optional
+
+
+def _create_invoicing_client() -> Any:
+    """Create an AWS Invoicing client.
+
+    The Region is intentionally not hard-coded. ``create_aws_client`` resolves
+    it from the ``AWS_REGION`` environment variable and falls back to
+    ``us-east-1`` (the home Region of the global Invoicing service).
+
+    Returns:
+        boto3.client: AWS Invoicing client.
+    """
+    return create_aws_client('invoicing')
+
+
+def _normalize_timestamps(obj: Any) -> Any:
+    """Recursively convert ``datetime`` values to ISO 8601 UTC strings.
+
+    boto3 returns Python ``datetime`` objects for AWS timestamp fields (for
+    example ``LastModified``). These are not JSON-serializable, so we walk the
+    response and convert every ``datetime`` to a human-readable ISO 8601 string
+    while leaving all other values untouched. Walking the structure (rather than
+    normalizing named fields) keeps this correct as the API adds nested
+    timestamp fields.
+
+    Args:
+        obj: An arbitrary value from an AWS response (dict, list, or scalar).
+
+    Returns:
+        The value with any ``datetime`` instances converted to ISO 8601 strings.
+    """
+    if isinstance(obj, dict):
+        return {key: _normalize_timestamps(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_timestamps(item) for item in obj]
+    if isinstance(obj, datetime):
+        return timestamp_to_utc_iso_string(obj)
+    return obj
+
+
+async def list_invoice_units(
+    ctx: Context,
+    names: Optional[List[str]] = None,
+    invoice_receivers: Optional[List[str]] = None,
+    accounts: Optional[List[str]] = None,
+    bill_source_accounts: Optional[List[str]] = None,
+    as_of: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List AWS invoice unit definitions for the caller's organization.
+
+    Retrieves the invoice units (groups of accounts that receive a separate
+    invoice) visible to the management account. All filters are optional and
+    combine as an AND across filter types; within a single filter the list
+    values are an OR (match any).
+
+    Args:
+        ctx: The MCP context object.
+        names: Return only invoice units whose name matches one of these values.
+        invoice_receivers: Return only invoice units whose receiver account is
+            one of these 12-digit account IDs.
+        accounts: Return only invoice units that contain one of these member
+            account IDs.
+        bill_source_accounts: Return only invoice units with one of these bill
+            source account IDs.
+        as_of: Return the invoice unit definitions as they existed at this
+            UTC instant (``YYYY-MM-DD`` or ``YYYY-MM-DDTHH:MM:SS``). Defaults to
+            the current definitions when omitted.
+        max_results: Maximum number of results per page (1-100).
+        next_token: Pagination token from a previous response to resume from.
+        max_pages: Maximum number of pages to auto-paginate through. Defaults to
+            all pages.
+
+    Returns:
+        Dict containing ``invoice_units`` (with ISO 8601 timestamps) and a
+        ``pagination`` metadata block, or a standardized error response.
+    """
+    try:
+        request_params: Dict[str, Any] = {}
+
+        # --- Build the optional Filters (flattened, per BCM convention) ---
+        filters: Dict[str, Any] = {}
+        if names:
+            filters['Names'] = names
+        if invoice_receivers:
+            filters['InvoiceReceivers'] = invoice_receivers
+        if accounts:
+            filters['Accounts'] = accounts
+        if bill_source_accounts:
+            filters['BillSourceAccounts'] = bill_source_accounts
+        if filters:
+            request_params['Filters'] = filters
+
+        if as_of:
+            try:
+                request_params['AsOf'] = utc_datetime_string_to_epoch_seconds(as_of)
+            except ValueError as parse_error:
+                return format_response('error', {'message': str(parse_error)})
+
+        if max_results is not None:
+            request_params['MaxResults'] = max_results
+        if next_token:
+            request_params['NextToken'] = next_token
+
+        client = _create_invoicing_client()
+
+        units, pagination = await paginate_aws_response(
+            ctx,
+            'ListInvoiceUnits',
+            client.list_invoice_units,
+            request_params,
+            'InvoiceUnits',
+            token_param='NextToken',
+            token_key='NextToken',
+            max_pages=max_pages,
+        )
+
+        normalized = _normalize_timestamps(units)
+
+        await ctx.info(f'Successfully listed {len(normalized)} invoice units')
+
+        return format_response(
+            'success',
+            {'invoice_units': normalized, 'pagination': pagination},
+        )
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'ListInvoiceUnits', 'Invoicing')
+
+
+async def get_invoice_unit(
+    ctx: Context,
+    invoice_unit_arn: str,
+    as_of: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Retrieve the definition of a single AWS invoice unit.
+
+    Args:
+        ctx: The MCP context object.
+        invoice_unit_arn: The ARN of the invoice unit to retrieve (required).
+        as_of: Return the invoice unit definition as it existed at this UTC
+            instant (``YYYY-MM-DD`` or ``YYYY-MM-DDTHH:MM:SS``). Defaults to the
+            current definition when omitted.
+
+    Returns:
+        Dict containing the ``invoice_unit`` definition (with ISO 8601
+        timestamps), or a standardized error response.
+    """
+    try:
+        if not invoice_unit_arn:
+            return format_response(
+                'error', {'message': 'invoice_unit_arn is required for get_invoice_unit.'}
+            )
+
+        request_params: Dict[str, Any] = {'InvoiceUnitArn': invoice_unit_arn}
+        if as_of:
+            try:
+                request_params['AsOf'] = utc_datetime_string_to_epoch_seconds(as_of)
+            except ValueError as parse_error:
+                return format_response('error', {'message': str(parse_error)})
+
+        client = _create_invoicing_client()
+        response = client.get_invoice_unit(**request_params)
+        response.pop('ResponseMetadata', None)
+
+        await ctx.info(f'Successfully retrieved invoice unit: {invoice_unit_arn}')
+
+        return format_response('success', {'invoice_unit': _normalize_timestamps(response)})
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'GetInvoiceUnit', 'Invoicing')
+
+
+async def batch_get_invoice_profile(
+    ctx: Context,
+    account_ids: List[str],
+) -> Dict[str, Any]:
+    """Retrieve invoice receiver profiles for a set of linked accounts.
+
+    Returns high-level invoice receiver information (legal name, address,
+    email, issuer, tax registration number) for each requested account. The
+    accounts must be linked accounts under the requester's management account
+    organization.
+
+    Args:
+        ctx: The MCP context object.
+        account_ids: The 12-digit account IDs to retrieve invoice profiles for
+            (required, non-empty).
+
+    Returns:
+        Dict containing ``profiles``, or a standardized error response.
+    """
+    try:
+        if not account_ids:
+            return format_response(
+                'error',
+                {'message': 'account_ids must be a non-empty list for batch_get_invoice_profile.'},
+            )
+
+        client = _create_invoicing_client()
+        response = client.batch_get_invoice_profile(AccountIds=account_ids)
+        response.pop('ResponseMetadata', None)
+
+        profiles = _normalize_timestamps(response.get('Profiles', []))
+
+        await ctx.info(f'Successfully retrieved {len(profiles)} invoice profiles')
+
+        return format_response('success', {'profiles': profiles})
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'BatchGetInvoiceProfile', 'Invoicing')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_tools.py
@@ -66,13 +66,13 @@ async def _invoice_units(
         invoice_unit_arn: ARN of a single invoice unit (get_invoice_unit).
         names: Filter invoice units by name (list_invoice_units).
         invoice_receivers: Filter by receiver account ID (list_invoice_units).
-        accounts: Filter by member account ID (list_invoice_units).
+        accounts: Global-search filter across receiver, linked, and bill-source accounts (list_invoice_units).
         bill_source_accounts: Filter by bill source account ID
             (list_invoice_units).
         account_ids: Account IDs to fetch profiles for
             (batch_get_invoice_profile).
         as_of: Point-in-time UTC instant for list/get operations.
-        max_results: Maximum results per page (1-100).
+        max_results: Maximum results per page (1-500).
         next_token: Pagination token from a previous response.
         max_pages: Maximum pages to auto-paginate through (default: all).
 
@@ -130,13 +130,13 @@ async def _invoice_units(
 
 1) list_invoice_units - list invoice unit definitions visible to the management account
    Required: operation="list_invoice_units"
-   Optional filters (AND across types; OR within a list):
+   Optional filters (AND across types; OR within a list). Account IDs are 12-digit AWS account IDs:
      - names: match invoice unit names
-     - invoice_receivers: match receiver account IDs (12-digit)
-     - accounts: match member account IDs
-     - bill_source_accounts: match bill source account IDs
+     - invoice_receivers: match the invoice unit's receiver account
+     - bill_source_accounts: match a bill-source account
+     - accounts: global search — matches invoice units where the account appears as the receiver, a linked (member) account, OR a bill-source account
      - as_of: point-in-time UTC "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS" (definitions as of that instant; defaults to current)
-   Pagination: max_results caps items per page (1-100); max_pages caps pages fetched (default: all). The `pagination` block reports total_results, pages_fetched, has_more, and next_token.
+   Pagination: max_results caps items per page (1-500); max_pages caps pages fetched (default: all). The `pagination` block reports total_results, pages_fetched, has_more, and next_token.
    Returns: `data.invoice_units`, each with InvoiceUnitArn, Name, Description, InvoiceReceiver, TaxInheritanceDisabled, Rule {LinkedAccounts}, and LastModified (ISO 8601 UTC).
 
 2) get_invoice_unit - retrieve one invoice unit definition
@@ -145,7 +145,7 @@ async def _invoice_units(
    Returns: `data.invoice_unit` with the fields above.
 
 3) batch_get_invoice_profile - fetch invoice receiver profiles for accounts
-   Required: operation="batch_get_invoice_profile", account_ids (12-digit account IDs, linked under the management account)
+   Required: operation="batch_get_invoice_profile", account_ids (12-digit AWS account IDs; linked accounts or the payer account)
    Returns: `data.profiles`, each with AccountId, ReceiverName, ReceiverAddress, ReceiverEmail, Issuer, TaxRegistrationNumber.
 
 EXAMPLES
@@ -179,13 +179,13 @@ async def invoice_units(
         invoice_unit_arn: ARN of a single invoice unit (get_invoice_unit).
         names: Filter invoice units by name (list_invoice_units).
         invoice_receivers: Filter by receiver account ID (list_invoice_units).
-        accounts: Filter by member account ID (list_invoice_units).
+        accounts: Global-search filter across receiver, linked, and bill-source accounts (list_invoice_units).
         bill_source_accounts: Filter by bill source account ID
             (list_invoice_units).
         account_ids: Account IDs to fetch profiles for
             (batch_get_invoice_profile).
         as_of: Point-in-time UTC instant for list/get operations.
-        max_results: Maximum results per page (1-100).
+        max_results: Maximum results per page (1-500).
         next_token: Pagination token from a previous response.
         max_pages: Maximum pages to auto-paginate through (default: all).
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/invoice_units_tools.py
@@ -1,0 +1,208 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Invoice Unit tools for the AWS Billing and Cost Management MCP server.
+
+Exposes a single read-only ``invoice-units`` tool that routes by ``operation``
+across the AWS Invoice Configuration read APIs (mirroring the ``invoicing``
+tool). The rich tool description is the primary vehicle that gives the agent
+semantic context about every request parameter and response field.
+"""
+
+from ..utilities.aws_service_base import format_response
+from .invoice_units_operations import (
+    batch_get_invoice_profile as _batch_get_invoice_profile,
+)
+from .invoice_units_operations import (
+    get_invoice_unit as _get_invoice_unit,
+)
+from .invoice_units_operations import (
+    list_invoice_units as _list_invoice_units,
+)
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, List, Optional
+
+
+invoice_units_server = FastMCP(
+    name='invoice-units-tools',
+    instructions='Read-only tools for working with AWS Invoice Configuration (invoice units)',
+)
+
+
+async def _invoice_units(
+    ctx: Context,
+    operation: str,
+    invoice_unit_arn: Optional[str] = None,
+    names: Optional[List[str]] = None,
+    invoice_receivers: Optional[List[str]] = None,
+    accounts: Optional[List[str]] = None,
+    bill_source_accounts: Optional[List[str]] = None,
+    account_ids: Optional[List[str]] = None,
+    as_of: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Route an AWS Invoice Unit ``operation`` to its handler.
+
+    Kept separate from the FastMCP-decorated wrapper so the routing can be unit
+    tested directly (decorated tools cannot be invoked as plain functions).
+
+    Args:
+        ctx: The MCP context object.
+        operation: The invoice unit operation (``"list_invoice_units"``,
+            ``"get_invoice_unit"``, or ``"batch_get_invoice_profile"``).
+        invoice_unit_arn: ARN of a single invoice unit (get_invoice_unit).
+        names: Filter invoice units by name (list_invoice_units).
+        invoice_receivers: Filter by receiver account ID (list_invoice_units).
+        accounts: Filter by member account ID (list_invoice_units).
+        bill_source_accounts: Filter by bill source account ID
+            (list_invoice_units).
+        account_ids: Account IDs to fetch profiles for
+            (batch_get_invoice_profile).
+        as_of: Point-in-time UTC instant for list/get operations.
+        max_results: Maximum results per page (1-100).
+        next_token: Pagination token from a previous response.
+        max_pages: Maximum pages to auto-paginate through (default: all).
+
+    Returns:
+        The operation's response, or a standardized error for an unknown
+        operation.
+    """
+    await ctx.info(f'Invoice unit operation: {operation}')
+
+    if operation == 'list_invoice_units':
+        return await _list_invoice_units(
+            ctx,
+            names=names,
+            invoice_receivers=invoice_receivers,
+            accounts=accounts,
+            bill_source_accounts=bill_source_accounts,
+            as_of=as_of,
+            max_results=max_results,
+            next_token=next_token,
+            max_pages=max_pages,
+        )
+
+    if operation == 'get_invoice_unit':
+        if invoice_unit_arn is None:
+            return format_response(
+                'error',
+                {'message': 'invoice_unit_arn is required for get_invoice_unit.'},
+            )
+        return await _get_invoice_unit(ctx, invoice_unit_arn=invoice_unit_arn, as_of=as_of)
+
+    if operation == 'batch_get_invoice_profile':
+        if account_ids is None:
+            return format_response(
+                'error',
+                {'message': 'account_ids is required for batch_get_invoice_profile.'},
+            )
+        return await _batch_get_invoice_profile(ctx, account_ids=account_ids)
+
+    return format_response(
+        'error',
+        {
+            'message': (
+                f"Unsupported operation: '{operation}'. Supported operations: "
+                'list_invoice_units, get_invoice_unit, batch_get_invoice_profile.'
+            )
+        },
+    )
+
+
+@invoice_units_server.tool(
+    name='invoice-units',
+    description="""Access AWS Invoice Configuration (invoice units) — read-only. Invoice units are groups of AWS accounts that represent business entities and receive a separate invoice, each with a designated receiver account. Choose an action with the required `operation` parameter; the remaining parameters apply to specific operations.
+
+## OPERATIONS
+
+1) list_invoice_units - list invoice unit definitions visible to the management account
+   Required: operation="list_invoice_units"
+   Optional filters (AND across types; OR within a list):
+     - names: match invoice unit names
+     - invoice_receivers: match receiver account IDs (12-digit)
+     - accounts: match member account IDs
+     - bill_source_accounts: match bill source account IDs
+     - as_of: point-in-time UTC "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS" (definitions as of that instant; defaults to current)
+   Pagination: max_results caps items per page (1-100); max_pages caps pages fetched (default: all). The `pagination` block reports total_results, pages_fetched, has_more, and next_token.
+   Returns: `data.invoice_units`, each with InvoiceUnitArn, Name, Description, InvoiceReceiver, TaxInheritanceDisabled, Rule {LinkedAccounts}, and LastModified (ISO 8601 UTC).
+
+2) get_invoice_unit - retrieve one invoice unit definition
+   Required: operation="get_invoice_unit", invoice_unit_arn
+   Optional: as_of (point-in-time UTC, as above)
+   Returns: `data.invoice_unit` with the fields above.
+
+3) batch_get_invoice_profile - fetch invoice receiver profiles for accounts
+   Required: operation="batch_get_invoice_profile", account_ids (12-digit account IDs, linked under the management account)
+   Returns: `data.profiles`, each with AccountId, ReceiverName, ReceiverAddress, ReceiverEmail, Issuer, TaxRegistrationNumber.
+
+EXAMPLES
+- {"operation": "list_invoice_units"}
+- {"operation": "list_invoice_units", "invoice_receivers": ["123456789012"]}
+- {"operation": "get_invoice_unit", "invoice_unit_arn": "arn:aws:invoicing::123456789012:invoice-unit/abc123"}
+- {"operation": "batch_get_invoice_profile", "account_ids": ["123456789012", "210987654321"]}""",
+)
+async def invoice_units(
+    ctx: Context,
+    operation: str,
+    invoice_unit_arn: Optional[str] = None,
+    names: Optional[List[str]] = None,
+    invoice_receivers: Optional[List[str]] = None,
+    accounts: Optional[List[str]] = None,
+    bill_source_accounts: Optional[List[str]] = None,
+    account_ids: Optional[List[str]] = None,
+    as_of: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """FastMCP wrapper for AWS Invoice Unit operations.
+
+    Thin wrapper so the routing logic in ``_invoice_units`` can be unit tested
+    directly (FastMCP-decorated tools cannot be invoked as plain functions).
+
+    Args:
+        ctx: The MCP context object.
+        operation: The invoice unit operation to perform.
+        invoice_unit_arn: ARN of a single invoice unit (get_invoice_unit).
+        names: Filter invoice units by name (list_invoice_units).
+        invoice_receivers: Filter by receiver account ID (list_invoice_units).
+        accounts: Filter by member account ID (list_invoice_units).
+        bill_source_accounts: Filter by bill source account ID
+            (list_invoice_units).
+        account_ids: Account IDs to fetch profiles for
+            (batch_get_invoice_profile).
+        as_of: Point-in-time UTC instant for list/get operations.
+        max_results: Maximum results per page (1-100).
+        next_token: Pagination token from a previous response.
+        max_pages: Maximum pages to auto-paginate through (default: all).
+
+    Returns:
+        Dict containing the operation result.
+    """
+    return await _invoice_units(
+        ctx,
+        operation,
+        invoice_unit_arn=invoice_unit_arn,
+        names=names,
+        invoice_receivers=invoice_receivers,
+        accounts=accounts,
+        bill_source_accounts=bill_source_accounts,
+        account_ids=account_ids,
+        as_of=as_of,
+        max_results=max_results,
+        next_token=next_token,
+        max_pages=max_pages,
+    )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_operations.py
@@ -1,0 +1,181 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Procurement Portal Preference operations for the BCM MCP server.
+
+This module contains the read-only operation handlers for the
+``procurement-preferences`` tool (AWS Procurement Portal Preferences: SAP
+Business Network / Coupa connections and e-invoice delivery settings). Each
+operation performs the AWS API call, normalizes ``datetime`` timestamps to
+ISO 8601 strings for the agent, and returns a standardized response envelope.
+
+Note: procurement portal preference records may include portal connection
+details. Ensure IAM read-only policies are scoped appropriately.
+"""
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from ..utilities.time_utils import timestamp_to_utc_iso_string
+from datetime import datetime
+from fastmcp import Context
+from typing import Any, Dict, Optional
+
+
+def _create_invoicing_client() -> Any:
+    """Create an AWS Invoicing client.
+
+    The Region is intentionally not hard-coded. ``create_aws_client`` resolves
+    it from the ``AWS_REGION`` environment variable and falls back to
+    ``us-east-1`` (the home Region of the global Invoicing service).
+
+    Returns:
+        boto3.client: AWS Invoicing client.
+    """
+    return create_aws_client('invoicing')
+
+
+def _normalize_timestamps(obj: Any) -> Any:
+    """Recursively convert ``datetime`` values to ISO 8601 UTC strings.
+
+    boto3 returns Python ``datetime`` objects for AWS timestamp fields (for
+    example ``CreateDate``, ``LastUpdateDate``, and the nested
+    ``EinvoiceDeliveryActivationDate``). These are not JSON-serializable, so we
+    walk the response and convert every ``datetime`` to a human-readable ISO
+    8601 string while leaving all other values untouched.
+
+    Args:
+        obj: An arbitrary value from an AWS response (dict, list, or scalar).
+
+    Returns:
+        The value with any ``datetime`` instances converted to ISO 8601 strings.
+    """
+    if isinstance(obj, dict):
+        return {key: _normalize_timestamps(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_timestamps(item) for item in obj]
+    if isinstance(obj, datetime):
+        return timestamp_to_utc_iso_string(obj)
+    return obj
+
+
+async def list_procurement_portal_preferences(
+    ctx: Context,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List procurement portal preference configurations for the caller.
+
+    Retrieves the procurement portal connections and e-invoice delivery
+    settings (for example SAP Business Network or Coupa) configured for the
+    account.
+
+    Args:
+        ctx: The MCP context object.
+        max_results: Maximum number of results per page (1-100).
+        next_token: Pagination token from a previous response to resume from.
+        max_pages: Maximum number of pages to auto-paginate through. Defaults to
+            all pages.
+
+    Returns:
+        Dict containing ``procurement_portal_preferences`` (with ISO 8601
+        timestamps) and a ``pagination`` metadata block, or a standardized error
+        response.
+    """
+    try:
+        request_params: Dict[str, Any] = {}
+        if max_results is not None:
+            request_params['MaxResults'] = max_results
+        if next_token:
+            request_params['NextToken'] = next_token
+
+        client = _create_invoicing_client()
+
+        preferences, pagination = await paginate_aws_response(
+            ctx,
+            'ListProcurementPortalPreferences',
+            client.list_procurement_portal_preferences,
+            request_params,
+            'ProcurementPortalPreferences',
+            token_param='NextToken',
+            token_key='NextToken',
+            max_pages=max_pages,
+        )
+
+        normalized = _normalize_timestamps(preferences)
+
+        await ctx.info(f'Successfully listed {len(normalized)} procurement portal preferences')
+
+        return format_response(
+            'success',
+            {'procurement_portal_preferences': normalized, 'pagination': pagination},
+        )
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'ListProcurementPortalPreferences', 'Invoicing')
+
+
+async def get_procurement_portal_preference(
+    ctx: Context,
+    procurement_portal_preference_arn: str,
+) -> Dict[str, Any]:
+    """Retrieve a single procurement portal preference configuration.
+
+    Args:
+        ctx: The MCP context object.
+        procurement_portal_preference_arn: The ARN of the procurement portal
+            preference to retrieve (required).
+
+    Returns:
+        Dict containing the ``procurement_portal_preference`` (with ISO 8601
+        timestamps), or a standardized error response.
+    """
+    try:
+        if not procurement_portal_preference_arn:
+            return format_response(
+                'error',
+                {
+                    'message': (
+                        'procurement_portal_preference_arn is required for '
+                        'get_procurement_portal_preference.'
+                    )
+                },
+            )
+
+        client = _create_invoicing_client()
+        response = client.get_procurement_portal_preference(
+            ProcurementPortalPreferenceArn=procurement_portal_preference_arn
+        )
+        response.pop('ResponseMetadata', None)
+
+        await ctx.info(
+            f'Successfully retrieved procurement portal preference: '
+            f'{procurement_portal_preference_arn}'
+        )
+
+        return format_response(
+            'success',
+            {
+                'procurement_portal_preference': _normalize_timestamps(
+                    response.get('ProcurementPortalPreference', {})
+                )
+            },
+        )
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'GetProcurementPortalPreference', 'Invoicing')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_operations.py
@@ -30,8 +30,7 @@ from ..utilities.aws_service_base import (
     handle_aws_error,
     paginate_aws_response,
 )
-from ..utilities.time_utils import timestamp_to_utc_iso_string
-from datetime import datetime
+from ..utilities.time_utils import normalize_datetimes_to_iso
 from fastmcp import Context
 from typing import Any, Dict, Optional
 
@@ -47,30 +46,6 @@ def _create_invoicing_client() -> Any:
         boto3.client: AWS Invoicing client.
     """
     return create_aws_client('invoicing')
-
-
-def _normalize_timestamps(obj: Any) -> Any:
-    """Recursively convert ``datetime`` values to ISO 8601 UTC strings.
-
-    boto3 returns Python ``datetime`` objects for AWS timestamp fields (for
-    example ``CreateDate``, ``LastUpdateDate``, and the nested
-    ``EinvoiceDeliveryActivationDate``). These are not JSON-serializable, so we
-    walk the response and convert every ``datetime`` to a human-readable ISO
-    8601 string while leaving all other values untouched.
-
-    Args:
-        obj: An arbitrary value from an AWS response (dict, list, or scalar).
-
-    Returns:
-        The value with any ``datetime`` instances converted to ISO 8601 strings.
-    """
-    if isinstance(obj, dict):
-        return {key: _normalize_timestamps(value) for key, value in obj.items()}
-    if isinstance(obj, list):
-        return [_normalize_timestamps(item) for item in obj]
-    if isinstance(obj, datetime):
-        return timestamp_to_utc_iso_string(obj)
-    return obj
 
 
 async def list_procurement_portal_preferences(
@@ -117,7 +92,7 @@ async def list_procurement_portal_preferences(
             max_pages=max_pages,
         )
 
-        normalized = _normalize_timestamps(preferences)
+        normalized = normalize_datetimes_to_iso(preferences)
 
         await ctx.info(f'Successfully listed {len(normalized)} procurement portal preferences')
 
@@ -171,7 +146,7 @@ async def get_procurement_portal_preference(
         return format_response(
             'success',
             {
-                'procurement_portal_preference': _normalize_timestamps(
+                'procurement_portal_preference': normalize_datetimes_to_iso(
                     response.get('ProcurementPortalPreference', {})
                 )
             },

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_operations.py
@@ -35,6 +35,41 @@ from fastmcp import Context
 from typing import Any, Dict, Optional
 
 
+# ``ProcurementPortalSharedSecret`` is a shared secret / authentication
+# credential for the procurement portal. The tool must not expose it to the
+# LLM, so it is dropped from the response after the SDK call returns, before the
+# response is returned to the agent. The field is still returned by the AWS API
+# and remains accessible via a direct SDK call; we simply do not propagate it out
+# of this tool. Other preference attributes are intentionally retained.
+_SENSITIVE_FIELD_NAMES = frozenset({'ProcurementPortalSharedSecret'})
+
+
+def drop_sensitive_fields(value: Any) -> Any:
+    """Recursively drop known secret fields from an AWS response structure.
+
+    Walks nested dicts and lists and removes any key named in
+    ``_SENSITIVE_FIELD_NAMES``. Recursion makes the redaction robust against the
+    secret appearing at any depth (for example nested under
+    ``TestEnvPreference``) and against every item in a list, not just the first.
+
+    Args:
+        value: An arbitrary JSON-like structure (dict, list, or scalar).
+
+    Returns:
+        The same structure with sensitive keys removed. Dicts and lists are
+        mutated in place and also returned for convenience.
+    """
+    if isinstance(value, dict):
+        for key in [k for k in value if k in _SENSITIVE_FIELD_NAMES]:
+            del value[key]
+        for inner in value.values():
+            drop_sensitive_fields(inner)
+    elif isinstance(value, list):
+        for item in value:
+            drop_sensitive_fields(item)
+    return value
+
+
 def _create_invoicing_client() -> Any:
     """Create an AWS Invoicing client.
 
@@ -93,6 +128,9 @@ async def list_procurement_portal_preferences(
         )
 
         normalized = normalize_datetimes_to_iso(preferences)
+        # Drop procurement portal secrets before returning so they never reach
+        # the agent/LLM context (see drop_sensitive_fields / _SENSITIVE_FIELD_NAMES).
+        drop_sensitive_fields(normalized)
 
         await ctx.info(f'Successfully listed {len(normalized)} procurement portal preferences')
 
@@ -143,13 +181,15 @@ async def get_procurement_portal_preference(
             f'{procurement_portal_preference_arn}'
         )
 
+        # Drop procurement portal secrets before returning so they never reach
+        # the agent/LLM context (see drop_sensitive_fields / _SENSITIVE_FIELD_NAMES).
+        preference = drop_sensitive_fields(
+            normalize_datetimes_to_iso(response.get('ProcurementPortalPreference', {}))
+        )
+
         return format_response(
             'success',
-            {
-                'procurement_portal_preference': normalize_datetimes_to_iso(
-                    response.get('ProcurementPortalPreference', {})
-                )
-            },
+            {'procurement_portal_preference': preference},
         )
 
     except Exception as e:

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_tools.py
@@ -1,0 +1,159 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Procurement Portal Preference tools for the BCM MCP server.
+
+Exposes a single read-only ``procurement-preferences`` tool that routes by
+``operation`` across the AWS Procurement Portal Preferences read APIs
+(mirroring the ``invoicing`` tool). The rich tool description is the primary
+vehicle that gives the agent semantic context about every request parameter and
+response field.
+"""
+
+from ..utilities.aws_service_base import format_response
+from .procurement_preferences_operations import (
+    get_procurement_portal_preference as _get_procurement_portal_preference,
+)
+from .procurement_preferences_operations import (
+    list_procurement_portal_preferences as _list_procurement_portal_preferences,
+)
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, Optional
+
+
+procurement_preferences_server = FastMCP(
+    name='procurement-preferences-tools',
+    instructions='Read-only tools for AWS Procurement Portal Preferences (SAP/Coupa, e-invoice delivery)',
+)
+
+
+async def _procurement_preferences(
+    ctx: Context,
+    operation: str,
+    procurement_portal_preference_arn: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Route an AWS Procurement Portal Preference ``operation`` to its handler.
+
+    Kept separate from the FastMCP-decorated wrapper so the routing can be unit
+    tested directly (decorated tools cannot be invoked as plain functions).
+
+    Args:
+        ctx: The MCP context object.
+        operation: The operation (``"list_procurement_portal_preferences"`` or
+            ``"get_procurement_portal_preference"``).
+        procurement_portal_preference_arn: ARN of a single preference
+            (get_procurement_portal_preference).
+        max_results: Maximum results per page (1-100).
+        next_token: Pagination token from a previous response.
+        max_pages: Maximum pages to auto-paginate through (default: all).
+
+    Returns:
+        The operation's response, or a standardized error for an unknown
+        operation.
+    """
+    await ctx.info(f'Procurement portal preference operation: {operation}')
+
+    if operation == 'list_procurement_portal_preferences':
+        return await _list_procurement_portal_preferences(
+            ctx,
+            max_results=max_results,
+            next_token=next_token,
+            max_pages=max_pages,
+        )
+
+    if operation == 'get_procurement_portal_preference':
+        if procurement_portal_preference_arn is None:
+            return format_response(
+                'error',
+                {
+                    'message': (
+                        'procurement_portal_preference_arn is required for '
+                        'get_procurement_portal_preference.'
+                    )
+                },
+            )
+        return await _get_procurement_portal_preference(
+            ctx,
+            procurement_portal_preference_arn=procurement_portal_preference_arn,
+        )
+
+    return format_response(
+        'error',
+        {
+            'message': (
+                f"Unsupported operation: '{operation}'. Supported operations: "
+                'list_procurement_portal_preferences, get_procurement_portal_preference.'
+            )
+        },
+    )
+
+
+@procurement_preferences_server.tool(
+    name='procurement-preferences',
+    description="""Access AWS Procurement Portal Preferences — read-only. These are the procurement portal connections (e.g. SAP Business Network, Coupa) and e-invoice delivery / purchase-order retrieval settings configured for the account. Choose an action with the required `operation` parameter.
+
+## OPERATIONS
+
+1) list_procurement_portal_preferences - list configured procurement portal preferences
+   Required: operation="list_procurement_portal_preferences"
+   Pagination: max_results caps items per page (1-100); max_pages caps pages fetched (default: all). The `pagination` block reports total_results, pages_fetched, has_more, and next_token.
+   Returns: `data.procurement_portal_preferences`, each including the preference ARN, portal type/connection details, status, EinvoiceDeliveryPreference, and CreateDate / LastUpdateDate (ISO 8601 UTC).
+
+2) get_procurement_portal_preference - retrieve one procurement portal preference
+   Required: operation="get_procurement_portal_preference", procurement_portal_preference_arn
+   Returns: `data.procurement_portal_preference` with the fields above, including EinvoiceDeliveryPreference.EinvoiceDeliveryActivationDate (ISO 8601 UTC).
+
+NOTE: preference records may include procurement portal connection details; treat the output as sensitive.
+
+EXAMPLES
+- {"operation": "list_procurement_portal_preferences"}
+- {"operation": "get_procurement_portal_preference", "procurement_portal_preference_arn": "arn:aws:invoicing::123456789012:procurement-portal-preference/abc123"}""",
+)
+async def procurement_preferences(
+    ctx: Context,
+    operation: str,
+    procurement_portal_preference_arn: Optional[str] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """FastMCP wrapper for AWS Procurement Portal Preference operations.
+
+    Thin wrapper so the routing logic in ``_procurement_preferences`` can be
+    unit tested directly (FastMCP-decorated tools cannot be invoked as plain
+    functions).
+
+    Args:
+        ctx: The MCP context object.
+        operation: The operation to perform.
+        procurement_portal_preference_arn: ARN of a single preference
+            (get_procurement_portal_preference).
+        max_results: Maximum results per page (1-100).
+        next_token: Pagination token from a previous response.
+        max_pages: Maximum pages to auto-paginate through (default: all).
+
+    Returns:
+        Dict containing the operation result.
+    """
+    return await _procurement_preferences(
+        ctx,
+        operation,
+        procurement_portal_preference_arn=procurement_portal_preference_arn,
+        max_results=max_results,
+        next_token=next_token,
+        max_pages=max_pages,
+    )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/procurement_preferences_tools.py
@@ -117,7 +117,7 @@ async def _procurement_preferences(
    Required: operation="get_procurement_portal_preference", procurement_portal_preference_arn
    Returns: `data.procurement_portal_preference` with the fields above, including EinvoiceDeliveryPreference.EinvoiceDeliveryActivationDate (ISO 8601 UTC).
 
-NOTE: preference records may include procurement portal connection details; treat the output as sensitive.
+NOTE: preference records may include procurement portal connection details; treat the output as sensitive. The `ProcurementPortalSharedSecret` field is intentionally omitted from tool output and is only accessible via a direct SDK call.
 
 EXAMPLES
 - {"operation": "list_procurement_portal_preferences"}

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/time_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/time_utils.py
@@ -15,7 +15,7 @@
 """Time utility functions for the AWS Billing and Cost Management MCP server."""
 
 from datetime import datetime, timezone
-from typing import Union
+from typing import Any, Union
 
 
 # Supported UTC datetime formats, ordered from most specific to least specific.
@@ -68,3 +68,28 @@ def timestamp_to_utc_iso_string(timestamp: Union[int, float, datetime]) -> str:
             timestamp = timestamp.astimezone(timezone.utc)
         return timestamp.replace(tzinfo=None).isoformat()
     return datetime.fromtimestamp(timestamp, tz=timezone.utc).replace(tzinfo=None).isoformat()
+
+
+def normalize_datetimes_to_iso(obj: Any) -> Any:
+    """Recursively convert ``datetime`` values in a structure to ISO 8601 UTC strings.
+
+    boto3 returns Python ``datetime`` objects for AWS timestamp fields, which are
+    not JSON-serializable. This walks an arbitrary response value (dict, list, or
+    scalar) and converts every ``datetime`` to an ISO 8601 UTC string via
+    :func:`timestamp_to_utc_iso_string`, leaving all other values untouched.
+    Walking the structure (rather than normalizing named fields) stays correct as
+    APIs add nested timestamp fields.
+
+    Args:
+        obj: An arbitrary value from an AWS response (dict, list, or scalar).
+
+    Returns:
+        The value with any ``datetime`` instances converted to ISO 8601 strings.
+    """
+    if isinstance(obj, dict):
+        return {key: normalize_datetimes_to_iso(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [normalize_datetimes_to_iso(item) for item in obj]
+    if isinstance(obj, datetime):
+        return timestamp_to_utc_iso_string(obj)
+    return obj

--- a/src/billing-cost-management-mcp-server/tests/tools/test_invoice_units_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_invoice_units_tools.py
@@ -1,0 +1,433 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the invoice_units_operations and invoice_units_tools modules."""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.invoice_units_operations import (
+    batch_get_invoice_profile,
+    get_invoice_unit,
+    list_invoice_units,
+)
+from botocore.exceptions import ClientError
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+CREATE_CLIENT_PATH = (
+    'awslabs.billing_cost_management_mcp_server.tools.invoice_units_operations.create_aws_client'
+)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context with async logging methods."""
+    context = MagicMock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    context.debug = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def sample_unit():
+    """Return a sample InvoiceUnit as the AWS API would return it."""
+    return {
+        'InvoiceUnitArn': 'arn:aws:invoicing::123456789012:invoice-unit/abc123',
+        'InvoiceReceiver': '123456789012',
+        'Name': 'Engineering',
+        'Description': 'Engineering business unit',
+        'TaxInheritanceDisabled': False,
+        'Rule': {'LinkedAccounts': ['123456789012', '210987654321']},
+        'LastModified': datetime(2026, 5, 1, tzinfo=timezone.utc),
+    }
+
+
+class TestListInvoiceUnits:
+    """list_invoice_units filter construction, pagination, and normalization."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters_success(self, mock_context, sample_unit):
+        """A bare list call succeeds and sends no Filters."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': [sample_unit]}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(mock_context)
+
+        assert result['status'] == 'success'
+        assert 'Filters' not in mock_client.list_invoice_units.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_filters_are_flattened(self, mock_context, sample_unit):
+        """Flattened filter params build the nested Filters structure."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': [sample_unit]}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(
+                mock_context,
+                names=['Engineering'],
+                invoice_receivers=['123456789012'],
+                accounts=['210987654321'],
+                bill_source_accounts=['111122223333'],
+            )
+
+        assert result['status'] == 'success'
+        filters = mock_client.list_invoice_units.call_args.kwargs['Filters']
+        assert filters['Names'] == ['Engineering']
+        assert filters['InvoiceReceivers'] == ['123456789012']
+        assert filters['Accounts'] == ['210987654321']
+        assert filters['BillSourceAccounts'] == ['111122223333']
+
+    @pytest.mark.asyncio
+    async def test_as_of_uses_epoch_seconds(self, mock_context, sample_unit):
+        """as_of is converted to epoch seconds for the AsOf request field."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': [sample_unit]}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(mock_context, as_of='2026-05-01')
+
+        assert result['status'] == 'success'
+        assert mock_client.list_invoice_units.call_args.kwargs['AsOf'] == int(
+            datetime(2026, 5, 1, tzinfo=timezone.utc).timestamp()
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_as_of_returns_error(self, mock_context):
+        """A malformed as_of returns a format error without calling the API."""
+        result = await list_invoice_units(mock_context, as_of='not-a-date')
+
+        assert result['status'] == 'error'
+        assert 'YYYY-MM-DD' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_last_modified_normalized_to_iso(self, mock_context, sample_unit):
+        """The LastModified datetime is normalized to an ISO 8601 string."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': [sample_unit]}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(mock_context)
+
+        unit = result['data']['invoice_units'][0]
+        assert unit['LastModified'] == '2026-05-01T00:00:00'
+
+    @pytest.mark.asyncio
+    async def test_pagination_across_pages(self, mock_context, sample_unit):
+        """Multiple pages are aggregated and pagination metadata is accurate."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.side_effect = [
+            {'InvoiceUnits': [sample_unit], 'NextToken': 'page-2'},
+            {'InvoiceUnits': [sample_unit]},
+        ]
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(mock_context)
+
+        assert result['status'] == 'success'
+        assert mock_client.list_invoice_units.call_count == 2
+        assert result['data']['pagination']['total_results'] == 2
+        assert result['data']['pagination']['has_more'] is False
+
+    @pytest.mark.asyncio
+    async def test_max_results_and_next_token_forwarded(self, mock_context, sample_unit):
+        """max_results and next_token are forwarded to the request."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': [sample_unit]}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(
+                mock_context, max_results=10, next_token='resume-here'
+            )
+
+        assert result['status'] == 'success'
+        call = mock_client.list_invoice_units.call_args.kwargs
+        assert call['MaxResults'] == 10
+        assert call['NextToken'] == 'resume-here'
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_context):
+        """An empty result set returns success with zero total_results."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': []}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(mock_context)
+
+        assert result['status'] == 'success'
+        assert result['data']['invoice_units'] == []
+        assert result['data']['pagination']['total_results'] == 0
+
+    @pytest.mark.asyncio
+    async def test_api_client_error(self, mock_context):
+        """A ClientError from the API returns an error status."""
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'Not authorized'}},
+            'ListInvoiceUnits',
+        )
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_invoice_units(mock_context)
+
+        assert result['status'] == 'error'
+
+
+class TestGetInvoiceUnit:
+    """get_invoice_unit validation and normalization."""
+
+    @pytest.mark.asyncio
+    async def test_missing_arn_returns_error(self, mock_context):
+        """An empty invoice_unit_arn returns an error without calling the API."""
+        result = await get_invoice_unit(mock_context, invoice_unit_arn='')
+
+        assert result['status'] == 'error'
+        assert 'invoice_unit_arn is required' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_success_strips_metadata_and_normalizes(self, mock_context, sample_unit):
+        """A successful call strips ResponseMetadata and normalizes timestamps."""
+        mock_client = MagicMock()
+        response = dict(sample_unit)
+        response['ResponseMetadata'] = {'RequestId': 'abc'}
+        mock_client.get_invoice_unit.return_value = response
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await get_invoice_unit(
+                mock_context, invoice_unit_arn=sample_unit['InvoiceUnitArn']
+            )
+
+        assert result['status'] == 'success'
+        unit = result['data']['invoice_unit']
+        assert 'ResponseMetadata' not in unit
+        assert unit['LastModified'] == '2026-05-01T00:00:00'
+
+    @pytest.mark.asyncio
+    async def test_as_of_forwarded(self, mock_context, sample_unit):
+        """as_of is converted to epoch seconds and forwarded."""
+        mock_client = MagicMock()
+        mock_client.get_invoice_unit.return_value = dict(sample_unit)
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await get_invoice_unit(
+                mock_context, invoice_unit_arn=sample_unit['InvoiceUnitArn'], as_of='2026-05-01'
+            )
+
+        assert result['status'] == 'success'
+        assert mock_client.get_invoice_unit.call_args.kwargs['AsOf'] == int(
+            datetime(2026, 5, 1, tzinfo=timezone.utc).timestamp()
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_as_of_returns_error(self, mock_context, sample_unit):
+        """A malformed as_of returns a format error."""
+        result = await get_invoice_unit(
+            mock_context, invoice_unit_arn=sample_unit['InvoiceUnitArn'], as_of='bad'
+        )
+
+        assert result['status'] == 'error'
+        assert 'YYYY-MM-DD' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_api_client_error(self, mock_context):
+        """A ClientError from the API returns an error status."""
+        mock_client = MagicMock()
+        mock_client.get_invoice_unit.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Not found'}},
+            'GetInvoiceUnit',
+        )
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await get_invoice_unit(mock_context, invoice_unit_arn='arn:bad')
+
+        assert result['status'] == 'error'
+
+
+class TestBatchGetInvoiceProfile:
+    """batch_get_invoice_profile validation and passthrough."""
+
+    @pytest.mark.asyncio
+    async def test_empty_account_ids_returns_error(self, mock_context):
+        """An empty account_ids list returns an error without calling the API."""
+        result = await batch_get_invoice_profile(mock_context, account_ids=[])
+
+        assert result['status'] == 'error'
+        assert 'non-empty' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_success_returns_profiles(self, mock_context):
+        """A successful call returns the normalized profiles list."""
+        mock_client = MagicMock()
+        mock_client.batch_get_invoice_profile.return_value = {
+            'Profiles': [
+                {
+                    'AccountId': '123456789012',
+                    'ReceiverName': 'Example Corp',
+                    'ReceiverEmail': 'ap@example.com',
+                    'Issuer': 'Amazon Web Services, Inc.',
+                    'TaxRegistrationNumber': 'US123',
+                }
+            ],
+            'ResponseMetadata': {'RequestId': 'abc'},
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await batch_get_invoice_profile(mock_context, account_ids=['123456789012'])
+
+        assert result['status'] == 'success'
+        assert result['data']['profiles'][0]['AccountId'] == '123456789012'
+        assert mock_client.batch_get_invoice_profile.call_args.kwargs['AccountIds'] == [
+            '123456789012'
+        ]
+
+    @pytest.mark.asyncio
+    async def test_api_client_error(self, mock_context):
+        """A ClientError from the API returns an error status."""
+        mock_client = MagicMock()
+        mock_client.batch_get_invoice_profile.side_effect = ClientError(
+            {'Error': {'Code': 'ValidationException', 'Message': 'Bad account'}},
+            'BatchGetInvoiceProfile',
+        )
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await batch_get_invoice_profile(mock_context, account_ids=['x'])
+
+        assert result['status'] == 'error'
+
+
+class TestInvoiceUnitsServer:
+    """FastMCP sub-server registration."""
+
+    def test_server_name(self):
+        """The invoice-units sub-server is created with the expected name."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            invoice_units_server,
+        )
+
+        assert invoice_units_server.name == 'invoice-units-tools'
+
+
+class TestInvoiceUnitsRouting:
+    """Operation routing for the top-level ``invoice-units`` tool."""
+
+    @pytest.mark.asyncio
+    async def test_routes_list_invoice_units(self, mock_context, sample_unit):
+        """operation=list_invoice_units dispatches to the handler."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            _invoice_units,
+        )
+
+        mock_client = MagicMock()
+        mock_client.list_invoice_units.return_value = {'InvoiceUnits': [sample_unit]}
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await _invoice_units(mock_context, 'list_invoice_units')
+
+        assert result['status'] == 'success'
+        assert result['data']['invoice_units'][0]['Name'] == 'Engineering'
+
+    @pytest.mark.asyncio
+    async def test_routes_get_invoice_unit(self, mock_context, sample_unit):
+        """operation=get_invoice_unit dispatches to the handler."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            _invoice_units,
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_invoice_unit.return_value = dict(sample_unit)
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await _invoice_units(
+                mock_context,
+                'get_invoice_unit',
+                invoice_unit_arn=sample_unit['InvoiceUnitArn'],
+            )
+
+        assert result['status'] == 'success'
+        assert result['data']['invoice_unit']['Name'] == 'Engineering'
+
+    @pytest.mark.asyncio
+    async def test_routes_batch_get_invoice_profile(self, mock_context):
+        """operation=batch_get_invoice_profile dispatches to the handler."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            _invoice_units,
+        )
+
+        mock_client = MagicMock()
+        mock_client.batch_get_invoice_profile.return_value = {
+            'Profiles': [{'AccountId': '123456789012', 'ReceiverName': 'Example Corp'}]
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await _invoice_units(
+                mock_context, 'batch_get_invoice_profile', account_ids=['123456789012']
+            )
+
+        assert result['status'] == 'success'
+        assert result['data']['profiles'][0]['AccountId'] == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_unit_missing_arn_routes_error(self, mock_context):
+        """Routing get_invoice_unit without an ARN returns a standardized error."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            _invoice_units,
+        )
+
+        result = await _invoice_units(mock_context, 'get_invoice_unit')
+
+        assert result['status'] == 'error'
+        assert 'invoice_unit_arn is required' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_batch_get_invoice_profile_missing_ids_routes_error(self, mock_context):
+        """Routing batch_get_invoice_profile without account_ids returns an error."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            _invoice_units,
+        )
+
+        result = await _invoice_units(mock_context, 'batch_get_invoice_profile')
+
+        assert result['status'] == 'error'
+        assert 'account_ids is required' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_unknown_operation_returns_error(self, mock_context):
+        """An unsupported operation returns a standardized error."""
+        from awslabs.billing_cost_management_mcp_server.tools.invoice_units_tools import (
+            _invoice_units,
+        )
+
+        result = await _invoice_units(mock_context, 'not_a_real_operation')
+
+        assert result['status'] == 'error'
+        assert 'not_a_real_operation' in result['data']['message']

--- a/src/billing-cost-management-mcp-server/tests/tools/test_procurement_preferences_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_procurement_preferences_tools.py
@@ -1,0 +1,291 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the procurement_preferences_operations and _tools modules."""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_operations import (
+    get_procurement_portal_preference,
+    list_procurement_portal_preferences,
+)
+from botocore.exceptions import ClientError
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+CREATE_CLIENT_PATH = (
+    'awslabs.billing_cost_management_mcp_server.tools.'
+    'procurement_preferences_operations.create_aws_client'
+)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context with async logging methods."""
+    context = MagicMock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    context.debug = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def sample_preference():
+    """Return a sample ProcurementPortalPreference as the AWS API would return it."""
+    return {
+        'ProcurementPortalPreferenceArn': (
+            'arn:aws:invoicing::123456789012:procurement-portal-preference/abc123'
+        ),
+        'Status': 'ACTIVE',
+        'EinvoiceDeliveryPreference': {
+            'EinvoiceDeliveryActivationDate': datetime(2026, 3, 1, tzinfo=timezone.utc),
+        },
+        'CreateDate': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        'LastUpdateDate': datetime(2026, 2, 1, tzinfo=timezone.utc),
+    }
+
+
+class TestListProcurementPortalPreferences:
+    """list_procurement_portal_preferences pagination and normalization."""
+
+    @pytest.mark.asyncio
+    async def test_success_and_timestamp_normalization(self, mock_context, sample_preference):
+        """A successful call normalizes CreateDate/LastUpdateDate to ISO 8601."""
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.return_value = {
+            'ProcurementPortalPreferences': [sample_preference]
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_procurement_portal_preferences(mock_context)
+
+        assert result['status'] == 'success'
+        pref = result['data']['procurement_portal_preferences'][0]
+        assert pref['CreateDate'] == '2026-01-01T00:00:00'
+        assert pref['LastUpdateDate'] == '2026-02-01T00:00:00'
+
+    @pytest.mark.asyncio
+    async def test_pagination_across_pages(self, mock_context, sample_preference):
+        """Multiple pages are aggregated and pagination metadata is accurate."""
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.side_effect = [
+            {'ProcurementPortalPreferences': [sample_preference], 'NextToken': 'page-2'},
+            {'ProcurementPortalPreferences': [sample_preference]},
+        ]
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_procurement_portal_preferences(mock_context)
+
+        assert result['status'] == 'success'
+        assert mock_client.list_procurement_portal_preferences.call_count == 2
+        assert result['data']['pagination']['total_results'] == 2
+        assert result['data']['pagination']['has_more'] is False
+
+    @pytest.mark.asyncio
+    async def test_max_results_and_next_token_forwarded(self, mock_context, sample_preference):
+        """max_results and next_token are forwarded to the request."""
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.return_value = {
+            'ProcurementPortalPreferences': [sample_preference]
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_procurement_portal_preferences(
+                mock_context, max_results=5, next_token='resume-here'
+            )
+
+        assert result['status'] == 'success'
+        call = mock_client.list_procurement_portal_preferences.call_args.kwargs
+        assert call['MaxResults'] == 5
+        assert call['NextToken'] == 'resume-here'
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_context):
+        """An empty result set returns success with zero total_results."""
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.return_value = {
+            'ProcurementPortalPreferences': []
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_procurement_portal_preferences(mock_context)
+
+        assert result['status'] == 'success'
+        assert result['data']['procurement_portal_preferences'] == []
+        assert result['data']['pagination']['total_results'] == 0
+
+    @pytest.mark.asyncio
+    async def test_api_client_error(self, mock_context):
+        """A ClientError from the API returns an error status."""
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'Not authorized'}},
+            'ListProcurementPortalPreferences',
+        )
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_procurement_portal_preferences(mock_context)
+
+        assert result['status'] == 'error'
+
+
+class TestGetProcurementPortalPreference:
+    """get_procurement_portal_preference validation and nested normalization."""
+
+    @pytest.mark.asyncio
+    async def test_missing_arn_returns_error(self, mock_context):
+        """An empty ARN returns an error without calling the API."""
+        result = await get_procurement_portal_preference(
+            mock_context, procurement_portal_preference_arn=''
+        )
+
+        assert result['status'] == 'error'
+        assert 'procurement_portal_preference_arn is required' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_success_strips_metadata_and_normalizes_nested(
+        self, mock_context, sample_preference
+    ):
+        """The nested EinvoiceDeliveryActivationDate is normalized to ISO 8601."""
+        mock_client = MagicMock()
+        mock_client.get_procurement_portal_preference.return_value = {
+            'ProcurementPortalPreference': sample_preference,
+            'ResponseMetadata': {'RequestId': 'abc'},
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await get_procurement_portal_preference(
+                mock_context,
+                procurement_portal_preference_arn=sample_preference[
+                    'ProcurementPortalPreferenceArn'
+                ],
+            )
+
+        assert result['status'] == 'success'
+        pref = result['data']['procurement_portal_preference']
+        assert pref['CreateDate'] == '2026-01-01T00:00:00'
+        assert (
+            pref['EinvoiceDeliveryPreference']['EinvoiceDeliveryActivationDate']
+            == '2026-03-01T00:00:00'
+        )
+
+    @pytest.mark.asyncio
+    async def test_api_client_error(self, mock_context):
+        """A ClientError from the API returns an error status."""
+        mock_client = MagicMock()
+        mock_client.get_procurement_portal_preference.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Not found'}},
+            'GetProcurementPortalPreference',
+        )
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await get_procurement_portal_preference(
+                mock_context, procurement_portal_preference_arn='arn:bad'
+            )
+
+        assert result['status'] == 'error'
+
+
+class TestProcurementPreferencesServer:
+    """FastMCP sub-server registration."""
+
+    def test_server_name(self):
+        """The procurement-preferences sub-server has the expected name."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_tools import (
+            procurement_preferences_server,
+        )
+
+        assert procurement_preferences_server.name == 'procurement-preferences-tools'
+
+
+class TestProcurementPreferencesRouting:
+    """Operation routing for the top-level ``procurement-preferences`` tool."""
+
+    @pytest.mark.asyncio
+    async def test_routes_list(self, mock_context, sample_preference):
+        """operation=list_procurement_portal_preferences dispatches to the handler."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_tools import (
+            _procurement_preferences,
+        )
+
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.return_value = {
+            'ProcurementPortalPreferences': [sample_preference]
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await _procurement_preferences(
+                mock_context, 'list_procurement_portal_preferences'
+            )
+
+        assert result['status'] == 'success'
+        assert result['data']['procurement_portal_preferences'][0]['Status'] == 'ACTIVE'
+
+    @pytest.mark.asyncio
+    async def test_routes_get(self, mock_context, sample_preference):
+        """operation=get_procurement_portal_preference dispatches to the handler."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_tools import (
+            _procurement_preferences,
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_procurement_portal_preference.return_value = {
+            'ProcurementPortalPreference': sample_preference
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await _procurement_preferences(
+                mock_context,
+                'get_procurement_portal_preference',
+                procurement_portal_preference_arn=sample_preference[
+                    'ProcurementPortalPreferenceArn'
+                ],
+            )
+
+        assert result['status'] == 'success'
+        assert result['data']['procurement_portal_preference']['Status'] == 'ACTIVE'
+
+    @pytest.mark.asyncio
+    async def test_get_missing_arn_routes_error(self, mock_context):
+        """Routing get_procurement_portal_preference without an ARN returns an error."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_tools import (
+            _procurement_preferences,
+        )
+
+        result = await _procurement_preferences(mock_context, 'get_procurement_portal_preference')
+
+        assert result['status'] == 'error'
+        assert 'procurement_portal_preference_arn is required' in result['data']['message']
+
+    @pytest.mark.asyncio
+    async def test_unknown_operation_returns_error(self, mock_context):
+        """An unsupported operation returns a standardized error."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_tools import (
+            _procurement_preferences,
+        )
+
+        result = await _procurement_preferences(mock_context, 'not_a_real_operation')
+
+        assert result['status'] == 'error'
+        assert 'not_a_real_operation' in result['data']['message']

--- a/src/billing-cost-management-mcp-server/tests/tools/test_procurement_preferences_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_procurement_preferences_tools.py
@@ -49,6 +49,8 @@ def sample_preference():
             'arn:aws:invoicing::123456789012:procurement-portal-preference/abc123'
         ),
         'Status': 'ACTIVE',
+        # Sensitive: must never be propagated to the agent/LLM (dropped by the tool).
+        'ProcurementPortalSharedSecret': 'super-secret-shared-value',  # pragma: allowlist secret
         'EinvoiceDeliveryPreference': {
             'EinvoiceDeliveryActivationDate': datetime(2026, 3, 1, tzinfo=timezone.utc),
         },
@@ -76,6 +78,26 @@ class TestListProcurementPortalPreferences:
         pref = result['data']['procurement_portal_preferences'][0]
         assert pref['CreateDate'] == '2026-01-01T00:00:00'
         assert pref['LastUpdateDate'] == '2026-02-01T00:00:00'
+
+    @pytest.mark.asyncio
+    async def test_shared_secret_dropped(self, mock_context, sample_preference):
+        """ProcurementPortalSharedSecret is dropped from every listed item."""
+        mock_client = MagicMock()
+        mock_client.list_procurement_portal_preferences.return_value = {
+            'ProcurementPortalPreferences': [sample_preference, dict(sample_preference)]
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await list_procurement_portal_preferences(mock_context)
+
+        assert result['status'] == 'success'
+        prefs = result['data']['procurement_portal_preferences']
+        assert prefs, 'expected at least one preference'
+        for pref in prefs:
+            assert 'ProcurementPortalSharedSecret' not in pref
+        # Non-sensitive fields are preserved.
+        assert prefs[0]['Status'] == 'ACTIVE'
 
     @pytest.mark.asyncio
     async def test_pagination_across_pages(self, mock_context, sample_preference):
@@ -188,6 +210,29 @@ class TestGetProcurementPortalPreference:
         )
 
     @pytest.mark.asyncio
+    async def test_shared_secret_dropped(self, mock_context, sample_preference):
+        """ProcurementPortalSharedSecret is dropped from the retrieved preference."""
+        mock_client = MagicMock()
+        mock_client.get_procurement_portal_preference.return_value = {
+            'ProcurementPortalPreference': sample_preference,
+            'ResponseMetadata': {'RequestId': 'abc'},
+        }
+
+        with patch(CREATE_CLIENT_PATH) as mock_create:
+            mock_create.return_value = mock_client
+            result = await get_procurement_portal_preference(
+                mock_context,
+                procurement_portal_preference_arn=sample_preference[
+                    'ProcurementPortalPreferenceArn'
+                ],
+            )
+
+        assert result['status'] == 'success'
+        pref = result['data']['procurement_portal_preference']
+        assert 'ProcurementPortalSharedSecret' not in pref
+        assert pref['Status'] == 'ACTIVE'
+
+    @pytest.mark.asyncio
     async def test_api_client_error(self, mock_context):
         """A ClientError from the API returns an error status."""
         mock_client = MagicMock()
@@ -203,6 +248,47 @@ class TestGetProcurementPortalPreference:
             )
 
         assert result['status'] == 'error'
+
+
+class TestDropSensitiveFields:
+    """Direct tests for the recursive secret-dropping helper."""
+
+    def test_drops_top_level_and_nested_and_lists(self):
+        """The secret key is removed at any depth and in list items."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_operations import (
+            drop_sensitive_fields,
+        )
+
+        data = {
+            'ProcurementPortalSharedSecret': 'top',  # pragma: allowlist secret
+            'Status': 'ACTIVE',
+            'nested': {
+                'ProcurementPortalSharedSecret': 'deep',  # pragma: allowlist secret
+                'keep': 1,
+            },
+            'items': [
+                {'ProcurementPortalSharedSecret': 'a'},
+                {'ProcurementPortalSharedSecret': 'b', 'keep': 2},
+            ],
+        }
+
+        result = drop_sensitive_fields(data)
+
+        assert 'ProcurementPortalSharedSecret' not in result
+        assert 'ProcurementPortalSharedSecret' not in result['nested']
+        assert result['nested']['keep'] == 1
+        assert all('ProcurementPortalSharedSecret' not in item for item in result['items'])
+        assert result['items'][1]['keep'] == 2
+        assert result['Status'] == 'ACTIVE'
+
+    def test_noop_when_absent(self):
+        """Structures without the secret are returned unchanged."""
+        from awslabs.billing_cost_management_mcp_server.tools.procurement_preferences_operations import (
+            drop_sensitive_fields,
+        )
+
+        data = {'Status': 'ACTIVE', 'items': [{'keep': 1}]}
+        assert drop_sensitive_fields(data) == {'Status': 'ACTIVE', 'items': [{'keep': 1}]}
 
 
 class TestProcurementPreferencesServer:

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_time_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_time_utils.py
@@ -16,6 +16,7 @@
 
 import pytest
 from awslabs.billing_cost_management_mcp_server.utilities.time_utils import (
+    normalize_datetimes_to_iso,
     timestamp_to_utc_iso_string,
 )
 from datetime import datetime, timezone
@@ -110,3 +111,45 @@ class TestEpochSecondsToUtcIsoString:
         # 2025-01-01T00:00:00 UTC = 1735689600
         result = timestamp_to_utc_iso_string(1735689600)
         assert result == '2025-01-01T00:00:00'
+
+
+class TestNormalizeDatetimesToIso:
+    """Tests for normalize_datetimes_to_iso (recursive datetime walker)."""
+
+    def test_scalar_datetime(self):
+        """A bare datetime is converted to an ISO 8601 string."""
+        dt = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        assert normalize_datetimes_to_iso(dt) == '2026-05-01T00:00:00'
+
+    def test_nested_structure(self):
+        """Datetimes are converted at any nesting depth; other values untouched."""
+        obj = {
+            'Name': 'Engineering',
+            'LastModified': datetime(2026, 5, 1, tzinfo=timezone.utc),
+            'Rule': {'LinkedAccounts': ['123456789012']},
+            'Nested': {
+                'EinvoiceDeliveryActivationDate': datetime(2026, 3, 1, tzinfo=timezone.utc),
+            },
+            'Items': [
+                {'CreateDate': datetime(2026, 1, 1, tzinfo=timezone.utc)},
+                {'CreateDate': datetime(2026, 2, 1, tzinfo=timezone.utc)},
+            ],
+        }
+        result = normalize_datetimes_to_iso(obj)
+        assert result['LastModified'] == '2026-05-01T00:00:00'
+        assert result['Nested']['EinvoiceDeliveryActivationDate'] == '2026-03-01T00:00:00'
+        assert result['Items'][0]['CreateDate'] == '2026-01-01T00:00:00'
+        assert result['Items'][1]['CreateDate'] == '2026-02-01T00:00:00'
+        assert result['Name'] == 'Engineering'
+        assert result['Rule']['LinkedAccounts'] == ['123456789012']
+
+    def test_no_datetimes_unchanged(self):
+        """A structure with no datetimes is returned unchanged."""
+        obj = {'a': 1, 'b': ['x', 'y'], 'c': {'d': True}}
+        assert normalize_datetimes_to_iso(obj) == obj
+
+    def test_scalar_passthrough(self):
+        """Non-datetime scalars pass through untouched."""
+        assert normalize_datetimes_to_iso('hello') == 'hello'
+        assert normalize_datetimes_to_iso(42) == 42
+        assert normalize_datetimes_to_iso(None) is None


### PR DESCRIPTION
## Why this matters

Invoices have two sides: the summary/document side (covered by the `invoicing` tool in #4093) and the **configuration** side — how a customer's accounts are grouped into separate invoices, and how those invoices are delivered. This PR adds two read-only tools exposing that configuration: **`invoice-units`** (AWS Invoice Configuration) and **`procurement-preferences`** (AWS Procurement Portal Preferences), letting agents explain invoice-unit structure, invoice receivers, and procurement-portal (SAP Business Network / Coupa) e-invoice delivery — data previously unavailable via MCP.

## What this unlocks

Agent use cases now possible:

- "List my invoice units and the accounts in each."
- "Which invoice unit does account 123456789012 belong to, and who is the receiver?"
- "What's the invoice receiver profile (legal name, address, tax registration) for these accounts?"
- "Which procurement portals am I connected to (SAP Business Network / Coupa)?"
- "Is e-invoice delivery configured, and when was it activated?"

## What changed

| File | Change |
|------|--------|
| `tools/invoice_units_operations.py` | **New** — read logic for `ListInvoiceUnits`, `GetInvoiceUnit`, `BatchGetInvoiceProfile` (invoicing-2024-12-01) |
| `tools/invoice_units_tools.py` | **New** — FastMCP sub-server exposing the operation-routed `invoice-units` tool |
| `tools/procurement_preferences_operations.py` | **New** — read logic for `ListProcurementPortalPreferences`, `GetProcurementPortalPreference` |
| `tools/procurement_preferences_tools.py` | **New** — FastMCP sub-server exposing the operation-routed `procurement-preferences` tool |
| `tests/tools/test_invoice_units_tools.py` | **New** — unit tests |
| `tests/tools/test_procurement_preferences_tools.py` | **New** — unit tests |
| `server.py` | Register the two sub-servers |
| `README.md` | Features entries, Supported Services #12, IAM permissions |

Key design choices:
- **Hybrid tool surface (one tool per resource group).** Rather than piling every invoicing API into one tool, or exposing one tool per API, each resource group is its own operation-routed tool — `invoice-units` (Invoice Configuration) and `procurement-preferences` (Procurement Portal Preferences). This keeps each tool's parameters cohesive and its read/write boundary clean as the namespace grows. The existing `invoicing` (summaries) tool is unchanged and keeps its name.
- **Read-only** — only `List*` / `Get*` / `BatchGet*`; no create/update/delete.
- `BatchGetInvoiceProfile` is grouped under `invoice-units`, matching the botocore Invoice Configuration family (it's keyed on account IDs / receivers).
- Rich field documentation in each tool description so the LLM can interpret responses without external lookups.
- Uses `paginate_aws_response` for accurate pagination metadata on list operations.
- Region resolved from `AWS_REGION` (not hardcoded).
- All timestamps normalized to ISO 8601, including the nested `EinvoiceDeliveryActivationDate`.

## Response fields exposed

- **invoice-units:** `InvoiceUnitArn`, `Name`, `Description`, `InvoiceReceiver`, `TaxInheritanceDisabled`, `Rule { LinkedAccounts }`, `LastModified` (ISO 8601). `batch_get_invoice_profile` returns per account: `AccountId`, `ReceiverName`, `ReceiverAddress`, `ReceiverEmail`, `Issuer`, `TaxRegistrationNumber`.
- **procurement-preferences:** the preference ARN, portal connection details, status, `EinvoiceDeliveryPreference` (including `EinvoiceDeliveryActivationDate`), `CreateDate`, `LastUpdateDate` (ISO 8601).

## Testing

- `uv run --frozen pytest` — **976 passed** (37 new tests across the two tools).
- New modules: 100% coverage on the operations handlers, 96–97% on the routers.
- `uv run ruff check` + `uv run ruff format` — clean. `uv run pyright` — 0 errors.

## Design notes for reviewers

- Adds two tools to the existing server; no new MCP server introduced. `invoicing:` was already in `allowed_services` (from #4093), so no change there.
- The `invoicing` (summaries) tool is untouched; this PR only adds sibling tools.
- Required IAM permissions (all read-only): `invoicing:ListInvoiceUnits`, `invoicing:GetInvoiceUnit`, `invoicing:BatchGetInvoiceProfile`, `invoicing:ListProcurementPortalPreferences`, `invoicing:GetProcurementPortalPreference`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
