### PR TITLE
chore(deps): group Dependabot updates across directories to stop the per-directory PR explosion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,8 +31,7 @@ updates:
       uv-version-updates:
         # Collapse this dependency's bump across every matched directory into a
         # single PR. Without this, `directories: ["**/*"]` groups only WITHIN
-        # each directory, so a monorepo with ~55 `uv` packages produced ~55 PRs
-        # per upstream release. See #4258 (a single mcp bump → 57 PRs).
+        # each directory.
         group-by: dependency-name
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
       prefix: "chore(deps): update uv"
     groups:
       uv-version-updates:
+        # Collapse this dependency's bump across every matched directory into a
+        # single PR. Without this, `directories: ["**/*"]` groups only WITHIN
+        # each directory, so a monorepo with ~55 `uv` packages produced ~55 PRs
+        # per upstream release. See #4258 (a single mcp bump → 57 PRs).
+        group-by: dependency-name
         patterns:
           - "*"
 
@@ -41,6 +46,8 @@ updates:
       prefix: "chore(deps): update npm"
     groups:
       npm-version-updates:
+        # One PR per dependency across all directories (see uv note above).
+        group-by: dependency-name
         patterns:
           - "*"
 
@@ -53,5 +60,7 @@ updates:
       prefix: "chore(deps): update docker images"
     groups:
       docker-version-updates:
+        # One PR per image across all directories (see uv note above).
+        group-by: dependency-name
         patterns:
           - "*"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

Adds `group-by: dependency-name` to the `uv`, `npm`, and `docker` Dependabot update configs so a single upstream release produces **one** grouped PR per dependency **across all package directories**, instead of one grouped PR **per directory**.

### The problem

The three ecosystem configs use `directories: ["**/*"]` with a `groups:` block. Dependabot grouping is **per-directory**, so `**/*` (which matches ~55 package dirs in this monorepo) yields one grouped PR *per matched directory* for every dependency bump. Net effect today:

- **607 open Dependabot PRs**, of which **584 are `uv`** — the same handful of dependency bumps fanned out across every `src/*-mcp-server` and `samples/*` package.
- It recurs on every release: a single `mcp` bump most recently produced **57 PRs** (see #4258, which manually consolidates that one bump).

### The fix

`group-by: dependency-name` under each multi-directory group tells Dependabot to collapse a given dependency's update across all matched directories into a single PR. Applied to `uv`, `npm`, and `docker`. The `github-actions` group is left unchanged — it uses a single `directory: "/"`, so it never had the cross-directory fan-out.

```yaml
groups:
  uv-version-updates:
    group-by: dependency-name   # ← added
    patterns:
      - "*"
```

### Validation

Validated with the checker the config file itself declares in its header comment:

```
npx @bugron/validate-dependabot-yaml .github/dependabot.yml   # passes (exit 0)
```

`group-by: dependency-name` is an allowed enum value in that schema — confirmed by a control run where an invalid `group-by` value was correctly rejected.

## User experience

**Before:** one dependency bump → dozens of near-identical PRs (one per package directory); 600+ open at steady state.
**After:** one dependency bump → one PR spanning all affected directories. Dramatically smaller, reviewable queue.

> **Note on the existing backlog:** this config change governs *future* Dependabot runs — it does not retroactively collapse the 600+ PRs already open. Those will age out / be superseded as Dependabot re-evaluates on its next cycles (as the `mcp 1.27.2` batch already self-closed when `1.28.1` shipped), or can be cleared with a bulk `@dependabot close` / manual sweep separately. #4258 consolidates the current `mcp` bump specifically.

## Changes

Single-file change: `.github/dependabot.yml` — `group-by: dependency-name` added to the three multi-directory groups, with an explanatory comment on the `uv` group.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (validated with `@bugron/validate-dependabot-yaml`)
* [x] Changes are documented (inline comment + this description)

Is this a breaking change? (N)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
