### PR TITLE
fix(aws-transform-mcp-server): refuse downloads when write-base is fi…

### DIFF
--- a/src/aws-transform-mcp-server/CHANGELOG.md
+++ b/src/aws-transform-mcp-server/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Artifact downloads now return a clear, actionable error when the server is
+  spawned with the filesystem root (`/`) as its working directory. The
+  write-path confinement added for the arbitrary-file-write fix pinned the
+  allowed base to the current working directory; when that was `/`, the
+  confinement check rejected every path with a confusing "must be within the
+  working directory (/)" message. Downloads in this case are now refused with a
+  message telling the operator to set the new `AWS_TRANSFORM_MCP_WRITE_DIR`
+  environment variable to choose where downloads are written. The
+  arbitrary-write protection is unchanged for all other cases.
+- Added the `AWS_TRANSFORM_MCP_WRITE_DIR` environment variable to let an
+  operator pin the artifact-download base directory explicitly.
+- Artifact downloads now create the target directory if it does not already
+  exist (within the confined base), instead of failing with `FileNotFoundError`.
+
 ## [0.1.0] - 2026-05-07
 
 ### Added

--- a/src/aws-transform-mcp-server/README.md
+++ b/src/aws-transform-mcp-server/README.md
@@ -317,6 +317,7 @@ Set these in your MCP client config `env` block:
 | `AWS_PROFILE` | No | `default` profile | AWS profile from `~/.aws/credentials` to use for Control Plane tools (e.g., `accept_connector`). If you have multiple AWS profiles, set this to the one with access to your Transform account. If not set, boto3 uses the `[default]` profile, then falls back to environment variables (`AWS_ACCESS_KEY_ID`), then instance metadata. See [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) for the full resolution order. |
 | `AWS_REGION` | No | Profile region, then `us-east-1` | AWS region for Control Plane API calls. If not set, uses the region from your AWS profile (`~/.aws/config`), then falls back to `us-east-1`. |
 | `FASTMCP_LOG_LEVEL` | No | `INFO` | Log level for the MCP server (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+| `AWS_TRANSFORM_MCP_WRITE_DIR` | No | Server working directory | Base directory that artifact downloads (`get_resource`, `load_instructions`) are confined to. A `savePath` must resolve to this directory or a subdirectory of it; anything outside is rejected. If not set, the server's current working directory at startup is used. If that working directory is the filesystem root (`/`) — which happens when a desktop or IDE client launches the server outside a shell — downloads are refused until this variable is set, since confining to `/` would place no bound on writes. Set this to the directory you want downloads written to. |
 
 ## HITL Task Response System
 
@@ -369,7 +370,8 @@ All outbound HTTP calls use **HTTPS** exclusively. API endpoints are derived wit
 
 The server blocks reads and writes to sensitive files and directories to prevent credential exfiltration via tool misuse:
 
-- **Blocked filenames:** `.env`, `.netrc`, `.pgpass`, SSH keys (`id_rsa`, `id_ed25519`, etc.), `credentials`, `authorized_keys`, and others
+- **Write confinement:** artifact downloads are confined to an allowed base directory (see `AWS_TRANSFORM_MCP_WRITE_DIR`), which defaults to the server's working directory. A `savePath` that resolves outside the base is rejected, so an LLM-controlled path cannot write to arbitrary filesystem locations. If the base would be the filesystem root (`/`), downloads are refused until `AWS_TRANSFORM_MCP_WRITE_DIR` is set, rather than allowing unbounded writes.
+- **Blocked filenames:** `.env`, `.netrc`, `.pgpass`, SSH keys (`id_rsa`, `id_ed25519`, etc.), `credentials`, `authorized_keys`, and others — enforced on both reads and writes
 - **Blocked directories:** `~/.aws`, `~/.ssh`, `~/.gnupg`, `~/.docker`, `~/.aws-transform-mcp`
 - **Path traversal prevention:** all file paths are resolved and validated against directory boundaries
 - **Extension allowlisting:** only approved file extensions can be downloaded

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/file_validation.py
@@ -59,10 +59,26 @@ BLOCKED_READ_DIRS: tuple[str, ...] = (
     '/etc/passwd',
 )
 
-# Allowed base directory for write operations. All writes must resolve under
-# the current working directory at import time. This prevents LLM-controlled
-# savePath from writing to arbitrary filesystem locations.
-_ALLOWED_WRITE_BASE: str = os.path.realpath(os.getcwd())
+# Environment variable an operator may set to pin the write base explicitly.
+WRITE_BASE_ENV_VAR = 'AWS_TRANSFORM_MCP_WRITE_DIR'
+
+
+def _resolve_write_base() -> str:
+    """Resolve the allowed base directory for write operations.
+
+    All writes must resolve under this base, which prevents an LLM-controlled
+    savePath from writing to arbitrary filesystem locations. The base is taken
+    from AWS_TRANSFORM_MCP_WRITE_DIR if set, otherwise the current working
+    directory at import time.
+    """
+    configured = os.environ.get(WRITE_BASE_ENV_VAR)
+    if configured:
+        return os.path.realpath(os.path.expanduser(configured))
+    return os.path.realpath(os.getcwd())
+
+
+# Allowed base directory for write operations.
+_ALLOWED_WRITE_BASE: str = _resolve_write_base()
 
 
 def _is_blocked_name(path: str) -> bool:
@@ -106,6 +122,16 @@ def validate_write_path(save_path: str, file_name: Optional[str] = None) -> str:
     Returns the resolved absolute write path.
     Raises ValueError on any policy violation.
     """
+    # Refuse to write when the base is the filesystem root. Confining to '/'
+    # would place no bound on writes, so require an explicit base instead.
+    if _ALLOWED_WRITE_BASE == os.sep:
+        logger.warning('[security] Blocked write: allowed base is the filesystem root')
+        raise ValueError(
+            f'Cannot determine a safe save location: the server was started with the '
+            f'filesystem root as its working directory. Set the {WRITE_BASE_ENV_VAR} '
+            f'environment variable to the directory downloads should be written to.'
+        )
+
     resolved_dir = os.path.realpath(os.path.expanduser(save_path))
 
     # Confine writes to the allowed base directory.

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
@@ -269,6 +269,7 @@ async def download_s3_content(
                 full_path = validate_write_path(
                     os.path.dirname(save_path), os.path.basename(save_path)
                 )
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
             with open(full_path, 'wb') as fh:
                 fh.write(response.content)
             return {'savedTo': full_path, 'sizeBytes': len(response.content)}

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/get_resource.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/get_resource.py
@@ -179,7 +179,16 @@ class GetResourceHandler:
         ] = None,
         savePath: Annotated[
             Optional[str],
-            Field(description='Local path to save artifact file (artifact only)'),
+            Field(
+                description=(
+                    'Local path to save artifact file (artifact only). Must resolve '
+                    'within the allowed base directory (the server working directory, '
+                    'or AWS_TRANSFORM_MCP_WRITE_DIR if set); paths outside it are '
+                    'rejected. If the server was started with the filesystem root as '
+                    'its working directory, downloads are refused until '
+                    'AWS_TRANSFORM_MCP_WRITE_DIR is set to a non-root directory.'
+                )
+            ),
         ] = None,
         fileName: Annotated[
             Optional[str],

--- a/src/aws-transform-mcp-server/tests/test_file_validation.py
+++ b/src/aws-transform-mcp-server/tests/test_file_validation.py
@@ -294,3 +294,44 @@ class TestValidateWritePath:
                 assert result == os.path.join(os.path.realpath(subdir), 'output.zip')
             finally:
                 file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_write_rejected_when_base_is_filesystem_root(self):
+        """When the base is '/', every write is refused with a clear error.
+
+        Regression test for D464432980: if the server is spawned with the
+        filesystem root as its working directory, confining to '/' would place
+        no bound on writes. Rather than fall back to allowing writes, the
+        request is refused and the caller is told to set the write-dir env var.
+        """
+        from awslabs.aws_transform_mcp_server import file_validation
+        from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
+
+        original_base = file_validation._ALLOWED_WRITE_BASE
+        try:
+            file_validation._ALLOWED_WRITE_BASE = os.sep
+            for save_path, name in [
+                (os.path.join(os.sep, 'tmp', 'x'), 'artifact.json'),
+                ('/etc/cron.d', 'evil.sh'),
+                (file_validation._HOME, '.bashrc'),
+            ]:
+                with pytest.raises(ValueError, match=file_validation.WRITE_BASE_ENV_VAR):
+                    validate_write_path(save_path, name)
+        finally:
+            file_validation._ALLOWED_WRITE_BASE = original_base
+
+    def test_write_base_defaults_to_cwd(self, monkeypatch):
+        """Without the env var set, the base is the current working directory."""
+        from awslabs.aws_transform_mcp_server import file_validation
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.delenv(file_validation.WRITE_BASE_ENV_VAR, raising=False)
+            monkeypatch.setattr(os, 'getcwd', lambda: tmpdir)
+            assert file_validation._resolve_write_base() == os.path.realpath(tmpdir)
+
+    def test_write_base_honors_env_override(self, monkeypatch):
+        """An operator-set write dir env var pins the base explicitly."""
+        from awslabs.aws_transform_mcp_server import file_validation
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.setenv(file_validation.WRITE_BASE_ENV_VAR, tmpdir)
+            assert file_validation._resolve_write_base() == os.path.realpath(tmpdir)

--- a/src/aws-transform-mcp-server/tests/test_tool_utils.py
+++ b/src/aws-transform-mcp-server/tests/test_tool_utils.py
@@ -248,6 +248,32 @@ class TestDownloadS3Content:
                 assert fh.read() == b'binary data here'
 
     @pytest.mark.asyncio
+    async def test_creates_missing_save_directory(self, tmp_path):
+        """A save_path whose directory does not yet exist is created."""
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'binary data here'
+        mock_response.raise_for_status = lambda: None
+
+        with patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient') as MockClient:
+            instance = AsyncMock()
+            instance.get.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = instance
+
+            save_dir = os.path.join(str(tmp_path), 'new', 'nested') + '/'
+            assert not os.path.exists(save_dir)
+            result = await download_s3_content(
+                'https://s3.example.com/data.bin',
+                save_path=save_dir,
+                file_name='output.bin',
+            )
+            assert result['savedTo'] == os.path.join(str(tmp_path), 'new', 'nested', 'output.bin')
+            with open(result['savedTo'], 'rb') as fh:
+                assert fh.read() == b'binary data here'
+
+    @pytest.mark.asyncio
     async def test_uses_default_name(self, tmp_path):
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = 200


### PR DESCRIPTION
…lesystem root

The arbitrary-file-write fix (PR #3696) confined artifact downloads to a base directory pinned to the server's working directory at startup. When an MCP client spawns the server with the filesystem root as its working directory (common for desktop/IDE clients launched outside a shell), the base became '/', and the confinement check rejected every savePath with a confusing 'must be within the working directory (/)' error -- blocking all downloads.

Confining to '/' is never valid: it would place no bound on writes. Instead of silently falling back, downloads are now refused with a clear, actionable error that tells the operator to set AWS_TRANSFORM_MCP_WRITE_DIR to the directory downloads should be written to. That env var also lets any operator pin the base explicitly.

The confinement check is otherwise unchanged, so the arbitrary-write protection is preserved for all non-root cases: writes outside the base remain blocked.

Also create the target directory if it does not exist (within the confined base), so downloads to a new subfolder no longer fail with FileNotFoundError.

Adds regression tests for the root-base refusal, the env override, the CWD default, and directory auto-creation. Documents AWS_TRANSFORM_MCP_WRITE_DIR and the write-confinement behavior in the README.

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
