### PR TITLE
fix(aws-transform-mcp-server): run SigV4 client build off the event loop

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_client.py
@@ -202,14 +202,28 @@ async def call_fes_direct_sigv4(
     max_retries: int = MAX_RETRIES,
     region: Optional[str] = None,
 ) -> Any:
-    """Direct FES call with SigV4 auth from boto3 credentials."""
-    if region is None:
-        session = AwsHelper.create_session()
-        region = AwsHelper.resolve_region(session)
-    client = _create_sigv4_client(
-        endpoint, region=region, max_retries=max_retries, timeout=timeout_seconds
-    )
-    return await asyncio.to_thread(_call_boto3, client, operation, body or {})
+    """Direct FES call with SigV4 auth from boto3 credentials.
+
+    Region resolution, boto3 client construction, and the HTTP call are all run
+    off the event loop. ``_create_sigv4_client`` loads the vendored service model
+    synchronously (~1-2s) and blocks the loop if run inline, which serializes
+    otherwise-concurrent callers — notably the startup region discovery fan-out
+    in ``server.py``, where 9 inlined client builds blew past the discovery
+    timeout from hosts distant from their Transform profile's region (#4059).
+    """
+    resolved_region = region
+
+    def _build_and_call() -> Any:
+        nonlocal resolved_region
+        if resolved_region is None:
+            session = AwsHelper.create_session()
+            resolved_region = AwsHelper.resolve_region(session)
+        client = _create_sigv4_client(
+            endpoint, region=resolved_region, max_retries=max_retries, timeout=timeout_seconds
+        )
+        return _call_boto3(client, operation, body or {})
+
+    return await asyncio.to_thread(_build_and_call)
 
 
 async def call_fes_direct_cookie(

--- a/src/aws-transform-mcp-server/tests/test_transform_api_client.py
+++ b/src/aws-transform-mcp-server/tests/test_transform_api_client.py
@@ -15,6 +15,7 @@
 """Tests for transform_api_client: cookie/bearer modes, token refresh, errors (boto3-based)."""
 # ruff: noqa: D101, D102, D103
 
+import asyncio
 import pytest
 import time
 from awslabs.aws_transform_mcp_server.http_utils import HttpError
@@ -435,6 +436,44 @@ class TestCallFesDirectSigv4:
         await call_fes_direct_sigv4('https://fes.example.com', 'VerifySession', region='eu-west-1')
 
         assert mock_create.call_args[1]['region'] == 'eu-west-1'
+
+    async def test_client_build_runs_off_event_loop(self):
+        """Regression test for #4059.
+
+        ``_create_sigv4_client`` must run off the event loop so concurrent
+        callers (the startup region fan-out) are not serialized by the
+        synchronous service-model load. Three concurrent calls whose client
+        build each sleeps 0.3s should complete in well under 3 * 0.3s.
+        """
+        from awslabs.aws_transform_mcp_server.transform_api_client import call_fes_direct_sigv4
+
+        build_delay = 0.3
+
+        def _slow_create(*args, **kwargs):
+            time.sleep(build_delay)  # simulate the synchronous model load
+            return MagicMock()
+
+        with (
+            patch(f'{_MOD}._call_boto3', return_value={'ok': True}),
+            patch(f'{_MOD}._create_sigv4_client', side_effect=_slow_create),
+        ):
+            start = time.monotonic()
+            results = await asyncio.gather(
+                *(
+                    call_fes_direct_sigv4('https://fes.example.com', 'VerifySession', region=r)
+                    for r in ('us-east-1', 'eu-west-1', 'ap-southeast-2')
+                )
+            )
+            elapsed = time.monotonic() - start
+
+        assert results == [{'ok': True}] * 3
+        # Serialized builds would take >= 3 * build_delay = 0.9s. The default
+        # asyncio to_thread pool has plenty of workers to run three builds in
+        # parallel, so this completes in roughly one build_delay. Use a generous
+        # but decisive threshold well below the serialized floor.
+        assert elapsed < 2 * build_delay, (
+            f'client builds appear serialized: {elapsed:.2f}s >= {2 * build_delay}s'
+        )
 
 
 # ── call_transform_api with FESRequest body ─────────────────────────────────────


### PR DESCRIPTION
The startup credential probe (_discover_sigv4_regions) fans ListWorkspaces out across all 9 FES regions with asyncio.gather, but call_fes_direct_sigv4 built the boto3 client inline before the awaited HTTP call. _create_sigv4_client loads the vendored service model synchronously (~1-2s) and blocked the event loop, so the 9 concurrent coroutines were effectively serialized at ~18s total. Each region call was wrapped in a 7s timeout (PROFILE_DISCOVERY_TIMEOUT_SECONDS + 2), so the real region's response could not be delivered before the deadline and the probe reported no regions available — silently disabling IAM/SigV4 auth for hosts that are network-distant from their Transform profile's region.

This moves region resolution, client construction, and the boto3 call into a single function run via asyncio.to_thread, so the event loop stays free during the synchronous model load and the gather is genuinely concurrent. Behavior is unchanged for the single-region path; only concurrency is fixed.

Added a regression test that runs three concurrent calls with a slow (0.3s) client-build mock and asserts the total elapsed time is well under the serialized floor (0.9s), confirming the build no longer runs on the event loop. All 741 existing tests still pass.

Fixes #4059

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).