### PR TITLE
fix(agentcore-mcp): don't crash startup when llms.txt docs index is unreachable

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/cache.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/utils/cache.py
@@ -14,6 +14,7 @@
 
 from ..config import doc_config
 from . import doc_fetcher, indexer, text_processor
+from loguru import logger
 from typing import Dict
 
 
@@ -39,13 +40,28 @@ def load_links_only() -> None:
         - Populates _URL_TITLES with curated titles
         - Sets placeholder entries in _URL_CACHE
         - Sets _LINKS_LOADED to True
+
+    A transient or permanent failure to fetch a configured llms.txt source
+    (e.g. HTTP 404 because the upstream docs site moved) is logged and
+    skipped rather than propagated, so an unreachable docs index does not
+    prevent the server (and its non-docs tools) from starting.
     """
     global _INDEX, _LINKS_LOADED, _URL_TITLES, _URL_CACHE
     if _INDEX is None:
         _INDEX = indexer.IndexSearch()
 
     for src in doc_config.llm_texts_url:
-        for title, url in doc_fetcher.parse_llms_txt(src):
+        try:
+            links = doc_fetcher.parse_llms_txt(src)
+        except Exception as exc:
+            logger.warning(
+                'Failed to load documentation index from {}: {}; '
+                'documentation tools will have no indexed content.',
+                src,
+                exc,
+            )
+            continue
+        for title, url in links:
             # Record curated display title and placeholder cache
             _URL_TITLES[url] = title
             _URL_CACHE.setdefault(url, None)

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/browser/test_integ_mcp_protocol.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/browser/test_integ_mcp_protocol.py
@@ -787,12 +787,19 @@ class TestToolInvocation:
                 assert '2 session' in first.text
 
     async def test_docs_tool_invocation(self):
-        """search_agentcore_docs can be called through protocol."""
+        """search_agentcore_docs can be called through protocol.
+
+        The tool must stay callable (and not crash the server) even when the
+        upstream llms.txt docs index is unreachable — it returns an empty
+        result set in that case. See awslabs/mcp#4138.
+        """
         server = _build_server()
         async with create_connected_server_and_client_session(server) as client:
             result = await client.call_tool('search_agentcore_docs', {'query': 'browser'})
 
-            assert len(result.content) > 0
+            assert result.isError is False
+            assert result.structuredContent is not None
+            assert 'result' in result.structuredContent
 
     async def test_calling_nonexistent_tool_raises(self):
         """Calling a nonexistent tool raises an error."""

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/test_cache.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/test_cache.py
@@ -54,6 +54,33 @@ class TestCache:
         assert cache._URL_CACHE['https://example.com/overview'] is None
         assert cache._URL_CACHE['https://example.com/getting-started'] is None
 
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.utils.doc_fetcher.parse_llms_txt')
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.utils.text_processor.normalize')
+    @patch('awslabs.amazon_bedrock_agentcore_mcp_server.utils.text_processor.index_title_variants')
+    def test_load_links_only_skips_unreachable_source(
+        self, mock_index_variants, mock_normalize, mock_parse_llms
+    ):
+        """load_links_only logs and skips an llms.txt source that fails to fetch."""
+        import http.client
+        import urllib.error
+
+        mock_parse_llms.side_effect = urllib.error.HTTPError(
+            url='https://example.com/llms.txt',
+            code=404,
+            msg='Not Found',
+            hdrs=http.client.HTTPMessage(),
+            fp=None,
+        )
+
+        # Act — must not raise
+        cache.load_links_only()
+
+        # Assert — index still marked loaded (so ensure_ready won't keep retrying),
+        # no titles cached, and the index object exists.
+        assert cache._LINKS_LOADED is True
+        assert cache._INDEX is not None
+        assert cache._URL_TITLES == {}
+
     def test_ensure_ready_calls_load_links_only(self):
         """Test ensure_ready calls load_links_only when not loaded."""
         # Arrange


### PR DESCRIPTION
The amazon-bedrock-agentcore-mcp-server crashes on startup and never completes MCP initialization because main() calls cache.ensure_ready(), which fetches the hardcoded docs index at https://aws.github.io/bedrock-agentcore-starter-toolkit/llms.txt. That URL now returns HTTP 404 (the upstream docs site is deprecated and the llmstxt plugin was removed), and the fetch has no error handling, so the urllib HTTPError escapes main() and the process exits. Every tool group registers fine; only the docs index fetch kills it.

This wraps the per-source llms.txt fetch in load_links_only() in a try/except that logs a warning and continues, and still marks the index loaded so ensure_ready() does not retry on every call. The documentation search tools degrade to returning empty results while the runtime, memory, identity, gateway, policy, browser, and code interpreter tools keep working.

I also fixed test_docs_tool_invocation, whose len(result.content) > 0 assertion only passed because the 404 turned the call into an error response with text content; it now checks the tool stays callable and returns a well-formed (possibly empty) result set. Added a unit test for the graceful-skip path. Full server test suite (813 tests) passes and ruff is clean.

Fixes #4138

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).