### PR TITLE
fix(aws-iac-mcp-server): scope describe_events to the failed OperationId

### DIFF
--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/tools/cloudformation_deployment_troubleshooter.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/tools/cloudformation_deployment_troubleshooter.py
@@ -129,13 +129,36 @@ class DeploymentTroubleshooter:
                 stacks = self.cfn_client.describe_stacks(StackName=stack_name)['Stacks']
                 if not stacks:
                     raise Exception(f'Stack {stack_name} not found')
-                response['raw_data']['stack_status'] = stacks[0].get('StackStatus')
+                stack = stacks[0]
+                response['raw_data']['stack_status'] = stack.get('StackStatus')
             except self.cfn_client.exceptions.ClientError as e:
                 raise Exception(f'Stack {stack_name} not found or inaccessible: {str(e)}')
 
-            # Get failed events only using new API
+            # CloudFormation groups events by Operation ID (every update, rollback,
+            # etc. is its own operation). With FailedEvents=true and only a
+            # StackName, the API scopes to the latest operation — which for a
+            # rolled-back stack is the successful ROLLBACK, so the failed
+            # UPDATE/CREATE events are never returned. Scope describe_events to
+            # the most recent non-rollback operation so the events that actually
+            # failed are surfaced. See awslabs/mcp#4275.
+            last_operations = stack.get('LastOperations', [])
+            operation_id = next(
+                (
+                    op.get('OperationId')
+                    for op in last_operations
+                    if op.get('OperationType') != 'ROLLBACK'
+                ),
+                None,
+            )
+
+            describe_events_kwargs: Dict[str, Any] = {'Filters': {'FailedEvents': True}}
+            if operation_id:
+                describe_events_kwargs['OperationId'] = operation_id
+            else:
+                describe_events_kwargs['StackName'] = stack_name
+
             cloudformation_events = self.cfn_client.describe_events(
-                StackName=stack_name, Filters={'FailedEvents': True}
+                **describe_events_kwargs
             )['OperationEvents']
 
             # Match events against known failure patterns

--- a/src/aws-iac-mcp-server/tests/tools/test_cloudformation_deployment_troubleshooter.py
+++ b/src/aws-iac-mcp-server/tests/tools/test_cloudformation_deployment_troubleshooter.py
@@ -569,3 +569,124 @@ class TestAnalyzeDeploymentEdgeCases:
         )
 
         assert result['status'] == 'success'
+
+
+class TestDescribeEventsOperationIdScoping:
+    """Regression tests for scoping describe_events to the failed OperationId.
+
+    See awslabs/mcp#4275: a rolled-back stack's latest operation is the
+    (successful) ROLLBACK, so describe_events(FailedEvents=true) scoped only to
+    StackName returns nothing. The troubleshooter must scope to the most recent
+    non-rollback operation instead.
+    """
+
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_describe_events_scoped_to_non_rollback_operation_id(self, mock_boto_client):
+        """describe_events must be called with the UPDATE_STACK OperationId, not StackName."""
+        mock_cfn = Mock()
+        mock_cloudtrail = Mock()
+        mock_boto_client.side_effect = [mock_cfn, mock_cloudtrail]
+
+        update_op_id = '1c211b5a-abcd-1234-5678-aaaaaaaaaaaa'
+        rollback_op_id = 'd0f12313-ef00-0000-0000-bbbbbbbbbbbb'
+        mock_cfn.describe_stacks.return_value = {
+            'Stacks': [
+                {
+                    'StackStatus': 'UPDATE_ROLLBACK_COMPLETE',
+                    'LastOperations': [
+                        {'OperationType': 'ROLLBACK', 'OperationId': rollback_op_id},
+                        {'OperationType': 'UPDATE_STACK', 'OperationId': update_op_id},
+                    ],
+                }
+            ]
+        }
+        mock_cfn.describe_events.return_value = {
+            'OperationEvents': [
+                {
+                    'EventId': 'event-1',
+                    'ResourceType': 'AWS::S3::Bucket',
+                    'ResourceStatus': 'UPDATE_FAILED',
+                    'ResourceStatusReason': 'Bucket already exists',
+                    'LogicalResourceId': 'MyBucket',
+                    'Timestamp': datetime.now(timezone.utc),
+                }
+            ]
+        }
+
+        troubleshooter = DeploymentTroubleshooter(region='us-east-1')
+        result = troubleshooter.troubleshoot_stack_deployment(
+            'test-stack', include_cloudtrail=False
+        )
+
+        assert result['status'] == 'success'
+        assert result['raw_data']['failed_event_count'] == 1
+        # The key assertion: describe_events was scoped by OperationId, not StackName.
+        call_kwargs = mock_cfn.describe_events.call_args.kwargs
+        assert call_kwargs.get('OperationId') == update_op_id
+        assert 'StackName' not in call_kwargs
+        assert call_kwargs['Filters'] == {'FailedEvents': True}
+
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_describe_events_falls_back_to_stack_name_without_last_operations(self, mock_boto_client):
+        """When LastOperations is absent, fall back to StackName (older API behavior)."""
+        mock_cfn = Mock()
+        mock_cloudtrail = Mock()
+        mock_boto_client.side_effect = [mock_cfn, mock_cloudtrail]
+
+        mock_cfn.describe_stacks.return_value = {'Stacks': [{'StackStatus': 'CREATE_FAILED'}]}
+        mock_cfn.describe_events.return_value = {
+            'OperationEvents': [
+                {
+                    'EventId': 'event-1',
+                    'ResourceType': 'AWS::S3::Bucket',
+                    'ResourceStatus': 'CREATE_FAILED',
+                    'ResourceStatusReason': 'Bucket already exists',
+                    'LogicalResourceId': 'MyBucket',
+                    'Timestamp': datetime.now(timezone.utc),
+                }
+            ]
+        }
+
+        troubleshooter = DeploymentTroubleshooter(region='us-east-1')
+        result = troubleshooter.troubleshoot_stack_deployment(
+            'test-stack', include_cloudtrail=False
+        )
+
+        assert result['status'] == 'success'
+        call_kwargs = mock_cfn.describe_events.call_args.kwargs
+        assert call_kwargs.get('StackName') == 'test-stack'
+        assert 'OperationId' not in call_kwargs
+        assert call_kwargs['Filters'] == {'FailedEvents': True}
+
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_describe_events_picks_only_non_rollback_operation(self, mock_boto_client):
+        """If only ROLLBACK operations are present, fall back to StackName."""
+        mock_cfn = Mock()
+        mock_cloudtrail = Mock()
+        mock_boto_client.side_effect = [mock_cfn, mock_cloudtrail]
+
+        rollback_op_id = 'd0f12313-ef00-0000-0000-bbbbbbbbbbbb'
+        mock_cfn.describe_stacks.return_value = {
+            'Stacks': [
+                {
+                    'StackStatus': 'ROLLBACK_COMPLETE',
+                    'LastOperations': [
+                        {'OperationType': 'ROLLBACK', 'OperationId': rollback_op_id},
+                    ],
+                }
+            ]
+        }
+        mock_cfn.describe_events.return_value = {'OperationEvents': []}
+
+        troubleshooter = DeploymentTroubleshooter(region='us-east-1')
+        troubleshooter.troubleshoot_stack_deployment('test-stack', include_cloudtrail=False)
+
+        call_kwargs = mock_cfn.describe_events.call_args.kwargs
+        assert call_kwargs.get('StackName') == 'test-stack'
+        assert 'OperationId' not in call_kwargs


### PR DESCRIPTION
Fixes #4275

---

`troubleshoot_cloudformation_deployment` always returned an empty `cloudformation_events` list for a rolled-back stack (e.g. one in `UPDATE_ROLLBACK_COMPLETE`), even though `raw_data.stack_status` correctly showed the failed state. The root cause is that the tool called `describe_events` with only `StackName` and `Filters={FailedEvents: true}`.

CloudFormation groups events by Operation ID — every update, rollback, etc. is its own operation. On a rolled-back stack the latest operation is the (successful) `ROLLBACK`, so `describe_events` scoped to `StackName` finds nothing, and the actual failed `UPDATE_STACK`/`CREATE_STACK` events are never surfaced.

The fix reads `LastOperations` from the `describe_stacks` response, picks the most recent non-`ROLLBACK` operation, and passes its `OperationId` to `describe_events`. When `LastOperations` is absent (older API responses that predate the field) or only contains rollbacks, it falls back to `StackName` so existing behavior is preserved.

Added three regression tests covering the operation-scoped path, the `StackName` fallback, and the all-rollback fallback. The existing test suite passes unchanged (the old tests do not include `LastOperations`, so they exercise the fallback branch), and `cloudformation_deployment_troubleshooter.py` now has 100% line coverage.

Assisted-by: Hermes Agent

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).