### PR TITLE
fix(aws-network-mcp-server): match secondary private IPs in find_ip_address

### DIFF
--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/general/find_ip_address.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/general/find_ip_address.py
@@ -76,7 +76,7 @@ async def find_ip_address(
     if not all_regions:
         try:
             response = ec2_client.describe_network_interfaces(
-                Filters=[{'Name': 'private-ip-address', 'Values': [ip_address]}]
+                Filters=[{'Name': 'addresses.private-ip-address', 'Values': [ip_address]}]
             )
 
             if response['NetworkInterfaces']:
@@ -107,7 +107,7 @@ async def find_ip_address(
             ec2_client = get_aws_client('ec2', region, profile_name)
             try:
                 response = ec2_client.describe_network_interfaces(
-                    Filters=[{'Name': 'private-ip-address', 'Values': [ip_address]}]
+                    Filters=[{'Name': 'addresses.private-ip-address', 'Values': [ip_address]}]
                 )
 
                 if response['NetworkInterfaces']:

--- a/src/aws-network-mcp-server/tests/tools/general/test_find_ip_address.py
+++ b/src/aws-network-mcp-server/tests/tools/general/test_find_ip_address.py
@@ -64,7 +64,32 @@ class TestFindIpAddress:
         assert result == sample_eni_response
         mock_get_client.assert_called_once_with('ec2', 'us-east-1', None)
         mock_ec2_client.describe_network_interfaces.assert_called_once_with(
-            Filters=[{'Name': 'private-ip-address', 'Values': ['10.0.1.100']}]
+            Filters=[{'Name': 'addresses.private-ip-address', 'Values': ['10.0.1.100']}]
+        )
+
+    @patch.object(find_ip_module, 'get_aws_client')
+    async def test_find_secondary_private_ip_single_region_success(
+        self, mock_get_client, mock_ec2_client, sample_eni_response
+    ):
+        """Test that a secondary private IP is matched via the addresses.private-ip-address filter.
+
+        Regression for the bug where the tool only matched the ENI's primary private IP because
+        it used the 'private-ip-address' filter, which EC2 scopes to the primary address. The
+        'addresses.private-ip-address' filter walks every assigned private address on the ENI,
+        so secondary IPs are located as well.
+        """
+        mock_get_client.return_value = mock_ec2_client
+        mock_ec2_client.describe_network_interfaces.return_value = {
+            'NetworkInterfaces': [sample_eni_response]
+        }
+
+        result = await find_ip_module.find_ip_address(
+            ip_address='10.0.1.105', region='us-east-1', all_regions=False
+        )
+
+        assert result == sample_eni_response
+        mock_ec2_client.describe_network_interfaces.assert_called_once_with(
+            Filters=[{'Name': 'addresses.private-ip-address', 'Values': ['10.0.1.105']}]
         )
 
     @patch.object(find_ip_module, 'get_aws_client')


### PR DESCRIPTION
The find_ip_address tool used EC2's 'private-ip-address' filter, which only matches an ENI's primary private IP. When the supplied IP was configured as a secondary private IP on the ENI, the lookup failed with 'IP address ... not found in region ...' even though the ENI existed and carried that address.

This switches the filter in both the single-region and all-regions code paths to 'addresses.private-ip-address', which walks every private address assigned to the ENI and therefore locates secondary IPs as well as the primary one. Behaviour for primary IPs and public IPs is unchanged.

Adds a regression test (test_find_secondary_private_ip_single_region_success) that asserts the new filter name is sent for a secondary-IP lookup, and updates the existing single-region assertion to the new filter name. All 8 tests in tests/tools/general/test_find_ip_address.py pass.

Fixes #3495

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).