### PR TITLE
fix(stepfunctions-tool-mcp-server): paginate list_state_machines

### DIFF
--- a/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/server.py
+++ b/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/server.py
@@ -332,14 +332,24 @@ def filter_state_machines_by_tag(state_machines, tag_key, tag_value):
     return tagged_state_machines
 
 
+def get_all_state_machines():
+    """Retrieve all available Step Functions state machines using pagination."""
+    paginator = sfn_client.get_paginator('list_state_machines')
+    all_state_machines = []
+
+    for page in paginator.paginate():
+        all_state_machines.extend(page.get('stateMachines', []))
+
+    return all_state_machines
+
+
 def register_state_machines():
     """Register Step Functions state machines as individual tools."""
     try:
         logger.info('Registering Step Functions state machines as individual tools...')
-        state_machines = sfn_client.list_state_machines()
 
         # Get all state machines
-        all_state_machines = state_machines['stateMachines']
+        all_state_machines = get_all_state_machines()
         logger.info(f'Total Step Functions state machines found: {len(all_state_machines)}')
 
         # First filter by state machine name if prefix or list is set

--- a/src/stepfunctions-tool-mcp-server/tests/test_get_all_state_machines.py
+++ b/src/stepfunctions-tool-mcp-server/tests/test_get_all_state_machines.py
@@ -1,0 +1,67 @@
+"""Tests for the get_all_state_machines function."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+with pytest.MonkeyPatch().context() as CTX:
+    CTX.setattr('boto3.Session', MagicMock)
+    from awslabs.stepfunctions_tool_mcp_server.server import get_all_state_machines
+
+
+class TestGetAllStateMachines:
+    """Tests for the get_all_state_machines function."""
+
+    @patch('awslabs.stepfunctions_tool_mcp_server.server.sfn_client')
+    def test_single_page(self, mock_sfn_client):
+        """Test retrieving state machines when the API returns a single page."""
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {'name': 'machine1', 'stateMachineArn': 'arn:aws:states:machine1'},
+                    {'name': 'machine2', 'stateMachineArn': 'arn:aws:states:machine2'},
+                ]
+            }
+        ]
+
+        result = get_all_state_machines()
+
+        assert len(result) == 2
+        assert result[0]['name'] == 'machine1'
+        assert result[1]['name'] == 'machine2'
+        mock_sfn_client.get_paginator.assert_called_once_with('list_state_machines')
+
+    @patch('awslabs.stepfunctions_tool_mcp_server.server.sfn_client')
+    def test_multiple_pages(self, mock_sfn_client):
+        """Test retrieving state machines that span multiple pages via nextToken."""
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {'name': 'machine1', 'stateMachineArn': 'arn:aws:states:machine1'}
+                ]
+            },
+            {
+                'stateMachines': [
+                    {'name': 'machine2', 'stateMachineArn': 'arn:aws:states:machine2'}
+                ]
+            },
+            {
+                'stateMachines': [
+                    {'name': 'machine3', 'stateMachineArn': 'arn:aws:states:machine3'}
+                ]
+            },
+        ]
+
+        result = get_all_state_machines()
+
+        assert len(result) == 3
+        assert [sm['name'] for sm in result] == ['machine1', 'machine2', 'machine3']
+
+    @patch('awslabs.stepfunctions_tool_mcp_server.server.sfn_client')
+    def test_empty_result(self, mock_sfn_client):
+        """Test retrieving state machines when there are none."""
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [{'stateMachines': []}]
+
+        result = get_all_state_machines()
+
+        assert result == []

--- a/src/stepfunctions-tool-mcp-server/tests/test_register_state_machines.py
+++ b/src/stepfunctions-tool-mcp-server/tests/test_register_state_machines.py
@@ -19,20 +19,22 @@ class TestRegisterStateMachines:
     def test_register_machines_with_prefix(self, mock_create_tool, mock_sfn_client):
         """Test registering state machines filtered by prefix."""
         # Set up test data
-        mock_sfn_client.list_state_machines.return_value = {
-            'stateMachines': [
-                {
-                    'name': 'test-state-machine',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine',
-                    'type': 'STANDARD',
-                },
-                {
-                    'name': 'prefix-test-machine',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:prefix-test-machine',
-                    'type': 'STANDARD',
-                },
-            ]
-        }
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {
+                        'name': 'test-state-machine',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine',
+                        'type': 'STANDARD',
+                    },
+                    {
+                        'name': 'prefix-test-machine',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:prefix-test-machine',
+                        'type': 'STANDARD',
+                    },
+                ]
+            }
+        ]
 
         # Call the function
         register_state_machines()
@@ -48,6 +50,53 @@ class TestRegisterStateMachines:
         )
 
     @patch('awslabs.stepfunctions_tool_mcp_server.server.sfn_client')
+    @patch('awslabs.stepfunctions_tool_mcp_server.server.create_state_machine_tool')
+    def test_register_machines_across_multiple_pages(self, mock_create_tool, mock_sfn_client):
+        """Test registering state machines that span multiple paginated responses."""
+        # Set up test data across two pages
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {
+                        'name': 'machine-page1',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine-page1',
+                        'type': 'STANDARD',
+                    },
+                ]
+            },
+            {
+                'stateMachines': [
+                    {
+                        'name': 'machine-page2',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine-page2',
+                        'type': 'STANDARD',
+                    },
+                ]
+            },
+        ]
+
+        # Call the function
+        register_state_machines()
+
+        # Verify results
+        assert mock_create_tool.call_count == 2
+        mock_create_tool.assert_any_call(
+            'machine-page1',
+            'arn:aws:states:us-east-1:123456789012:stateMachine:machine-page1',
+            'STANDARD',
+            'AWS Step Functions state machine: machine-page1',
+            None,
+        )
+        mock_create_tool.assert_any_call(
+            'machine-page2',
+            'arn:aws:states:us-east-1:123456789012:stateMachine:machine-page2',
+            'STANDARD',
+            'AWS Step Functions state machine: machine-page2',
+            None,
+        )
+        mock_sfn_client.get_paginator.assert_called_with('list_state_machines')
+
+    @patch('awslabs.stepfunctions_tool_mcp_server.server.sfn_client')
     @patch(
         'awslabs.stepfunctions_tool_mcp_server.server.STATE_MACHINE_LIST', ['machine1', 'machine2']
     )
@@ -55,25 +104,27 @@ class TestRegisterStateMachines:
     def test_register_machines_with_list(self, mock_create_tool, mock_sfn_client):
         """Test registering state machines filtered by list."""
         # Set up test data
-        mock_sfn_client.list_state_machines.return_value = {
-            'stateMachines': [
-                {
-                    'name': 'machine1',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine1',
-                    'type': 'STANDARD',
-                },
-                {
-                    'name': 'machine2',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine2',
-                    'type': 'STANDARD',
-                },
-                {
-                    'name': 'machine3',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine3',
-                    'type': 'STANDARD',
-                },
-            ]
-        }
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {
+                        'name': 'machine1',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine1',
+                        'type': 'STANDARD',
+                    },
+                    {
+                        'name': 'machine2',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine2',
+                        'type': 'STANDARD',
+                    },
+                    {
+                        'name': 'machine3',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:machine3',
+                        'type': 'STANDARD',
+                    },
+                ]
+            }
+        ]
 
         # Call the function
         register_state_machines()
@@ -102,15 +153,17 @@ class TestRegisterStateMachines:
     def test_register_machines_with_tags(self, mock_create_tool, mock_sfn_client):
         """Test registering state machines filtered by tags."""
         # Set up test data
-        mock_sfn_client.list_state_machines.return_value = {
-            'stateMachines': [
-                {
-                    'name': 'tagged-machine',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:tagged-machine',
-                    'type': 'STANDARD',
-                },
-            ]
-        }
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {
+                        'name': 'tagged-machine',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:tagged-machine',
+                        'type': 'STANDARD',
+                    },
+                ]
+            }
+        ]
         mock_sfn_client.list_tags_for_resource.return_value = {
             'tags': [{'key': 'test-key', 'value': 'test-value'}]
         }
@@ -132,15 +185,17 @@ class TestRegisterStateMachines:
     def test_register_machines_with_comments(self, mock_create_tool, mock_sfn_client):
         """Test registering state machines with workflow comments."""
         # Set up test data
-        mock_sfn_client.list_state_machines.return_value = {
-            'stateMachines': [
-                {
-                    'name': 'test-machine',
-                    'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:test-machine',
-                    'type': 'STANDARD',
-                },
-            ]
-        }
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'stateMachines': [
+                    {
+                        'name': 'test-machine',
+                        'stateMachineArn': 'arn:aws:states:us-east-1:123456789012:stateMachine:test-machine',
+                        'type': 'STANDARD',
+                    },
+                ]
+            }
+        ]
         mock_sfn_client.describe_state_machine.return_value = {
             'description': 'Test Description',
             'definition': '{"Comment": "Workflow Comment", "StartAt": "State1", "States": {"State1": {"Type": "Pass", "End": true}}}',
@@ -164,7 +219,7 @@ class TestRegisterStateMachines:
     def test_register_machines_incomplete_tag_config(self, mock_sfn_client, caplog):
         """Test registering state machines with incomplete tag configuration."""
         # Set up test data
-        mock_sfn_client.list_state_machines.return_value = {'stateMachines': []}
+        mock_sfn_client.get_paginator.return_value.paginate.return_value = [{'stateMachines': []}]
 
         # Call the function and check logging
         with caplog.at_level(logging.WARNING):
@@ -180,7 +235,7 @@ class TestRegisterStateMachines:
     def test_register_machines_error_handling(self, mock_sfn_client, caplog):
         """Test error handling during state machine registration."""
         # Set up mock to raise an exception
-        mock_sfn_client.list_state_machines.side_effect = Exception('List error')
+        mock_sfn_client.get_paginator.side_effect = Exception('List error')
 
         # Call the function and check logging
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
Fixes #2050

## Summary

### Changes

`register_state_machines()` in `src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/server.py` called `sfn_client.list_state_machines()` exactly once and never followed `nextToken`. In an AWS account with more than 100 state machines, everything past the first page was silently dropped: those state machines never got registered as MCP tools, with no error surfaced anywhere.

This adds a `get_all_state_machines()` helper that uses the boto3 paginator (`sfn_client.get_paginator('list_state_machines')`) to walk every page and concatenate `stateMachines` across all of them. `register_state_machines()` now calls this helper instead of the single unpaginated call. This mirrors the pattern `lambda-tool-mcp-server` already uses for `list_functions` (`get_all_lambda_functions()`), so the fix follows the existing in-repo convention for AWS API pagination rather than introducing a new one.

Existing unit tests in `test_register_state_machines.py` were updated to mock the paginator instead of the direct `list_state_machines` call. Added `test_get_all_state_machines.py` covering single-page, multi-page, and empty results, plus a new `test_register_machines_across_multiple_pages` regression test in `test_register_state_machines.py` that mocks a two-page paginated response and asserts state machines from both pages get registered as tools.

### User experience

Before: in an account with >100 state machines, only the first 100 (by API return order) were ever exposed as MCP tools. State machines past that boundary were invisible to the agent with no warning.

After: all state machines across all pages are registered as tools, regardless of account size.

### Prior art

This exact fix was previously submitted in #1923 by @JulienJBO but received no maintainer review and was auto-closed by the stale bot in January 2026. The bug was independently reconfirmed on `main` and the same paginator approach was recommended in a comment on this issue by @edobusy (who also pointed at the `lambda-tool-mcp-server` precedent) while asking to be assigned; as of this PR that request had gone unanswered for several days and no PR had been opened against it. I'm resubmitting the fix along these same lines, crediting both of them, rather than presenting it as a new discovery.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? (Y/N)

N

**RFC issue number**:

N/A

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
