### PR TITLE
fix(aws-network-mcp-server): handle Cloud WAN blackhole routes without Destinations

### DIFF
--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/cloud_wan/get_cloudwan_routes.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/cloud_wan/get_cloudwan_routes.py
@@ -105,18 +105,26 @@ async def get_cwan_routes(
                 'routes': 'No network routes found with the given parameters.',
             }
         else:
-            result['segment'] = {
-                'name': segment,
-                'routes': [
+            routes = []
+
+            for route in routes_response.get('NetworkRoutes', []):
+                target = None
+                if route.get('Destinations'):
+                    dest = route['Destinations'][0]
+                    target = dest.get('CoreNetworkAttachmentId') or dest.get('ResourceId')
+
+                routes.append(
                     {
                         'destination': route.get('DestinationCidrBlock'),
-                        'target': route['Destinations'][0].get('CoreNetworkAttachmentId')
-                        or route['Destinations'][0].get('ResourceId'),
+                        'target': target,
                         'type': route.get('Type', '').lower(),
                         'state': route.get('State', '').lower(),
                     }
-                    for route in routes_response.get('NetworkRoutes', [])
-                ],
+                )
+
+            result['segment'] = {
+                'name': segment,
+                'routes': routes,
             }
 
     if network_function_group:
@@ -137,18 +145,25 @@ async def get_cwan_routes(
                 'routes': 'No network routes found with the given parameters.',
             }
         else:
-            result['network_function_group'] = {
-                'name': network_function_group,
-                'routes': [
+            routes = []
+
+            for route in routes_response.get('NetworkRoutes', []):
+                target = None
+                if route.get('Destinations'):
+                    dest = route['Destinations'][0]
+                    target = dest.get('CoreNetworkAttachmentId') or dest.get('ResourceId')
+
+                routes.append(
                     {
                         'destination': route.get('DestinationCidrBlock'),
-                        'target': route['Destinations'][0].get('CoreNetworkAttachmentId')
-                        or route['Destinations'][0].get('ResourceId'),
+                        'target': target,
                         'type': route.get('Type', '').lower(),
                         'state': route.get('State', '').lower(),
                     }
-                    for route in routes_response.get('NetworkRoutes', [])
-                ],
-            }
+                )
 
+            result['network_function_group'] = {
+                'name': network_function_group,
+                'routes': routes,
+            }
     return result

--- a/src/aws-network-mcp-server/tests/tools/cloud_wan/test_get_cloudwan_routes.py
+++ b/src/aws-network-mcp-server/tests/tools/cloud_wan/test_get_cloudwan_routes.py
@@ -60,6 +60,47 @@ class TestGetCloudwanRoutes:
             ]
         }
 
+    @pytest.fixture
+    def mock_blackhole_routes_response(self):
+        """Mock blackhole route without Destinations."""
+        return {
+            'NetworkRoutes': [
+                {
+                    'DestinationCidrBlock': '0.0.0.0/0',
+                    'Type': 'STATIC',
+                    'State': 'BLACKHOLE',
+                }
+            ]
+        }
+
+    @patch.object(routes_module, 'get_aws_client')
+    async def test_segment_with_blackhole_route_without_destinations(
+        self,
+        mock_get_client,
+        mock_core_network,
+        mock_blackhole_routes_response,
+    ):
+        """Regression test for blackhole routes without Destinations."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_core_network.return_value = mock_core_network
+        mock_client.get_network_routes.return_value = mock_blackhole_routes_response
+
+        result = await routes_module.get_cwan_routes(
+            core_network_id='core-network-123',
+            region='us-east-1',
+            segment='segment-a',
+        )
+
+        assert result['segment']['routes'] == [
+            {
+                'destination': '0.0.0.0/0',
+                'target': None,
+                'type': 'static',
+                'state': 'blackhole',
+            }
+        ]
+
     async def test_missing_parameters(self):
         """Test error when neither segment nor network_function_group provided."""
         with pytest.raises(ToolError, match='Please provide a segment or network_function_group'):


### PR DESCRIPTION
## Summary

Fixes `get_cwan_routes` failing with a `KeyError: 'Destinations'` when processing Cloud WAN blackhole routes that do not include a `Destinations` field.

Fixes #4285

## Changes

- Safely handle routes without a `Destinations` field by returning `target: None`.
- Add a regression test covering blackhole routes without `Destinations`.

## Testing

- Added a regression test reproducing the reported failure.
- Verified the regression test passes after the fix.
- Verified all tests in `tests/tools/cloud_wan/test_get_cloudwan_routes.py` pass.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).