### PR TITLE
refactor(aws-documentation-mcp-server): drop seo_abstract from search result context

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -561,12 +561,9 @@ async def search_documentation(
                 text_suggestion = suggestion['textExcerptSuggestion']
                 context = None
 
-                # Use SEO abstract if available, as it is designed for this task explicitly.
-                # Fallback to authored summary and finally content body
+                # Use the authored summary if available, falling back to content body.
                 metadata = text_suggestion.get('metadata', {})
-                if 'seo_abstract' in metadata:
-                    context = metadata['seo_abstract']
-                elif 'summary' in text_suggestion:
+                if 'summary' in text_suggestion:
                     context = text_suggestion['summary']
                 elif 'suggestionBody' in text_suggestion:
                     context = text_suggestion['suggestionBody']

--- a/src/aws-documentation-mcp-server/tests/test_metadata_handling.py
+++ b/src/aws-documentation-mcp-server/tests/test_metadata_handling.py
@@ -30,44 +30,8 @@ class TestMetadataHandling:
     """Tests for the new metadata handling logic in search results."""
 
     @pytest.mark.asyncio
-    async def test_seo_abstract_priority(self):
-        """Test that seo_abstract is used when available."""
-        ctx = MockContext()
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            'queryId': 'test-query-id',
-            'suggestions': [
-                {
-                    'textExcerptSuggestion': {
-                        'link': 'https://docs.aws.amazon.com/test',
-                        'title': 'Test Page',
-                        'summary': 'Regular summary',
-                        'suggestionBody': 'Suggestion body text',
-                        'metadata': {
-                            'seo_abstract': 'SEO optimized abstract',
-                            'abstract': 'Regular abstract',
-                            'summary': 'Metadata summary',
-                        },
-                    }
-                }
-            ],
-        }
-
-        with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value = mock_response
-
-            response = await search_documentation(
-                ctx, search_phrase='test', limit=10, product_types=None, guide_types=None
-            )
-            results = response.search_results
-            assert len(results) == 1
-            assert results[0].context == 'SEO optimized abstract'
-
-    @pytest.mark.asyncio
-    async def test_summary_fallback_when_no_seo_abstract(self):
-        """Test that summary is used when seo_abstract is not available."""
+    async def test_summary_priority(self):
+        """The authored summary is used for context; the metadata.summary key is not consulted."""
         ctx = MockContext()
 
         mock_response = MagicMock()
@@ -101,7 +65,7 @@ class TestMetadataHandling:
 
     @pytest.mark.asyncio
     async def test_summary_fallback(self):
-        """Test that summary is used when metadata abstracts are not available."""
+        """Test that summary is used when metadata is empty."""
         ctx = MockContext()
 
         mock_response = MagicMock()
@@ -238,7 +202,7 @@ class TestMetadataHandling:
                         'link': 'https://docs.aws.amazon.com/test1',
                         'title': 'Test Page 1',
                         'summary': 'Regular summary 1',
-                        'metadata': {'seo_abstract': 'SEO abstract 1'},
+                        'metadata': {},
                     }
                 },
                 {
@@ -276,7 +240,7 @@ class TestMetadataHandling:
             )
             results = response.search_results
             assert len(results) == 4
-            assert results[0].context == 'SEO abstract 1'
+            assert results[0].context == 'Regular summary 1'
             assert results[1].context == 'Regular summary 2'
             assert results[2].context == 'Regular summary 3'
             assert results[3].context == 'Suggestion body 4'
@@ -302,7 +266,6 @@ class TestMetadataHandling:
                             'abstract': "This document introduces Amazon S3, a scalable object storage service offering various storage classes, management features, access controls, and data processing capabilities. It covers S3's core concepts, bucket types, versioning, consistency model, and integration with other AWS services.",
                             'last_updated': '2025-07-29T22:20:53.000Z',
                             'summary': "This document introduces Amazon S3, a scalable object storage service offering various storage classes, management features, access controls, and data processing capabilities. It covers S3's core concepts, bucket types, versioning, consistency model, and integration with other AWS services.",
-                            'seo_abstract': 'Amazon S3 offers object storage service with scalability, availability, security, and performance. Manage storage classes, lifecycle policies, access permissions, data transformations, usage metrics, and query tabular data.',
                         },
                     }
                 },
@@ -325,12 +288,12 @@ class TestMetadataHandling:
             )
             results = response.search_results
             assert len(results) == 2
-            # First result should use seo_abstract
+            # First result should use the authored summary
             assert (
                 results[0].context
-                == 'Amazon S3 offers object storage service with scalability, availability, security, and performance. Manage storage classes, lifecycle policies, access permissions, data transformations, usage metrics, and query tabular data.'
+                == 'Store data in the cloud and learn the core concepts of buckets and objects with the Amazon S3 web service.'
             )
-            # Second result should use suggestionBody since no seo_abstract or abstract in metadata
+            # Second result should use suggestionBody since no summary is present
             assert results[1].context == 'funasS3OrNull():S3?'
 
     @pytest.mark.asyncio

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -758,7 +758,6 @@ class TestSearchDocumentation:
                         'link': 'https://docs.aws.amazon.com/s3/latest/userguide/bucket-configuration.html',
                         'title': 'S3 Bucket Configuration Guide',
                         'metadata': {
-                            'seo_abstract': 'Complete guide to configuring S3 buckets',
                             'sections': [
                                 'Bucket Naming Rules',
                                 'Access Control Settings',
@@ -797,7 +796,8 @@ class TestSearchDocumentation:
                 == 'https://docs.aws.amazon.com/s3/latest/userguide/bucket-configuration.html'
             )
             assert first_result.title == 'S3 Bucket Configuration Guide'
-            assert first_result.context == 'Complete guide to configuring S3 buckets'
+            # seo_abstract is no longer used for context; with no summary/suggestionBody it is None.
+            assert first_result.context is None
 
             assert first_result.sections is not None
             assert len(first_result.sections) == 3


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

Drops the `seo_abstract` branch from search-result context resolution. The search backend no longer emits the `seo_abstract` metadata field, so the handling for it is dead code. Context now resolves from the authored `summary`, falling back to `suggestionBody`.

### Changes

* **`server_aws.py`:** removed the `if 'seo_abstract' in metadata` branch in `search_documentation`. Context resolution is now `summary` → `suggestionBody`.
* **Behavior is unchanged** whether or not a response includes `seo_abstract`: the field is simply no longer consulted. Every metadata access remains defensively guarded, and all `SearchResult`/metadata fields stay optional.
* **Tests:** scrubbed `seo_abstract` from all fixtures and assertions in `test_metadata_handling.py` and `test_server_aws.py`; context now asserts against `summary`/`suggestionBody`.

### User experience

No agent-facing change. Search results still return a `context` for each result:

* When the backend provides an authored `summary`, that is used (unchanged).
* When no `summary` is present, `suggestionBody` is used as before.
* `seo_abstract` is no longer produced by the backend, so its removal has no runtime effect - this is a dead-code cleanup, not a behavior change.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
