### PR TITLE
fix(amazon-qindex-mcp-server): use UrlElicitationRequiredError in AuthorizeQIndex

### DIFF
--- a/src/amazon-qindex-mcp-server/README.md
+++ b/src/amazon-qindex-mcp-server/README.md
@@ -21,7 +21,7 @@ For Amazon Q Business application owners, direct integration support is not yet 
   - isv_redirect_url (str): Redirect URL registered during ISV registration
   - oauth_state (str): Random string for CSRF protection
   - idc_application_arn (str): Amazon Q Business application ID
-- Returns: Authorization URL for user authentication
+- Raises: `UrlElicitationRequiredError` (MCP 2025-11-25 URL-mode elicitation) carrying the OIDC authorization URL for explicit user consent
 
 #### CreateTokenWithIAM
 - Creates authentication token using authorization code through IAM

--- a/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/server.py
+++ b/src/amazon-qindex-mcp-server/awslabs/amazon_qindex_mcp_server/server.py
@@ -20,6 +20,7 @@ import sys
 from awslabs.amazon_qindex_mcp_server.clients import QBusinessClient, QBusinessClientError
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import ElicitRequestURLParams, UrlElicitationRequiredError
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, Dict, List, Optional
 
@@ -137,7 +138,7 @@ async def authorize_qindex(
     idc_application_arn: str = Field(
         description='The Amazon Q Business application ID provided by the customer'
     ),
-) -> Dict:
+) -> None:
     """Generate the OIDC authorization URL for Q index authentication.
 
     This tool generates the URL that users need to visit to authenticate with their
@@ -149,11 +150,10 @@ async def authorize_qindex(
         oauth_state (str): Random string to prevent CSRF attacks
         idc_application_arn (str): The Amazon Q Business application ID provided by the customer
 
-    Returns:
-        Dict: Response containing the authorization URL
-        {
-            'authorization_url': 'string'
-        }
+    Raises:
+        UrlElicitationRequiredError: Always raised with the OIDC authorization URL so that
+            spec-aware MCP clients (MCP 2025-11-25) can present the URL for explicit user
+            consent per the URL-mode elicitation flow.
     """
     auth_url = (
         f'https://oidc.{idc_region}.amazonaws.com/authorize'
@@ -163,11 +163,20 @@ async def authorize_qindex(
         f'&client_id={idc_application_arn}'
     )
 
-    # Ask the user to visit the URL and provide the authorization code
-    raise ValueError(
+    message = (
         f'Please visit this URL to sign in: {auth_url}\n'
         'After signing in, you will be redirected to your redirect URL.\n'
         'Please provide the authorization code from the redirect URL to continue.'
+    )
+    raise UrlElicitationRequiredError(
+        [
+            ElicitRequestURLParams(
+                message='Please sign in to authorize Q index access.',
+                url=auth_url,
+                elicitationId='authorize-qindex',
+            )
+        ],
+        message=message,
     )
 
 

--- a/src/amazon-qindex-mcp-server/tests/test_server.py
+++ b/src/amazon-qindex-mcp-server/tests/test_server.py
@@ -24,6 +24,7 @@ from awslabs.amazon_qindex_mcp_server.server import (
     create_token_with_iam,
     mcp,
 )
+from mcp.shared.exceptions import UrlElicitationRequiredError
 
 
 class TestMCPServer:
@@ -65,7 +66,7 @@ class TestAuthorizeQIndex:
 
     @pytest.mark.asyncio
     async def test_authorize_qindex_success(self):
-        """Test successful authorize call."""
+        """Test that authorize_qindex raises UrlElicitationRequiredError with the OIDC URL."""
         expected_url = (
             f'https://oidc.{self.TEST_DATA["idc_region"]}.amazonaws.com/authorize'
             f'?response_type=code'
@@ -74,7 +75,7 @@ class TestAuthorizeQIndex:
             f'&client_id={self.TEST_DATA["idc_application_arn"]}'
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(UrlElicitationRequiredError) as exc_info:
             await authorize_qindex(
                 idc_region=self.TEST_DATA['idc_region'],
                 isv_redirect_url=self.TEST_DATA['isv_redirect_url'],
@@ -82,7 +83,12 @@ class TestAuthorizeQIndex:
                 idc_application_arn=self.TEST_DATA['idc_application_arn'],
             )
 
-        assert expected_url in str(exc_info.value)
+        error = exc_info.value
+        assert len(error.elicitations) == 1
+        elicitation = error.elicitations[0]
+        assert elicitation.url == expected_url
+        assert elicitation.mode == 'url'
+        assert expected_url in str(error)
 
 
 class TestCreateTokenWithIAM:


### PR DESCRIPTION
## Summary

- Replace `raise ValueError(url_in_message)` in `AuthorizeQIndex` with `raise UrlElicitationRequiredError([ElicitRequestURLParams(...)])` so spec-aware MCP 2025-11-25 clients receive a structured URL elicitation (JSON-RPC code `-32042`) instead of an opaque error string.
- Correct the `-> Dict` return-type annotation to `-> None` (the function always raises).
- Update the docstring `Raises:` section to reflect the real behavior.
- Update the README Tools table entry to say _Raises_ instead of _Returns_.
- Update the test to assert `UrlElicitationRequiredError` with the correct `url` and `mode` fields.

## Test plan

- [x] All 15 existing `tests/test_server.py` tests pass (`uv run pytest tests/test_server.py -v`).
- [x] `test_authorize_qindex_success` now asserts `UrlElicitationRequiredError` is raised, with `elicitation.url` equal to the constructed OIDC URL and `elicitation.mode == 'url'`.

Fixes #3327

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).