### PR TITLE
fix(aws-network-mcp-server): skip inaccessible regions in find_ip_address all_regions search

### DIFF
--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/general/find_ip_address.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/general/find_ip_address.py
@@ -102,7 +102,7 @@ async def find_ip_address(
         response = ec2_client.describe_regions()
         regions = [region['RegionName'] for region in response['Regions']]
 
-        error = None
+        skipped_regions: list[dict[str, str]] = []
         for region in regions:
             ec2_client = get_aws_client('ec2', region, profile_name)
             try:
@@ -122,13 +122,29 @@ async def find_ip_address(
                     return response['NetworkInterfaces'][0]
 
             except Exception as e:
-                error = str(e)
+                skipped_regions.append({'region': region, 'error': str(e)})
                 continue
 
-        # Return error if we got one during the search to not hide it.
-        if error:
+        # If every region raised an error (none were searchable), surface all of
+        # them so genuine permission or connectivity problems are not hidden.
+        if skipped_regions and len(skipped_regions) == len(regions):
+            skipped_summary = ', '.join(
+                f"{r['region']} ({r['error']})" for r in skipped_regions
+            )
             raise ToolError(
-                f'Error searching IP address in all regions: {error}. REQUIRED TO REMEDIATE BEFORE CONTINUING'
+                f'Error searching IP address in all regions - could not search any region: {skipped_summary}. REQUIRED TO REMEDIATE BEFORE CONTINUING'
+            )
+
+        # At least one region was searchable but the IP was not found. Report the
+        # skipped regions so the caller knows the search was not exhaustive.
+        if skipped_regions:
+            skipped_summary = ', '.join(
+                f"{r['region']} ({r['error']})" for r in skipped_regions
+            )
+            raise ToolError(
+                f'IP address {ip_address} was not found in any searchable region. '
+                f'The following regions were skipped due to errors: {skipped_summary}. '
+                f'REQUIRED TO REMEDIATE BEFORE CONTINUING'
             )
 
         raise ToolError('IP address was not found in any region')

--- a/src/aws-network-mcp-server/tests/tools/general/test_find_ip_address.py
+++ b/src/aws-network-mcp-server/tests/tools/general/test_find_ip_address.py
@@ -195,8 +195,8 @@ class TestFindIpAddress:
         assert 'REQUIRED TO REMEDIATE BEFORE CONTINUING' in str(exc_info.value)
 
     @patch.object(find_ip_module, 'get_aws_client')
-    async def test_find_ip_all_regions_with_error(self, mock_get_client):
-        """Test handling errors while searching all regions."""
+    async def test_find_ip_all_regions_with_partial_error(self, mock_get_client):
+        """Test that a single region error is surfaced but doesn't stop the search."""
         mock_clients = {}
 
         def client_side_effect(service, region, profile):
@@ -225,5 +225,85 @@ class TestFindIpAddress:
                 ip_address='10.0.1.100', region='us-east-1', all_regions=True
             )
 
-        assert 'Error searching IP address in all regions: Network timeout' in str(exc_info.value)
+        assert 'not found in any searchable region' in str(exc_info.value)
+        assert 'us-east-1' in str(exc_info.value)
+        assert 'Network timeout' in str(exc_info.value)
         assert 'REQUIRED TO REMEDIATE BEFORE CONTINUING' in str(exc_info.value)
+
+    @patch.object(find_ip_module, 'get_aws_client')
+    async def test_find_ip_all_regions_all_errors(self, mock_get_client):
+        """Test that when every region raises an error the search reports it clearly."""
+        mock_clients = {}
+
+        def client_side_effect(service, region, profile):
+            if region not in mock_clients:
+                mock_clients[region] = MagicMock()
+            return mock_clients[region]
+
+        mock_get_client.side_effect = client_side_effect
+
+        mock_clients['us-east-1'] = MagicMock()
+        mock_clients['us-east-1'].describe_regions.return_value = {
+            'Regions': [{'RegionName': 'us-east-1'}, {'RegionName': 'us-west-2'}]
+        }
+
+        mock_clients['us-east-1'].describe_network_interfaces.side_effect = Exception(
+            'UnauthorizedOperation'
+        )
+        mock_clients['us-west-2'] = MagicMock()
+        mock_clients['us-west-2'].describe_network_interfaces.side_effect = Exception(
+            'UnauthorizedOperation'
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await find_ip_module.find_ip_address(
+                ip_address='10.0.1.100', region='us-east-1', all_regions=True
+            )
+
+        assert 'could not search any region' in str(exc_info.value)
+        assert 'us-east-1' in str(exc_info.value)
+        assert 'us-west-2' in str(exc_info.value)
+
+    @patch.object(find_ip_module, 'get_aws_client')
+    async def test_find_ip_all_regions_skip_inaccessible_finds_in_next(
+        self, mock_get_client, sample_eni_response
+    ):
+        """Test that an inaccessible region is skipped and the IP is found in a later region."""
+        mock_clients = {}
+
+        def client_side_effect(service, region, profile):
+            if region not in mock_clients:
+                mock_clients[region] = MagicMock()
+            return mock_clients[region]
+
+        mock_get_client.side_effect = client_side_effect
+
+        mock_clients['us-east-1'] = MagicMock()
+        mock_clients['us-east-1'].describe_regions.return_value = {
+            'Regions': [
+                {'RegionName': 'us-east-1'},
+                {'RegionName': 'eu-west-1'},
+                {'RegionName': 'us-west-2'},
+            ]
+        }
+
+        # us-east-1: access denied (SCP), eu-west-1: access denied, us-west-2: found
+        mock_clients['us-east-1'].describe_network_interfaces.side_effect = Exception(
+            'UnauthorizedOperation: explicit deny in SCP'
+        )
+        mock_clients['eu-west-1'] = MagicMock()
+        mock_clients['eu-west-1'].describe_network_interfaces.side_effect = Exception(
+            'UnauthorizedOperation: explicit deny in SCP'
+        )
+        mock_clients['us-west-2'] = MagicMock()
+        mock_clients['us-west-2'].describe_network_interfaces.return_value = {
+            'NetworkInterfaces': [sample_eni_response]
+        }
+
+        result = await find_ip_module.find_ip_address(
+            ip_address='10.0.1.100',
+            region='us-east-1',
+            all_regions=True,
+        )
+
+        assert result == sample_eni_response


### PR DESCRIPTION
When all_regions=True, find_ip_address loops through every enabled region calling ec2:DescribeNetworkInterfaces. If the calling role is denied access in even one region (e.g. via an AWS Organizations SCP), the old code captured that error and raised it as the final result after the loop — even if the IP exists in an accessible region that was searched later.

The fix records each region that errors into a skipped list instead of overwriting a single error variable. If at least one region was searchable the tool reports the IP as not found and lists which regions were skipped and why, so the caller knows the search was not exhaustive. If every region was inaccessible it surfaces the collective errors. The IP is still returned as soon as any searchable region finds it, so the common case (IP is in an allowed region) just works now.

Added three test cases: partial error (one region fails, rest succeed, IP not found), all errors (every region denied), and the key scenario from the issue (two regions SCP-denied, IP found in the third). All 9 tests pass.

Fixes #4287

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).