### PR TITLE
fix(aws-api-mcp-server): Security Policy Bypass via Startup Initialization Failure

### DIFF
--- a/src/aws-api-mcp-server/CHANGELOG.md
+++ b/src/aws-api-mcp-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Security
+
+- Fail closed when security policy enforcement data cannot be initialized at startup. Previously, if loading the read-only operations index failed (e.g. a transient network error), the server continued running with the configured security policy (denylist / elicitList) silently skipped for the entire process lifetime, allowing denylisted operations to execute unchecked. The server now refuses to start when this data cannot be loaded, and requests are denied at execution time if the index is unavailable.
+
 ### Fixed
 
 - Remove max range check on parameters to remain forwards compatible with any API changes (#2445)

--- a/src/aws-api-mcp-server/README.md
+++ b/src/aws-api-mcp-server/README.md
@@ -457,6 +457,8 @@ To determine the exact format for a command:
 
 **Note**: IAM permissions remain the primary security control mechanism. The security policy provides an additional layer of protection but cannot override IAM restrictions.
 
+**Fail-closed startup**: Enforcing the security policy (denylist / elicitList as well as `READ_OPERATIONS_ONLY` and `REQUIRE_MUTATION_CONSENT`) requires the server to load its read-only operations metadata at startup, which involves a network call. If that data cannot be loaded, the server **refuses to start** rather than running with security policy checks disabled. If startup fails due to a transient network issue (DNS, VPN, egress proxy), retry once connectivity is restored.
+
 ## License
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/src/aws-api-mcp-server/README.md
+++ b/src/aws-api-mcp-server/README.md
@@ -457,8 +457,6 @@ To determine the exact format for a command:
 
 **Note**: IAM permissions remain the primary security control mechanism. The security policy provides an additional layer of protection but cannot override IAM restrictions.
 
-**Fail-closed startup**: Enforcing the security policy (denylist / elicitList as well as `READ_OPERATIONS_ONLY` and `REQUIRE_MUTATION_CONSENT`) requires the server to load its read-only operations metadata at startup, which involves a network call. If that data cannot be loaded, the server **refuses to start** rather than running with security policy checks disabled. If startup fails due to a transient network issue (DNS, VPN, egress proxy), retry once connectivity is restored.
-
 ## License
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.3.47'
+__version__ = '1.3.46'

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -34,9 +34,7 @@ from .core.common.config import (
     HOST,
     MAX_BATCH_COMMANDS,
     PORT,
-    READ_ONLY_KEY,
     READ_OPERATIONS_ONLY_MODE,
-    REQUIRE_MUTATION_CONSENT,
     STATELESS_HTTP,
     TRANSPORT,
     WORKING_DIRECTORY,
@@ -319,26 +317,23 @@ async def call_aws_helper(
     )
 
     try:
-        # Check security policy
-        if READ_OPERATIONS_INDEX is not None:
-            policy_decision = check_security_policy(ir, READ_OPERATIONS_INDEX, ctx)
+        # Check security policy.
+        if READ_OPERATIONS_INDEX is None:
+            error_message = (
+                'Execution of this operation is denied because the security policy '
+                'enforcement data failed to initialize.'
+            )
+            await ctx.error(error_message)
+            raise AwsApiMcpError(error_message)
 
-            if policy_decision == PolicyDecision.DENY:
-                error_message = 'Execution of this operation is denied by security policy.'
-                await ctx.error(error_message)
-                raise AwsApiMcpError(error_message)
-            elif policy_decision == PolicyDecision.ELICIT:
-                await request_consent(cli_command, ctx)
-        else:
-            if READ_OPERATIONS_ONLY_MODE:
-                error_message = (
-                    'Execution of this operation is not allowed because read only mode is enabled. '
-                    f'It can be disabled by setting the {READ_ONLY_KEY} environment variable to False.'
-                )
-                await ctx.error(error_message)
-                raise AwsApiMcpError(error_message)
-            elif REQUIRE_MUTATION_CONSENT:
-                await request_consent(cli_command, ctx)
+        policy_decision = check_security_policy(ir, READ_OPERATIONS_INDEX, ctx)
+
+        if policy_decision == PolicyDecision.DENY:
+            error_message = 'Execution of this operation is denied by security policy.'
+            await ctx.error(error_message)
+            raise AwsApiMcpError(error_message)
+        elif policy_decision == PolicyDecision.ELICIT:
+            await request_consent(cli_command, ctx)
 
         if ir.command and ir.command.is_help_operation:
             return await get_help_document(cli_command, ctx)
@@ -437,12 +432,15 @@ def main():
     validate_aws_region(DEFAULT_REGION)
     logger.info('AWS_REGION: {}', DEFAULT_REGION)
 
-    # Always load read operations index for security policy checking
     try:
         READ_OPERATIONS_INDEX = get_read_only_operations()
     except Exception as e:
-        logger.warning('Failed to load read operations index: {}', e)
-        READ_OPERATIONS_INDEX = None
+        logger.error(
+            'Failed to load read operations index required for security policy '
+            'enforcement; refusing to start: {}',
+            e,
+        )
+        raise
 
     if TRANSPORT == 'stdio':
         server.run(

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.47"
+version = "1.3.46"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/tests/test_security_policy.py
+++ b/src/aws-api-mcp-server/tests/test_security_policy.py
@@ -588,6 +588,47 @@ async def test_call_aws_security_policy_elicit(
     assert isinstance(result[0].response, ProgramInterpretationResponse)
 
 
+@patch('awslabs.aws_api_mcp_server.server.interpret_command')
+@patch('awslabs.aws_api_mcp_server.server.validate')
+@patch('awslabs.aws_api_mcp_server.server.translate_cli_to_ir')
+@patch('awslabs.aws_api_mcp_server.server.check_security_policy')
+@patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_INDEX', None)
+async def test_call_aws_denied_when_index_unavailable(
+    mock_check_security_policy,
+    mock_translate_cli_to_ir,
+    mock_validate,
+    mock_interpret,
+):
+    """Fail closed: deny execution when the security policy index failed to initialize.
+
+    Regression test for the policy fail-open advisory. When the read operations
+    index (required to make a policy decision) is unavailable, the request must be
+    denied rather than falling through to execution with policy checks skipped.
+    """
+    mock_ir = MagicMock()
+    mock_ir.command_metadata = MagicMock()
+    mock_ir.command.is_awscli_customization = False
+    mock_ir.command.is_help_operation = False
+    mock_translate_cli_to_ir.return_value = mock_ir
+
+    mock_validation = MagicMock()
+    mock_validation.validation_failed = False
+    mock_validate.return_value = mock_validation
+
+    ctx = DummyCtx()
+    response_list = await call_aws('aws iam create-access-key', ctx)
+
+    assert len(response_list) == 1
+    assert (
+        response_list[0].error
+        == 'Execution of this operation is denied because the security policy '
+        'enforcement data failed to initialize.'
+    )
+    # The policy decision must never be reached / the operation never interpreted
+    mock_check_security_policy.assert_not_called()
+    mock_interpret.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_check_elicitation_support():
     """Test elicitation support checking."""

--- a/src/aws-api-mcp-server/tests/test_server.py
+++ b/src/aws-api-mcp-server/tests/test_server.py
@@ -1,3 +1,4 @@
+import awslabs.aws_api_mcp_server.server as server_module
 import os
 import pytest
 import requests
@@ -13,6 +14,7 @@ from awslabs.aws_api_mcp_server.core.common.models import (
     InterpretationResponse,
     ProgramInterpretationResponse,
 )
+from awslabs.aws_api_mcp_server.core.security.policy import PolicyDecision
 from awslabs.aws_api_mcp_server.server import (
     _execute_single_command,
     call_aws,
@@ -27,19 +29,41 @@ from tests.fixtures import TEST_CREDENTIALS, DummyCtx
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+@pytest.fixture(autouse=True)
+def _present_security_policy_index():
+    """Provide a loaded read operations index and a default-ALLOW policy decision.
+
+    The server fails closed when the read operations index is unavailable (see the
+    policy fail-open advisory), so request-path tests must run with the index
+    present. Tests that exercise a specific policy decision (deny / elicit /
+    read-only) override ``check_security_policy`` explicitly.
+    """
+    with (
+        patch.object(server_module, 'READ_OPERATIONS_INDEX', MagicMock()),
+        patch.object(server_module, 'check_security_policy', return_value=PolicyDecision.ALLOW),
+    ):
+        yield
+
+
 @patch('awslabs.aws_api_mcp_server.server.os.chdir')
 @patch('awslabs.aws_api_mcp_server.server.get_read_only_operations')
 @patch('awslabs.aws_api_mcp_server.server.server')
 def test_main_read_operations_index_load_failure(mock_server, mock_get_read_ops, mock_chdir):
-    """Test main function when read operations index loading fails."""
+    """Test main refuses to start when the read operations index fails to load.
+
+    The read operations index is required to enforce the security policy, so a
+    failure to load it must fail closed (refuse to start) rather than fail open
+    (start with policy checks skipped).
+    """
     mock_get_read_ops.side_effect = Exception('Failed to load operations')
 
     with patch('awslabs.aws_api_mcp_server.server.WORKING_DIRECTORY', '/tmp/test'):
         with patch('awslabs.aws_api_mcp_server.server.DEFAULT_REGION', 'us-east-1'):
             with patch('awslabs.aws_api_mcp_server.server.validate_aws_region'):
-                # Should not raise exception, just log warning
-                main()
-                mock_server.run.assert_called_once()
+                # Must propagate the failure and never start serving requests
+                with pytest.raises(Exception, match='Failed to load operations'):
+                    main()
+                mock_server.run.assert_not_called()
 
 
 @patch('awslabs.aws_api_mcp_server.server.DEFAULT_REGION', 'us-east-1')
@@ -184,11 +208,13 @@ async def test_call_aws_helper_passes_region_to_customization(
     mock_validate.return_value = MagicMock(validation_failed=False)
     mock_execute.return_value = AwsCliAliasResponse(response='', error='')
 
-    # Avoid policy gating
+    # Allow the operation through the policy gate (index present, decision ALLOW)
     with (
-        patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_INDEX', None),
-        patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_ONLY_MODE', False),
-        patch('awslabs.aws_api_mcp_server.server.REQUIRE_MUTATION_CONSENT', False),
+        patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_INDEX', MagicMock()),
+        patch(
+            'awslabs.aws_api_mcp_server.server.check_security_policy',
+            return_value=PolicyDecision.ALLOW,
+        ),
     ):
         # Act
         result = await call_aws_helper(
@@ -233,11 +259,13 @@ async def test_call_aws_helper_passes_region_to_interpret(
         failed_constraints=None,
     )
 
-    # Avoid policy gating
+    # Allow the operation through the policy gate (index present, decision ALLOW)
     with (
-        patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_INDEX', None),
-        patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_ONLY_MODE', False),
-        patch('awslabs.aws_api_mcp_server.server.REQUIRE_MUTATION_CONSENT', False),
+        patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_INDEX', MagicMock()),
+        patch(
+            'awslabs.aws_api_mcp_server.server.check_security_policy',
+            return_value=PolicyDecision.ALLOW,
+        ),
     ):
         # Act
         result = await call_aws_helper(
@@ -255,18 +283,20 @@ async def test_call_aws_helper_passes_region_to_interpret(
 
 
 @patch('awslabs.aws_api_mcp_server.server.DEFAULT_REGION', 'us-east-1')
-@patch('awslabs.aws_api_mcp_server.server.REQUIRE_MUTATION_CONSENT', True)
+@patch(
+    'awslabs.aws_api_mcp_server.server.check_security_policy',
+    return_value=PolicyDecision.ELICIT,
+)
 @patch('awslabs.aws_api_mcp_server.server.interpret_command')
 @patch('awslabs.aws_api_mcp_server.server.validate')
 @patch('awslabs.aws_api_mcp_server.server.translate_cli_to_ir')
-@patch('awslabs.aws_api_mcp_server.core.aws.service.is_operation_read_only')
 async def test_call_aws_with_consent_and_accept(
-    mock_is_operation_read_only,
     mock_translate_cli_to_ir,
     mock_validate,
     mock_interpret,
+    mock_check_security_policy,
 ):
-    """Test call_aws with mutating action and consent enabled."""
+    """Test call_aws with a mutating action the policy requires consent for (accepted)."""
     # Create a proper ProgramInterpretationResponse mock
     mock_response = InterpretationResponse(error=None, json='{"Buckets": []}', status_code=200)
 
@@ -278,8 +308,6 @@ async def test_call_aws_with_consent_and_accept(
         failed_constraints=None,
     )
     mock_interpret.return_value = mock_result
-
-    mock_is_operation_read_only.return_value = False
 
     # Mock IR with command metadata
     mock_ir = MagicMock()
@@ -314,20 +342,20 @@ async def test_call_aws_with_consent_and_accept(
 
 
 @patch('awslabs.aws_api_mcp_server.server.DEFAULT_REGION', 'us-east-1')
-@patch('awslabs.aws_api_mcp_server.server.REQUIRE_MUTATION_CONSENT', True)
+@patch(
+    'awslabs.aws_api_mcp_server.server.check_security_policy',
+    return_value=PolicyDecision.ELICIT,
+)
 @patch('awslabs.aws_api_mcp_server.server.interpret_command')
 @patch('awslabs.aws_api_mcp_server.server.validate')
 @patch('awslabs.aws_api_mcp_server.server.translate_cli_to_ir')
-@patch('awslabs.aws_api_mcp_server.core.aws.service.is_operation_read_only')
 async def test_call_aws_with_consent_and_reject(
-    mock_is_operation_read_only,
     mock_translate_cli_to_ir,
     mock_validate,
     mock_interpret,
+    mock_check_security_policy,
 ):
-    """Test call_aws with mutating action and consent enabled."""
-    mock_is_operation_read_only.return_value = False
-
+    """Test call_aws with a mutating action the policy requires consent for (rejected)."""
     # Mock IR with command metadata
     mock_ir = MagicMock()
     mock_ir.command_metadata = MagicMock()
@@ -357,18 +385,15 @@ async def test_call_aws_with_consent_and_reject(
 
 
 @patch('awslabs.aws_api_mcp_server.server.DEFAULT_REGION', 'us-east-1')
-@patch('awslabs.aws_api_mcp_server.server.REQUIRE_MUTATION_CONSENT', False)
 @patch('awslabs.aws_api_mcp_server.server.interpret_command')
 @patch('awslabs.aws_api_mcp_server.server.validate')
 @patch('awslabs.aws_api_mcp_server.server.translate_cli_to_ir')
-@patch('awslabs.aws_api_mcp_server.core.aws.service.is_operation_read_only')
 async def test_call_aws_without_consent(
-    mock_is_operation_read_only,
     mock_translate_cli_to_ir,
     mock_validate,
     mock_interpret,
 ):
-    """Test call_aws with mutating action and with consent disabled."""
+    """Test call_aws with a mutating action the policy allows without consent."""
     # Create a proper ProgramInterpretationResponse mock
     mock_response = InterpretationResponse(error=None, json='{"Buckets": []}', status_code=200)
 
@@ -380,8 +405,6 @@ async def test_call_aws_without_consent(
         failed_constraints=None,
     )
     mock_interpret.return_value = mock_result
-
-    mock_is_operation_read_only.return_value = False
 
     # Mock IR with command metadata
     mock_ir = MagicMock()
@@ -578,17 +601,18 @@ async def test_call_aws_non_aws_command():
         assert "Command must start with 'aws'" in result[0].error
 
 
+@patch(
+    'awslabs.aws_api_mcp_server.server.check_security_policy',
+    return_value=PolicyDecision.DENY,
+)
 @patch('awslabs.aws_api_mcp_server.server.validate')
 @patch('awslabs.aws_api_mcp_server.server.translate_cli_to_ir')
-@patch('awslabs.aws_api_mcp_server.core.aws.service.is_operation_read_only')
-@patch('awslabs.aws_api_mcp_server.server.READ_OPERATIONS_ONLY_MODE')
 async def test_when_operation_is_not_allowed(
-    mock_read_operations_only_mode,
-    mock_is_operation_read_only,
     mock_translate_cli_to_ir,
     mock_validate,
+    mock_check_security_policy,
 ):
-    """Test call_aws returns error when operation is not allowed in read-only mode."""
+    """Test call_aws returns error when the security policy denies the operation."""
     # Mock IR with command metadata
     mock_ir = MagicMock()
     mock_ir.command_metadata = MagicMock()
@@ -600,14 +624,10 @@ async def test_when_operation_is_not_allowed(
     mock_ir.command.is_help_operation = False
     mock_translate_cli_to_ir.return_value = mock_ir
 
-    mock_read_operations_only_mode.return_value = True
-
     # Mock validation response
     mock_response = MagicMock()
     mock_response.validation_failed = False
     mock_validate.return_value = mock_response
-
-    mock_is_operation_read_only.return_value = False
 
     # Execute and verify
     result = await call_aws('aws s3api list-buckets', DummyCtx())
@@ -615,10 +635,7 @@ async def test_when_operation_is_not_allowed(
     assert len(result) == 1
     assert result[0].cli_command == 'aws s3api list-buckets'
     assert result[0].error is not None
-    assert (
-        'Execution of this operation is not allowed because read only mode is enabled'
-        in result[0].error
-    )
+    assert 'Execution of this operation is denied by security policy.' in result[0].error
 
 
 @patch('awslabs.aws_api_mcp_server.server.validate')

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -135,7 +135,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.3.47"
+version = "1.3.46"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Fail closed when security policy enforcement data cannot be initialized at startup. The server now refuses to start if this data can't be loaded, and denies requests at execution time when it's unavailable. See CHANGELOG for details.

### User experience

> Please share what the user experience looks like before and after this change

The security policy (denylist / elicitList) is now consistently enforced. If enforcement data can't be initialized, the server fails to start rather than running with the policy silently skipped.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
