### PR TITLE
feat(bedrock-kb-retrieval-mcp-server): expose document metadata and add metadata_filter to QueryKnowledgeBases

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -407,7 +407,7 @@
         "filename": "src/bedrock-kb-retrieval-mcp-server/README.md",
         "hashed_secret": "057903c2553b3682d069157a6e8ae538eab79250",
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 161,
         "is_secret": false
       }
     ],
@@ -1256,5 +1256,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-16T18:42:37Z"
+  "generated_at": "2026-07-23T16:52:38Z"
 }

--- a/src/bedrock-kb-retrieval-mcp-server/CHANGELOG.md
+++ b/src/bedrock-kb-retrieval-mcp-server/CHANGELOG.md
@@ -17,3 +17,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project setup
+- Document `metadata` is now included in `QueryKnowledgeBases` results
+- Optional `metadata_filter` parameter on `QueryKnowledgeBases` for metadata-based filtering using the Bedrock RetrievalFilter schema; composed with `data_source_ids` via `andAll` when both are provided (merged into an existing top-level `andAll` to respect the Retrieve API's one-level filter embedding limit)

--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -15,12 +15,20 @@ MCP server for accessing Amazon Bedrock Knowledge Bases
 - Retrieve information using conversational queries
 - Get relevant passages from your knowledge bases
 - Access citation information for all results
+- Access document metadata attributes (system `x-amz-bedrock-kb-*` attributes and custom attributes) for all results
 
 ### Filter results by data source
 
 - Focus your queries on specific data sources
 - Include or exclude specific data sources
 - Prioritize results from specific data sources
+
+### Filter results by document metadata
+
+- Apply rich metadata filters to your queries using the [Bedrock RetrievalFilter](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalFilter.html) schema via the `metadata_filter` parameter
+- Use any filter operator the Retrieve API supports (`equals`, `notEquals`, `greaterThan`, `lessThan`, `in`, `startsWith`, `andAll`, `orAll`, etc.)
+- Combine with data source filtering — when both `metadata_filter` and `data_source_ids` are provided, they are composed with `andAll`: a top-level `andAll` filter has the data-source condition merged into its member list (preserving filter depth); any other filter is wrapped together with the data-source condition in a new `andAll`
+- Note that the Retrieve API allows only [one level of embedded filter groups](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-config.html) — a top-level `orAll` filter that already contains embedded `andAll`/`orAll` groups cannot be combined with `data_source_ids` (the server raises an error); fold the data-source condition into the filter yourself using the `x-amz-bedrock-kb-data-source-id` key instead
 
 ### Rerank results
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
@@ -34,6 +34,7 @@ async def query_knowledge_base(
     reranking: bool = False,
     reranking_model_name: Literal['COHERE', 'AMAZON'] = 'AMAZON',
     data_source_ids: list[str] | None = None,
+    metadata_filter: dict | None = None,
 ) -> str:
     """# Amazon Bedrock Knowledge Base query tool.
 
@@ -45,6 +46,7 @@ async def query_knowledge_base(
         reranking (bool): Whether to rerank the results. Can be globally configured using the BEDROCK_KB_RERANKING_ENABLED environment variable.
         reranking_model_name (Literal['COHERE', 'AMAZON']): The name of the reranking model to use.
         data_source_ids (list[str] | None): The data source IDs to filter the knowledge base by.
+        metadata_filter (dict | None): A Bedrock RetrievalFilter object to filter results by document metadata attributes. Passed through unchanged. Raises ValueError if empty, since the API rejects an empty filter. When combined with data_source_ids: a top-level 'andAll' filter has the data-source condition merged into its list (preserving depth); otherwise both are wrapped in a new 'andAll'. Raises ValueError if the filter is a top-level 'orAll' containing embedded filter groups, since no composition fits Bedrock's one-level embedding limit.
 
     ## Warning: You must use the `ListKnowledgeBases` tool to get the knowledge base ID and optionally a data source ID first.
 
@@ -68,13 +70,54 @@ async def query_knowledge_base(
         }
     }
 
+    if metadata_filter is not None and not metadata_filter:
+        raise ValueError(
+            'metadata_filter must not be empty; omit the parameter to query without '
+            'a metadata filter.'
+        )
+
+    ds_filter: dict | None = None
     if data_source_ids:
-        retrieve_request['vectorSearchConfiguration']['filter'] = {  # type: ignore
+        ds_filter = {
             'in': {
                 'key': 'x-amz-bedrock-kb-data-source-id',
-                'value': data_source_ids,  # type: ignore
+                'value': data_source_ids,
             }
         }
+
+    combined_filter: dict | None = None
+    if ds_filter is not None and metadata_filter is not None:
+        # The Retrieve API allows only one level of embedded filter groups, so the
+        # data-source condition must compose without deepening the user's filter.
+        if set(metadata_filter) == {'andAll'} and isinstance(metadata_filter['andAll'], list):
+            # AND is associative: merging preserves both semantics and depth. The API
+            # requires andAll to have at least 2 members, so a merged list of one
+            # (from a vacuous {'andAll': []}) is emitted as a bare condition.
+            members = [*metadata_filter['andAll'], ds_filter]
+            combined_filter = {'andAll': members} if len(members) >= 2 else members[0]
+        elif (
+            set(metadata_filter) == {'orAll'}
+            and isinstance(metadata_filter['orAll'], list)
+            and any(
+                isinstance(member, dict) and ('andAll' in member or 'orAll' in member)
+                for member in metadata_filter['orAll']
+            )
+        ):
+            raise ValueError(
+                'Cannot combine data_source_ids with this metadata_filter within '
+                "Bedrock's one-level filter embedding limit; fold the data-source "
+                'condition into metadata_filter using key '
+                "'x-amz-bedrock-kb-data-source-id', or omit data_source_ids."
+            )
+        else:
+            combined_filter = {'andAll': [metadata_filter, ds_filter]}
+    elif metadata_filter is not None:
+        combined_filter = metadata_filter
+    elif ds_filter is not None:
+        combined_filter = ds_filter
+
+    if combined_filter is not None:
+        retrieve_request['vectorSearchConfiguration']['filter'] = combined_filter  # type: ignore
 
     if reranking:
         model_name_mapping = {
@@ -107,6 +150,7 @@ async def query_knowledge_base(
                     'content': result['content'],
                     'location': result.get('location', ''),
                     'score': result.get('score', ''),
+                    'metadata': result.get('metadata', {}),
                 }
             )
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -30,7 +30,7 @@ from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.retrieval import (
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 
 # Remove all default handlers then add our own
@@ -81,6 +81,7 @@ mcp = FastMCP(
     - Knowledge bases contain structured data from various data sources (documents, websites, databases)
     - Each knowledge base has a unique ID that must be used when querying
     - You can filter by specific data sources within a knowledge base using data_source_ids
+    - You can filter by document metadata attributes using metadata_filter with the Bedrock RetrievalFilter schema
     - Always verify that the knowledge base ID exists in the ListKnowledgeBases tool response before querying
     """,
     dependencies=['boto3'],
@@ -153,6 +154,25 @@ async def query_knowledge_bases_tool(
         None,
         description='The data source IDs to filter the knowledge base by. It must be a list of valid data source IDs from the ListKnowledgeBases tool',
     ),
+    metadata_filter: Optional[Dict] = Field(
+        None,
+        description=(
+            'A metadata filter to apply to the knowledge base query, following the Bedrock '
+            'RetrievalFilter schema (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalFilter.html). '
+            "It is passed through unchanged to the Retrieve API's "
+            'vectorSearchConfiguration.filter field. Must not be an empty object — omit '
+            'the parameter entirely to query without a metadata filter. Supports '
+            'operators such as equals, notEquals, greaterThan, lessThan, in, startsWith, '
+            "andAll, orAll, etc. Example: {'equals': {'key': 'doc_type', 'value': 'runbook'}}. "
+            'When combined with data_source_ids: if the filter is a top-level andAll, the '
+            'data-source condition is merged into its list (preserving filter depth); '
+            "otherwise both are wrapped in a new andAll. Note Bedrock's limit of one level "
+            'of embedded filter groups: a top-level orAll that already contains embedded '
+            'andAll/orAll groups cannot be combined with data_source_ids (a ValueError is '
+            'raised); fold the data-source condition into the filter using key '
+            "'x-amz-bedrock-kb-data-source-id' instead."
+        ),
+    ),
 ) -> str:
     """Query an Amazon Bedrock Knowledge Base using natural language.
 
@@ -171,6 +191,7 @@ async def query_knowledge_bases_tool(
     - content: The text content of the document
     - location: The source location of the document
     - score: The relevance score of the document
+    - metadata: The metadata attributes of the document, including system attributes (x-amz-bedrock-kb-*) and any custom attributes indexed with the document
 
 
     ## Interpretation Best Practices
@@ -188,6 +209,7 @@ async def query_knowledge_bases_tool(
         reranking=reranking,
         reranking_model_name=reranking_model_name,
         data_source_ids=data_source_ids,
+        metadata_filter=metadata_filter,
     )
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/tests/conftest.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/conftest.py
@@ -31,11 +31,23 @@ def mock_bedrock_agent_runtime_client():
                 'content': {'text': 'This is a test document content.', 'type': 'TEXT'},
                 'location': {'s3Location': {'uri': 's3://test-bucket/test-document.txt'}},
                 'score': 0.95,
+                'metadata': {
+                    'x-amz-bedrock-kb-source-uri': 's3://test-bucket/test-document.txt',
+                    'x-amz-bedrock-kb-data-source-id': 'ds-12345',
+                    'doc_type': 'runbook',
+                    'service': 'test-service',
+                },
             },
             {
                 'content': {'text': 'This is another test document content.', 'type': 'TEXT'},
                 'location': {'s3Location': {'uri': 's3://test-bucket/another-document.txt'}},
                 'score': 0.85,
+                'metadata': {
+                    'x-amz-bedrock-kb-source-uri': 's3://test-bucket/another-document.txt',
+                    'x-amz-bedrock-kb-data-source-id': 'ds-67890',
+                    'doc_type': 'faq',
+                    'service': 'another-service',
+                },
             },
         ]
     }

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
@@ -161,6 +161,356 @@ class TestQueryKnowledgeBase:
         mock_bedrock_agent_runtime_client.retrieve.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_query_knowledge_base_includes_metadata(self, mock_bedrock_agent_runtime_client):
+        """Test that document metadata is included in the query results."""
+        # Call the function
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+        )
+
+        # Parse the result as JSON
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+
+        # Check that the metadata is included in the results
+        assert len(documents) == 2
+        assert documents[0]['metadata'] == {
+            'x-amz-bedrock-kb-source-uri': 's3://test-bucket/test-document.txt',
+            'x-amz-bedrock-kb-data-source-id': 'ds-12345',
+            'doc_type': 'runbook',
+            'service': 'test-service',
+        }
+        assert documents[1]['metadata'] == {
+            'x-amz-bedrock-kb-source-uri': 's3://test-bucket/another-document.txt',
+            'x-amz-bedrock-kb-data-source-id': 'ds-67890',
+            'doc_type': 'faq',
+            'service': 'another-service',
+        }
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_without_metadata_in_response(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that documents without metadata default to an empty metadata object."""
+        # Modify the mock to return a result without a metadata field
+        mock_bedrock_agent_runtime_client.retrieve.return_value = {
+            'retrievalResults': [
+                {
+                    'content': {'text': 'This is a test document content.', 'type': 'TEXT'},
+                    'location': {'s3Location': {'uri': 's3://test-bucket/test-document.txt'}},
+                    'score': 0.95,
+                },
+            ]
+        }
+
+        # Call the function
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+        )
+
+        # Parse the result as JSON
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+
+        # Check that the metadata defaults to an empty object
+        assert len(documents) == 1
+        assert documents[0]['metadata'] == {}
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_with_metadata_filter(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test querying a knowledge base with a metadata filter only."""
+        metadata_filter = {'equals': {'key': 'doc_type', 'value': 'runbook'}}
+
+        # Call the function with a metadata filter
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+            metadata_filter=metadata_filter,
+        )
+
+        # Parse the result as JSON
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+
+        # Check that the result is correct
+        assert len(documents) == 2
+
+        # Check that the filter is passed through unchanged (no andAll wrapper)
+        mock_bedrock_agent_runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId='kb-12345',
+            retrievalQuery={'text': 'test query'},
+            retrievalConfiguration={
+                'vectorSearchConfiguration': {
+                    'numberOfResults': 20,
+                    'filter': metadata_filter,
+                }
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_with_data_source_ids_only(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that data source IDs alone produce a bare filter condition."""
+        # Call the function with data source IDs only
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+            data_source_ids=['ds-12345', 'ds-67890'],
+        )
+
+        # Parse the result as JSON
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+
+        # Check that the result is correct
+        assert len(documents) == 2
+
+        # Check that the single condition is not wrapped in andAll
+        mock_bedrock_agent_runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId='kb-12345',
+            retrievalQuery={'text': 'test query'},
+            retrievalConfiguration={
+                'vectorSearchConfiguration': {
+                    'numberOfResults': 20,
+                    'filter': {
+                        'in': {
+                            'key': 'x-amz-bedrock-kb-data-source-id',
+                            'value': ['ds-12345', 'ds-67890'],
+                        }
+                    },
+                }
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_with_data_source_ids_and_metadata_filter(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that a simple metadata filter and data source IDs are wrapped in a new andAll."""
+        metadata_filter = {'equals': {'key': 'doc_type', 'value': 'runbook'}}
+
+        # Call the function with both data source IDs and a metadata filter
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+            data_source_ids=['ds-12345', 'ds-67890'],
+            metadata_filter=metadata_filter,
+        )
+
+        # Parse the result as JSON
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+
+        # Check that the result is correct
+        assert len(documents) == 2
+
+        # Check that both filters are composed with andAll
+        mock_bedrock_agent_runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId='kb-12345',
+            retrievalQuery={'text': 'test query'},
+            retrievalConfiguration={
+                'vectorSearchConfiguration': {
+                    'numberOfResults': 20,
+                    'filter': {
+                        'andAll': [
+                            metadata_filter,
+                            {
+                                'in': {
+                                    'key': 'x-amz-bedrock-kb-data-source-id',
+                                    'value': ['ds-12345', 'ds-67890'],
+                                }
+                            },
+                        ]
+                    },
+                }
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_merges_data_source_ids_into_existing_and_all(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that a top-level andAll filter has the data-source condition merged in."""
+        metadata_filter = {
+            'andAll': [
+                {
+                    'orAll': [
+                        {'equals': {'key': 'doc_type', 'value': 'runbook'}},
+                        {'equals': {'key': 'doc_type', 'value': 'faq'}},
+                    ]
+                },
+                {'equals': {'key': 'service', 'value': 'test-service'}},
+            ]
+        }
+
+        # Call the function with both data source IDs and an andAll metadata filter
+        await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+            data_source_ids=['ds-12345'],
+            metadata_filter=metadata_filter,
+        )
+
+        # Check that the data-source condition is appended to the existing andAll list,
+        # preserving the filter's embedding depth
+        mock_bedrock_agent_runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId='kb-12345',
+            retrievalQuery={'text': 'test query'},
+            retrievalConfiguration={
+                'vectorSearchConfiguration': {
+                    'numberOfResults': 20,
+                    'filter': {
+                        'andAll': [
+                            *metadata_filter['andAll'],
+                            {
+                                'in': {
+                                    'key': 'x-amz-bedrock-kb-data-source-id',
+                                    'value': ['ds-12345'],
+                                }
+                            },
+                        ]
+                    },
+                }
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_wraps_flat_or_all_with_data_source_ids(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that a top-level orAll with flat members is wrapped in a new andAll."""
+        metadata_filter = {
+            'orAll': [
+                {'equals': {'key': 'doc_type', 'value': 'runbook'}},
+                {'equals': {'key': 'doc_type', 'value': 'faq'}},
+            ]
+        }
+
+        # Call the function with both data source IDs and a flat orAll metadata filter
+        await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+            data_source_ids=['ds-12345'],
+            metadata_filter=metadata_filter,
+        )
+
+        # Check that the orAll filter and the data-source condition are wrapped in andAll,
+        # which adds exactly one embedding level (within the API limit)
+        mock_bedrock_agent_runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId='kb-12345',
+            retrievalQuery={'text': 'test query'},
+            retrievalConfiguration={
+                'vectorSearchConfiguration': {
+                    'numberOfResults': 20,
+                    'filter': {
+                        'andAll': [
+                            metadata_filter,
+                            {
+                                'in': {
+                                    'key': 'x-amz-bedrock-kb-data-source-id',
+                                    'value': ['ds-12345'],
+                                }
+                            },
+                        ]
+                    },
+                }
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_rejects_nested_or_all_with_data_source_ids(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that an orAll with embedded groups plus data source IDs raises ValueError."""
+        metadata_filter = {
+            'orAll': [
+                {
+                    'andAll': [
+                        {'equals': {'key': 'doc_type', 'value': 'runbook'}},
+                        {'equals': {'key': 'service', 'value': 'test-service'}},
+                    ]
+                },
+                {'equals': {'key': 'doc_type', 'value': 'faq'}},
+            ]
+        }
+
+        # Call the function with both data source IDs and a nested orAll metadata filter
+        with pytest.raises(ValueError) as excinfo:
+            await query_knowledge_base(
+                query='test query',
+                knowledge_base_id='kb-12345',
+                kb_agent_client=mock_bedrock_agent_runtime_client,
+                data_source_ids=['ds-12345'],
+                metadata_filter=metadata_filter,
+            )
+
+        # Check that the error message is actionable
+        assert 'Cannot combine data_source_ids with this metadata_filter' in str(excinfo.value)
+        assert 'x-amz-bedrock-kb-data-source-id' in str(excinfo.value)
+
+        # Check that the client methods were not called
+        mock_bedrock_agent_runtime_client.retrieve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_rejects_empty_metadata_filter(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that an empty metadata filter raises ValueError instead of failing silently."""
+        # Call the function with an empty metadata filter
+        with pytest.raises(ValueError) as excinfo:
+            await query_knowledge_base(
+                query='test query',
+                knowledge_base_id='kb-12345',
+                kb_agent_client=mock_bedrock_agent_runtime_client,
+                metadata_filter={},
+            )
+
+        # Check that the error message is actionable
+        assert 'metadata_filter must not be empty' in str(excinfo.value)
+
+        # Check that the client methods were not called
+        mock_bedrock_agent_runtime_client.retrieve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_merges_empty_and_all_to_bare_condition(
+        self, mock_bedrock_agent_runtime_client
+    ):
+        """Test that a vacuous andAll filter plus data source IDs emits a bare condition."""
+        # Call the function with an empty andAll list and data source IDs
+        await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock_bedrock_agent_runtime_client,
+            data_source_ids=['ds-12345'],
+            metadata_filter={'andAll': []},
+        )
+
+        # Check that the single merged member is emitted bare, since the API
+        # requires andAll to have at least 2 members
+        mock_bedrock_agent_runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId='kb-12345',
+            retrievalQuery={'text': 'test query'},
+            retrievalConfiguration={
+                'vectorSearchConfiguration': {
+                    'numberOfResults': 20,
+                    'filter': {
+                        'in': {
+                            'key': 'x-amz-bedrock-kb-data-source-id',
+                            'value': ['ds-12345'],
+                        }
+                    },
+                }
+            },
+        )
+
+    @pytest.mark.asyncio
     async def test_query_knowledge_base_with_image_content(
         self, mock_bedrock_agent_runtime_client
     ):

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
@@ -107,6 +107,7 @@ class TestQueryKnowledgeBasesTool:
                 'content': {'text': 'This is a test document content.', 'type': 'TEXT'},
                 'location': {'s3Location': {'uri': 's3://test-bucket/test-document.txt'}},
                 'score': 0.95,
+                'metadata': {'doc_type': 'runbook'},
             }
         )
 
@@ -118,12 +119,14 @@ class TestQueryKnowledgeBasesTool:
             reranking=True,
             reranking_model_name='AMAZON',
             data_source_ids=['ds-12345', 'ds-67890'],
+            metadata_filter=None,
         )
 
         # Check that the result is correct
         assert 'This is a test document content.' in result
         assert 's3://test-bucket/test-document.txt' in result
         assert '0.95' in result
+        assert 'runbook' in result
 
         # Check that query_knowledge_base was called with the correct arguments
         mock_query_knowledge_base.assert_called_once_with(
@@ -134,6 +137,50 @@ class TestQueryKnowledgeBasesTool:
             reranking=True,
             reranking_model_name='AMAZON',
             data_source_ids=['ds-12345', 'ds-67890'],
+            metadata_filter=None,
+        )
+
+    @pytest.mark.asyncio
+    @patch('awslabs.bedrock_kb_retrieval_mcp_server.server.query_knowledge_base')
+    async def test_query_knowledge_bases_tool_with_metadata_filter(
+        self, mock_query_knowledge_base
+    ):
+        """Test that the metadata filter is passed through to query_knowledge_base."""
+        # Set up the mock
+        mock_query_knowledge_base.return_value = json.dumps(
+            {
+                'content': {'text': 'This is a test document content.', 'type': 'TEXT'},
+                'location': {'s3Location': {'uri': 's3://test-bucket/test-document.txt'}},
+                'score': 0.95,
+                'metadata': {'doc_type': 'runbook'},
+            }
+        )
+        metadata_filter = {'equals': {'key': 'doc_type', 'value': 'runbook'}}
+
+        # Call the function
+        result = await query_knowledge_bases_tool(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            number_of_results=10,
+            reranking=False,
+            reranking_model_name='AMAZON',
+            data_source_ids=None,
+            metadata_filter=metadata_filter,
+        )
+
+        # Check that the result is correct
+        assert 'This is a test document content.' in result
+
+        # Check that query_knowledge_base was called with the metadata filter
+        mock_query_knowledge_base.assert_called_once_with(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=mock.ANY,  # We can't directly access the global variable in tests
+            number_of_results=10,
+            reranking=False,
+            reranking_model_name='AMAZON',
+            data_source_ids=None,
+            metadata_filter=metadata_filter,
         )
 
 


### PR DESCRIPTION
Closes #2935

## Description

Two backward-compatible changes to `src/bedrock-kb-retrieval-mcp-server`, as discussed in #2935:

1. **Expose document `metadata` in results.** The Bedrock `Retrieve` API returns a `metadata` object per result (system `x-amz-bedrock-kb-*` attributes plus any custom attributes from `.metadata.json` sidecars), but `knowledgebases/retrieval.py` previously built the emitted document from `content`, `location`, and `score` only. Each emitted document now includes `'metadata': result.get('metadata', {})`. Existing callers just see one additional key.

2. **Add optional `metadata_filter` parameter to `QueryKnowledgeBases`.** A raw passthrough of the documented [`RetrievalFilter`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalFilter.html) schema into `retrievalConfiguration.vectorSearchConfiguration.filter`. This imposes no schema opinions and supports any filter expression the Bedrock API supports (`equals`, `notEquals`, `greaterThan`, `lessThan`, `in`, `startsWith`, `andAll`, `orAll`, etc.). The existing `data_source_ids` filter logic was refactored so that when both are provided they are composed via `andAll`; a single condition stays bare, preserving the exact request shape emitted today for `data_source_ids`-only calls.

   The composition respects the Retrieve API's documented [one-level filter embedding limit](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-config.html): a top-level `andAll` filter has the data-source condition merged into its member list (AND is associative, so this preserves both semantics and depth); any other filter is wrapped together with the data-source condition in a new `andAll`. The one unresolvable corner — a top-level `orAll` that already contains embedded filter groups, combined with `data_source_ids` — raises a `ValueError` with an actionable message rather than sending a request the API would reject. An empty `metadata_filter` object also raises an actionable `ValueError` (the API rejects an empty `RetrievalFilter` tagged union, so passing it through would only produce an opaque botocore `ParamValidationError`), and a vacuous `{'andAll': []}` merged with the data-source condition degrades to the bare condition to respect the API's two-member minimum for `andAll`.

## Validation

- Validated against a real knowledge base with ~26k documents (metadata present in results; `metadata_filter` alone; `data_source_ids` alone; both combined under `andAll`).
- New unit tests covering: metadata present in output, metadata defaulting to `{}` when absent from the API response, filter passthrough alone (no `andAll` wrapper), empty-object filter rejected with an actionable `ValueError`, `data_source_ids` alone (unchanged request shape), simple filter + `data_source_ids` wrapped in `andAll`, top-level `andAll` merged in place (depth preserved), vacuous `{'andAll': []}` degrading to the bare data-source condition, flat `orAll` wrapped correctly, and the nested-`orAll` + `data_source_ids` `ValueError`.
- Full test suite passes (49 tests), `ruff check` / `ruff format` clean, `pyright` 0 errors.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented (server README tool docs, tool docstring, CHANGELOG)
- [x] Changes generate no new warnings
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
