### PR TITLE
fix(aws-transform-mcp-server): discover instruction docs inside artifact-store folders

### DIFF
--- a/src/aws-transform-mcp-server/CHANGELOG.md
+++ b/src/aws-transform-mcp-server/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `load_instructions` now discovers instruction documents stored inside
+  artifact-store folders. Customer uploads (the `upload_artifact` tool and the
+  AWS Transform web console) are stored under the store's `User Uploads/`
+  folder, and the unprefixed `ListArtifacts` discovery listing does not descend
+  into folders, so uploaded instruction documents were never found regardless
+  of file name. Discovery now re-scans each folder the root listing reports
+  (plus the canonical `User Uploads/` prefix as a fallback) and matches the
+  instruction label against the path basename. A folder whose scan fails is
+  skipped rather than failing the call.
+- `upload_artifact` re-arms the one-shot instructions check when the uploaded
+  file matches an instruction label, so a document uploaded mid-session is
+  picked up by the next `load_instructions` call.
 - Artifact downloads now return a clear, actionable error when the server is
   spawned with the filesystem root (`/`) as its working directory. The
   write-path confinement added for the arbitrary-file-write fix pinned the

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/guidance_nudge.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/guidance_nudge.py
@@ -14,18 +14,36 @@
 
 """Tracks which jobIds have had load_instructions called.
 
-Any tool receiving a jobId checks this before proceeding.
+Any tool receiving a jobId checks this before proceeding. Also owns what
+counts as an instruction artifact, shared by discovery (load_instructions)
+and upload (upload_artifact).
 """
 
 from typing import Optional, Set
 
 
+INSTRUCTION_ARTIFACT_LABELS = ['JOB_INSTRUCTIONS']
+
 _checked_jobs: Set[str] = set()
+
+
+def matches_instruction_label(path: str) -> bool:
+    """True if a stored artifact path names an instruction document.
+
+    Customer uploads carry the store folder in their path (e.g.
+    'User Uploads/JOB_INSTRUCTIONS'), so match on the path's base name.
+    """
+    return path.rsplit('/', 1)[-1] in INSTRUCTION_ARTIFACT_LABELS
 
 
 def mark_job_checked(job_id: str) -> None:
     """Record that load_instructions has been called for this job."""
     _checked_jobs.add(job_id)
+
+
+def unmark_job(job_id: str) -> None:
+    """Forget that a job was checked, so the next job-scoped call nudges a re-load."""
+    _checked_jobs.discard(job_id)
 
 
 def job_needs_check(job_id: Optional[str]) -> Optional[str]:

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py
@@ -25,6 +25,10 @@ import os
 from awslabs.aws_transform_mcp_server.audit import audited_tool
 from awslabs.aws_transform_mcp_server.config_store import is_fes_available
 from awslabs.aws_transform_mcp_server.file_validation import validate_read_path
+from awslabs.aws_transform_mcp_server.guidance_nudge import (
+    matches_instruction_label,
+    unmark_job,
+)
 from awslabs.aws_transform_mcp_server.tool_utils import (
     MUTATE,
     error_result,
@@ -199,6 +203,12 @@ class ArtifactHandler:
                     artifactId=init_result['artifactId'],
                 ),
             )
+
+            # A newly uploaded instruction document must be discoverable:
+            # forget the one-shot check so the next job-scoped call nudges
+            # the agent into re-running load_instructions.
+            if resolved_file_name and matches_instruction_label(resolved_file_name):
+                unmark_job(jobId)
 
             return success_result({'artifactId': init_result['artifactId']})
 

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/load_instructions.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/load_instructions.py
@@ -16,7 +16,10 @@
 
 from awslabs.aws_transform_mcp_server.audit import audited_tool
 from awslabs.aws_transform_mcp_server.config_store import is_fes_available
-from awslabs.aws_transform_mcp_server.guidance_nudge import mark_job_checked
+from awslabs.aws_transform_mcp_server.guidance_nudge import (
+    mark_job_checked,
+    matches_instruction_label,
+)
 from awslabs.aws_transform_mcp_server.tool_utils import (
     READ_ONLY,
     download_s3_content,
@@ -30,16 +33,43 @@ from awslabs.aws_transform_mcp_server.transform_api_models import (
     JobFilter,
     ListArtifactsRequest,
 )
+from loguru import logger
 from mcp.server.fastmcp import Context
 from pydantic import Field
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, List, Optional, Tuple
 
 
 _NOT_CONFIGURED_CODE = 'NOT_CONFIGURED'
 _NOT_CONFIGURED_MSG = 'Not connected to AWS Transform.'
 _NOT_CONFIGURED_ACTION = 'Call configure with authMode "cookie" or "sso".'
 
-INSTRUCTION_ARTIFACT_LABELS = ['JOB_INSTRUCTIONS']
+
+async def _scan_for_instruction_artifact(
+    workspace_id: str, job_id: str, path_prefix: Optional[str] = None
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    """Paginated ListArtifacts scan for an instruction artifact.
+
+    Returns (matching artifact or None, folders seen across all pages).
+    """
+    folders: List[str] = []
+    next_token: Optional[str] = None
+    while True:
+        list_req = ListArtifactsRequest(
+            workspaceId=workspace_id,
+            jobFilter=JobFilter(jobId=job_id),
+            nextToken=next_token,
+            pathPrefix=path_prefix,
+        )
+        result = await call_transform_api('ListArtifacts', list_req)
+        for artifact in result.get('artifacts', []):
+            if matches_instruction_label((artifact.get('fileMetadata') or {}).get('path') or ''):
+                return artifact, folders
+        for folder in result.get('folders') or []:
+            if folder not in folders:
+                folders.append(folder)
+        next_token = result.get('nextToken')
+        if not next_token:
+            return None, folders
 
 
 class LoadInstructionsHandler:
@@ -70,29 +100,41 @@ class LoadInstructionsHandler:
             return error_result(_NOT_CONFIGURED_CODE, _NOT_CONFIGURED_MSG, _NOT_CONFIGURED_ACTION)
 
         try:
-            instruction_artifact = None
-            next_token = None
-            while True:
-                list_req = ListArtifactsRequest(
-                    workspaceId=workspaceId,
-                    jobFilter=JobFilter(jobId=jobId),
-                    nextToken=next_token,
+            instruction_artifact, folders = await _scan_for_instruction_artifact(
+                workspaceId, jobId
+            )
+            if instruction_artifact is None:
+                # Customer uploads (MCP upload_artifact and the web console)
+                # land inside store folders such as 'User Uploads/', and the
+                # unprefixed listing does not descend into folders. Re-scan
+                # each folder the root listing reported, using the folder
+                # string verbatim as the pathPrefix. Some stages omit the
+                # folders array from the root listing entirely, so always
+                # include the managed store's canonical customer-upload
+                # prefix as a fallback.
+                canonical_uploads_prefix = (
+                    f'AWSTransform/Workspaces/{workspaceId}/Jobs/{jobId}/User Uploads/'
                 )
-                artifacts_result = await call_transform_api('ListArtifacts', list_req)
-                artifacts = artifacts_result.get('artifacts', [])
-                instruction_artifact = next(
-                    (
-                        a
-                        for a in artifacts
-                        if a.get('fileMetadata', {}).get('path') in INSTRUCTION_ARTIFACT_LABELS
-                    ),
-                    None,
-                )
-                if instruction_artifact:
-                    break
-                next_token = artifacts_result.get('nextToken')
-                if not next_token:
-                    break
+                if canonical_uploads_prefix not in folders:
+                    folders.append(canonical_uploads_prefix)
+                for folder in folders:
+                    # The store validates that a pathPrefix carries the correct
+                    # workspace/job identifiers; a folder string that fails that
+                    # check must not abort discovery of the remaining folders.
+                    try:
+                        instruction_artifact, _ = await _scan_for_instruction_artifact(
+                            workspaceId, jobId, folder
+                        )
+                    except Exception as scan_error:
+                        logger.warning(
+                            '[tool:load_instructions] folder scan failed, skipping | '
+                            'prefix={} | {}',
+                            folder,
+                            scan_error,
+                        )
+                        continue
+                    if instruction_artifact is not None:
+                        break
 
             if not instruction_artifact:
                 mark_job_checked(jobId)

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/load_instructions.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/load_instructions.py
@@ -108,15 +108,17 @@ class LoadInstructionsHandler:
                 # land inside store folders such as 'User Uploads/', and the
                 # unprefixed listing does not descend into folders. Re-scan
                 # each folder the root listing reported, using the folder
-                # string verbatim as the pathPrefix. Some stages omit the
-                # folders array from the root listing entirely, so always
-                # include the managed store's canonical customer-upload
-                # prefix as a fallback.
+                # string verbatim as the pathPrefix. Scan the managed store's
+                # canonical customer-upload folder first: it is where uploaded
+                # instruction documents live, so the common case resolves in
+                # one extra single-page call. It also covers stages whose root
+                # listing omits the folders array entirely.
                 canonical_uploads_prefix = (
                     f'AWSTransform/Workspaces/{workspaceId}/Jobs/{jobId}/User Uploads/'
                 )
-                if canonical_uploads_prefix not in folders:
-                    folders.append(canonical_uploads_prefix)
+                if canonical_uploads_prefix in folders:
+                    folders.remove(canonical_uploads_prefix)
+                folders.insert(0, canonical_uploads_prefix)
                 for folder in folders:
                     # The store validates that a pathPrefix carries the correct
                     # workspace/job identifiers; a folder string that fails that

--- a/src/aws-transform-mcp-server/tests/test_artifact.py
+++ b/src/aws-transform-mcp-server/tests/test_artifact.py
@@ -403,3 +403,107 @@ class TestUploadArtifactConnector:
         # Verify CompleteArtifactUpload was NOT called (only 1 FES call: CreateArtifactUploadUrl)
         assert mock_fes.call_count == 1
         assert mock_fes.call_args_list[0][0][0] == 'CreateArtifactUploadUrl'
+
+
+class TestUploadInstructionInvalidatesCheck:
+    """Uploading an instruction document re-arms the load_instructions nudge."""
+
+    @patch('awslabs.aws_transform_mcp_server.tools.artifact.httpx.AsyncClient')
+    @patch(
+        'awslabs.aws_transform_mcp_server.tools.artifact.call_transform_api',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'awslabs.aws_transform_mcp_server.tools.artifact.is_fes_available',
+        return_value=True,
+    )
+    async def test_job_instructions_upload_unmarks_job(
+        self, _mock_cfg, mock_fes, mock_httpx_cls, handler, ctx
+    ):
+        from awslabs.aws_transform_mcp_server.guidance_nudge import (
+            _checked_jobs,
+            job_needs_check,
+            mark_job_checked,
+        )
+
+        _checked_jobs.clear()
+        mark_job_checked('job-1')
+
+        mock_fes.side_effect = [
+            {'s3PreSignedUrl': 'https://s3.example.com/upload', 'artifactId': 'art-ji-1'},
+            {},
+        ]
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_httpx_cls.return_value = mock_client
+
+        result = await handler.upload_artifact(
+            ctx,
+            workspaceId='ws-1',
+            jobId='job-1',
+            content='# steering rules',
+            encoding='utf-8',
+            categoryType='CUSTOMER_INPUT',
+            fileType='MARKDOWN',
+            fileName='JOB_INSTRUCTIONS',
+            planStepId=None,
+        )
+        parsed = _parse(result)
+
+        assert parsed['success'] is True
+        assert job_needs_check('job-1') is not None
+        _checked_jobs.clear()
+
+    @patch('awslabs.aws_transform_mcp_server.tools.artifact.httpx.AsyncClient')
+    @patch(
+        'awslabs.aws_transform_mcp_server.tools.artifact.call_transform_api',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'awslabs.aws_transform_mcp_server.tools.artifact.is_fes_available',
+        return_value=True,
+    )
+    async def test_ordinary_upload_leaves_check_alone(
+        self, _mock_cfg, mock_fes, mock_httpx_cls, handler, ctx
+    ):
+        from awslabs.aws_transform_mcp_server.guidance_nudge import (
+            _checked_jobs,
+            job_needs_check,
+            mark_job_checked,
+        )
+
+        _checked_jobs.clear()
+        mark_job_checked('job-1')
+
+        mock_fes.side_effect = [
+            {'s3PreSignedUrl': 'https://s3.example.com/upload', 'artifactId': 'art-x'},
+            {},
+        ]
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_httpx_cls.return_value = mock_client
+
+        result = await handler.upload_artifact(
+            ctx,
+            workspaceId='ws-1',
+            jobId='job-1',
+            content='hello',
+            encoding='utf-8',
+            categoryType='CUSTOMER_INPUT',
+            fileType='TXT',
+            fileName='notes.txt',
+            planStepId=None,
+        )
+        parsed = _parse(result)
+
+        assert parsed['success'] is True
+        assert job_needs_check('job-1') is None
+        _checked_jobs.clear()

--- a/src/aws-transform-mcp-server/tests/test_guidance_nudge.py
+++ b/src/aws-transform-mcp-server/tests/test_guidance_nudge.py
@@ -20,6 +20,8 @@ from awslabs.aws_transform_mcp_server.guidance_nudge import (
     _checked_jobs,
     job_needs_check,
     mark_job_checked,
+    matches_instruction_label,
+    unmark_job,
 )
 
 
@@ -58,3 +60,36 @@ class TestJobNeedsCheck:
 
     def test_returns_none_for_empty_string(self):
         assert job_needs_check('') is None
+
+
+class TestUnmarkJob:
+    def test_forgets_checked_job(self):
+        mark_job_checked('job-1')
+        unmark_job('job-1')
+        assert job_needs_check('job-1') is not None
+
+    def test_noop_for_unknown_job(self):
+        unmark_job('job-never-seen')
+        assert 'job-never-seen' not in _checked_jobs
+
+
+class TestMatchesInstructionLabel:
+    def test_bare_name(self):
+        assert matches_instruction_label('JOB_INSTRUCTIONS')
+
+    def test_inside_store_folder(self):
+        assert matches_instruction_label('User Uploads/JOB_INSTRUCTIONS')
+
+    def test_deep_store_path(self):
+        assert matches_instruction_label(
+            'AWSTransform/Workspaces/ws/Jobs/j/User Uploads/JOB_INSTRUCTIONS'
+        )
+
+    def test_other_name_no_match(self):
+        assert not matches_instruction_label('User Uploads/coding-conventions.md')
+
+    def test_prefix_only_no_match(self):
+        assert not matches_instruction_label('JOB_INSTRUCTIONS/other.md')
+
+    def test_empty(self):
+        assert not matches_instruction_label('')

--- a/src/aws-transform-mcp-server/tests/test_load_instructions.py
+++ b/src/aws-transform-mcp-server/tests/test_load_instructions.py
@@ -116,6 +116,25 @@ class TestLoadInstructions:
     @patch(f'{_MOD}.download_s3_content', new_callable=AsyncMock)
     @patch(f'{_MOD}.call_transform_api', new_callable=AsyncMock)
     @patch(f'{_MOD}.is_fes_available', return_value=True)
+    async def test_matches_basename_at_root_too(self, _, mock_fes, mock_download, handler, ctx):
+        """A root-level artifact with a folderless path still matches (agent-side uploads)."""
+        mock_fes.side_effect = [
+            {
+                'artifacts': [
+                    {'artifactId': 'art-1', 'fileMetadata': {'path': 'JOB_INSTRUCTIONS'}},
+                ]
+            },
+            {'s3PreSignedUrl': 'https://s3.example.com/file'},
+        ]
+        mock_download.return_value = {'content': '# Steering content'}
+        result = await handler.load_instructions(ctx, workspaceId='ws-1', jobId='j-1')
+        parsed = _parse(result)
+        assert parsed['data']['instructionsFound'] is True
+
+    @pytest.mark.asyncio
+    @patch(f'{_MOD}.download_s3_content', new_callable=AsyncMock)
+    @patch(f'{_MOD}.call_transform_api', new_callable=AsyncMock)
+    @patch(f'{_MOD}.is_fes_available', return_value=True)
     async def test_empty_content_returns_error_and_does_not_mark_checked(
         self, _, mock_fes, mock_download, handler, ctx
     ):
@@ -314,3 +333,124 @@ class TestInstructionGateIntegration:
         )
         parsed = _parse(result)
         assert parsed['success'] is True
+
+    @pytest.mark.asyncio
+    @patch(f'{_MOD}.download_s3_content', new_callable=AsyncMock)
+    @patch(f'{_MOD}.call_transform_api', new_callable=AsyncMock)
+    @patch(f'{_MOD}.is_fes_available', return_value=True)
+    async def test_finds_instructions_inside_user_uploads_folder(
+        self, _, mock_fes, mock_download, handler, ctx
+    ):
+        """Customer uploads land in a store folder; discovery must walk it."""
+        mock_fes.side_effect = [
+            # Root listing: no artifacts, one folder (live-observed shape)
+            {
+                'artifacts': [],
+                'folders': ['AWSTransform/Workspaces/ws-1/Jobs/j-1/User Uploads/'],
+            },
+            # Prefixed listing inside the folder
+            {
+                'artifacts': [
+                    {
+                        'artifactId': 'art-9',
+                        'fileMetadata': {'path': 'User Uploads/JOB_INSTRUCTIONS'},
+                    },
+                ]
+            },
+            {'s3PreSignedUrl': 'https://s3.example.com/file'},
+        ]
+        mock_download.return_value = {'content': '# Steering content'}
+        result = await handler.load_instructions(ctx, workspaceId='ws-1', jobId='j-1')
+        parsed = _parse(result)
+        assert parsed['success'] is True
+        assert parsed['data']['instructionsFound'] is True
+        assert parsed['data']['artifactId'] == 'art-9'
+        folder_req = mock_fes.call_args_list[1].args[1]
+        assert folder_req.pathPrefix == ('AWSTransform/Workspaces/ws-1/Jobs/j-1/User Uploads/')
+        assert 'j-1' in _checked_jobs
+
+    @pytest.mark.asyncio
+    @patch(f'{_MOD}.call_transform_api', new_callable=AsyncMock)
+    @patch(f'{_MOD}.is_fes_available', return_value=True)
+    async def test_folder_walk_finds_nothing(self, _, mock_fes, handler, ctx):
+        mock_fes.side_effect = [
+            {'artifacts': [], 'folders': ['User Uploads/']},
+            {
+                'artifacts': [
+                    {
+                        'artifactId': 'art-2',
+                        'fileMetadata': {'path': 'User Uploads/report.html'},
+                    },
+                ]
+            },
+            # canonical-prefix fallback scan
+            {'artifacts': []},
+        ]
+        result = await handler.load_instructions(ctx, workspaceId='ws-1', jobId='j-1')
+        parsed = _parse(result)
+        assert parsed['data']['instructionsFound'] is False
+        assert 'j-1' in _checked_jobs
+
+    @pytest.mark.asyncio
+    @patch(f'{_MOD}.download_s3_content', new_callable=AsyncMock)
+    @patch(f'{_MOD}.call_transform_api', new_callable=AsyncMock)
+    @patch(f'{_MOD}.is_fes_available', return_value=True)
+    async def test_canonical_prefix_fallback_when_no_folders_reported(
+        self, _, mock_fes, mock_download, handler, ctx
+    ):
+        """Stages that omit the folders array still get the canonical scan."""
+        mock_fes.side_effect = [
+            {'artifacts': []},  # root: nothing, no folders array
+            {
+                'artifacts': [
+                    {
+                        'artifactId': 'art-c',
+                        'fileMetadata': {'path': 'User Uploads/JOB_INSTRUCTIONS'},
+                    },
+                ]
+            },
+            {'s3PreSignedUrl': 'https://s3.example.com/file'},
+        ]
+        mock_download.return_value = {'content': '# Steering content'}
+        result = await handler.load_instructions(ctx, workspaceId='ws-1', jobId='j-1')
+        parsed = _parse(result)
+        assert parsed['data']['instructionsFound'] is True
+        fallback_req = mock_fes.call_args_list[1].args[1]
+        assert fallback_req.pathPrefix == ('AWSTransform/Workspaces/ws-1/Jobs/j-1/User Uploads/')
+
+    @pytest.mark.asyncio
+    @patch(f'{_MOD}.download_s3_content', new_callable=AsyncMock)
+    @patch(f'{_MOD}.call_transform_api', new_callable=AsyncMock)
+    @patch(f'{_MOD}.is_fes_available', return_value=True)
+    async def test_failing_folder_scan_skips_to_next_folder(
+        self, _, mock_fes, mock_download, handler, ctx
+    ):
+        """A folder whose prefixed scan raises must not abort the walk."""
+        mock_fes.side_effect = [
+            # Root listing: two folders, no artifacts
+            {
+                'artifacts': [],
+                'folders': [
+                    'bad folder/',
+                    'AWSTransform/Workspaces/ws-1/Jobs/j-1/User Uploads/',
+                ],
+            },
+            # First folder scan: store rejects the prefix
+            Exception('ValidationException: invalid pathPrefix'),
+            # Second folder scan: finds the document
+            {
+                'artifacts': [
+                    {
+                        'artifactId': 'art-ok',
+                        'fileMetadata': {'path': 'User Uploads/JOB_INSTRUCTIONS'},
+                    },
+                ]
+            },
+            {'s3PreSignedUrl': 'https://s3.example.com/file'},
+        ]
+        mock_download.return_value = {'content': '# Steering content'}
+        result = await handler.load_instructions(ctx, workspaceId='ws-1', jobId='j-1')
+        parsed = _parse(result)
+        assert parsed['success'] is True
+        assert parsed['data']['instructionsFound'] is True
+        assert parsed['data']['artifactId'] == 'art-ok'

--- a/src/aws-transform-mcp-server/tests/test_load_instructions.py
+++ b/src/aws-transform-mcp-server/tests/test_load_instructions.py
@@ -375,6 +375,8 @@ class TestInstructionGateIntegration:
     async def test_folder_walk_finds_nothing(self, _, mock_fes, handler, ctx):
         mock_fes.side_effect = [
             {'artifacts': [], 'folders': ['User Uploads/']},
+            # canonical-prefix scan (walked first)
+            {'artifacts': []},
             {
                 'artifacts': [
                     {
@@ -383,8 +385,6 @@ class TestInstructionGateIntegration:
                     },
                 ]
             },
-            # canonical-prefix fallback scan
-            {'artifacts': []},
         ]
         result = await handler.load_instructions(ctx, workspaceId='ws-1', jobId='j-1')
         parsed = _parse(result)
@@ -427,22 +427,19 @@ class TestInstructionGateIntegration:
     ):
         """A folder whose prefixed scan raises must not abort the walk."""
         mock_fes.side_effect = [
-            # Root listing: two folders, no artifacts
+            # Root listing: one reported folder, no artifacts
             {
                 'artifacts': [],
-                'folders': [
-                    'bad folder/',
-                    'AWSTransform/Workspaces/ws-1/Jobs/j-1/User Uploads/',
-                ],
+                'folders': ['reports/'],
             },
-            # First folder scan: store rejects the prefix
+            # Canonical User Uploads scan (walked first): store rejects it
             Exception('ValidationException: invalid pathPrefix'),
-            # Second folder scan: finds the document
+            # Reported-folder scan: finds the document
             {
                 'artifacts': [
                     {
                         'artifactId': 'art-ok',
-                        'fileMetadata': {'path': 'User Uploads/JOB_INSTRUCTIONS'},
+                        'fileMetadata': {'path': 'reports/JOB_INSTRUCTIONS'},
                     },
                 ]
             },
@@ -454,3 +451,8 @@ class TestInstructionGateIntegration:
         assert parsed['success'] is True
         assert parsed['data']['instructionsFound'] is True
         assert parsed['data']['artifactId'] == 'art-ok'
+        # Canonical prefix is scanned before folders the root listing reported.
+        assert mock_fes.call_args_list[1].args[1].pathPrefix == (
+            'AWSTransform/Workspaces/ws-1/Jobs/j-1/User Uploads/'
+        )
+        assert mock_fes.call_args_list[2].args[1].pathPrefix == 'reports/'


### PR DESCRIPTION
`load_instructions` discovers instruction documents by calling `ListArtifacts` with no `pathPrefix`. That listing returns only the artifacts at the top level of the job's artifact store and the names of its folders; it does not descend into them. Customer uploads (both the `upload_artifact` tool and the AWS Transform web console) are stored inside the store's `User Uploads/` folder, so an uploaded instruction document can never be discovered, regardless of its file name. The same one-sided check affects `guidance_nudge`: it runs once per job at creation time, before any upload has happened, and never re-runs.

This change makes discovery walk the store:

- The root listing runs as before; if no instruction document is found there, each folder the root listing reports is scanned with `pathPrefix`. The canonical `AWSTransform/Workspaces/{workspaceId}/Jobs/{jobId}/User Uploads/` prefix is appended as a fallback in case the root listing omits it. Per-folder scans are individually guarded so a folder that fails path validation is skipped rather than aborting discovery.
- Label matching compares against the path basename, so `User Uploads/JOB_INSTRUCTIONS` matches the `JOB_INSTRUCTIONS` label the same way a root-level upload does.
- `upload_artifact` re-arms the one-shot guidance check when the uploaded file matches an instruction label, so a document uploaded mid-session is picked up on the next `load_instructions` call.

Verified end to end against a live AWS Transform job: with an instruction document uploaded through `upload_artifact`, the released v0.1.6 server returns `instructionsFound=false`, and this patched server finds the document and returns its content. Ten new unit tests cover the folder walk (including the `pathPrefix` values passed), the canonical-prefix fallback, basename label matching, and the re-arm on upload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
