### PR TITLE
fix(aws-iac-mcp-server): handle missing url in CDK documentation results

### DIFF
--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/client/aws_knowledge_client.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/client/aws_knowledge_client.py
@@ -78,10 +78,10 @@ def _parse_search_documentation_result(result: CallToolResult) -> List[Knowledge
 
     results = [
         KnowledgeResult(
-            rank=item['rank_order'],
-            title=item['title'],
-            url=item['url'],
-            context=item['context'],
+            rank=item.get('rank_order', 0),
+            title=item.get('title', ''),
+            url=item.get('url'),
+            context=item.get('context', ''),
         )
         for item in raw_results
     ]

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/knowledge_models.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/knowledge_models.py
@@ -22,8 +22,8 @@ class KnowledgeResult:
 
     rank: int
     title: str
-    url: str
     context: str
+    url: Optional[str] = None
 
 
 @dataclass

--- a/src/aws-iac-mcp-server/tests/client/test_aws_knowledge_client.py
+++ b/src/aws-iac-mcp-server/tests/client/test_aws_knowledge_client.py
@@ -237,11 +237,12 @@ class TestParseSearchResult:
         with pytest.raises(KeyError):
             _parse_search_documentation_result(mock_result)
 
-    def test_missing_required_field_in_item(self):
-        """Test handling of search result items missing required fields.
+    def test_missing_url_field_in_item(self):
+        """Test handling of search result items missing the optional 'url' field.
 
-        Verifies that search result items missing required fields like
-        'url' or 'context' are rejected with appropriate error messages.
+        Verifies that result items missing 'url' are returned with url=None
+        instead of raising a KeyError, so a single incomplete item does not
+        discard the entire result set.
         """
         mock_result = MagicMock()
         mock_result.is_error = False
@@ -254,7 +255,8 @@ class TestParseSearchResult:
                             {
                                 'rank_order': 1,
                                 'title': 'AWS Lambda',
-                                # Missing url and context
+                                'context': 'Serverless compute service',
+                                # Missing url
                             }
                         ]
                     }
@@ -263,5 +265,79 @@ class TestParseSearchResult:
         )
         mock_result.content = [mock_content]
 
-        with pytest.raises(KeyError):
-            _parse_search_documentation_result(mock_result)
+        parsed = _parse_search_documentation_result(mock_result)
+
+        assert len(parsed) == 1
+        assert parsed[0].rank == 1
+        assert parsed[0].title == 'AWS Lambda'
+        assert parsed[0].url is None
+        assert parsed[0].context == 'Serverless compute service'
+
+    def test_mixed_items_some_missing_url(self):
+        """Test that well-formed items are returned even when other items lack 'url'.
+
+        Verifies that a single item without 'url' does not discard the items
+        that are fully formed.
+        """
+        mock_result = MagicMock()
+        mock_result.is_error = False
+        mock_content = TextContent(
+            type='text',
+            text=json.dumps(
+                {
+                    'content': {
+                        'result': [
+                            {
+                                'rank_order': 1,
+                                'title': 'AWS S3',
+                                'url': 'https://docs.aws.amazon.com/s3/',
+                                'context': 'Object storage',
+                            },
+                            {
+                                'rank_order': 2,
+                                'title': 'AWS Lambda',
+                                'context': 'Serverless compute service',
+                                # Missing url
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+        mock_result.content = [mock_content]
+
+        parsed = _parse_search_documentation_result(mock_result)
+
+        assert len(parsed) == 2
+        assert parsed[0].url == 'https://docs.aws.amazon.com/s3/'
+        assert parsed[1].url is None
+
+    def test_missing_optional_fields_use_defaults(self):
+        """Test that missing optional fields fall back to defaults.
+
+        Verifies that items missing rank_order, title, url, or context
+        are returned with sensible defaults instead of raising a KeyError.
+        """
+        mock_result = MagicMock()
+        mock_result.is_error = False
+        mock_content = TextContent(
+            type='text',
+            text=json.dumps(
+                {
+                    'content': {
+                        'result': [
+                            {}  # completely empty item
+                        ]
+                    }
+                }
+            ),
+        )
+        mock_result.content = [mock_content]
+
+        parsed = _parse_search_documentation_result(mock_result)
+
+        assert len(parsed) == 1
+        assert parsed[0].rank == 0
+        assert parsed[0].title == ''
+        assert parsed[0].url is None
+        assert parsed[0].context == ''


### PR DESCRIPTION
## Summary

- `_parse_search_documentation_result` used direct dict subscripting (`item['url']`, `item['rank_order']`, etc.) when building `KnowledgeResult` objects. Any backend response that omits `url` (or another field) raises `KeyError` and discards the entire result set, making `search_cdk_documentation` completely unusable.
- Switch to `.get()` with sensible defaults so a single incomplete item no longer aborts the whole call.
- Make `KnowledgeResult.url` an `Optional[str]` defaulting to `None` to reflect that the field is not always present in backend responses.

## Test plan

- [x] Existing tests pass unchanged (all 15 pass)
- [x] New `test_missing_url_field_in_item` -- item without `url` returns `url=None` instead of `KeyError`
- [x] New `test_mixed_items_some_missing_url` -- well-formed items are returned even when sibling items lack `url`
- [x] New `test_missing_optional_fields_use_defaults` -- fully empty item uses defaults (rank=0, title='', url=None, context='')

Fixes #4340

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).