### PR TITLE
feat(docusaurus): refresh typography, category colors, and card hover states

### DIFF
--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -40,20 +40,19 @@ MCP servers enhance the capabilities of foundation models (FMs) in several key w
 ## Getting Started Essentials
 
 <div style={{
-  background: '#F9FAFB',
-  border: '1px solid #E5E7EB',
-  borderLeft: '4px solid #0078D4',
-  padding: '1.25rem',
+  background: '#FFF8EE',
+  border: '1px solid #FADFB5',
+  padding: '1.25rem 1.5rem',
   marginBottom: '2rem',
-  borderRadius: '4px',
+  borderRadius: '8px',
   display: 'flex',
   alignItems: 'center',
   gap: '1rem'
 }}>
 
   <div>
-    <div style={{ fontWeight: 600, color: '#111827', marginBottom: '0.25rem' }}>New from AWS re:Invent 2025!</div>
-    <div style={{ color: '#6B7280', fontSize: '0.875rem' }}>Essential MCP servers for AWS resource management</div>
+    <div style={{ fontWeight: 700, color: '#232F3E', marginBottom: '0.25rem' }}>New from AWS re:Invent 2025!</div>
+    <div style={{ color: '#5F6B7A', fontSize: '0.875rem' }}>Essential MCP servers for AWS resource management</div>
   </div>
 </div>
 

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -39,6 +39,28 @@ const config: Config = {
   // Add scripts to be loaded in the client
   scripts: [],
 
+  // Brand typography: Public Sans (AWS's open-source UI face) + IBM Plex Mono.
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap',
+      rel: 'stylesheet',
+    },
+  ],
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {rel: 'preconnect', href: 'https://fonts.googleapis.com'},
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://fonts.gstatic.com',
+        crossorigin: 'anonymous',
+      },
+    },
+  ],
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/docusaurus/src/categoryMeta.ts
+++ b/docusaurus/src/categoryMeta.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared category metadata for the server catalog.
+ *
+ * `id` values match the derived category ids in server-cards.json
+ * (lowercase name, non-word chars stripped, spaces -> hyphens).
+ * Each `color` is chosen to clear 4.5:1 contrast on white so it can be
+ * used directly as chip/label text; light tints are derived at render
+ * time with color-mix().
+ */
+
+export type CategoryId =
+  | 'essential-setup'
+  | 'core'
+  | 'documentation'
+  | 'infrastructure-deployment'
+  | 'ai-machine-learning'
+  | 'data-analytics'
+  | 'developer-tools-support'
+  | 'integration-messaging'
+  | 'cost-operations'
+  | 'healthcare-lifesciences';
+
+export type CategoryMeta = {
+  /** Accent color, safe as text on white. */
+  color: string;
+  /** Feather icon file (in /static/assets/icons). */
+  icon: string;
+};
+
+export const CATEGORY_META: Record<string, CategoryMeta> = {
+  'essential-setup': { color: '#C2410C', icon: 'key' },
+  core: { color: '#B7791F', icon: 'zap' },
+  documentation: { color: '#0972D3', icon: 'book-open' },
+  'infrastructure-deployment': { color: '#6D28D9', icon: 'server' },
+  'ai-machine-learning': { color: '#0E7490', icon: 'cpu' },
+  'data-analytics': { color: '#9333EA', icon: 'database' },
+  'developer-tools-support': { color: '#0F766E', icon: 'tool' },
+  'integration-messaging': { color: '#BE185D', icon: 'share-2' },
+  'cost-operations': { color: '#15803D', icon: 'dollar-sign' },
+  'healthcare-lifesciences': { color: '#BE123C', icon: 'activity' },
+};
+
+const FALLBACK: CategoryMeta = { color: '#5F6B7A', icon: 'help-circle' };
+
+/** Turn a human category name into the derived id used across the site. */
+export function toCategoryId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function metaForCategory(name: string): CategoryMeta {
+  return CATEGORY_META[toCategoryId(name)] ?? FALLBACK;
+}
+
+/** Absolute (baseUrl-aware) path to a category icon. */
+export function iconPath(icon: string): string {
+  return `/mcp/assets/icons/${icon}.svg`;
+}

--- a/docusaurus/src/components/ServerCards/index.tsx
+++ b/docusaurus/src/components/ServerCards/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 import serverCardsData from '@site/static/assets/server-cards.json';
+import { metaForCategory, iconPath, toCategoryId } from '@site/src/categoryMeta';
 
 type ServerCardProps = {
   id: string;
@@ -30,29 +31,8 @@ type WorkflowProps = {
 };
 
 const ServerCard: React.FC<{ server: ServerCardProps }> = ({ server }) => {
-  const categoryId = server.category.toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/[\s_-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  // Map category to local SVG icon path
-  const getCategoryIcon = (category: string) => {
-    const iconMap: Record<string, string> = {
-      'Essential Setup': '/mcp/assets/icons/key.svg',
-      'Documentation': '/mcp/assets/icons/book-open.svg',
-      'Infrastructure & Deployment': '/mcp/assets/icons/server.svg',
-      'AI & Machine Learning': '/mcp/assets/icons/cpu.svg',
-      'Data & Analytics': '/mcp/assets/icons/database.svg',
-      'Developer Tools & Support': '/mcp/assets/icons/tool.svg',
-      'Integration & Messaging': '/mcp/assets/icons/share-2.svg',
-      'Cost & Operations': '/mcp/assets/icons/dollar-sign.svg',
-      'Healthcare & Lifesciences': '/mcp/assets/icons/activity.svg',
-      'Core': '/mcp/assets/icons/zap.svg'
-    };
-    return iconMap[category] || '/mcp/assets/icons/help-circle.svg';
-  };
-
-  const categoryIconPath = getCategoryIcon(server.category);
+  const meta = metaForCategory(server.category);
+  const categoryId = toCategoryId(server.category);
 
   // Use external URL if source_path is a full URL, otherwise use local path
   const linkHref = server.source_path && (server.source_path.startsWith('http://') || server.source_path.startsWith('https://'))
@@ -60,11 +40,22 @@ const ServerCard: React.FC<{ server: ServerCardProps }> = ({ server }) => {
     : `/mcp/servers/${server.id}`;
 
   return (
-    <a href={linkHref} className={styles.serverCardLink}>
+    <a
+      href={linkHref}
+      className={styles.serverCardLink}
+      style={{ ['--cat' as string]: meta.color }}
+    >
       <div className={clsx(styles.serverCard)} data-id={server.id}>
         <div className={styles.serverCardHeader}>
           <div className={styles.serverCardIcon}>
-            <img src={categoryIconPath} alt={`${server.category} icon`} style={{ width: '22px', height: '22px' }} />
+            <span
+              className={styles.serverCardIconGlyph}
+              style={{
+                maskImage: `url(${iconPath(meta.icon)})`,
+                WebkitMaskImage: `url(${iconPath(meta.icon)})`,
+              }}
+              aria-hidden="true"
+            />
           </div>
           <div className={styles.serverCardTitleSection}>
             <h3 className={styles.serverCardTitle}>{server.name || 'Unknown Server'}</h3>
@@ -80,17 +71,6 @@ const ServerCard: React.FC<{ server: ServerCardProps }> = ({ server }) => {
               </span>
               {server.workflows?.map((workflow, index) => {
                 const workflowData = serverCardsData.workflows.find(w => w.id === workflow);
-                // Map workflow IDs to local SVG icon paths
-                const getWorkflowIcon = (workflowId) => {
-                  const iconMap = {
-                    'vibe-coding': '/mcp/assets/icons/code.svg',
-                    'conversational': '/mcp/assets/icons/message-circle.svg',
-                    'autonomous': '/mcp/assets/icons/cpu.svg'
-                  };
-                  return iconMap[workflowId] || '/mcp/assets/icons/zap.svg';
-                };
-
-                const workflowIconPath = getWorkflowIcon(workflow);
 
                 return (
                   <span key={index} className={styles.serverCardWorkflow} data-workflow={workflow}>
@@ -112,12 +92,28 @@ const ServerCard: React.FC<{ server: ServerCardProps }> = ({ server }) => {
   );
 };
 
+// Read an initial filter value from the URL query string (client-side only).
+function initialParam(key: string): string {
+  if (typeof window === 'undefined') return '';
+  const value = new URLSearchParams(window.location.search).get(key);
+  return value ? decodeURIComponent(value) : '';
+}
+
 export default function ServerCards(): React.ReactNode {
   const [searchQuery, setSearchQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
   const [workflowFilter, setWorkflowFilter] = useState('');
   const [sortOption, setSortOption] = useState('name-asc');
   const [filteredServers, setFilteredServers] = useState(serverCardsData.servers);
+
+  // Hydrate filters from URL params (e.g. /servers?category=Data%20%26%20Analytics)
+  // so links can deep-link into a pre-filtered view.
+  useEffect(() => {
+    const cat = initialParam('category');
+    const wf = initialParam('workflow');
+    if (cat) setCategoryFilter(cat);
+    if (wf) setWorkflowFilter(wf);
+  }, []);
 
   useEffect(() => {
     // Filter servers based on search query and filters
@@ -162,6 +158,8 @@ export default function ServerCards(): React.ReactNode {
     setFilteredServers(sorted);
   }, [searchQuery, categoryFilter, workflowFilter, sortOption]);
 
+  const hasActiveFilters = Boolean(searchQuery || categoryFilter || workflowFilter);
+
   return (
     <div className={styles.serverCardsContainer} id="server-cards-container">
       <div className={styles.cardControls}>
@@ -183,6 +181,7 @@ export default function ServerCards(): React.ReactNode {
               className={styles.cardControlsSelect}
               value={categoryFilter}
               onChange={(e) => setCategoryFilter(e.target.value)}
+              aria-label="Filter by category"
             >
               <option value="">All Categories</option>
               {serverCardsData.categories.map((category: CategoryProps) => (
@@ -199,6 +198,7 @@ export default function ServerCards(): React.ReactNode {
               className={styles.cardControlsSelect}
               value={workflowFilter}
               onChange={(e) => setWorkflowFilter(e.target.value)}
+              aria-label="Filter by workflow"
             >
               <option value="">All Workflows</option>
               {serverCardsData.workflows.map((workflow: WorkflowProps) => (
@@ -215,6 +215,7 @@ export default function ServerCards(): React.ReactNode {
               className={styles.cardControlsSelect}
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value)}
+              aria-label="Sort servers"
             >
               <option value="name-asc">Sort by Name (A-Z)</option>
               <option value="name-desc">Sort by Name (Z-A)</option>
@@ -226,7 +227,22 @@ export default function ServerCards(): React.ReactNode {
       </div>
 
       <div className={styles.cardStats}>
-        Showing <span className={styles.cardStatsCount}>{filteredServers.length}</span> of <span className={styles.cardStatsTotal}>{serverCardsData.servers.length}</span> servers
+        <span>
+          Showing <span className={styles.cardStatsCount}>{filteredServers.length}</span> of <span className={styles.cardStatsTotal}>{serverCardsData.servers.length}</span> servers
+        </span>
+        {hasActiveFilters && (
+          <button
+            type="button"
+            className={styles.cardStatsClear}
+            onClick={() => {
+              setSearchQuery('');
+              setCategoryFilter('');
+              setWorkflowFilter('');
+            }}
+          >
+            Clear filters
+          </button>
+        )}
       </div>
 
       <div className={styles.cardGrid}>

--- a/docusaurus/src/components/ServerCards/styles.module.css
+++ b/docusaurus/src/components/ServerCards/styles.module.css
@@ -11,8 +11,8 @@
   gap: 1rem;
   margin-bottom: 2rem;
   padding: 1.5rem;
-  background-color: var(--ifm-background-surface-color);
-  border-radius: 8px;
+  background-color: var(--aws-ink-050, #f8fafb);
+  border-radius: 12px;
   border: 1px solid var(--ifm-color-emphasis-300);
 }
 
@@ -77,6 +77,10 @@
 
 /* Results Stats */
 .cardStats {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
   margin-bottom: 1rem;
   padding: 0.5rem 0;
   font-size: 0.875rem;
@@ -84,7 +88,25 @@
 }
 
 .cardStatsCount {
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+.cardStatsClear {
+  appearance: none;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: #fff;
+  color: var(--aws-ink-700, #414d5c);
+  font-size: 0.8rem;
   font-weight: 600;
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.cardStatsClear:hover {
+  border-color: var(--ifm-color-primary);
   color: var(--ifm-color-primary);
 }
 
@@ -137,21 +159,42 @@
 }
 
 .serverCard {
+  position: relative;
   display: flex;
   flex-direction: column;
   background-color: var(--ifm-background-color);
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 6px;
-  padding: .9rem;
-  transition: all 0.2s ease;
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  transition: transform 0.2s var(--aws-ease-out, ease),
+    box-shadow 0.2s var(--aws-ease-out, ease),
+    border-color 0.2s var(--aws-ease-out, ease);
   height: 150px; /* Reduced from 185px to 150px */
   width: 100%; /* Ensure the card takes full width of its grid cell */
   cursor: pointer;
+  overflow: hidden;
+}
+
+/* Category-colored top hairline, revealed on hover */
+.serverCard::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: var(--cat, var(--ifm-color-primary));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.28s var(--aws-ease-out, ease);
 }
 
 .serverCard:hover {
-  border-color: var(--ifm-color-primary-light);
-  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--cat, var(--ifm-color-primary)) 40%, var(--ifm-color-emphasis-200));
+  transform: translateY(-3px);
+  box-shadow: var(--aws-shadow-md, 0 4px 12px rgba(22, 25, 31, 0.08));
+}
+
+.serverCard:hover::before {
+  transform: scaleX(1);
 }
 
 /* Card Header */
@@ -168,9 +211,22 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
-  font-size: 1.2rem;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--cat, var(--ifm-color-primary)) 10%, #fff);
+}
+
+.serverCardIconGlyph {
+  width: 19px;
+  height: 19px;
+  background-color: var(--cat, var(--ifm-color-primary));
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
 }
 
 .serverCardTitleSection {
@@ -200,12 +256,13 @@
 
 .serverCardCategory {
   display: inline-block;
-  padding: 0.15rem 0.2rem;
-  background-color: var(--ifm-menu-color-background-active);
-  font-size: 0.6rem;
-  font-weight: 500;
-  border-radius: 3px;
-  letter-spacing: 0;
+  padding: 0.15rem 0.4rem;
+  background-color: color-mix(in srgb, var(--cat, var(--ifm-color-primary)) 12%, #fff);
+  color: var(--cat, var(--ifm-color-primary));
+  font-size: 0.62rem;
+  font-weight: 700;
+  border-radius: 4px;
+  letter-spacing: 0.01em;
   width: fit-content;
 }
 
@@ -225,7 +282,7 @@
   opacity: 0.85;
   margin-top: 0.5rem;
   margin-bottom: 0rem; /* Reduced from 0.3rem to 0.2rem */
-  margin-left: 32px;
+  margin-left: 44px;
   flex: 1;
   height: 2.6rem; /* Reduced from 3.8rem to 2.6rem */
   overflow: hidden;
@@ -238,13 +295,13 @@
 /* Workflow Tags */
 .serverCardWorkflow {
   display: inline-block;
-  padding: 0.15rem 0.2rem;
-  background-color: var(--ifm-menu-color-background-active);
-  color: var(--ifm-font-color-base);
-  font-size: 0.6rem;
-  font-weight: 500;
-  border-radius: 3px;
-  letter-spacing: 0;
+  padding: 0.15rem 0.4rem;
+  background-color: var(--aws-ink-100, #f2f4f6);
+  color: var(--aws-ink-700, #414d5c);
+  font-size: 0.62rem;
+  font-weight: 600;
+  border-radius: 4px;
+  letter-spacing: 0.01em;
   white-space: nowrap;
   width: fit-content;
 }
@@ -276,11 +333,16 @@
 
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
-  .serverCard {
+  .serverCard,
+  .serverCard::before {
     transition: none;
   }
 
   .serverCard:hover {
     transform: none;
+  }
+
+  .serverCard:hover::before {
+    transform: scaleX(1);
   }
 }

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -1,54 +1,160 @@
 /**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
+ * Global styles. Bundles Infima (Docusaurus classic theme) plus the
+ * AWS identity system layered on top: Squid Ink navy + Smile Orange,
+ * Cloudscape action blue for interaction. Per-category accent colors
+ * live in src/categoryMeta.ts.
  */
 
-/* You can override the default Infima variables here. */
+/* ------------------------------------------------------------------ *
+ * Design tokens
+ * ------------------------------------------------------------------ */
 :root {
-  --ifm-font-color-base: #000000;
-  --ifm-color-primary: #006ce0;
-  --ifm-color-primary-dark: #0061ca;
-  --ifm-color-primary-darker: #005cbe;
-  --ifm-color-primary-darkest: #004c9d;
-  --ifm-color-primary-light: #0077f6;
-  --ifm-color-primary-lighter: #037cff;
-  --ifm-color-primary-lightest: #248eff;
+  /* AWS brand */
+  --aws-squid-ink: #232f3e;
+  --aws-squid-ink-deep: #161d26;
+  --aws-smile-orange: #ff9900;
+  --aws-anchor-link: #0972d3;
+
+  /* Neutral ramp (cool-tinted toward squid ink, not warm) */
+  --aws-ink-700: #414d5c;
+  --aws-ink-300: #d5dbdb;
+  --aws-ink-200: #e5e9ec;
+  --aws-ink-100: #f2f4f6;
+  --aws-ink-050: #f8fafb;
+
+  /* Elevation */
+  --aws-shadow-md: 0 4px 12px rgba(22, 25, 31, 0.08),
+    0 2px 4px rgba(22, 25, 31, 0.05);
+
+  /* Motion */
+  --aws-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Infima overrides -------------------------------------------------- */
+  --ifm-color-primary: #0972d3;
+  --ifm-color-primary-dark: #0868be;
+  --ifm-color-primary-darker: #0862b4;
+  --ifm-color-primary-darkest: #065194;
+  --ifm-color-primary-light: #1a80dd;
+  --ifm-color-primary-lighter: #2a89e0;
+  --ifm-color-primary-lightest: #4c9de6;
   --ifm-color-secondary: #ebedf0;
-  --ifm-color-success: #00802f;
-  --ifm-color-info: #54c7ec;
-  --ifm-color-warning: #f2cd54;
-  --ifm-color-danger: #db0000;
+  --ifm-color-success: #037f51;
+  --ifm-color-info: #0972d3;
+  --ifm-color-warning: #b25900;
+  --ifm-color-danger: #d13212;
+
+  --ifm-font-color-base: #16191f;
+  --ifm-heading-color: var(--aws-squid-ink);
+  --ifm-font-family-base: 'Public Sans', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --ifm-font-family-monospace: 'IBM Plex Mono', ui-monospace, 'SF Mono',
+    'JetBrains Mono', 'Fira Code', Menlo, Consolas, monospace;
+  --ifm-heading-font-weight: 700;
   --ifm-h1-font-size: 37px;
-  --ifm-menu-color: #000000;
+
+  --ifm-menu-color: #16191f;
+  --ifm-navbar-background-color: #ffffff;
+  --ifm-navbar-shadow: inset 0 -1px 0 var(--aws-ink-200);
+  --ifm-background-surface-color: #ffffff;
+  --ifm-toc-border-color: var(--aws-ink-200);
+  --ifm-code-font-size: 90%;
   --doc-sidebar-width: 325px;
 }
 
+/* Dark surfaces reuse the same primary; the site ships light-only. */
+[data-theme='dark'] {
+  --ifm-color-primary: #4c9de6;
+  --ifm-color-primary-dark: #2a89e0;
+  --ifm-color-primary-darker: #1a80dd;
+  --ifm-color-primary-darkest: #0868be;
+  --ifm-color-primary-light: #6cb0eb;
+  --ifm-color-primary-lighter: #7dbaed;
+  --ifm-color-primary-lightest: #a6d0f3;
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+/* ------------------------------------------------------------------ *
+ * Markdown doc typography (unchanged rhythm from the original)
+ * ------------------------------------------------------------------ */
 .markdown h1:first-child {
   font-size: 32px;
+  letter-spacing: -0.02em;
 }
 
 .markdown > h2 {
   font-size: 24px;
+  letter-spacing: -0.01em;
 }
 
 .markdown {
-    --ifm-h1-vertical-rhythm-top: 2;
-    --ifm-h2-vertical-rhythm-top: 1.5;
-    --ifm-h3-vertical-rhythm-top: 1.1;
-    --ifm-heading-vertical-rhythm-top: 1.25;
-    --ifm-h1-vertical-rhythm-bottom: 1;
-    --ifm-heading-vertical-rhythm-bottom: 1;
+  --ifm-h1-vertical-rhythm-top: 2;
+  --ifm-h2-vertical-rhythm-top: 1.5;
+  --ifm-h3-vertical-rhythm-top: 1.1;
+  --ifm-heading-vertical-rhythm-top: 1.25;
+  --ifm-h1-vertical-rhythm-bottom: 1;
+  --ifm-heading-vertical-rhythm-bottom: 1;
+  --ifm-line-height-base: 1.65;
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-primary: #006ce0;
-  --ifm-color-primary-dark: #0061ca;
-  --ifm-color-primary-darker: #005cbe;
-  --ifm-color-primary-darkest: #004c9d;
-  --ifm-color-primary-light: #0077f6;
-  --ifm-color-primary-lighter: #037cff;
-  --ifm-color-primary-lightest: #248eff;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+/* ------------------------------------------------------------------ *
+ * Navbar: keep it console-clean, brand the wordmark
+ * ------------------------------------------------------------------ */
+.navbar {
+  backdrop-filter: saturate(1.1);
+}
+
+.navbar__title {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--aws-squid-ink);
+}
+
+.navbar__logo {
+  height: 1.75rem;
+}
+
+.navbar__link,
+.navbar__brand:hover .navbar__title {
+  transition: color 0.15s var(--aws-ease-out);
+}
+
+/* ------------------------------------------------------------------ *
+ * Buttons — flatter, Cloudscape-flavored
+ * ------------------------------------------------------------------ */
+.button {
+  border-radius: 8px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  transition: transform 0.15s var(--aws-ease-out),
+    box-shadow 0.15s var(--aws-ease-out), background-color 0.15s var(--aws-ease-out);
+}
+
+.button--primary {
+  --ifm-button-background-color: var(--aws-anchor-link);
+  --ifm-button-border-color: var(--aws-anchor-link);
+}
+
+/* ------------------------------------------------------------------ *
+ * Footer — deepen the navy and add the Smile Orange rule
+ * ------------------------------------------------------------------ */
+.footer--dark {
+  --ifm-footer-background-color: var(--aws-squid-ink-deep);
+  --ifm-footer-color: var(--aws-ink-300);
+  --ifm-footer-link-color: var(--aws-ink-200);
+  --ifm-footer-title-color: #ffffff;
+  border-top: 3px solid var(--aws-smile-orange);
+}
+
+.footer__link-item:hover {
+  color: var(--aws-smile-orange);
+}
+
+/* ------------------------------------------------------------------ *
+ * Reduced motion
+ * ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .navbar__link {
+    transition: none;
+  }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes N/A

## Summary

### Changes

Visual refresh of the documentation site, scoped to typography, category color coding, and server card hover interactions. No content or routing changes.

* Add `src/categoryMeta.ts` as a single source of truth mapping each of the 10 server categories to an accent color and a Feather icon. All colors clear 4.5:1 contrast on white. `ServerCards` consumes it instead of its previous inline icon maps.
* Color-code the server catalog cards by category: tinted icon chip, colored category label, and a category-colored top hairline revealed on hover, with a subtle lift and shadow. Honors `prefers-reduced-motion`.
* Support `?category=` and `?workflow=` URL params on the catalog so links can open a pre-filtered view, and add a "Clear filters" button.
* Introduce brand typography (Public Sans for UI text, IBM Plex Mono for code, loaded via Google Fonts with preconnect) and design tokens in `custom.css`: Squid Ink headings, Cloudscape action blue as the Infima primary, a neutral ink ramp, and a Smile Orange footer rule.
* Restyle the re:Invent callout on the intro page to match the new palette.

### User experience

Before: all server cards look identical regardless of category (single blue accent, plain text category tag), system default fonts, and no way to link to a filtered catalog view.

After: each category has a consistent accent color across icon, label, and hover treatment, making the catalog easier to scan; headings and body text use AWS brand typography; catalog views are deep-linkable via URL params. Verified with `npm run build` (both `en` and `ja` locales pass link checking; the one broken-anchor warning on `healthimaging-mcp-server#installation` is pre-existing).

#### Screenshots

Server catalog (`/servers`):

| Before | After |
| --- | --- |
| ![Server catalog before](https://raw.githubusercontent.com/jimmieego/mcp/pr-4348-screenshots/pr-assets/before-catalog.png) | ![Server catalog after](https://raw.githubusercontent.com/jimmieego/mcp/pr-4348-screenshots/pr-assets/after-catalog.png) |

Card hover state (first card hovered — after adds a lift, shadow, and category-colored top hairline):

| Before | After |
| --- | --- |
| ![Card hover before](https://raw.githubusercontent.com/jimmieego/mcp/pr-4348-screenshots/pr-assets/before-card-hover.png) | ![Card hover after](https://raw.githubusercontent.com/jimmieego/mcp/pr-4348-screenshots/pr-assets/after-card-hover.png) |

Intro page typography (Public Sans body/headings, Squid Ink heading color):

| Before | After |
| --- | --- |
| ![Intro page before](https://raw.githubusercontent.com/jimmieego/mcp/pr-4348-screenshots/pr-assets/before-intro.png) | ![Intro page after](https://raw.githubusercontent.com/jimmieego/mcp/pr-4348-screenshots/pr-assets/after-intro.png) |

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

