### PR TITLE
chore(dynamodb-mcp-server): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,7 +52,7 @@ NOTICE                                                         @awslabs/mcp-admi
 /src/cloudwatch-mcp-server                                     @awslabs/mcp-admins @awslabs/mcp-maintainers  @gcacace @shri-tambe @agiuliano @goranmod @rashmidwaraka @bhatsarthak
 /src/document-loader-mcp-server                                @awslabs/mcp-admins @awslabs/mcp-maintainers  @andywidjaja @hvital @HaoOliv
 /src/documentdb-mcp-server                                     @awslabs/mcp-admins @awslabs/mcp-maintainers  @nitinahuja89
-/src/dynamodb-mcp-server                                       @awslabs/mcp-admins @awslabs/mcp-maintainers  @akeyesamzn @valeriodelbello-amazon @LeeroyHannigan @amzn-erdemkemer
+/src/dynamodb-mcp-server                                       @awslabs/mcp-admins @awslabs/mcp-maintainers  @LeeroyHannigan @willykev
 /src/ecs-mcp-server                                            @awslabs/mcp-admins @awslabs/mcp-maintainers  @guitar80ep @matthewgoodman13 @nineonine @biagic @tusharbabbar @lewisct
 /src/eks-mcp-server                                            @awslabs/mcp-admins @awslabs/mcp-maintainers  @patrick-yu-amzn @lynnnnnnluo @djtung @BrianS99 @nolanzzz @okjuliankim
 /src/elasticache-mcp-server                                    @awslabs/mcp-admins @awslabs/mcp-maintainers  @swarnaprakash @madolson @allenss-amazon @kevinmcgehee


### PR DESCRIPTION
## Description

Updates the CODEOWNERS entry for `/src/dynamodb-mcp-server` to reflect the current owners.

- Removed: `@akeyesamzn`, `@valeriodelbello-amazon`, `@amzn-erdemkemer`
- Retained: `@awslabs/mcp-admins`, `@awslabs/mcp-maintainers`, `@LeeroyHannigan`
- Added: `@willykev`

## Type of change

- [x] Chore (no functional change)

## Checklist

- [x] Single-line change to `.github/CODEOWNERS`; no code or dependency changes
- [x] Verified `@willykev` is a valid GitHub account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
