### PR TITLE
fix(pricing,serverless): pin mcp[cli]<2 so the servers start again

### DIFF
--- a/src/aws-pricing-mcp-server/pyproject.toml
+++ b/src/aws-pricing-mcp-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "An AWS Labs Model Context Protocol (MCP) server for official pric
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.23.0",
+    "mcp[cli]>=1.23.0,<2",
     "pydantic>=2.10.5",
     "boto3>=1.39.4",
     "pytest>=8.1.1",

--- a/src/aws-pricing-mcp-server/uv.lock
+++ b/src/aws-pricing-mcp-server/uv.lock
@@ -72,7 +72,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.39.4" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "pytest", specifier = ">=8.1.1" },
     { name = "pytest-asyncio", specifier = ">=0.20.3" },

--- a/src/aws-serverless-mcp-server/pyproject.toml
+++ b/src/aws-serverless-mcp-server/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "boto3>=1.37.27",
-    "mcp[cli]>=1.23.0",
+    "mcp[cli]>=1.23.0,<2",
     "pydantic>=2.10.6",
     "requests>=2.31.0",
     "jinja2>=3.1.0",

--- a/src/aws-serverless-mcp-server/uv.lock
+++ b/src/aws-serverless-mcp-server/uv.lock
@@ -74,7 +74,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.37.27" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "loguru", specifier = ">=0.7.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "requests", specifier = ">=2.31.0" },
 ]


### PR DESCRIPTION
Fixes #4354

## Summary

### Changes

The MCP Python SDK `2.0.0` removed the vendored `mcp.server.fastmcp` module. `aws-pricing-mcp-server` and `aws-serverless-mcp-server` both import it:

```python
from mcp.server.fastmcp import Context, FastMCP
```

but declare `"mcp[cli]>=1.23.0"` with no upper bound, so any fresh resolution (`uvx ...@latest`) pulls `mcp 2.0.0` and the process dies at import time with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. MCP clients just see the process exit before the `initialize` handshake.

This PR adds the upper bound to both packages and refreshes their `uv.lock`:

```diff
-    "mcp[cli]>=1.23.0",
+    "mcp[cli]>=1.23.0,<2",
```

Four files, one line each:

- `src/aws-pricing-mcp-server/pyproject.toml`
- `src/aws-pricing-mcp-server/uv.lock`
- `src/aws-serverless-mcp-server/pyproject.toml`
- `src/aws-serverless-mcp-server/uv.lock`

Locked package versions are unchanged — only the recorded specifier moves — so `uv sync --frozen` stays green.

This is the minimal unblocking fix. Migrating the imports off the removed module (to the standalone `fastmcp` package, as `aws-iac-mcp-server` already does, or to the new `mcp.server.MCPServer` API) is a larger change and is better done separately.

### User experience

Before — server never starts:

```console
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | uvx awslabs.aws-pricing-mcp-server@latest
Traceback (most recent call last):
  ...
  File ".../awslabs/aws_pricing_mcp_server/server.py", line 51, in <module>
    from mcp.server.fastmcp import Context, FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

After — the handshake completes:

```console
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | uvx --with "mcp[cli]<2" awslabs.aws-pricing-mcp-server@latest
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{...},"serverInfo":{"name":"awslabs.aws-pricing-mcp-server",...}}}
```

Same result for `aws-serverless-mcp-server --allow-write`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Testing performed: reproduced the failure with an unconstrained resolve, confirmed both servers answer `initialize` with the SDK constrained to `<2`, and ran `uv lock --check` in both package directories (79 and 81 packages resolved, no drift).

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
