### PR TITLE
fix(amazon-bedrock-agentcore-mcp-server): expire cached browser clients to pick up refreshed credentials

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/CHANGELOG.md
+++ b/src/amazon-bedrock-agentcore-mcp-server/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Browser client credential caching** — `get_browser_client` cached a `BrowserClient` per region at module level and never invalidated it. Because the wrapped boto3 clients resolve credentials at construction time, a long-lived MCP server kept using credentials captured at first use, so a refresh (`ada credentials update`, IAM role rotation, expired STS session) had no effect until the process was restarted. Cache entries now expire after a TTL (default 300s, configurable via `AGENTCORE_BROWSER_CLIENT_TTL_SECONDS`; `0` disables caching) and are rebuilt on the next call, forcing credentials to be re-resolved.
 - **Browser `browser_evaluate`** — preserve non-ASCII text (CJK, emoji) in object/array results instead of emitting `\uXXXX` escapes, matching the scalar-string return path (`ensure_ascii=False`)
 - Server crash on startup when the configured `llms.txt` documentation source is unreachable (#4138). The hardcoded default URL (`aws.github.io/bedrock-agentcore-starter-toolkit/llms.txt`) was deprecated and returns HTTP 404, causing an unhandled `HTTPError` to propagate out of `main()` and kill the process before MCP initialization. `load_links_only()` now isolates each source and logs a warning on fetch failure so the server starts with all other tool groups functional. The default source was also updated to the official AWS AgentCore Developer Guide index (`docs.aws.amazon.com/bedrock-agentcore/latest/devguide/llms.txt`), restoring documentation search
 

--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/browser/browser_client.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/tools/browser/browser_client.py
@@ -14,38 +14,96 @@
 
 """AWS client utilities via bedrock-agentcore SDK."""
 
+import time
 from bedrock_agentcore.tools import BrowserClient
 from loguru import logger
 from os import getenv
 
 
+# Cached BrowserClient instances keyed by region, with the monotonic
+# timestamp at which each entry was created. Entries older than the
+# configured TTL are discarded and recreated so that refreshed AWS
+# credentials (e.g. after `ada credentials update` or IAM role rotation)
+# are picked up without restarting the process.
 _browser_clients: dict[str, BrowserClient] = {}
+_browser_client_created_at: dict[str, float] = {}
 
 MCP_INTEGRATION_SOURCE = 'awslabs-agentcore-mcp-server'
+
+# How long a cached BrowserClient may be reused before it is recreated.
+# A BrowserClient wraps boto3 clients whose credential providers resolve and
+# cache credentials at construction time; caching the wrapper indefinitely
+# means rotated credentials are never observed until the process restarts.
+# The TTL bounds that staleness window. Overridable via the
+# AGENTCORE_BROWSER_CLIENT_TTL_SECONDS environment variable.
+DEFAULT_BROWSER_CLIENT_TTL_SECONDS = 300
+
+
+def _get_ttl_seconds() -> float:
+    """Resolve the client cache TTL from the environment, with a safe default."""
+    raw = getenv('AGENTCORE_BROWSER_CLIENT_TTL_SECONDS')
+    if raw is None:
+        return DEFAULT_BROWSER_CLIENT_TTL_SECONDS
+    try:
+        ttl = float(raw)
+    except ValueError:
+        logger.warning(
+            f'Invalid AGENTCORE_BROWSER_CLIENT_TTL_SECONDS={raw!r}; '
+            f'falling back to {DEFAULT_BROWSER_CLIENT_TTL_SECONDS}s'
+        )
+        return DEFAULT_BROWSER_CLIENT_TTL_SECONDS
+    # A non-positive TTL disables caching entirely (always recreate).
+    return max(ttl, 0.0)
 
 
 def get_browser_client(
     region_name: str | None = None,
 ) -> BrowserClient:
-    """Get a cached BrowserClient for the specified region.
+    """Get a BrowserClient for the specified region, recreating stale ones.
 
     Uses the bedrock-agentcore SDK to manage boto3 clients, endpoint
     resolution, and user-agent tagging. Credentials are resolved from
     the environment (AWS_PROFILE, AWS_ACCESS_KEY_ID, IAM role, etc.).
 
+    Clients are cached per region for performance, but each cache entry
+    expires after a TTL (see ``DEFAULT_BROWSER_CLIENT_TTL_SECONDS``). Once
+    an entry expires it is rebuilt on the next call, which forces the
+    underlying boto3 clients to re-resolve credentials. Without this the
+    cache would serve a client bound to credentials captured at first use
+    forever, so a credential refresh (``ada credentials update``, IAM role
+    rotation, expired STS session) would not take effect until the process
+    was restarted.
+
     Args:
         region_name: AWS region. Defaults to AWS_REGION env var or us-east-1.
 
     Returns:
-        Cached BrowserClient instance.
+        A BrowserClient instance for the region (cached when still fresh).
     """
     region = region_name or getenv('AWS_REGION') or 'us-east-1'
 
-    if region in _browser_clients:
-        return _browser_clients[region]
+    ttl = _get_ttl_seconds()
+    now = time.monotonic()
+
+    cached = _browser_clients.get(region)
+    if cached is not None:
+        age = now - _browser_client_created_at.get(region, 0.0)
+        if ttl > 0 and age < ttl:
+            return cached
+        # Expired (or caching disabled): drop it and rebuild below so that
+        # refreshed credentials are picked up.
+        logger.info(
+            f'BrowserClient for region={region} expired after {age:.0f}s '
+            f'(ttl={ttl:.0f}s); recreating to refresh credentials'
+        )
+        _browser_clients.pop(region, None)
+        _browser_client_created_at.pop(region, None)
 
     client = BrowserClient(region=region, integration_source=MCP_INTEGRATION_SOURCE)
-    _browser_clients[region] = client
+
+    if ttl > 0:
+        _browser_clients[region] = client
+        _browser_client_created_at[region] = now
 
     logger.info(f'Created BrowserClient for region={region}')
     return client

--- a/src/amazon-bedrock-agentcore-mcp-server/tests/browser/test_unit_browser_client.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/tests/browser/test_unit_browser_client.py
@@ -14,8 +14,11 @@
 
 """Unit tests for AWS client utility (BrowserClient wrapper)."""
 
+from awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser import browser_client
 from awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser.browser_client import (
+    DEFAULT_BROWSER_CLIENT_TTL_SECONDS,
     MCP_INTEGRATION_SOURCE,
+    _browser_client_created_at,
     _browser_clients,
     get_browser_client,
 )
@@ -25,6 +28,9 @@ from unittest.mock import MagicMock, patch
 PATCH_BROWSER_CLIENT = (
     'awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser.browser_client.BrowserClient'
 )
+PATCH_MONOTONIC = (
+    'awslabs.amazon_bedrock_agentcore_mcp_server.tools.browser.browser_client.time.monotonic'
+)
 
 
 class TestGetBrowserClient:
@@ -33,6 +39,7 @@ class TestGetBrowserClient:
     def setup_method(self):
         """Clear client cache before each test."""
         _browser_clients.clear()
+        _browser_client_created_at.clear()
 
     @patch.dict('os.environ', {}, clear=True)
     @patch(PATCH_BROWSER_CLIENT)
@@ -77,7 +84,7 @@ class TestGetBrowserClient:
 
     @patch(PATCH_BROWSER_CLIENT)
     def test_caches_client(self, mock_browser_client_cls):
-        """Returns cached client on subsequent calls with same region."""
+        """Returns cached client on subsequent calls with same region (within TTL)."""
         mock_instance = MagicMock()
         mock_browser_client_cls.return_value = mock_instance
 
@@ -107,3 +114,73 @@ class TestGetBrowserClient:
 
         call_kwargs = mock_browser_client_cls.call_args.kwargs
         assert call_kwargs['integration_source'] == MCP_INTEGRATION_SOURCE
+
+    @patch(PATCH_MONOTONIC)
+    @patch(PATCH_BROWSER_CLIENT)
+    def test_recreates_client_after_ttl_expiry(self, mock_browser_client_cls, mock_monotonic):
+        """A cache entry older than the TTL is recreated (picks up refreshed creds).
+
+        This is the credential-caching regression guard: without TTL expiry the
+        first client would be returned forever, serving credentials captured at
+        construction time even after `ada credentials update` / role rotation.
+        """
+        first, second = MagicMock(), MagicMock()
+        mock_browser_client_cls.side_effect = [first, second]
+
+        # t=0 create; t just past TTL -> must recreate.
+        mock_monotonic.side_effect = [0.0, DEFAULT_BROWSER_CLIENT_TTL_SECONDS + 1.0]
+
+        client1 = get_browser_client(region_name='us-east-1')
+        client2 = get_browser_client(region_name='us-east-1')
+
+        assert client1 is first
+        assert client2 is second
+        assert client1 is not client2
+        assert mock_browser_client_cls.call_count == 2
+
+    @patch(PATCH_MONOTONIC)
+    @patch(PATCH_BROWSER_CLIENT)
+    def test_reuses_client_within_ttl(self, mock_browser_client_cls, mock_monotonic):
+        """A cache entry younger than the TTL is reused (no rebuild)."""
+        mock_browser_client_cls.side_effect = [MagicMock(), MagicMock()]
+        # Second call is still inside the TTL window.
+        mock_monotonic.side_effect = [0.0, DEFAULT_BROWSER_CLIENT_TTL_SECONDS - 1.0]
+
+        client1 = get_browser_client(region_name='us-east-1')
+        client2 = get_browser_client(region_name='us-east-1')
+
+        assert client1 is client2
+        assert mock_browser_client_cls.call_count == 1
+
+    @patch.dict('os.environ', {'AGENTCORE_BROWSER_CLIENT_TTL_SECONDS': '0'}, clear=True)
+    @patch(PATCH_BROWSER_CLIENT)
+    def test_ttl_zero_disables_caching(self, mock_browser_client_cls):
+        """TTL of 0 disables caching: every call builds a fresh client."""
+        mock_browser_client_cls.side_effect = [MagicMock(), MagicMock()]
+
+        client1 = get_browser_client(region_name='us-east-1')
+        client2 = get_browser_client(region_name='us-east-1')
+
+        assert client1 is not client2
+        assert mock_browser_client_cls.call_count == 2
+        # Nothing should be retained in the cache when disabled.
+        assert 'us-east-1' not in _browser_clients
+
+    @patch.dict('os.environ', {'AGENTCORE_BROWSER_CLIENT_TTL_SECONDS': 'not-a-number'}, clear=True)
+    @patch(PATCH_BROWSER_CLIENT)
+    def test_invalid_ttl_env_falls_back_to_default(self, mock_browser_client_cls):
+        """An unparseable TTL env var falls back to the default and still caches."""
+        mock_browser_client_cls.return_value = MagicMock()
+
+        assert browser_client._get_ttl_seconds() == DEFAULT_BROWSER_CLIENT_TTL_SECONDS
+
+        client1 = get_browser_client(region_name='us-east-1')
+        client2 = get_browser_client(region_name='us-east-1')
+
+        assert client1 is client2
+        assert mock_browser_client_cls.call_count == 1
+
+    @patch.dict('os.environ', {'AGENTCORE_BROWSER_CLIENT_TTL_SECONDS': '900'}, clear=True)
+    def test_ttl_env_override_parsed(self):
+        """A valid TTL env var overrides the default."""
+        assert browser_client._get_ttl_seconds() == 900.0


### PR DESCRIPTION
Fixes stale-credential behavior in the AgentCore browser MCP server.

## Summary

### Changes

`get_browser_client` cached a `BrowserClient` per region at module level and never invalidated it. The wrapped boto3 clients resolve credentials at construction time, so a long-lived MCP server kept using the credentials captured at first use — after rotation (`ada credentials update`, IAM role rotation, expired STS session) every browser call failed until the process was restarted.

This change adds TTL-based cache expiry:

- Cache entries older than the TTL are discarded and rebuilt on the next call, forcing credential re-resolution
- Default TTL 300s, configurable via `AGENTCORE_BROWSER_CLIENT_TTL_SECONDS`; a non-positive value disables caching entirely
- Invalid TTL input logs a warning and falls back to the default
- Uses a monotonic clock, so wall-clock changes can't wedge the cache

### User experience

Before: after credential rotation, browser tools return auth errors until the MCP server process is restarted.
After: within one TTL window (≤5 min by default) the client is rebuilt with fresh credentials automatically; no restart needed.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested — `tests/browser/test_unit_browser_client.py`: 11 passed, including the regression guard `test_recreates_client_after_ttl_expiry` (monotonic clock mocked past TTL asserts a second construction) and invalid-TTL fallback cases
* [x] Changes are documented — CHANGELOG entry + module docstrings

Is this a breaking change? (N)

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
