### PR TITLE
fix(bedrock-kb-retrieval): preserve non-ASCII characters in tool output

### DIFF
--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
@@ -110,4 +110,4 @@ async def query_knowledge_base(
                 }
             )
 
-    return '\n\n'.join([json.dumps(document) for document in documents])
+    return '\n\n'.join([json.dumps(document, ensure_ascii=False) for document in documents])

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -125,7 +125,7 @@ async def list_knowledge_bases_tool() -> str:
     3. Use the names to determine which knowledge base and data source(s) are most relevant to the user's query
     """
     knowledge_bases = await discover_knowledge_bases(kb_agent_mgmt_client, kb_inclusion_tag_key)
-    return json.dumps(knowledge_bases)
+    return json.dumps(knowledge_bases, ensure_ascii=False)
 
 
 @mcp.tool(name='QueryKnowledgeBases')

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
@@ -17,10 +17,37 @@
 import json
 import pytest
 from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.retrieval import query_knowledge_base
+from unittest.mock import MagicMock
 
 
 class TestQueryKnowledgeBase:
     """Tests for the query_knowledge_base function."""
+
+    @pytest.mark.asyncio
+    async def test_query_knowledge_base_preserves_non_ascii_characters(self):
+        r"""Test that non-ASCII content is returned as readable text, not \uXXXX escapes."""
+        client = MagicMock()
+        client.retrieve.return_value = {
+            'retrievalResults': [
+                {
+                    'content': {'text': '東京は日本の首都です。 🗼', 'type': 'TEXT'},
+                    'location': {'s3Location': {'uri': 's3://test-bucket/ja-document.txt'}},
+                    'score': 0.9,
+                },
+            ]
+        }
+
+        result = await query_knowledge_base(
+            query='test query',
+            knowledge_base_id='kb-12345',
+            kb_agent_client=client,
+        )
+
+        assert '東京は日本の首都です。 🗼' in result
+        assert '\\u' not in result
+
+        documents = [json.loads(doc) for doc in result.split('\n\n')]
+        assert documents[0]['content']['text'] == '東京は日本の首都です。 🗼'
 
     @pytest.mark.asyncio
     async def test_query_knowledge_base_default(self, mock_bedrock_agent_runtime_client):

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
@@ -93,6 +93,28 @@ class TestListKnowledgeBasesTool:
         # Check that discover_knowledge_bases was called with the correct arguments
         mock_discover_knowledge_bases.assert_called_once()
 
+    @pytest.mark.asyncio
+    @patch('awslabs.bedrock_kb_retrieval_mcp_server.server.discover_knowledge_bases')
+    async def test_list_knowledge_bases_tool_preserves_non_ascii(
+        self, mock_discover_knowledge_bases
+    ):
+        """Test that non-ASCII names/descriptions are returned as readable text."""
+        mock_discover_knowledge_bases.return_value = {
+            'kb-12345': {
+                'name': '東京ナレッジベース',
+                'description': 'サポート文書 🗼',
+                'data_sources': [],
+            },
+        }
+
+        result = await list_knowledge_bases_tool()
+
+        assert '\\u' not in result
+
+        kb_mapping = json.loads(result)
+        assert kb_mapping['kb-12345']['name'] == '東京ナレッジベース'
+        assert kb_mapping['kb-12345']['description'] == 'サポート文書 🗼'
+
 
 class TestQueryKnowledgeBasesTool:
     """Tests for the query_knowledge_bases_tool function."""


### PR DESCRIPTION
Fixes #3820

`json.dumps()` defaults to `ensure_ascii=True`, so any non-ASCII text in a
Knowledge Base (Japanese/Korean/Chinese, emoji, accented characters) was
coming back as `\uXXXX` escapes instead of the actual text. Besides being
unreadable, it also bloats token usage since each CJK char turns into a
6-char escape sequence.

Added `ensure_ascii=False` in the two places that serialize results
(`server.py` and `knowledgebases/retrieval.py`) since the transport is
UTF-8 anyway.

Added tests for both spots to make sure non-ASCII text round-trips without
getting escaped. Ran the full suite + pre-commit, all green.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).