### PR TITLE
fix(aurora-dsql-mcp-server): raise dollar-quote timing threshold to fix flaky CI

### DIFF
--- a/src/aurora-dsql-mcp-server/tests/test_readonly_enforcement.py
+++ b/src/aurora-dsql-mcp-server/tests/test_readonly_enforcement.py
@@ -391,12 +391,15 @@ class TestReadonlyEnforcement:
 
         # 500k `$`: linear cost is well under 1s; the reverted O(n^2) slice version
         # takes tens of seconds at this size, so this reliably catches a regression.
+        # The threshold is set generously (5s) so that a loaded CI runner does not
+        # trip a false positive while still detecting a genuine O(n^2) regression
+        # (which takes 30+ seconds at this payload size).
         payload = '$' * 500_000
         start = time.perf_counter()
         detect_mutating_keywords(payload)
         check_sql_injection_risk(payload)
         elapsed = time.perf_counter() - start
-        assert elapsed < 2.0, f'dollar-heavy input too slow ({elapsed:.2f}s) — possible O(n^2)'
+        assert elapsed < 5.0, f'dollar-heavy input too slow ({elapsed:.2f}s) — possible O(n^2)'
 
     def test_double_quoted_identifier_apostrophe_does_not_bypass(self):
         """An apostrophe inside a double-quoted identifier must not desync scanning.


### PR DESCRIPTION
Raise the timing threshold from 2.0s to 5.0s in test_dollar_quote_scan_is_linear to stop flaky CI failures on loaded runners. The linear implementation runs in about 0.6s locally but occasionally hits 2.04s on shared CI runners, failing the whole build. The O(n-squared) regression this test catches takes 30+ seconds at this payload size, so 5.0s still detects it reliably.

Closes #4366 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).