### PR TITLE
feat(aws-transform-mcp-server)!: remove legacy jobType from create_job

### DIFF
--- a/src/aws-transform-mcp-server/CHANGELOG.md
+++ b/src/aws-transform-mcp-server/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the legacy `jobType` parameter from the `create_job` tool and the
+  `CreateJobRequest` model. AWS Transform no longer honors `jobType` on
+  `CreateJob`; callers must use `orchestratorAgent` instead. The
+  `orchestratorAgent` description no longer suggests retrying with it after a
+  `jobType` failure.
+
 ### Fixed
 
 - `load_instructions` now discovers instruction documents stored inside

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/job.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/job.py
@@ -74,14 +74,12 @@ class JobHandler:
         jobName: Annotated[str, Field(description='Name for the job')],
         objective: Annotated[str, Field(description='The transformation objective')],
         intent: Annotated[str, Field(description='The transformation intent')],
-        jobType: Annotated[Optional[str], Field(description='The type of transformation')] = None,
         orchestratorAgent: Annotated[
             Optional[str],
             Field(
                 description=(
                     'The orchestrator agent name (alphanumeric, hyphens, underscores). '
-                    'Only orchestrator agents can be used here -- not sub-agents. '
-                    'If the request fails with jobType, retry using orchestratorAgent instead.'
+                    'Only orchestrator agents can be used here -- not sub-agents.'
                 ),
             ),
         ] = None,
@@ -103,7 +101,6 @@ class JobHandler:
             create_req = CreateJobRequest(
                 workspaceId=workspaceId,
                 jobName=jobName,
-                jobType=jobType,
                 objective=objective,
                 intent=intent,
                 idempotencyToken=str(uuid.uuid4()),

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_models.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/transform_api_models.py
@@ -397,7 +397,6 @@ class CreateJobRequest(FESRequest):
     idempotencyToken: Optional[str] = None
     intent: str
     jobName: str
-    jobType: Optional[str] = None
     objective: str
     orchestratorAgent: Optional[str] = None
     workspaceId: str

--- a/src/aws-transform-mcp-server/tests/test_field_defaults.py
+++ b/src/aws-transform-mcp-server/tests/test_field_defaults.py
@@ -251,7 +251,7 @@ class TestHitlFieldDefaults:
 
 
 # ── job.py: create_job ──────────────────────────────────────────────────
-# MEDIUM-RISK defaults: jobType=None, orchestratorAgent=None
+# MEDIUM-RISK defaults: orchestratorAgent=None
 
 
 class TestJobFieldDefaults:
@@ -259,7 +259,7 @@ class TestJobFieldDefaults:
     @patch('awslabs.aws_transform_mcp_server.tools.job.call_transform_api', new_callable=AsyncMock)
     @patch('awslabs.aws_transform_mcp_server.tools.job.is_fes_available', return_value=True)
     async def test_create_job_with_only_required_params(self, _, mock_fes):
-        """Omit jobType and orchestratorAgent — should be None, not FieldInfo."""
+        """Omit orchestratorAgent — should be None, not FieldInfo."""
         from awslabs.aws_transform_mcp_server.tools.job import JobHandler
 
         handler = JobHandler(_mcp())
@@ -281,9 +281,8 @@ class TestJobFieldDefaults:
         parsed = _parse(result)
         assert parsed['success'] is True, f'Expected success, got: {parsed}'
 
-        # Verify jobType and orchestratorAgent are None (not FieldInfo)
+        # Verify orchestratorAgent is None (not FieldInfo)
         create_req = mock_fes.call_args_list[0][0][1]
-        assert create_req.jobType is None
         assert create_req.orchestratorAgent is None
 
 


### PR DESCRIPTION
The JobManager service no longer honors the legacy jobType parameter on CreateJob; callers must use orchestratorAgent instead. Remove jobType from the create_job tool signature and the CreateJobRequest model so the server stops sending it, and drop the outdated 'retry using orchestratorAgent' hint from the orchestratorAgent description.

- tools/job.py: drop jobType param and CreateJobRequest(jobType=...) arg; reword orchestratorAgent description.
- transform_api_models.py: remove CreateJobRequest.jobType field.
- tests/test_field_defaults.py: drop the jobType assertion/comments.

The vendored C2J service-2.json is intentionally left unchanged (the pydantic<->C2J drift check is one-directional).

<!-- markdownlint-disable MD041 MD043 -->
Fixes N/A
  
  ## Summary

  ### Changes

  Remove the legacy `jobType` parameter from the aws-transform-mcp-server
  `create_job` tool and the `CreateJobRequest` model. AWS Transform's
  JobManager no longer honors `jobType` on `CreateJob` — callers must use
  `orchestratorAgent`. This stops the server from sending `jobType` on the
  wire and removes the now-misleading "retry using orchestratorAgent if
  jobType fails" hint from the `orchestratorAgent` description.

  - `tools/job.py`: drop the `jobType` param and the `CreateJobRequest(jobType=...)`
    argument; reword the `orchestratorAgent` description.
  - `transform_api_models.py`: remove `CreateJobRequest.jobType`.
  - `tests/test_field_defaults.py`: drop the `jobType` assertion/comments.
  - `CHANGELOG.md`: add a `### Removed` entry.

  The vendored C2J `service-2.json` is intentionally left unchanged (the
  pydantic↔C2J drift check is one-directional).

  ### User experience
  
  Before: `create_job` accepted a `jobType` argument and forwarded it. The
  service ignored it and rejected such requests, so the tool's hint told the
  model to retry with `orchestratorAgent`.

  After: `create_job` exposes only `orchestratorAgent`. There is no `jobType`
  to pass, so the retry hint is gone and callers land on the supported path
  directly.

  ## Checklist
  
  * [x] I have reviewed the contributing guidelines
  * [x] I have performed a self-review of this change
  * [x] Changes have been tested
  * [x] Changes are documented

  Is this a breaking change? (Y/N) **Y** — `jobType` is removed from the
  `create_job` tool interface. It was already ignored server-side, so no
  functional regression for callers on `orchestratorAgent`.

  **RFC issue number**: N/A
Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
