### PR TITLE
fix(aws-transform): enforce explicit httpx timeouts in S3 artifact paths

### DIFF
--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
@@ -242,6 +242,9 @@ def failure_result(error: Exception, hint: Optional[str] = None) -> Dict[str, An
 
 # ── S3 download helper ───────────────────────────────────────────────────
 
+# Explicit timeout for S3 GET to avoid unbounded awaits on redirects/slow links
+DEFAULT_S3_GET_TIMEOUT_SECONDS = 30.0
+
 
 async def download_s3_content(
     s3_url: str,
@@ -257,7 +260,7 @@ async def download_s3_content(
     """
     from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(DEFAULT_S3_GET_TIMEOUT_SECONDS)) as client:
         response = await client.get(s3_url, follow_redirects=True)
         response.raise_for_status()
 

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py
@@ -53,6 +53,9 @@ _NOT_CONFIGURED_CODE = 'NOT_CONFIGURED'
 _NOT_CONFIGURED_MSG = 'Not connected to AWS Transform.'
 _NOT_CONFIGURED_ACTION = 'Call configure with authMode "cookie" or "sso".'
 
+# Explicit timeout for S3 PUT operations to avoid unbounded awaits
+S3_HTTP_TIMEOUT_SECONDS = 60.0
+
 
 class ArtifactHandler:
     """Registers artifact-related MCP tools."""
@@ -171,7 +174,7 @@ class ArtifactHandler:
                     if values:
                         put_headers[key] = ', '.join(values)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(S3_HTTP_TIMEOUT_SECONDS)) as client:
                 s3_response = await client.put(
                     init_result['s3PreSignedUrl'],
                     content=content_bytes,

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/upload_helper.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/upload_helper.py
@@ -40,6 +40,9 @@ from typing import Dict, List, Optional
 # Maximum file size for uploads (500 MB).
 MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024
 
+# Explicit timeout for S3 PUT operations to avoid unbounded awaits
+S3_HTTP_TIMEOUT_SECONDS = 60.0
+
 
 def _flatten_request_headers(
     request_headers: Optional[Dict[str, List[str]]],
@@ -97,7 +100,7 @@ async def upload_json_artifact(
 
     put_headers = _flatten_request_headers(init_result.get('requestHeaders'))
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(S3_HTTP_TIMEOUT_SECONDS)) as client:
         s3_response = await client.put(
             init_result['s3PreSignedUrl'],
             content=content_bytes,
@@ -178,7 +181,7 @@ async def upload_file_artifact(
 
     put_headers = _flatten_request_headers(init_result.get('requestHeaders'))
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(S3_HTTP_TIMEOUT_SECONDS)) as client:
         s3_response = await client.put(
             init_result['s3PreSignedUrl'],
             content=content_bytes,

--- a/src/aws-transform-mcp-server/tests/test_s3_timeouts.py
+++ b/src/aws-transform-mcp-server/tests/test_s3_timeouts.py
@@ -1,0 +1,100 @@
+# ruff: noqa: D100, D101, D102, D103
+import asyncio
+import httpx
+import json
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.mark.asyncio
+@patch('awslabs.aws_transform_mcp_server.upload_helper.httpx.AsyncClient')
+@patch('awslabs.aws_transform_mcp_server.upload_helper.call_transform_api', new_callable=AsyncMock)
+async def test_upload_json_artifact_uses_timeout(mock_call_api, mock_httpx_cls):
+    from awslabs.aws_transform_mcp_server.upload_helper import upload_json_artifact, S3_HTTP_TIMEOUT_SECONDS
+
+    mock_call_api.side_effect = [
+        {'s3PreSignedUrl': 'https://s3.example.com/upload', 'artifactId': 'a-1', 'requestHeaders': {}},
+        {},
+    ]
+    mock_resp = MagicMock(status_code=200, text='OK')
+    mock_client = AsyncMock()
+    mock_client.put = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_cls.return_value = mock_client
+
+    res = await upload_json_artifact('ws', 'job', json.dumps({'k': 'v'}))
+    assert res == 'a-1'
+
+    assert mock_httpx_cls.call_args is not None
+    kwargs = mock_httpx_cls.call_args.kwargs
+    assert 'timeout' in kwargs
+    to = kwargs['timeout']
+    assert isinstance(to, httpx.Timeout)
+    # httpx.Timeout(total) propagates to per-phase values
+    assert to.read == pytest.approx(S3_HTTP_TIMEOUT_SECONDS)
+    assert to.connect == pytest.approx(S3_HTTP_TIMEOUT_SECONDS)
+
+
+@pytest.mark.asyncio
+@patch('awslabs.aws_transform_mcp_server.upload_helper.httpx.AsyncClient')
+@patch('awslabs.aws_transform_mcp_server.upload_helper.call_transform_api', new_callable=AsyncMock)
+@patch('awslabs.aws_transform_mcp_server.upload_helper.validate_read_path')
+async def test_upload_file_artifact_uses_timeout(mock_validate, mock_call_api, mock_httpx_cls, tmp_path):
+    from awslabs.aws_transform_mcp_server.upload_helper import upload_file_artifact, S3_HTTP_TIMEOUT_SECONDS
+
+    test_file = tmp_path / 'data.json'
+    test_file.write_text('{"a":1}')
+    mock_validate.return_value = str(test_file)
+
+    mock_call_api.side_effect = [
+        {'s3PreSignedUrl': 'https://s3.example.com/upload', 'artifactId': 'a-2', 'requestHeaders': {}},
+        {},
+    ]
+
+    mock_resp = MagicMock(status_code=200, text='OK')
+    mock_client = AsyncMock()
+    mock_client.put = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_cls.return_value = mock_client
+
+    res = await upload_file_artifact('ws', 'job', str(test_file))
+    assert res == 'a-2'
+
+    assert mock_httpx_cls.call_args is not None
+    kwargs = mock_httpx_cls.call_args.kwargs
+    assert 'timeout' in kwargs
+    to = kwargs['timeout']
+    assert isinstance(to, httpx.Timeout)
+    assert to.read == pytest.approx(S3_HTTP_TIMEOUT_SECONDS)
+    assert to.connect == pytest.approx(S3_HTTP_TIMEOUT_SECONDS)
+
+
+@pytest.mark.asyncio
+@patch('awslabs.aws_transform_mcp_server.tool_utils.httpx.AsyncClient')
+async def test_download_s3_content_uses_timeout(mock_httpx_cls, tmp_path):
+    from awslabs.aws_transform_mcp_server.tool_utils import download_s3_content, DEFAULT_S3_GET_TIMEOUT_SECONDS
+
+    mock_resp = MagicMock()
+    mock_resp.text = 'ok'
+    mock_resp.content = b'ok'
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_cls.return_value = mock_client
+
+    res = await download_s3_content('https://s3.example.com/file')
+    assert res == {'content': 'ok'}
+
+    assert mock_httpx_cls.call_args is not None
+    kwargs = mock_httpx_cls.call_args.kwargs
+    assert 'timeout' in kwargs
+    to = kwargs['timeout']
+    assert isinstance(to, httpx.Timeout)
+    assert to.read == pytest.approx(DEFAULT_S3_GET_TIMEOUT_SECONDS)
+    assert to.connect == pytest.approx(DEFAULT_S3_GET_TIMEOUT_SECONDS)


### PR DESCRIPTION
## Summary
Enforce explicit `httpx.Timeout` bounds when constructing `httpx.AsyncClient` instances across S3 artifact upload and download paths in the `aws-transform-mcp-server` package.

## Technical Details & Impact
- **Root Cause**: Calls to `httpx.AsyncClient()` in `upload_helper.py`, `tools/artifact.py`, and `tool_utils.py` omitted timeout parameters.
- **Impact**: Stalled pre-signed S3 URL transfers could cause coroutines to block indefinitely, risking event-loop starvation and degraded MCP server availability under adverse network conditions.
- **Fix**: Added explicit timeouts (60s for upload helpers/tools, 30s for download helper) using `httpx.Timeout`, aligning with the timeout patterns used in other server packages within this repository.

## Affected Files
- `src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/upload_helper.py`
- `src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py`
- `src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py`
- `src/aws-transform-mcp-server/tests/test_s3_timeouts.py`

## Testing
Unit tests added in `test_s3_timeouts.py` verify that `httpx.AsyncClient` is initialized with explicit timeout arguments during upload and download operations.

Signed-off-by: Kiell Tampubolon <yeheskieltampubolon@gmail.com>

### Local Verification & CI Notes
- **Target Unit Test**: `pytest -q src/aws-transform-mcp-server/tests/test_s3_timeouts.py`
- **Package Test Suite**: `pytest -q src/aws-transform-mcp-server/tests/`
- **Python Compatibility**: 3.10 – 3.12 (aligns with repository CI matrix)
- **Dependencies**: Uses existing `httpx`, `pytest`, and `unittest.mock` (no new dependencies added).