### PR TITLE
fix(aws-support-mcp-server): handle communications missing submittedBy/timeCreated

### DIFF
--- a/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/formatters.py
+++ b/src/aws-support-mcp-server/awslabs/aws_support_mcp_server/formatters.py
@@ -233,7 +233,9 @@ def format_markdown_case_summary(case: Dict[str, Any]) -> str:
     if case.get('recentCommunications'):
         markdown += '\n## Recent Communications\n\n'
         for comm in case['recentCommunications'].get('communications', []):
-            comm_header = f'### {comm["submittedBy"]} - {comm["timeCreated"]}'
+            comm_header = (
+                f'### {comm.get("submittedBy", "N/A")} - {comm.get("timeCreated", "N/A")}'
+            )
             comm_body = comm['body']
             markdown += f'{comm_header}\n\n{comm_body}\n\n'
 

--- a/src/aws-support-mcp-server/tests/test_aws_support_mcp_server.py
+++ b/src/aws-support-mcp-server/tests/test_aws_support_mcp_server.py
@@ -1877,6 +1877,21 @@ class TestFormatMarkdown:
         assert first_comm['body'] in markdown
         assert first_comm['submittedBy'] in markdown
 
+    def test_format_markdown_case_summary_communication_missing_optional_fields(
+        self, support_case_data
+    ):
+        """A communication missing submittedBy/timeCreated (e.g. system-generated) must not raise KeyError."""
+        support_case_data['recentCommunications']['communications'][0] = {
+            'caseId': 'case-12345678910-2013-c4c1d2bf33c5cf47',
+            'body': 'System-generated communication with no submittedBy/timeCreated.',
+        }
+        formatted_case = format_case(support_case_data)
+
+        markdown = format_markdown_case_summary(formatted_case)
+
+        assert 'System-generated communication' in markdown
+        assert '### N/A - N/A' in markdown
+
     def test_format_markdown_services(self, services_response_data):
         """Test formatting services in Markdown."""
         formatted_services = format_services(services_response_data['services'])


### PR DESCRIPTION
Fixes: no existing issue — found via direct code audit, no issue tracker entry yet.

## Summary

### Changes

`Communication.model_dump()` in `awslabs/aws_support_mcp_server/models.py` conditionally omits the `submittedBy`/`timeCreated` keys when those `Optional[str]` fields are falsy — this is common for system-generated communications on a support case, which don't always carry a submitter identity or timestamp from the Support API. `format_markdown_case_summary()` in `formatters.py` then unconditionally subscripts `comm["submittedBy"]`/`comm["timeCreated"]` on that same dict:

```python
comm_header = f'### {comm["submittedBy"]} - {comm["timeCreated"]}'
```

So the `describe_support_cases` tool crashes with a bare `KeyError` whenever `format='markdown'` is requested and any communication in the case lacks those fields — a self-inflicted bug, since the crash is caused by the model's own optional-serialization contract being violated by its own renderer two functions later.

Reproduced directly against `main` before writing the fix:
```python
case = {..., "recentCommunications": {"communications": [{"body": "..."}]}}  # no submittedBy/timeCreated
format_markdown_case_summary(case)
# KeyError: 'submittedBy'
```

Fixed with `comm.get("submittedBy", "N/A")` / `comm.get("timeCreated", "N/A")`, matching the existing fallback pattern already used a few lines above for the case-level `displayId` field (`case.get("displayId", "N/A")`) — same convention, not a new one.

### User experience

Before: `describe_support_cases` (or any tool path rendering a case to markdown) throws an unhandled `KeyError` and fails entirely if any communication is missing these optional fields.

After: the case renders normally; a communication missing these fields shows `### N/A - N/A` as its header instead of crashing the whole response.

## How was this tested?

- Reproduced the crash live against unpatched `main` first.
- Added `test_format_markdown_case_summary_communication_missing_optional_fields`, confirmed it fails against unpatched `formatters.py` (`git stash`) with the exact `KeyError`, and passes after the fix.
- Full suite: `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing` — 195 passed (194 existing + 1 new), coverage unchanged at 96% for this server.
- `ruff check` / `ruff format --check` — clean.
- `pyright` — 0 errors, 0 warnings.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented (no user-facing docs describe this error path today; nothing to update)

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).