### PR TITLE
feat(redshift-mcp-server): surface table and column design metadata

### DIFF
--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -24,8 +24,8 @@ QUERY_TIMEOUT = 3600
 QUERY_POLL_INTERVAL = 1
 SESSION_KEEPALIVE = 600
 
-# SQL discovery commands. Results are read positionally; {placeholders} are
-# filled with quoted identifiers by the caller.
+# SQL discovery commands. Results are mapped to model fields by column name, so
+# columns the models do not declare are ignored;
 DATABASES_SQL = 'SHOW DATABASES;'
 SCHEMAS_SQL = 'SHOW SCHEMAS FROM DATABASE {database};'
 TABLES_SQL = 'SHOW TABLES FROM SCHEMA {database}.{schema};'

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
@@ -125,6 +125,13 @@ class RedshiftTable(RedshiftDataModel):
         description='The type of the table (views, base tables, external tables, shared tables)',
     )
     remarks: Optional[str] = Field(None, description='Remarks about the table')
+    dist_style: Optional[str] = Field(
+        None,
+        description=(
+            'The distribution style of the table (for example EVEN, KEY, ALL, '
+            'AUTO (ALL), AUTO (EVEN), or AUTO (KEY))'
+        ),
+    )
 
 
 class RedshiftColumn(RedshiftDataModel):
@@ -148,6 +155,28 @@ class RedshiftColumn(RedshiftDataModel):
     numeric_precision: Optional[int] = Field(None, description='The numeric precision')
     numeric_scale: Optional[int] = Field(None, description='The numeric scale')
     remarks: Optional[str] = Field(None, description='Remarks about the column')
+    sort_key_type: Optional[str] = Field(
+        None,
+        description=(
+            'The sort key type on a sort key column (for example COMPOUND or INTERLEAVED), '
+            'or null when the column is not part of the sort key; tables with an AUTO sort '
+            'key report AUTO on every column'
+        ),
+    )
+    sort_key: Optional[int] = Field(
+        None,
+        description=(
+            'The 1-based position of the column within the sort key, '
+            'or 0 when it is not part of the sort key'
+        ),
+    )
+    dist_key: Optional[int] = Field(
+        None,
+        description='Set to 1 on the distribution key column, or null on other columns',
+    )
+    encoding: Optional[str] = Field(
+        None, description='The compression encoding of the column (for example az64, lzo, raw)'
+    )
 
 
 class QueryResult(BaseModel):

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -400,6 +400,7 @@ async def list_tables_tool(
     - table_acl: The permissions for the specified user or user group for the table.
     - table_type: The type of the table (views, base tables, external tables, shared tables).
     - remarks: Remarks about the table.
+    - dist_style: The distribution style of the table (for example EVEN, KEY, ALL, AUTO (ALL), AUTO (EVEN), or AUTO (KEY)).
 
     ## Usage Tips
 
@@ -501,6 +502,13 @@ async def list_columns_tool(
     - numeric_precision: The numeric precision.
     - numeric_scale: The numeric scale.
     - remarks: Remarks about the column.
+    - sort_key_type: The sort key type on a sort key column (for example COMPOUND or
+      INTERLEAVED), or null when the column is not part of the sort key. Tables with an
+      AUTO sort key report AUTO on every column.
+    - sort_key: The 1-based position of the column within the sort key, or 0 when it is
+      not part of the sort key.
+    - dist_key: Set to 1 on the distribution key column, or null on other columns.
+    - encoding: The compression encoding of the column (for example az64, lzo, raw).
 
     ## Usage Tips
 

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -1535,6 +1535,12 @@ class TestDiscoverFunctions:
                     {'name': 'table_type'},
                     {'name': 'table_acl'},
                     {'name': 'remarks'},
+                    # SHOW TABLES also returns these; only dist_style is modelled.
+                    {'name': 'owner'},
+                    {'name': 'last_altered_time'},
+                    {'name': 'last_modified_time'},
+                    {'name': 'dist_style'},
+                    {'name': 'table_subtype'},
                 ],
                 'Records': [
                     [
@@ -1544,6 +1550,11 @@ class TestDiscoverFunctions:
                         {'stringValue': 'TABLE'},
                         {'stringValue': 'user=admin'},
                         {'stringValue': 'User data table'},
+                        {'stringValue': 'admin'},
+                        {'stringValue': '2026-03-31 04:47:07.525940'},
+                        {'stringValue': '2026-03-31 04:47:07.525936'},
+                        {'stringValue': 'AUTO (ALL)'},
+                        {'stringValue': 'REGULAR TABLE'},
                     ]
                 ],
             },
@@ -1560,6 +1571,8 @@ class TestDiscoverFunctions:
         assert result[0].table_type == 'TABLE'
         assert result[0].table_acl == 'user=admin'
         assert result[0].remarks == 'User data table'
+        # Distribution style explains redistribution decisions in a plan.
+        assert result[0].dist_style == 'AUTO (ALL)'
 
         # db.schema is embedded as quoted identifiers (no bind params).
         mock_execute_protected.assert_called_once()
@@ -1608,6 +1621,12 @@ class TestDiscoverFunctions:
                     {'name': 'numeric_precision'},
                     {'name': 'numeric_scale'},
                     {'name': 'remarks'},
+                    # Design columns SHOW COLUMNS also returns; collation is not modelled.
+                    {'name': 'sort_key_type'},
+                    {'name': 'sort_key'},
+                    {'name': 'dist_key'},
+                    {'name': 'encoding'},
+                    {'name': 'collation'},
                 ],
                 'Records': [
                     [
@@ -1623,6 +1642,11 @@ class TestDiscoverFunctions:
                         {'longValue': 32},
                         {'longValue': 0},
                         {'stringValue': 'Primary key'},
+                        {'stringValue': 'COMPOUND'},
+                        {'longValue': 1},
+                        {'longValue': 1},
+                        {'stringValue': 'az64'},
+                        {'stringValue': ''},
                     ]
                 ],
             },
@@ -1638,6 +1662,12 @@ class TestDiscoverFunctions:
         assert result[0].column_name == 'id'
         assert result[0].ordinal_position == 1
         assert result[0].data_type == 'integer'
+
+        # Design metadata explains redistribution and zone-map pruning in a plan.
+        assert result[0].sort_key_type == 'COMPOUND'
+        assert result[0].sort_key == 1
+        assert result[0].dist_key == 1
+        assert result[0].encoding == 'az64'
 
         # db.schema.table is embedded as quoted identifiers (no bind params).
         mock_execute_protected.assert_called_once()

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -296,21 +296,25 @@ class TestListTablesTool:
         """Test successful table discovery."""
         mock_discover_tables = mocker.patch('awslabs.redshift_mcp_server.server.discover_tables')
         mock_discover_tables.return_value = [
-            RedshiftTable(
-                database_name='dev',
-                schema_name='public',
-                table_name='users',
-                table_acl='user=admin',
-                table_type='TABLE',
-                remarks='User data table',
+            RedshiftTable.model_validate(
+                {
+                    'database_name': 'dev',
+                    'schema_name': 'public',
+                    'table_name': 'users',
+                    'table_acl': 'user=admin',
+                    'table_type': 'TABLE',
+                    'remarks': 'User data table',
+                }
             ),
-            RedshiftTable(
-                database_name='dev',
-                schema_name='public',
-                table_name='user_view',
-                table_acl='user=admin',
-                table_type='VIEW',
-                remarks='User view',
+            RedshiftTable.model_validate(
+                {
+                    'database_name': 'dev',
+                    'schema_name': 'public',
+                    'table_name': 'user_view',
+                    'table_acl': 'user=admin',
+                    'table_type': 'VIEW',
+                    'remarks': 'User view',
+                }
             ),
         ]
 
@@ -369,33 +373,37 @@ class TestListColumnsTool:
         """Test successful column discovery."""
         mock_discover_columns = mocker.patch('awslabs.redshift_mcp_server.server.discover_columns')
         mock_discover_columns.return_value = [
-            RedshiftColumn(
-                database_name='dev',
-                schema_name='public',
-                table_name='users',
-                column_name='id',
-                ordinal_position=1,
-                column_default=None,
-                is_nullable='NO',
-                data_type='integer',
-                character_maximum_length=None,
-                numeric_precision=None,
-                numeric_scale=None,
-                remarks='Primary key',
+            RedshiftColumn.model_validate(
+                {
+                    'database_name': 'dev',
+                    'schema_name': 'public',
+                    'table_name': 'users',
+                    'column_name': 'id',
+                    'ordinal_position': 1,
+                    'column_default': None,
+                    'is_nullable': 'NO',
+                    'data_type': 'integer',
+                    'character_maximum_length': None,
+                    'numeric_precision': None,
+                    'numeric_scale': None,
+                    'remarks': 'Primary key',
+                }
             ),
-            RedshiftColumn(
-                database_name='dev',
-                schema_name='public',
-                table_name='users',
-                column_name='name',
-                ordinal_position=2,
-                column_default=None,
-                is_nullable='YES',
-                data_type='varchar',
-                character_maximum_length=255,
-                numeric_precision=None,
-                numeric_scale=None,
-                remarks='User name',
+            RedshiftColumn.model_validate(
+                {
+                    'database_name': 'dev',
+                    'schema_name': 'public',
+                    'table_name': 'users',
+                    'column_name': 'name',
+                    'ordinal_position': 2,
+                    'column_default': None,
+                    'is_nullable': 'YES',
+                    'data_type': 'varchar',
+                    'character_maximum_length': 255,
+                    'numeric_precision': None,
+                    'numeric_scale': None,
+                    'remarks': 'User name',
+                }
             ),
         ]
 


### PR DESCRIPTION
## Summary and changes

SHOW TABLES and SHOW COLUMNS already return physical design columns that the models did not declare, so they were fetched and then discarded. Declare the ones that explain an execution plan, which costs no extra query and no additional IAM permission:

- RedshiftColumn: sort_key_type, sort_key, dist_key, encoding
- RedshiftTable: dist_style

- These explain redistribution (DS_BCAST/DS_DIST_*), zone-map pruning, and scan cost. Columns that do not serve plan analysis (owner, last_altered_time, last_modified_time, table_subtype, collation) are deliberately left out to keep responses small; adding them later is backward compatible.

Also correct the consts comment that still described positional result reading, and build the models in test_server via model_validate so optional field defaults are not reported as missing constructor arguments.

## Testing

<details>

```
% kiro-cli chat \
    --model claude-opus-5 \
    --no-interactive \
    --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
'Use Redshift MCP Server to run end-to-end (integration) tests covering the scenarios for the changes introduced in the current branch only. Get the test scenario ideas from the unit tests under the project directory. Provide a short testing summary, one line per scenario.'
```
...



> Ran the branch's changes (dist_style on RedshiftTable; sort_key_type, sort_key, dist_key, encoding on RedshiftColumn) end-to-end against live Redshift via the locally-run MCP server, using the unit-test
assertions in tests/test_redshift.py as the scenario source and svv_table_info/pg_table_def as the independent oracle.

Environment: redshift-cluster-1 (provisioned), redshift-cluster-serverless (serverless), test-drive-consumer-personal (datashare consumer), region us-east-1.

Testing summary — all 13 scenarios passed:

1. dist_style EVEN — dev.public.mcp_test_even → EVEN, matches svv_table_info.
2. dist_style KEY — dev.public.mcp_test_key → KEY (name-less, as documented; key column identified via dist_key), oracle KEY(id).
3. dist_style ALL — dev.public.mcp_test_all → ALL, matches oracle.
4. dist_style AUTO (EVEN) — dev.public.mcp_test_auto → AUTO (EVEN), matches oracle AUTO(EVEN).
5. dist_style AUTO (ALL) — serverless dev.public.admin_table → AUTO (ALL), matches oracle.
6. dist_style on a view — dev.public.mcp_test_view → null, no spurious value.
7. COMPOUND sort key ordering — mcp_test_compound → a=(COMPOUND,1), b=(COMPOUND,2), matches pg_table_def sortkey 1/2.
8. INTERLEAVED sort key — mcp_test_interleaved → a/b = (INTERLEAVED,1)/(INTERLEAVED,2); pg_table_def marks interleaved as -1/2, consistent.
9. Non-sort-key column — mcp_test_compound.c and mcp_test_interleaved.c → sort_key_type=null, sort_key=0.
10. AUTO sort key reports on every column — mcp_test_key/mcp_test_even → sort_key_type=AUTO, sort_key=0 on all columns, oracle AUTO(SORTKEY).
11. dist_key isolation — mcp_test_key.id=1 / val=null, and sample_data_dev.tickit.sales.listid=1 only; oracle distkey=true on exactly those.
12. encoding — az64, lzo, and raw all surfaced; oracle agrees (pg_table_def spells raw as none).
13. Unmodelled columns ignored — raw SHOW COLUMNS returns collation (and SHOW TABLES returns owner, last_altered_time, table_subtype); none appear in tool output and no parse errors occur.

Cross-cutting confirmation: the new fields populate identically on provisioned, serverless, and datashare-consumer paths (shared sample_data_dev.tickit.category correctly reports dist_key=1 + COMPOUND/1 on catid),
and views return null for all four column-design fields rather than failing validation. No extra queries or IAM permissions were needed, as the commit claims.


```
% kiro-cli chat \
    --model claude-opus-5 \
    --no-interactive \
    --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
'Use Redshift MCP Server to run a complete set of end-to-end (integration) tests covering all its tools. Check both provisioned and serverless clusters, including the database schema exploration in both. Check the SQL read-only protection, transaction breaker protection, failed user SQL behavior. Get the test scenario ideas from the unit tests under the project directory. Provide a short testing summary, one line per tool.'
```
...


> All 7 tools exercised live against provisioned redshift-cluster-1 and serverless redshift-cluster-serverless (us-east-1), with scenarios lifted from tests/test_sql_guard.py and tests/test_redshift.py.

## Summary — one line per tool

| Tool | Result |
|---|---|
| list_clusters | PASS — returned 6 resources, correctly typed: 4 provisioned (one paused) + 2 serverless, with serverless nulling node_type/master_username. |
| list_databases | PASS — both cluster types; local + auto mounted catalog types resolved; paused cluster failed cleanly with "Redshift endpoint is not available". |
| list_schemas | PASS — both types; sample_data_dev returned local schemas (tickit, tpcds, tpch on provisioned; tickit on serverless) with ACLs. |
| list_tables | PASS — identical 7 tickit tables on both, table_type=TABLE, dist_style=KEY. |
| list_columns | PASS — 10 tickit.sales columns on both, matching ordinal/type/precision plus dist_key on listid and COMPOUND sort_key on dateid. |
| execute_query | PASS — reads worked on both (provisioned 344,912 rows / serverless 172,456); guard, engine backstop, and error paths all behaved (detail below). |
| review_cluster | PASS — provisioned: 11 signals, 11 findings, 10 deduped recommendations; serverless: 8 signals, 0 findings, with provisioned-only sections (NodeDetails, WLMConfig, WorkloadEvaluation,
CopyPerformance) skipped and ServerlessScaling added. |

## Protection results

Guard rejections (never reached the engine): TRUNCATE, GRANT, UNLOAD, COMMIT, ABORT, START TRANSACTION, and END TRANSACTION (reported as COMMIT, matching the exp.Commit mapping in the unit tests). Multi-statement
stacking, including the SET transaction_read_only TO off; CREATE TABLE … escalation attempt, was rejected with "Only a single SQL statement is allowed". The nested-comment bypass regression (
/* a /* b */ SELECT 1 FROM */ TRUNCATE …) was still classified as TRUNCATE. Unparseable SQL failed closed with the generic "SQL could not be parsed".

No false positives: SELECT '; COMMIT;' AS literal_not_flagged, 1 AS grant and SHOW search_path both ran.

Engine backstop: CREATE TABLE (provisioned) and DELETE (serverless) passed the guard as designed and were rejected by the read-only transaction with ERROR: transaction is read-only. Verified no side effects — the
probe table does not exist (pg_tables count 0) and tickit.sales still has 172,456 rows.

Transaction breaker: a SET search_path TO tickit succeeded, but a follow-up SHOW search_path returned the default $user, public, confirming the BEGIN READ ONLY … ROLLBACK wrapper renders session settings inert
rather than leaking them into the shared session.

Failed user SQL: nonexistent relation and division-by-zero both surfaced the real engine message, and the very next query on the same session succeeded on both clusters — the finally-block ROLLBACK closed the
aborted transaction rather than wedging the session. Invalid cluster identifiers were caught before any Data API call.

One fail-closed case I did not exercise live: the >64 KB MAX_SQL_LEN rejection, which would require a 65 KB payload — it remains covered by unit tests only.

</details>

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) - No


Checklist:

* [N/A] Migration process documented
* [N/A] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
