### PR TITLE
fix(aws-api-mcp-server): use botocore.xform_name for policy operation name conversion

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/policy.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/policy.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import json
-import re
 from ...core.common.config import READ_OPERATIONS_ONLY_MODE, REQUIRE_MUTATION_CONSENT
+from botocore import xform_name
 from enum import Enum
 from loguru import logger
 from pathlib import Path
@@ -113,8 +113,7 @@ class SecurityPolicy:
 
         Priority: deny > elicit > default behavior
         """
-        operation_kebab = operation.replace('_', '-')
-        operation_kebab = re.sub('([A-Z])', r'-\1', operation_kebab).lower().lstrip('-')
+        operation_kebab = xform_name(operation).replace('_', '-')
 
         api_call = f'aws {service} {operation_kebab}'
 
@@ -156,8 +155,7 @@ class SecurityPolicy:
         operation = ir.command_metadata.operation_sdk_name
 
         # Convert operation to kebab-case if needed
-        operation_kebab = operation.replace('_', '-')
-        operation_kebab = re.sub('([A-Z])', r'-\1', operation_kebab).lower().lstrip('-')
+        operation_kebab = xform_name(operation).replace('_', '-')
 
         base_cmd = f'{service} {operation_kebab}'
 

--- a/src/aws-api-mcp-server/tests/test_security_policy.py
+++ b/src/aws-api-mcp-server/tests/test_security_policy.py
@@ -252,6 +252,36 @@ def test_security_policy_operation_name_conversion():
         assert decision == PolicyDecision.DENY
 
 
+def test_security_policy_acronym_operation_names():
+    """Test that operations with acronyms (SAML, MFA, SSH, OpenID) are correctly matched."""
+    with patch.object(Path, 'exists', return_value=False):
+        policy = SecurityPolicy(create_mock_ctx())
+        policy.denylist = {
+            'aws iam create-saml-provider',
+            'aws iam create-virtual-mfa-device',
+            'aws iam upload-ssh-public-key',
+            'aws iam add-client-id-to-open-id-connect-provider',
+        }
+
+        decision = policy.determine_policy_effect('iam', 'CreateSAMLProvider', False)
+        assert decision == PolicyDecision.DENY
+
+        decision = policy.determine_policy_effect('iam', 'CreateVirtualMFADevice', False)
+        assert decision == PolicyDecision.DENY
+
+        decision = policy.determine_policy_effect('iam', 'UploadSSHPublicKey', False)
+        assert decision == PolicyDecision.DENY
+
+        decision = policy.determine_policy_effect(
+            'iam', 'AddClientIDToOpenIDConnectProvider', False
+        )
+        assert decision == PolicyDecision.DENY
+
+        # Verify a non-denied acronym operation is allowed
+        decision = policy.determine_policy_effect('iam', 'DeleteSAMLProvider', False)
+        assert decision == PolicyDecision.ALLOW
+
+
 # Customization Tests
 def test_security_policy_customization_parent_deny():
     """Test customization when parent command is in denylist."""


### PR DESCRIPTION
## Summary

### Changes

Replace hand-rolled regex in `policy.py` with `botocore.xform_name(operation).replace('_', '-')` for converting operation names to CLI-style kebab-case. The regex splits acronyms letter-by-letter (e.g. `CreateSAMLProvider` → `create-s-a-m-l-provider`), causing `denyList`/`elicitList` entries to fail to match for ~642 operations.

### User experience

**Before:** `denyList: ["aws iam create-saml-provider"]` does nothing — the server computes `create-s-a-m-l-provider` internally so the match fails.

**After:** The conversion matches the real AWS CLI naming, so the deny works as expected.

### Reproduction

```python
import re
from botocore import xform_name
import botocore.session

def old_convert(op):
    return re.sub('([A-Z])', r'-\1', op.replace('_', '-')).lower().lstrip('-')

session = botocore.session.get_session()
mismatches = []
for svc in sorted(session.get_available_services()):
    try:
        model = session.get_service_model(svc)
    except Exception:
        continue
    for op in model.operation_names:
        old = old_convert(op)
        correct = xform_name(op).replace('_', '-')
        if old != correct:
            mismatches.append((svc, op, old, correct))

print(f'Affected: {len(mismatches)} operations')
for svc, op, old, correct in mismatches[:10]:
    print(f'  {svc} {op}: "{old}" vs "{correct}"')
```

```
Affected: 642 operations

  amplifybackend CreateBackendAPI: "create-backend-a-p-i" vs "create-backend-api"
  amplifybackend DeleteBackendAPI: "delete-backend-a-p-i" vs "delete-backend-api"
  amplifybackend GenerateBackendAPIModels: "generate-backend-a-p-i-models" vs "generate-backend-api-models"
  amplifybackend GetBackendAPI: "get-backend-a-p-i" vs "get-backend-api"
  amplifybackend GetBackendAPIModels: "get-backend-a-p-i-models" vs "get-backend-api-models"
  amplifybackend UpdateBackendAPI: "update-backend-a-p-i" vs "update-backend-api"
  appstream CreateAppBlockBuilderStreamingURL: "create-app-block-builder-streaming-u-r-l" vs "create-app-block-builder-streaming-url"
  appstream CreateImageBuilderStreamingURL: "create-image-builder-streaming-u-r-l" vs "create-image-builder-streaming-url"
  appstream CreateStreamingURL: "create-streaming-u-r-l" vs "create-streaming-url"
  athena ListApplicationDPUSizes: "list-application-d-p-u-sizes" vs "list-application-dpu-sizes"
  ... (632 more)
```

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).