### PR TITLE
fix(billing-cost-management-mcp-server): correct Compute Optimizer re…

### DIFF
--- a/src/billing-cost-management-mcp-server/CHANGELOG.md
+++ b/src/billing-cost-management-mcp-server/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added AWS Billing tools for managing and querying billing views
 - Added optional `billing_view_arn` parameter to 7 Cost Explorer operations to scope queries to specific billing views (PRIMARY, BILLING_GROUP, CUSTOM, BILLING_TRANSFER, BILLING_TRANSFER_SHOWBACK)
 
+### Fixed
+- Corrected AWS Compute Optimizer recommendation response field names so EC2, Auto Scaling group, Lambda, and RDS tools return actual values instead of null. Fixed the shared savings-opportunity parser (`savingsOpportunityPercentage`), projected utilization metrics, EC2/RDS idle flags, nested ASG instance types, and the RDS instance/storage recommendation schema.
+
 ## [0.0.4] - 2025-10-27
 ### Added
 - Initial support for Billing and Cost Management Pricing Calculator's Workload estimate (`GetPreferences`, `GetWorkloadEstimate`, `ListWorkloadEstimates`, and `ListWorkloadEstimateUsage`) (#1486).

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/compute_optimizer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/compute_optimizer_tools.py
@@ -341,6 +341,7 @@ async def get_ec2_instance_recommendations(
             'instance_type': recommendation.get('currentInstanceType'),
             'instance_name': recommendation.get('instanceName'),
             'finding': recommendation.get('finding'),
+            'idle': recommendation.get('idle'),
         }
 
         # Get the recommended instance options
@@ -348,8 +349,9 @@ async def get_ec2_instance_recommendations(
         for option in recommendation.get('recommendationOptions', []):
             instance_option = {
                 'instance_type': option.get('instanceType'),
-                'projected_utilization': option.get('projectedUtilization'),
+                'projected_utilization_metrics': option.get('projectedUtilizationMetrics'),
                 'performance_risk': option.get('performanceRisk'),
+                'rank': option.get('rank'),
                 'savings_opportunity': format_savings_opportunity(
                     option.get('savingsOpportunity', {})
                 ),
@@ -404,18 +406,21 @@ async def get_auto_scaling_group_recommendations(
     # Parse the recommendations
     for recommendation in response.get('autoScalingGroupRecommendations', []):
         # Get the current configuration
+        current_asg_config = recommendation.get('currentConfiguration', {})
         current_config = {
-            'instance_type': recommendation.get('currentInstanceType'),
+            'instance_type': current_asg_config.get('instanceType'),
             'finding': recommendation.get('finding'),
         }
 
         # Get the recommended options
         recommended_options = []
         for option in recommendation.get('recommendationOptions', []):
+            option_config = option.get('configuration', {})
             recommended_option = {
-                'instance_type': option.get('instanceType'),
-                'projected_utilization': option.get('projectedUtilization'),
+                'instance_type': option_config.get('instanceType'),
+                'projected_utilization_metrics': option.get('projectedUtilizationMetrics'),
                 'performance_risk': option.get('performanceRisk'),
+                'rank': option.get('rank'),
                 'savings_opportunity': format_savings_opportunity(
                     option.get('savingsOpportunity', {})
                 ),
@@ -557,7 +562,7 @@ async def get_lambda_function_recommendations(
         for option in recommendation.get('memorySizeRecommendationOptions', []):
             recommended_option = {
                 'memory_size': option.get('memorySize'),
-                'projected_utilization': option.get('projectedUtilization'),
+                'projected_utilization_metrics': option.get('projectedUtilizationMetrics'),
                 'rank': option.get('rank'),
                 'savings_opportunity': format_savings_opportunity(
                     option.get('savingsOpportunity', {})
@@ -629,10 +634,13 @@ async def get_rds_recommendations(ctx, co_client, max_results, filters, account_
 
     # Parse the recommendations
     for recommendation in response.get('rdsDBRecommendations', []):
+        resource_arn = recommendation.get('resourceArn')
+
         # Get the current configuration
         current_config = {
-            'instance_class': recommendation.get('currentInstanceClass'),
-            'finding': recommendation.get('finding'),
+            'instance_class': recommendation.get('currentDBInstanceClass'),
+            'instance_finding': recommendation.get('instanceFinding'),
+            'idle': recommendation.get('idle'),
             'engine': recommendation.get('engine'),
             'engine_version': recommendation.get('engineVersion'),
             'storage_finding': recommendation.get('storageFinding'),
@@ -641,23 +649,43 @@ async def get_rds_recommendations(ctx, co_client, max_results, filters, account_
 
         # Get the recommended options
         recommended_options = []
-        for option in recommendation.get('recommendationOptions', []):
+        for option in recommendation.get('instanceRecommendationOptions', []):
             recommended_option = {
-                'instance_class': option.get('instanceClass'),
+                'instance_class': option.get('dbInstanceClass'),
                 'performance_risk': option.get('performanceRisk'),
+                'rank': option.get('rank'),
                 'savings_opportunity': format_savings_opportunity(
                     option.get('savingsOpportunity', {})
                 ),
             }
             recommended_options.append(recommended_option)
 
+        # Get the recommended storage options
+        storage_options = []
+        for option in recommendation.get('storageRecommendationOptions', []):
+            storage_options.append(
+                {
+                    'storage_configuration': option.get('storageConfiguration'),
+                    'rank': option.get('rank'),
+                    'savings_opportunity': format_savings_opportunity(
+                        option.get('savingsOpportunity', {})
+                    ),
+                }
+            )
+
         # Create the formatted recommendation
         formatted_recommendation = {
-            'instance_arn': recommendation.get('instanceArn'),
-            'instance_name': recommendation.get('instanceName'),
+            'instance_arn': resource_arn,
+            'instance_name': resource_arn.split(':')[-1] if resource_arn else None,
             'account_id': recommendation.get('accountId'),
             'current_configuration': current_config,
             'recommendation_options': recommended_options,
+            'storage_recommendation_options': storage_options,
+            'utilization_metrics': recommendation.get('utilizationMetrics'),
+            'lookback_period_in_days': recommendation.get('lookbackPeriodInDays'),
+            'savings_estimation_mode': recommendation.get(
+                'effectiveRecommendationPreferences', {}
+            ).get('savingsEstimationMode'),
             'last_refresh_timestamp': format_timestamp(recommendation.get('lastRefreshTimestamp')),
         }
 
@@ -788,7 +816,7 @@ def format_savings_opportunity(savings_opportunity):
         return None
 
     return {
-        'savings_percentage': savings_opportunity.get('savingsPercentage'),
+        'savings_percentage': savings_opportunity.get('savingsOpportunityPercentage'),
         'estimated_monthly_savings': {
             'currency': savings_opportunity.get('estimatedMonthlySavings', {}).get('currency'),
             'value': savings_opportunity.get('estimatedMonthlySavings', {}).get('value'),

--- a/src/billing-cost-management-mcp-server/tests/tools/test_compute_optimizer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_compute_optimizer_tools.py
@@ -55,6 +55,7 @@ def mock_co_client():
                 'accountId': '123456789012',
                 'currentInstanceType': 't3.micro',
                 'finding': 'OVERPROVISIONED',
+                'idle': 'False',
                 'instanceArn': 'arn:aws:ec2:us-east-1:123456789012:instance/i-0abcdef1234567890',
                 'instanceName': 'test-instance',
                 'lastRefreshTimestamp': datetime(2023, 1, 1),
@@ -62,9 +63,12 @@ def mock_co_client():
                     {
                         'instanceType': 't2.nano',
                         'performanceRisk': 'LOW',
-                        'projectedUtilization': 45.0,
+                        'rank': 1,
+                        'projectedUtilizationMetrics': [
+                            {'name': 'CPU', 'statistic': 'MAXIMUM', 'value': 45.0}
+                        ],
                         'savingsOpportunity': {
-                            'savingsPercentage': 30.0,
+                            'savingsOpportunityPercentage': 30.0,
                             'estimatedMonthlySavings': {
                                 'currency': 'USD',
                                 'value': 10.50,
@@ -83,16 +87,23 @@ def mock_co_client():
                 'accountId': '123456789012',
                 'autoScalingGroupArn': 'arn:aws:autoscaling:us-east-1:123456789012:autoScalingGroup:123',
                 'autoScalingGroupName': 'test-asg',
-                'currentInstanceType': 't3.medium',
+                'currentConfiguration': {
+                    'instanceType': 't3.medium',
+                },
                 'finding': 'NOT_OPTIMIZED',
                 'lastRefreshTimestamp': datetime(2023, 1, 1),
                 'recommendationOptions': [
                     {
-                        'instanceType': 't3.small',
+                        'configuration': {
+                            'instanceType': 't3.small',
+                        },
                         'performanceRisk': 'MEDIUM',
-                        'projectedUtilization': 60.0,
+                        'rank': 1,
+                        'projectedUtilizationMetrics': [
+                            {'name': 'CPU', 'statistic': 'MAXIMUM', 'value': 60.0}
+                        ],
                         'savingsOpportunity': {
-                            'savingsPercentage': 25.0,
+                            'savingsOpportunityPercentage': 25.0,
                             'estimatedMonthlySavings': {
                                 'currency': 'USD',
                                 'value': 15.75,
@@ -126,7 +137,7 @@ def mock_co_client():
                         },
                         'performanceRisk': 'LOW',
                         'savingsOpportunity': {
-                            'savingsPercentage': 40.0,
+                            'savingsOpportunityPercentage': 40.0,
                             'estimatedMonthlySavings': {
                                 'currency': 'USD',
                                 'value': 8.20,
@@ -152,9 +163,11 @@ def mock_co_client():
                     {
                         'memorySize': 512,
                         'rank': 1,
-                        'projectedUtilization': 60.0,
+                        'projectedUtilizationMetrics': [
+                            {'name': 'Duration', 'statistic': 'Average', 'value': 60.0}
+                        ],
                         'savingsOpportunity': {
-                            'savingsPercentage': 50.0,
+                            'savingsOpportunityPercentage': 50.0,
                             'estimatedMonthlySavings': {
                                 'currency': 'USD',
                                 'value': 5.20,
@@ -171,17 +184,21 @@ def mock_co_client():
         'rdsDBRecommendations': [
             {
                 'accountId': '123456789012',
-                'instanceArn': 'arn:aws:rds:us-east-1:123456789012:db:test-db',
-                'instanceName': 'test-db',
-                'currentInstanceClass': 'db.r5.large',
-                'finding': 'OVER_PROVISIONED',
+                'resourceArn': 'arn:aws:rds:us-east-1:123456789012:db:test-db',
+                'engine': 'mysql',
+                'engineVersion': '8.0.45',
+                'currentDBInstanceClass': 'db.r5.large',
+                'idle': 'False',
+                'instanceFinding': 'OVER_PROVISIONED',
+                'storageFinding': 'Optimized',
                 'lastRefreshTimestamp': datetime(2023, 1, 1),
-                'recommendationOptions': [
+                'instanceRecommendationOptions': [
                     {
-                        'instanceClass': 'db.r5.medium',
+                        'dbInstanceClass': 'db.r5.medium',
                         'performanceRisk': 'LOW',
+                        'rank': 1,
                         'savingsOpportunity': {
-                            'savingsPercentage': 35.0,
+                            'savingsOpportunityPercentage': 35.0,
                             'estimatedMonthlySavings': {
                                 'currency': 'USD',
                                 'value': 25.80,
@@ -189,6 +206,11 @@ def mock_co_client():
                         },
                     }
                 ],
+                'effectiveRecommendationPreferences': {
+                    'lookBackPeriod': 'DAYS_14',
+                    'savingsEstimationMode': {'source': 'CostOptimizationHub'},
+                },
+                'lookbackPeriodInDays': 14.0,
             }
         ],
         'nextToken': 'next-token-rds',
@@ -208,7 +230,7 @@ def mock_co_client():
                         'instanceClass': 'db.r5.medium',
                         'performanceRisk': 'LOW',
                         'savingsOpportunity': {
-                            'savingsPercentage': 35.0,
+                            'savingsOpportunityPercentage': 35.0,
                             'estimatedMonthlySavings': {
                                 'currency': 'USD',
                                 'value': 25.80,
@@ -272,6 +294,15 @@ class TestGetEC2InstanceRecommendations:
         assert len(result['data']['recommendations']) == 1
         assert result['data']['next_token'] == 'next-token-123'
 
+        recommendation = result['data']['recommendations'][0]
+        assert recommendation['current_instance']['instance_type'] == 't3.micro'
+        assert recommendation['current_instance']['idle'] == 'False'
+
+        option = recommendation['recommendation_options'][0]
+        assert option['instance_type'] == 't2.nano'
+        assert option['projected_utilization_metrics'][0]['value'] == 45.0
+        assert option['savings_opportunity']['savings_percentage'] == 30.0
+
 
 @pytest.mark.asyncio
 class TestGetAutoScalingGroupRecommendations:
@@ -310,6 +341,11 @@ class TestGetAutoScalingGroupRecommendations:
         assert recommendation['account_id'] == '123456789012'
         assert recommendation['current_configuration']['instance_type'] == 't3.medium'
         assert recommendation['current_configuration']['finding'] == 'NOT_OPTIMIZED'
+
+        option = recommendation['recommendation_options'][0]
+        assert option['instance_type'] == 't3.small'
+        assert option['projected_utilization_metrics'][0]['value'] == 60.0
+        assert option['savings_opportunity']['savings_percentage'] == 25.0
 
 
 @pytest.mark.asyncio
@@ -379,7 +415,7 @@ class TestGetLambdaFunctionRecommendations:
         assert len(recommendation['recommendation_options']) == 1
         option = recommendation['recommendation_options'][0]
         assert option['memory_size'] == 512
-        assert option['projected_utilization'] == 60.0
+        assert option['projected_utilization_metrics'][0]['value'] == 60.0
         assert option['rank'] == 1
         assert option['savings_opportunity']['savings_percentage'] == 50.0
         assert option['savings_opportunity']['estimated_monthly_savings']['currency'] == 'USD'
@@ -454,7 +490,7 @@ class TestGetRDSRecommendations:
         assert recommendation['instance_name'] == 'test-db'
         assert recommendation['account_id'] == '123456789012'
         assert recommendation['current_configuration']['instance_class'] == 'db.r5.large'
-        assert recommendation['current_configuration']['finding'] == 'OVER_PROVISIONED'
+        assert recommendation['current_configuration']['instance_finding'] == 'OVER_PROVISIONED'
 
         # Verify the recommendation options
         assert len(recommendation['recommendation_options']) == 1
@@ -508,7 +544,7 @@ class TestHelperFunctions:
         """Test format_savings_opportunity function."""
         # Test with complete data
         savings = {
-            'savingsPercentage': 50.0,
+            'savingsOpportunityPercentage': 50.0,
             'estimatedMonthlySavings': {
                 'currency': 'USD',
                 'value': 100.0,
@@ -1149,18 +1185,22 @@ class TestComputeOptimizerCoverageGaps:
         mock_co_client.get_rds_database_recommendations.return_value = {
             'rdsDBRecommendations': [
                 {
-                    'instanceArn': 'arn:aws:rds:us-east-1:123456789012:db:test-db',
-                    'instanceName': 'test-db',
+                    'resourceArn': 'arn:aws:rds:us-east-1:123456789012:db:test-db',
                     'accountId': '123456789012',
-                    'currentInstanceClass': 'db.r5.large',
-                    'finding': 'OVER_PROVISIONED',
+                    'engine': 'mysql',
+                    'engineVersion': '8.0.45',
+                    'currentDBInstanceClass': 'db.r5.large',
+                    'idle': 'False',
+                    'instanceFinding': 'OVER_PROVISIONED',
+                    'storageFinding': 'Optimized',
                     'lastRefreshTimestamp': None,
-                    'recommendationOptions': [
+                    'instanceRecommendationOptions': [
                         {
-                            'instanceClass': 'db.r5.medium',
+                            'dbInstanceClass': 'db.r5.medium',
                             'performanceRisk': 'LOW',
+                            'rank': 1,
                             'savingsOpportunity': {
-                                'savingsPercentage': 35.0,
+                                'savingsOpportunityPercentage': 35.0,
                                 'estimatedMonthlySavings': {
                                     'currency': 'USD',
                                     'value': 25.80,
@@ -1233,7 +1273,7 @@ class TestGetECSServiceRecommendations:
                             ],
                             'projectedPerformance': None,
                             'savingsOpportunity': {
-                                'savingsPercentage': None,
+                                'savingsOpportunityPercentage': None,
                                 'estimatedMonthlySavings': {'currency': 'USD', 'value': 30.275},
                             },
                         }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

  ## Summary

  ### Changes

  Corrects AWS Compute Optimizer response field names in the
  billing-cost-management-mcp-server tools. Several fields were read using
  non-existent SDK keys, so the tools silently returned `null` for the affected
  values. Every field name was verified against the botocore `compute-optimizer/2019-11-01` service model and the public boto3 documentation.

  - **`format_savings_opportunity` (shared by all resource types):** read
    `savingsOpportunityPercentage` instead of the non-existent `savingsPercentage`.
    This helper is used by EC2/ASG/EBS/Lambda/RDS/ECS, so the savings percentage
    was `null` for every resource type.
  - **EC2 / ASG / Lambda:** projected utilization is `projectedUtilizationMetrics`
    (an array), not `projectedUtilization`. Also surface `idle` (EC2) and `rank`.
  - **Auto Scaling groups:** instance type is nested — current in
    `currentConfiguration.instanceType`, option in `configuration.instanceType`
    (there is no top-level `currentInstanceType`/`instanceType`).
  - **RDS:** aligned to the RDS schema, which differs from EC2 — `resourceArn`,
    `currentDBInstanceClass`, `instanceFinding`, and `instanceRecommendationOptions`
    with `dbInstanceClass`. Also added storage recommendation options, utilization
    metrics, lookback period, and savings-estimation mode, and derive the instance
    name from the ARN (RDS has no `instanceName` field).

  ### User experience

  **Before:** Compute Optimizer recommendation tools returned recommendations with
  mostly empty/`null` fields — savings percentages, projected utilization, and RDS
  instance classes/findings all came back `null` because the code read field names
  that don't exist in the API response.

  **After:** the tools return the actual values from the Compute Optimizer API —
  savings percentages, projected utilization metrics, idle flags, and complete RDS
  instance/storage recommendations.

  ## Checklist

  If your change doesn't seem to apply, please leave them unchecked.

  * [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
  * [x] I have performed a self-review of this change
  * [x] Changes have been tested
  * [x] Changes are documented

  Is this a breaking change? (Y/N) N

  **RFC issue number**: N/A

  Checklist:

  * [ ] Migration process documented
  * [ ] Implement warnings (if it can live side by side)

  ## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
