### PR TITLE
feat(billing-cost-management): add AWS Billing credits tool

### DIFF
--- a/src/billing-cost-management-mcp-server/CHANGELOG.md
+++ b/src/billing-cost-management-mcp-server/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Added AWS Billing credits support via a `credits` tool (`GetCredits`, `GetCreditAllocationHistory`) covering credit balance, expiration, product applicability, sharing configuration, and the per-service allocation ledger
 - Added AWS Compute Optimizer Automation support via a `compute-optimizer-automation` tool (`GetAutomationEvent`, `GetAutomationRule`, `GetEnrollmentConfiguration`, `ListAccounts`, `ListAutomationEvents`, `ListAutomationEventSteps`, `ListAutomationEventSummaries`, `ListAutomationRules`, `ListRecommendedActions`, `ListRecommendedActionSummaries`, `ListAutomationRulePreview`, `ListAutomationRulePreviewSummaries`, `ListTagsForResource`)
 - Extending support for Billing and Cost Management Pricing Calculator's Workload estimate (`CreateWorkloadEstimate`, `BatchCreateWorkloadEstimateUsage`).
 - Added AWS Billing Conductor tools to analize billing groups, account associations, billing group cost reports, pricing rules/plans, and custom line items

--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -322,6 +322,10 @@ AWS Invoicing:
 - invoicing:ListProcurementPortalPreferences
 - invoicing:GetProcurementPortalPreference
 
+AWS Billing:
+- billing:GetCredits
+- billing:GetCreditAllocationHistory
+
 #### Configuration
 
 The server uses these key environment variables:
@@ -435,3 +439,6 @@ The server currently supports the following AWS services
     - `invoicing` tool: list_invoice_summaries
     - `invoice-units` tool: list_invoice_units, get_invoice_unit, batch_get_invoice_profile
     - `procurement-preferences` tool: list_procurement_portal_preferences, get_procurement_portal_preference
+
+13. **AWS Credits**
+    - `credits` tool: get_credits, get_credit_allocation_history

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -60,6 +60,7 @@ from awslabs.billing_cost_management_mcp_server.tools.cost_explorer_tools import
 from awslabs.billing_cost_management_mcp_server.tools.cost_optimization_hub_tools import (
     cost_optimization_hub_server,
 )
+from awslabs.billing_cost_management_mcp_server.tools.credits_tools import credits_server
 from awslabs.billing_cost_management_mcp_server.tools.free_tier_usage_tools import (
     free_tier_usage_server,
 )
@@ -226,6 +227,7 @@ def setup():
     mcp.mount(invoicing_server)
     mcp.mount(invoice_units_server)
     mcp.mount(procurement_preferences_server)
+    mcp.mount(credits_server)
 
     register_prompts()
 

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/credits_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/credits_operations.py
@@ -1,0 +1,862 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS credits operations for the AWS Billing and Cost Management MCP server.
+
+This module contains the operation handlers for the ``credits`` tool. Each
+operation performs the AWS API call, converts calendar-date inputs into the
+epoch timestamps the API expects, normalizes epoch timestamps for the agent,
+and returns a standardized response envelope.
+"""
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+)
+from ..utilities.sql_utils import convert_response_if_needed
+from ..utilities.time_utils import (
+    timestamp_to_utc_iso_string,
+    utc_datetime_string_to_epoch_seconds,
+)
+from botocore.exceptions import ClientError
+from calendar import monthrange
+from datetime import datetime, timezone
+from fastmcp import Context
+from typing import Any, Dict, Optional
+
+
+# CreditData fields that AWS returns as timestamps. We normalize these to
+# human-readable strings so the values are JSON-serializable and
+# self-explanatory to the agent, while leaving every other field untouched.
+_CREDIT_TIMESTAMP_FIELDS = ('startDate', 'endDate', 'exhaustDate')
+
+# GetCreditAllocationHistory rejects ranges longer than 24 months. Kept
+# as a literal rather than computed so the enforced window is obvious
+# at a glance and cannot drift with calendar arithmetic.
+MAX_ALLOCATION_HISTORY_SECONDS = 63072000
+
+# GetCredits rejects a start date more than one year before now, a tighter
+# limit than the allocation ledger's. 365 days is used rather than a calendar
+# year because it is never wider than the limit, including across a leap day.
+MAX_CREDITS_LOOKBACK_SECONDS = 31536000
+
+# IAM action required by each operation, used to build an actionable message
+# when the caller's policy is missing it.
+_REQUIRED_IAM_ACTIONS = {
+    'GetCredits': 'billing:GetCredits',
+    'GetCreditAllocationHistory': 'billing:GetCreditAllocationHistory',
+}
+
+
+def _create_billing_client() -> Any:
+    """Create an AWS Billing client.
+
+    Returns:
+        boto3.client: AWS Billing client.
+    """
+    return create_aws_client('billing')
+
+
+def _normalize_credit_data(credit: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a raw CreditData item for agent consumption.
+
+    Converts the epoch timestamp fields (``startDate``, ``endDate`` and
+    ``exhaustDate``) into human-readable strings. All other fields are returned
+    exactly as provided by the AWS API to preserve fidelity, so monetary
+    amounts remain decimal strings.
+
+    Args:
+        credit: A single ``CreditData`` object from the Billing API.
+
+    Returns:
+        The credit with its timestamp fields converted to ISO 8601 strings.
+    """
+    for field in _CREDIT_TIMESTAMP_FIELDS:
+        value = credit.get(field)
+        if value is not None and not isinstance(value, str):
+            credit[field] = timestamp_to_utc_iso_string(value)
+    return credit
+
+
+def _parse_epoch_range(
+    start_date: Optional[str], end_date: Optional[str], require_end: bool
+) -> tuple:
+    """Validate and convert a calendar-date range into epoch seconds.
+
+    Rejects a missing start date, a missing end date when the operation requires
+    one, an unparseable date, and an end date that precedes the start.
+
+    Args:
+        start_date: Inclusive range start in ``YYYY-MM-DD`` UTC format.
+        end_date: Inclusive range end in the same format.
+        require_end: Whether the operation requires an end date.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch, error) where error is a standardized
+        error response and the epochs are None when validation fails. end_epoch
+        is None when the caller omitted an optional end date.
+    """
+    if not start_date or (require_end and not end_date):
+        needed = (
+            'start_date and end_date are both required'
+            if require_end
+            else 'start_date is required'
+        )
+        return (
+            None,
+            None,
+            format_response('error', {'message': f'{needed} (YYYY-MM-DD, e.g. "2026-01-01").'}),
+        )
+
+    try:
+        start_epoch = utc_datetime_string_to_epoch_seconds(start_date)
+        end_epoch = utc_datetime_string_to_epoch_seconds(end_date) if end_date else None
+    except ValueError as parse_error:
+        return None, None, format_response('error', {'message': str(parse_error)})
+
+    if end_epoch is not None and end_epoch < start_epoch:
+        return (
+            None,
+            None,
+            format_response('error', {'message': 'end_date must not precede start_date.'}),
+        )
+
+    return start_epoch, end_epoch, None
+
+
+def _expand_billing_period(billing_period: str) -> tuple:
+    """Expand a ``YYYY-MM`` billing period into the range covering that month.
+
+    Args:
+        billing_period: Calendar month in ``YYYY-MM`` format.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch, error) spanning the first to the last
+        day of the month, where error is a standardized error response when the
+        value is not a valid calendar month.
+    """
+    invalid = format_response(
+        'error',
+        {'message': f'billing_period must be in YYYY-MM format, got {billing_period!r}.'},
+    )
+
+    parts = billing_period.split('-')
+    if len(parts) != 2:
+        return None, None, invalid
+
+    try:
+        year, month = int(parts[0]), int(parts[1])
+        last_day = monthrange(year, month)[1]
+        start_epoch = utc_datetime_string_to_epoch_seconds(f'{year:04d}-{month:02d}-01')
+        end_epoch = utc_datetime_string_to_epoch_seconds(f'{year:04d}-{month:02d}-{last_day:02d}')
+    except (ValueError, TypeError, OverflowError):
+        return None, None, invalid
+
+    return start_epoch, end_epoch, None
+
+
+def _convert_credit_id(credit_id: Optional[Any]) -> tuple:
+    """Convert a credit ID from a string to the integer the API expects.
+
+    ``GetCreditAllocationHistory`` declares ``creditId`` as a long while
+    ``GetCredits`` returns it as a string, so an agent chaining the two calls
+    would otherwise send the wrong type and get a ValidationException.
+
+    Args:
+        credit_id: The caller-supplied credit ID, or None.
+
+    Returns:
+        Tuple of (converted_id, error) where error is a standardized error
+        response when the value is not numeric.
+    """
+    if credit_id is None:
+        return None, None
+
+    try:
+        return int(credit_id), None
+    except (TypeError, ValueError):
+        return None, format_response(
+            'error',
+            {
+                'message': (
+                    f'credit_id must be numeric, got {credit_id!r}. Use the '
+                    'creditId value returned by get_credits.'
+                )
+            },
+        )
+
+
+def _build_get_credit_allocation_history_time_range(
+    start_epoch: int, end_epoch: int, requested_start: int, requested_end: int
+) -> Dict[str, Any]:
+    """Describe the window actually queried alongside the one requested.
+
+    Reporting both makes a narrowed window visible to the agent so a clamped
+    result is never mistaken for a complete one.
+
+    Args:
+        start_epoch: Effective range start after clamping.
+        end_epoch: Effective range end after clamping.
+        requested_start: Range start as the caller supplied it.
+        requested_end: Range end as the caller supplied it.
+
+    Returns:
+        Dict describing both windows and the enforced maximum.
+    """
+    return {
+        'start_date': timestamp_to_utc_iso_string(start_epoch),
+        'end_date': timestamp_to_utc_iso_string(end_epoch),
+        'narrowed_from_request': (start_epoch != requested_start or end_epoch != requested_end),
+        'requested_start_date': timestamp_to_utc_iso_string(requested_start),
+        'requested_end_date': timestamp_to_utc_iso_string(requested_end),
+        'max_range_months': 24,
+    }
+
+
+def _clamp_get_credit_allocation_history_range(start_epoch: int, end_epoch: int) -> tuple:
+    """Narrow a range to the enforced 24-month window ending no later than now.
+
+    Args:
+        start_epoch: Requested range start in epoch seconds.
+        end_epoch: Requested range end in epoch seconds.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch) after clamping.
+    """
+    now_epoch = int(datetime.now(timezone.utc).timestamp())
+    end_epoch = min(end_epoch, now_epoch)
+    if end_epoch - start_epoch > MAX_ALLOCATION_HISTORY_SECONDS:
+        start_epoch = end_epoch - MAX_ALLOCATION_HISTORY_SECONDS
+    return start_epoch, end_epoch
+
+
+async def _handle_billing_error(ctx: Context, error: Exception, api_name: str) -> Dict[str, Any]:
+    """Handle a Billing API error, adding a permission hint for access denials.
+
+    Billing operations raise ``AccessDeniedException`` when the caller's IAM
+    policy omits the specific action. The failure names the missing permission
+    instead of returning an opaque access error that could be mistaken for
+    "no data". Operations absent from ``_REQUIRED_IAM_ACTIONS`` fall back to a
+    derived action name. Every other failure falls through to the shared handler.
+
+    Args:
+        ctx: The MCP context object.
+        error: The exception that was raised.
+        api_name: The AWS API operation name (for example ``"GetCredits"``).
+
+    Returns:
+        Dict containing the standardized error response.
+    """
+    if isinstance(error, ClientError):
+        aws_error = error.response.get('Error', {})
+        error_code = aws_error.get('Code', '')
+        if error_code in ('AccessDeniedException', 'AccessDenied'):
+            required_action = _REQUIRED_IAM_ACTIONS.get(api_name, f'billing:{api_name}')
+            return {
+                'status': 'error',
+                'service': 'Billing',
+                'operation': api_name,
+                'error_type': 'access_denied',
+                'message': (
+                    f'Access denied for Billing {api_name}. '
+                    f'Ensure you have the {required_action} permission. '
+                    'This is a permission failure, not an absence of credits.'
+                ),
+                'resolution': (
+                    f'Add {required_action} to the caller IAM policy. Policies created '
+                    'before the credit allocation-history launch may grant '
+                    'billing:GetCredits without billing:GetCreditAllocationHistory.'
+                ),
+                'request_id': error.response.get('ResponseMetadata', {}).get(
+                    'RequestId', 'Unknown'
+                ),
+                'http_status': error.response.get('ResponseMetadata', {}).get('HTTPStatusCode', 0),
+            }
+
+    return await handle_aws_error(ctx, error, api_name, 'Billing')
+
+
+async def _resolve_account_id(ctx: Context, account_id: Optional[str]) -> str:
+    """Return the account ID to query, auto-detecting the caller's when omitted.
+
+    Billing operations that are account-scoped require ``accountId``, so the
+    caller's own account is resolved via STS when the agent does not supply one.
+
+    Args:
+        ctx: The MCP context object.
+        account_id: 12-digit AWS account ID, or None to auto-detect.
+
+    Returns:
+        The resolved 12-digit AWS account ID.
+    """
+    if account_id:
+        return account_id
+
+    sts_client = create_aws_client('sts')
+    resolved = sts_client.get_caller_identity()['Account']
+    await ctx.info(f'Auto-detected account ID: {resolved}')
+    return resolved
+
+
+async def _paginate_get_credit_allocation_history(
+    ctx: Context,
+    client: Any,
+    request_params: Dict[str, Any],
+    max_results: Optional[int],
+    next_token: Optional[str],
+    max_pages: Optional[int],
+) -> tuple:
+    """Page the allocation ledger with the SDK paginator, keeping completeness flags.
+
+    The SDK declares ``partialResults`` and ``failedMonths`` as non-aggregate keys, so
+    they appear on each page rather than being summed. Both are combined across pages
+    here, because a total computed over an incomplete ledger would otherwise read as
+    authoritative.
+
+    The resume point is read from the page the caller stopped on rather than from the
+    iterator, because the SDK only populates its own resume token when it applies its
+    internal item limit, never when a consumer breaks out of the loop.
+
+    Args:
+        ctx: The MCP context object.
+        client: The billing client.
+        request_params: Operation parameters, without paging controls.
+        max_results: Items per page, or None for the service default.
+        next_token: Continuation token to resume from, or None.
+        max_pages: Maximum pages to fetch, or None for all.
+
+    Returns:
+        Tuple of (rows, pagination_metadata, completeness).
+    """
+    started = datetime.now(timezone.utc)
+    paging: Dict[str, Any] = {}
+    if max_results is not None:
+        paging['PageSize'] = max_results
+    if next_token:
+        paging['StartingToken'] = next_token
+
+    paginator = client.get_paginator('get_credit_allocation_history')
+    pages = paginator.paginate(**request_params, PaginationConfig=paging)
+
+    rows: list = []
+    failed_months: list = []
+    partial_results = False
+    pages_fetched = 0
+    resume_token = None
+
+    for page in pages:
+        rows.extend(page.get('creditAllocationHistoryList') or [])
+        partial_results = partial_results or bool(page.get('partialResults'))
+        for month in page.get('failedMonths') or []:
+            if month not in failed_months:
+                failed_months.append(month)
+        pages_fetched += 1
+        resume_token = page.get('nextToken')
+        if max_pages is not None and pages_fetched >= max_pages:
+            break
+    duration_ms = (datetime.now(timezone.utc) - started).total_seconds() * 1000
+    await ctx.info(f'Fetched {pages_fetched} page(s), {len(rows)} allocation records')
+
+    pagination = {
+        'complete_dataset': resume_token is None,
+        'pages_fetched': pages_fetched,
+        'total_results': len(rows),
+        'has_more': resume_token is not None,
+        'next_token': resume_token,
+        'duration_ms': int(duration_ms),
+    }
+    completeness = {'partial_results': partial_results, 'failed_months': failed_months}
+    return rows, pagination, completeness
+
+
+def _build_get_credits_request(
+    account_id: str,
+    start_epoch: int,
+    end_epoch: Optional[int],
+    payer_account_flag: Optional[bool],
+) -> Dict[str, Any]:
+    """Assemble GetCredits request parameters, omitting the optional ones.
+
+    Args:
+        account_id: Resolved 12-digit AWS account ID.
+        start_epoch: Range start in epoch seconds.
+        end_epoch: Range end in epoch seconds, or None.
+        payer_account_flag: Whether to query at the payer-account level.
+
+    Returns:
+        Dict of API request parameters.
+    """
+    request_params: Dict[str, Any] = {'accountId': account_id, 'startDate': start_epoch}
+    if end_epoch is not None:
+        request_params['endDate'] = end_epoch
+    if payer_account_flag is not None:
+        request_params['payerAccountFlag'] = payer_account_flag
+    return request_params
+
+
+def _build_get_credit_allocation_history_request(
+    account_id: str,
+    start_epoch: int,
+    end_epoch: int,
+    credit_id: Optional[int],
+) -> Dict[str, Any]:
+    """Assemble GetCreditAllocationHistory request parameters.
+
+    Args:
+        account_id: Resolved 12-digit AWS account ID.
+        start_epoch: Effective range start in epoch seconds.
+        end_epoch: Effective range end in epoch seconds.
+        credit_id: Single credit to restrict the ledger to, or None.
+
+    Returns:
+        Dict of API request parameters, without paging controls.
+    """
+    request_params: Dict[str, Any] = {
+        'accountId': account_id,
+        'startDate': start_epoch,
+        'endDate': end_epoch,
+    }
+    if credit_id is not None:
+        request_params['creditId'] = credit_id
+    return request_params
+
+
+def _clamp_get_credits_range(start_epoch: int, end_epoch: Optional[int]) -> tuple:
+    """Narrow a range to the enforced one-year lookback ending no later than now.
+
+    An omitted end date is left as None because the API defaults it to the
+    current date, so supplying one would only restate the default.
+
+    Args:
+        start_epoch: Requested range start in epoch seconds.
+        end_epoch: Requested range end in epoch seconds, or None when omitted.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch) after clamping.
+    """
+    now_epoch = int(datetime.now(timezone.utc).timestamp())
+    if end_epoch is not None:
+        end_epoch = min(end_epoch, now_epoch)
+    start_epoch = max(start_epoch, now_epoch - MAX_CREDITS_LOOKBACK_SECONDS)
+    return start_epoch, end_epoch
+
+
+def _reject_get_credits_pre_lookback_window(end_epoch: Optional[int]) -> Optional[Dict[str, Any]]:
+    """Reject a window that ends before the earliest date GetCredits accepts.
+
+    Such a window has no overlap with the supported lookback, so clamping the
+    start forward would push it past the end and invert the range. A window that
+    only partly predates the floor is clamped instead, since part of it is
+    answerable.
+
+    Args:
+        end_epoch: Requested range end in epoch seconds, or None when omitted.
+
+    Returns:
+        A standardized error response, or None when the window is answerable.
+    """
+    if end_epoch is None:
+        return None
+
+    floor_epoch = int(datetime.now(timezone.utc).timestamp()) - MAX_CREDITS_LOOKBACK_SECONDS
+    if end_epoch >= floor_epoch:
+        return None
+
+    return format_response(
+        'error',
+        {
+            'message': (
+                'GetCredits supports start dates within the last year, and the '
+                f'requested window ends on {timestamp_to_utc_iso_string(end_epoch)}, '
+                'before that limit. Request a window that reaches into the last year.'
+            )
+        },
+    )
+
+
+def _build_get_credits_time_range(
+    start_epoch: int,
+    end_epoch: Optional[int],
+    requested_start: int,
+    requested_end: Optional[int],
+) -> Dict[str, Any]:
+    """Describe the window actually queried alongside the one requested.
+
+    Reporting both makes a narrowed window visible to the agent so a clamped
+    result is never mistaken for a complete one. A null end date means the API
+    default of the current date applies.
+
+    Args:
+        start_epoch: Effective range start after clamping.
+        end_epoch: Effective range end after clamping, or None when omitted.
+        requested_start: Range start as the caller supplied it.
+        requested_end: Range end as the caller supplied it, or None when omitted.
+
+    Returns:
+        Dict describing both windows and the enforced maximum lookback.
+    """
+    return {
+        'start_date': timestamp_to_utc_iso_string(start_epoch),
+        'end_date': (timestamp_to_utc_iso_string(end_epoch) if end_epoch is not None else None),
+        'narrowed_from_request': (start_epoch != requested_start or end_epoch != requested_end),
+        'requested_start_date': timestamp_to_utc_iso_string(requested_start),
+        'requested_end_date': (
+            timestamp_to_utc_iso_string(requested_end) if requested_end is not None else None
+        ),
+        'max_lookback_months': 12,
+    }
+
+
+async def _resolve_get_credits_window(
+    ctx: Context, start_epoch: int, end_epoch: Optional[int]
+) -> tuple:
+    """Clamp the requested range and describe both windows, logging any change.
+
+    Args:
+        ctx: The MCP context object.
+        start_epoch: Requested range start in epoch seconds.
+        end_epoch: Requested range end in epoch seconds, or None when omitted.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch, time_range) after clamping.
+    """
+    requested_start, requested_end = start_epoch, end_epoch
+    start_epoch, end_epoch = _clamp_get_credits_range(start_epoch, end_epoch)
+    time_range = _build_get_credits_time_range(
+        start_epoch, end_epoch, requested_start, requested_end
+    )
+    if time_range['narrowed_from_request']:
+        await ctx.info('Requested range narrowed to the enforced one-year lookback ending now')
+    return start_epoch, end_epoch, time_range
+
+
+async def _finalize_response(
+    ctx: Context, response: Dict[str, Any], api_name: str, **conversion_kwargs: Any
+) -> Dict[str, Any]:
+    """Offload an oversized response to session SQL and wrap it in the envelope.
+
+    Args:
+        ctx: The MCP context object.
+        response: The assembled response body.
+        api_name: Conversion key identifying the operation.
+        **conversion_kwargs: Query context passed through to the converter.
+
+    Returns:
+        The standardized success envelope.
+    """
+    converted = await convert_response_if_needed(ctx, response, api_name, **conversion_kwargs)
+    return format_response('success', converted)
+
+
+def _reject_future_window(start_epoch: int) -> Optional[Dict[str, Any]]:
+    """Reject a window that has not started yet.
+
+    Clamping a future end date back to now would otherwise leave the start after
+    the end, producing an inverted range and a time_range block that misreports
+    the period queried.
+
+    Args:
+        start_epoch: Requested range start in epoch seconds.
+
+    Returns:
+        A standardized error response, or None when the window has started.
+    """
+    if start_epoch <= int(datetime.now(timezone.utc).timestamp()):
+        return None
+
+    return format_response(
+        'error',
+        {
+            'message': (
+                'The requested window starts in the future, so no credit data exists for it yet.'
+            )
+        },
+    )
+
+
+def _validate_get_credit_allocation_history_inputs(
+    start_date: Optional[str],
+    end_date: Optional[str],
+    billing_period: Optional[str],
+    credit_id: Optional[Any],
+) -> tuple:
+    """Validate the allocation-history inputs before any API call.
+
+    The window may be given either as a single ``billing_period`` or as a
+    ``start_date``/``end_date`` pair, but not both.
+
+    Args:
+        start_date: Inclusive range start in ``YYYY-MM-DD`` UTC format.
+        end_date: Inclusive range end in the same format.
+        billing_period: Single calendar month in ``YYYY-MM`` format.
+        credit_id: Caller-supplied credit ID, or None.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch, converted_credit_id, error) where error
+        is a standardized error response when any input is invalid.
+    """
+    if billing_period and (start_date or end_date):
+        return (
+            None,
+            None,
+            None,
+            format_response(
+                'error',
+                {
+                    'message': (
+                        'billing_period and start_date/end_date are mutually '
+                        'exclusive. Provide one or the other.'
+                    )
+                },
+            ),
+        )
+
+    if billing_period:
+        start_epoch, end_epoch, error = _expand_billing_period(billing_period)
+    else:
+        start_epoch, end_epoch, error = _parse_epoch_range(start_date, end_date, True)
+    if error:
+        return None, None, None, error
+
+    error = _reject_future_window(start_epoch)
+    if error:
+        return None, None, None, error
+
+    converted_credit_id, error = _convert_credit_id(credit_id)
+    if error:
+        return None, None, None, error
+
+    return start_epoch, end_epoch, converted_credit_id, None
+
+
+async def _resolve_get_credit_allocation_history_window(
+    ctx: Context, start_epoch: int, end_epoch: int
+) -> tuple:
+    """Clamp the requested range and describe both windows, logging any change.
+
+    Args:
+        ctx: The MCP context object.
+        start_epoch: Requested range start in epoch seconds.
+        end_epoch: Requested range end in epoch seconds.
+
+    Returns:
+        Tuple of (start_epoch, end_epoch, time_range) after clamping.
+    """
+    requested_start, requested_end = start_epoch, end_epoch
+    start_epoch, end_epoch = _clamp_get_credit_allocation_history_range(start_epoch, end_epoch)
+    time_range = _build_get_credit_allocation_history_time_range(
+        start_epoch, end_epoch, requested_start, requested_end
+    )
+    if time_range['narrowed_from_request']:
+        await ctx.info('Requested range narrowed to the enforced 24-month window ending now')
+    return start_epoch, end_epoch, time_range
+
+
+async def _fetch_get_credit_allocation_history(
+    ctx: Context,
+    client: Any,
+    request_params: Dict[str, Any],
+    time_range: Dict[str, Any],
+    max_results: Optional[int],
+    next_token: Optional[str],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Page the allocation ledger and assemble the response body.
+
+    Args:
+        ctx: The MCP context object.
+        client: The billing client.
+        request_params: Operation parameters, without paging controls.
+        time_range: Description of the window queried.
+        max_results: Items per page, or None for the service default.
+        next_token: Continuation token to resume from, or None.
+        max_pages: Maximum pages to fetch, or None for all.
+
+    Returns:
+        The assembled response body.
+    """
+    allocations, pagination, completeness = await _paginate_get_credit_allocation_history(
+        ctx, client, request_params, max_results, next_token, max_pages
+    )
+    await ctx.info(f'Successfully retrieved {len(allocations)} credit allocation records')
+    return {
+        'credit_allocation_history': allocations,
+        'time_range': time_range,
+        'completeness': completeness,
+        'pagination': pagination,
+    }
+
+
+async def get_credits(
+    ctx: Context,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    account_id: Optional[str] = None,
+    payer_account_flag: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Get credit balance, expiration and applicability for an account.
+
+    Returns every credit object visible to the account within the requested window,
+    including initial and remaining amounts, expiration and exhaustion dates,
+    applicable products, and credit-sharing configuration.
+
+    A payer-level query can return a large credit portfolio, so the shared size
+    threshold decides whether to offload to session SQL via convert_response_if_needed.
+
+    Args:
+        ctx: The MCP context object.
+        start_date: Inclusive range start in ``YYYY-MM-DD`` (or
+            ``YYYY-MM-DDTHH:MM:SS``) UTC format.
+        end_date: Optional inclusive range end in the same format.
+        account_id: 12-digit AWS account ID. Auto-detected from the caller
+            identity via STS when omitted.
+        payer_account_flag: Set True to query at the payer-account level rather
+            than for the individual account.
+
+    Returns:
+        Dict containing ``credits`` with timestamps, or a standardized error
+        response.
+    """
+    try:
+        start_epoch, end_epoch, error = _parse_epoch_range(start_date, end_date, False)
+        if error:
+            return error
+
+        error = _reject_future_window(start_epoch) or _reject_get_credits_pre_lookback_window(
+            end_epoch
+        )
+        if error:
+            return error
+
+        start_epoch, end_epoch, time_range = await _resolve_get_credits_window(
+            ctx, start_epoch, end_epoch
+        )
+
+        resolved_account_id = await _resolve_account_id(ctx, account_id)
+
+        request_params = _build_get_credits_request(
+            resolved_account_id, start_epoch, end_epoch, payer_account_flag
+        )
+        client = _create_billing_client()
+
+        api_response = client.get_credits(**request_params)
+
+        credits = [_normalize_credit_data(credit) for credit in api_response.get('credits', [])]
+
+        await ctx.info(f'Successfully retrieved {len(credits)} credits')
+
+        response = {
+            'credits': credits,
+            'time_range': time_range,
+        }
+
+        return await _finalize_response(
+            ctx,
+            response,
+            'credits_get_credits',
+            account_id=resolved_account_id,
+            start_date=start_date,
+            end_date=end_date,
+            time_range=time_range,
+        )
+
+    except Exception as e:
+        return await _handle_billing_error(ctx, e, 'GetCredits')
+
+
+async def get_credit_allocation_history(
+    ctx: Context,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    billing_period: Optional[str] = None,
+    account_id: Optional[str] = None,
+    credit_id: Optional[Any] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Get credits ledger to show how credits were applied per service per billing period.
+
+    Returns the credit-level allocation ledger.
+
+    The API rejects ranges longer than 24 months. A longer request is narrowed to
+    the most recent 24 months rather than failing, and the response reports the
+    window actually queried so a narrowed result is never mistaken for a
+    complete one.
+
+    Multi-month allocation windows can exceed the inline size threshold,
+    in which case the shared helper offloads the rows to session SQL via
+    convert_response_if_needed.
+
+    Args:
+        ctx: The MCP context object.
+        start_date: Inclusive range start in ``YYYY-MM-DD`` (or
+            ``YYYY-MM-DDTHH:MM:SS``) UTC format. Required by the API.
+        end_date: Inclusive range end in the same format. Required by the API.
+        billing_period: Single calendar month in ``YYYY-MM`` format, expanded to
+            cover that whole month. Mutually exclusive with
+            ``start_date``/``end_date``.
+        account_id: 12-digit AWS account ID. Auto-detected from the caller
+            identity via STS when omitted.
+        credit_id: Restrict the ledger to a single credit. The API declares this
+            as a long, while ``GetCredits`` returns ``creditId`` as a string, so
+            a string value is converted to an integer here.
+        max_results: Maximum number of results per page.
+        next_token: Pagination token from a previous response to resume from.
+        max_pages: Maximum number of pages to auto-paginate through. Defaults to
+            all pages.
+
+    Returns:
+        Dict containing ``credit_allocation_history``, the ``time_range``
+        actually queried, completeness flags, and a ``pagination`` metadata
+        block, or a standardized error response.
+    """
+    try:
+        start_epoch, end_epoch, converted_credit_id, error = (
+            _validate_get_credit_allocation_history_inputs(
+                start_date, end_date, billing_period, credit_id
+            )
+        )
+        if error:
+            return error
+
+        start_epoch, end_epoch, time_range = await _resolve_get_credit_allocation_history_window(
+            ctx, start_epoch, end_epoch
+        )
+
+        resolved_account_id = await _resolve_account_id(ctx, account_id)
+
+        request_params = _build_get_credit_allocation_history_request(
+            resolved_account_id, start_epoch, end_epoch, converted_credit_id
+        )
+        client = _create_billing_client()
+
+        response = await _fetch_get_credit_allocation_history(
+            ctx, client, request_params, time_range, max_results, next_token, max_pages
+        )
+
+        return await _finalize_response(
+            ctx,
+            response,
+            'credits_get_credit_allocation_history',
+            pagination_token_key='nextToken',
+            account_id=resolved_account_id,
+            time_range=response['time_range'],
+            completeness=response['completeness'],
+            pagination=response['pagination'],
+        )
+
+    except Exception as e:
+        return await _handle_billing_error(ctx, e, 'GetCreditAllocationHistory')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/credits_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/credits_tools.py
@@ -1,0 +1,210 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS credits tools for the AWS Billing and Cost Management MCP server.
+
+Exposes a single ``credits`` tool that routes by ``operation`` so additional AWS
+credits APIs can be added later as new operations under one tool (mirroring the
+cost-explorer and invoicing tools). The rich tool description is the primary
+vehicle that gives the agent semantic context about every request parameter and
+response field.
+"""
+
+from ..utilities.aws_service_base import format_response
+from .credits_operations import get_credit_allocation_history as _get_credit_allocation_history
+from .credits_operations import get_credits as _get_credits
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, Optional
+
+
+credits_server = FastMCP(
+    name='credits-tools',
+    instructions='Tools for working with AWS credits via the AWS Billing API',
+)
+
+
+async def _credits(
+    ctx: Context,
+    operation: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    billing_period: Optional[str] = None,
+    account_id: Optional[str] = None,
+    payer_account_flag: Optional[bool] = None,
+    credit_id: Optional[Any] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Route an AWS credits ``operation`` to its handler.
+
+    Kept separate from the FastMCP-decorated wrapper so the routing can be unit
+    tested directly (decorated tools cannot be invoked as plain functions).
+
+    Args:
+        ctx: The MCP context object.
+        operation: The credits operation to perform (e.g. ``"get_credits"``).
+        start_date: Inclusive range start in ``YYYY-MM-DD`` UTC format.
+        end_date: Inclusive range end in ``YYYY-MM-DD`` UTC format.
+        billing_period: Single calendar month in ``YYYY-MM`` format (allocation
+            history only). Mutually exclusive with start_date/end_date.
+        account_id: 12-digit AWS account ID. Auto-detected via STS when omitted.
+        payer_account_flag: Query at the payer-account level (get_credits only).
+        credit_id: Restrict the ledger to one credit (allocation history only).
+        max_results: Maximum results per page (allocation history only).
+        next_token: Pagination token from a previous response.
+        max_pages: Maximum pages to auto-paginate through (default: all).
+
+    Returns:
+        The operation's response, or a standardized error for an unknown
+        operation.
+    """
+    await ctx.info(f'Credits operation: {operation}')
+
+    if operation == 'get_credits':
+        return await _get_credits(
+            ctx,
+            start_date=start_date,
+            end_date=end_date,
+            account_id=account_id,
+            payer_account_flag=payer_account_flag,
+        )
+
+    if operation == 'get_credit_allocation_history':
+        return await _get_credit_allocation_history(
+            ctx,
+            start_date=start_date,
+            end_date=end_date,
+            billing_period=billing_period,
+            account_id=account_id,
+            credit_id=credit_id,
+            max_results=max_results,
+            next_token=next_token,
+            max_pages=max_pages,
+        )
+
+    return format_response(
+        'error',
+        {
+            'message': (
+                f"Unsupported operation: '{operation}'. Supported operations: "
+                'get_credits, get_credit_allocation_history.'
+            )
+        },
+    )
+
+
+@credits_server.tool(
+    name='credits',
+    description="""Access AWS credits data: balance, expiration, product applicability, sharing configuration, and the per-service allocation ledger. Choose an action with the required `operation` parameter; the remaining parameters apply to specific operations.
+
+## OPERATIONS
+
+1) get_credits - the credits objects held by an account: balance, expiration, applicability and sharing
+   Required: operation="get_credits", start_date. start_date is accepted only within one year before today; a request reaching further back is narrowed to that limit.
+   Optional:
+     - end_date: inclusive range end. Cannot be in the future. Omit it to use the API default of today.
+     - account_id: 12-digit AWS account ID. Auto-detected via STS GetCallerIdentity when omitted.
+     - payer_account_flag: set true only when the caller is the management account (the payer account of a consolidated billing family). When true and the caller is the management account, the response aggregates credits across the entire family; use this for "credits across my organization" questions. When false, omitted, or when the caller is a member account, the response covers only the account in `account_id`. Setting it true from a member account does NOT error: the call succeeds and returns just that account's credits, so an empty or small result must not be read as the organization having no credits, only as the caller not being the management account.
+   Not paginated: the API returns the complete set in one call.
+   Returns: `data.credits`, a list where each item contains:
+     - creditId; accountId; creditType; description
+     - initialAmount, remainingAmount, estimatedAmount: each {currencyCode, currencyAmount}. remainingAmount is the unused balance. estimatedAmount is the estimated remaining balance including in-flight (open) bills not yet finalized, so the two can differ. For "how much credit do I have left", report remainingAmount, and name estimatedAmount only alongside what it includes.
+     - startDate, endDate, exhaustDate: dates (converted from epoch). endDate is the expiration date. exhaustDate is the date the balance reached zero, a past event and NOT a forecast. Do not report exhaustDate as an expiration, and do not present it as a projection of when credit will run out.
+     - applicableProductNames: services the credit can apply to. An empty list means no product restriction was surfaced, not that the credit applies to nothing.
+     - creditStatus (ENABLED|DISABLED); applicationType (BEFORE_CROSS_SERVICE_DISCOUNTS|AFTER_DISCOUNTS); purchaseTypeApplications: restricts which purchase types the credit applies to. Null or omitted means all purchase types, not none.
+     - creditSharingType (DEFAULT|DISABLED|CUSTOM|COST_CATEGORY_RULE); shareableAccounts; accountHasCreditSharingEnabled; costCategoryArn; ruleName
+     - creditConsoleVisibility
+   Also returns `data.time_range`, which must be read before stating a period (see below).
+
+2) get_credit_allocation_history - the ledger of how credits were applied, per service per billing month
+   Required: operation="get_credit_allocation_history", and a window (choose one form):
+     - billing_period: a single calendar month "YYYY-MM" (e.g. "2026-06"), expanded to cover that whole month. PREFER THIS for single-month questions such as "how were my credits applied in June 2026" so no date arithmetic is needed.
+     - start_date + end_date: an inclusive range, required together and mutually exclusive with billing_period.
+   Optional:
+     - account_id: as above.
+     - credit_id: restrict the ledger to one credit. Pass the `creditId` string from get_credits unchanged; the tool converts it to the numeric type this API requires.
+     - max_results: items per page. max_pages: pages to fetch (default: all). next_token: resume from a previous response.
+   Returns: `data.credit_allocation_history`, sorted by billingMonth descending, a list where each item contains creditId, creditAmount {currencyCode, currencyAmount} where a negative value means the credit reduced that bill, description, accountId, appliedServiceName, billingMonth (YYYY-MM), and isEstimatedBill (true when the entry applied to an in-flight bill that is not yet finalized).
+   Also returns `data.completeness` and `data.time_range`, both of which must be read before summarizing (see below).
+
+## READING THE RESPONSE CORRECTLY
+
+- MONETARY AMOUNTS ARE STRINGS to preserve decimal precision. Parse as decimals, never floats. Report them exactly as returned.
+- CHECK `data.completeness` BEFORE TOTALLING. When `partial_results` is true, some months failed and are listed in `failed_months`. Any sum over the returned rows is incomplete: report the total AND name the months missing from it. Never present a partial total as the full picture.
+- CHECK `data.time_range` BEFORE STATING A PERIOD. Both operations narrow a window they cannot serve, and neither queries the future. The limits differ: get_credit_allocation_history caps the range at 24 months, while get_credits caps the lookback at one year before today. When `narrowed_from_request` is true, the answer covers `start_date` to `end_date`, NOT `requested_start_date` to `requested_end_date`. Say which window was actually used. A window with no answerable overlap at all, entirely in the future or entirely before the lookback limit, returns an error rather than a narrowed result.
+- Dates go in as YYYY-MM-DD. Never compute an epoch timestamp yourself; the tool converts.
+- A LARGE LEDGER IS OFFLOADED TO SQL. When the response carries `data_stored: true` and a `table_name` instead of an inline list, query it with the session-sql tool. Nested values are stored as JSON text, so aggregate money with json_extract, not directly: `SELECT appliedServiceName, SUM(CAST(json_extract(creditAmount, '$.currencyAmount') AS REAL)) FROM <table_name> GROUP BY appliedServiceName`. A bare `SUM(creditAmount)` returns 0, silently. The `time_range`, `completeness` and `pagination` blocks are still present alongside the table reference.
+- An empty result is a real answer. Zero allocation rows for a month means no credits were applied in that month, which is different from having no credits.
+- An access_denied error means the caller's IAM policy is missing the named permission. It does NOT mean the account has no credits, and it must not be reported as an absence of data or worked around with Cost Explorer.
+
+## CHOOSING BETWEEN THIS TOOL AND COST EXPLORER
+
+get_credit_allocation_history is authoritative for "how were my credits applied". Cost Explorer's RECORD_TYPE=Credit reports the aggregated effect of credits on billed cost, which is a different figure: one credit split across several services in a month appears as multiple rows here and as one adjustment per service there. Cost Explorer also cannot return credit-level metadata such as source, expiration or sharing status. Prefer this tool for the ledger, and when reconciling against a Cost Explorer figure, state which cost metric was used and surface both numbers rather than forcing them to agree.
+
+EXAMPLES
+- {"operation": "get_credits", "start_date": "2026-01-01"}
+- {"operation": "get_credits", "start_date": "2026-01-01", "end_date": "2026-06-30", "payer_account_flag": true}
+- {"operation": "get_credit_allocation_history", "billing_period": "2026-06"}
+- {"operation": "get_credit_allocation_history", "start_date": "2026-06-01", "end_date": "2026-06-30"}
+- {"operation": "get_credit_allocation_history", "start_date": "2026-01-01", "end_date": "2026-06-30", "credit_id": "1234567890"}""",
+)
+async def credits(
+    ctx: Context,
+    operation: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    billing_period: Optional[str] = None,
+    account_id: Optional[str] = None,
+    payer_account_flag: Optional[bool] = None,
+    credit_id: Optional[Any] = None,
+    max_results: Optional[int] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """FastMCP wrapper for AWS credits operations.
+
+    Thin wrapper so the routing logic in ``_credits`` can be unit tested
+    directly (FastMCP-decorated tools cannot be invoked as plain functions).
+
+    Args:
+        ctx: The MCP context object.
+        operation: The credits operation to perform (e.g. ``"get_credits"``).
+        start_date: Inclusive range start in ``YYYY-MM-DD`` UTC format.
+        end_date: Inclusive range end in ``YYYY-MM-DD`` UTC format.
+        billing_period: Single calendar month in ``YYYY-MM`` format (allocation
+            history only). Mutually exclusive with start_date/end_date.
+        account_id: 12-digit AWS account ID. Auto-detected via STS when omitted.
+        payer_account_flag: Query at the payer-account level (get_credits only).
+        credit_id: Restrict the ledger to one credit (allocation history only).
+        max_results: Maximum results per page (allocation history only).
+        next_token: Pagination token from a previous response.
+        max_pages: Maximum pages to auto-paginate through (default: all).
+
+    Returns:
+        Dict containing the operation result.
+    """
+    return await _credits(
+        ctx,
+        operation,
+        start_date=start_date,
+        end_date=end_date,
+        billing_period=billing_period,
+        account_id=account_id,
+        payer_account_flag=payer_account_flag,
+        credit_id=credit_id,
+        max_results=max_results,
+        next_token=next_token,
+        max_pages=max_pages,
+    )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -368,6 +368,11 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
     if operation_name.startswith('compute_optimizer_automation_'):
         return 'records'
 
+    # Credits operations return {<list_key>: [...]} plus sibling metadata blocks;
+    # store one row per item so an offloaded credit ledger stays aggregatable.
+    if operation_name.startswith('credits_get_'):
+        return 'records'
+
     return None
 
 

--- a/src/billing-cost-management-mcp-server/pyproject.toml
+++ b/src/billing-cost-management-mcp-server/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "mcp[cli]>=1.23.0",
     "pydantic>=2.10.6",
     "fastmcp>=3.2.0",
-    "boto3>=1.42.4",
+    "boto3>=1.43.41",
     "python-dotenv>=1.0.0",
     "sqlglot>=20.0.0",
 ]

--- a/src/billing-cost-management-mcp-server/tests/test_server.py
+++ b/src/billing-cost-management-mcp-server/tests/test_server.py
@@ -97,7 +97,7 @@ def test_setup_function(mock_register_prompts, mock_mcp):
 
     setup()
 
-    assert mock_mcp.mount.call_count == 22
+    assert mock_mcp.mount.call_count == 23
     mock_register_prompts.assert_called_once()
 
 

--- a/src/billing-cost-management-mcp-server/tests/tools/test_credits_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_credits_operations.py
@@ -1,0 +1,1049 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the credits_operations module."""
+
+import boto3
+import pytest
+import sqlite3
+from awslabs.billing_cost_management_mcp_server.tools.credits_operations import (
+    MAX_ALLOCATION_HISTORY_SECONDS,
+    MAX_CREDITS_LOOKBACK_SECONDS,
+    get_credit_allocation_history,
+    get_credits,
+)
+from awslabs.billing_cost_management_mcp_server.utilities import sql_utils
+from botocore.exceptions import ClientError
+from botocore.stub import ANY, Stubber
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+CREATE_CLIENT_PATH = (
+    'awslabs.billing_cost_management_mcp_server.tools.credits_operations.create_aws_client'
+)
+CONVERT_PATH = (
+    'awslabs.billing_cost_management_mcp_server.tools.credits_operations.'
+    'convert_response_if_needed'
+)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context with async logging methods."""
+    context = MagicMock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    context.debug = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def sample_credit():
+    """Return a sample CreditData item as the AWS API would return it."""
+    return {
+        'creditId': '4242',
+        'accountId': '123456789012',
+        'creditType': 'Promotion',
+        'description': 'Migration credit',
+        'initialAmount': {'currencyCode': 'USD', 'currencyAmount': '1000.00'},
+        'remainingAmount': {'currencyCode': 'USD', 'currencyAmount': '250.50'},
+        'startDate': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        'endDate': datetime(2026, 12, 31, tzinfo=timezone.utc),
+        'exhaustDate': datetime(2026, 9, 30, tzinfo=timezone.utc),
+        'applicableProductNames': ['AmazonEC2'],
+        'creditStatus': 'ENABLED',
+    }
+
+
+@pytest.fixture
+def sample_allocation():
+    """Return a sample allocation-history row as the AWS API would return it."""
+    return {
+        'creditId': '4242',
+        'creditAmount': {'currencyCode': 'USD', 'currencyAmount': '100.25'},
+        'accountId': '123456789012',
+        'appliedServiceName': 'AmazonEC2',
+        'billingMonth': '2026-06',
+        'isEstimatedBill': False,
+    }
+
+
+def _await_call(mock):
+    """Return a mock's most recent await, asserting one happened."""
+    assert mock.await_args is not None
+    return mock.await_args
+
+
+def _client_factory(mock_client, mock_sts):
+    """Build a create_aws_client side_effect returning per-service mocks."""
+
+    def _factory(service_name, **kwargs):
+        return mock_sts if service_name == 'sts' else mock_client
+
+    return _factory
+
+
+def _sts_mock(account_id='123456789012'):
+    """Build an STS mock resolving to the given account."""
+    mock_sts = MagicMock()
+    mock_sts.get_caller_identity.return_value = {'Account': account_id}
+    return mock_sts
+
+
+def _get_credits_client(credits):
+    """Build a billing client mock whose get_credits returns the given list."""
+    mock_client = MagicMock()
+    mock_client.get_credits.return_value = {'credits': credits}
+    return mock_client
+
+
+def _get_credit_allocation_history_client(pages):
+    """Build a billing client mock whose paginator yields the given pages.
+
+    The mock deliberately exposes no resume token, so a test cannot assert
+    truncation reporting that the real SDK paginator would not produce.
+
+    Args:
+        pages: Raw API page dicts to yield in order.
+
+    Returns:
+        A client mock wired through get_paginator.
+    """
+    page_iterator = MagicMock()
+    page_iterator.__iter__ = lambda self: iter(pages)
+    paginator = MagicMock()
+    paginator.paginate.return_value = page_iterator
+    mock_client = MagicMock()
+    mock_client.get_paginator.return_value = paginator
+    return mock_client
+
+
+def _paginate_call(mock_client):
+    """Return the keyword arguments the paginator was invoked with."""
+    return mock_client.get_paginator.return_value.paginate.call_args.kwargs
+
+
+def _offset_date(days):
+    """Return a UTC calendar date the given number of days from today.
+
+    Windows for GetCredits are validated against the current date, so tests use
+    offsets rather than literals. A literal would silently start exercising the
+    clamp once it aged past the one-year lookback.
+
+    Args:
+        days: Day offset from today. Negative is in the past.
+
+    Returns:
+        Date string in ``YYYY-MM-DD`` format.
+    """
+    return (datetime.now(timezone.utc) + timedelta(days=days)).strftime('%Y-%m-%d')
+
+
+def _epoch_of(date_string):
+    """Convert a ``YYYY-MM-DD`` date to epoch seconds without the module's converter.
+
+    Computing the expected value independently keeps the conversion assertion
+    from merely restating the implementation.
+
+    Args:
+        date_string: Date in ``YYYY-MM-DD`` format.
+
+    Returns:
+        Epoch seconds at UTC midnight on that date.
+    """
+    parsed = datetime.strptime(date_string, '%Y-%m-%d').replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp())
+
+
+async def _call_get_credits(ctx, mock_client, **kwargs):
+    """Invoke get_credits with the billing and STS clients patched."""
+    with patch(CREATE_CLIENT_PATH) as mock_create:
+        mock_create.side_effect = _client_factory(mock_client, _sts_mock())
+        return await get_credits(ctx, **kwargs)
+
+
+async def _call_get_credit_allocation_history(ctx, mock_client, **kwargs):
+    """Invoke get_credit_allocation_history with the clients patched."""
+    with patch(CREATE_CLIENT_PATH) as mock_create:
+        mock_create.side_effect = _client_factory(mock_client, _sts_mock())
+        return await get_credit_allocation_history(ctx, **kwargs)
+
+
+class TestGetCredits:
+    """Successful GetCredits calls and response shaping."""
+
+    @pytest.mark.asyncio
+    async def test_converts_dates_to_epoch(self, mock_context, sample_credit):
+        """Calendar dates are converted to epoch seconds for the API."""
+        client = _get_credits_client([sample_credit])
+        start, end = _offset_date(-200), _offset_date(-10)
+
+        result = await _call_get_credits(mock_context, client, start_date=start, end_date=end)
+
+        assert result['status'] == 'success'
+        call = client.get_credits.call_args.kwargs
+        assert call['startDate'] == _epoch_of(start)
+        assert call['endDate'] == _epoch_of(end)
+
+    @pytest.mark.asyncio
+    async def test_normalizes_timestamp_fields(self, mock_context, sample_credit):
+        """startDate, endDate and exhaustDate become readable strings."""
+        client = _get_credits_client([sample_credit])
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        credit = result['data']['credits'][0]
+        assert credit['startDate'] == '2026-01-01T00:00:00'
+        assert credit['endDate'] == '2026-12-31T00:00:00'
+        assert credit['exhaustDate'] == '2026-09-30T00:00:00'
+
+    @pytest.mark.asyncio
+    async def test_monetary_amounts_untouched(self, mock_context, sample_credit):
+        """Monetary structures are returned exactly as the API provided them."""
+        client = _get_credits_client([sample_credit])
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        credit = result['data']['credits'][0]
+        assert credit['remainingAmount'] == {'currencyCode': 'USD', 'currencyAmount': '250.50'}
+        assert credit['initialAmount']['currencyAmount'] == '1000.00'
+
+    @pytest.mark.asyncio
+    async def test_auto_detects_account_id(self, mock_context, sample_credit):
+        """The caller's account is resolved via STS when none is supplied."""
+        client = _get_credits_client([sample_credit])
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        assert result['status'] == 'success'
+        assert client.get_credits.call_args.kwargs['accountId'] == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_explicit_account_id_is_used(self, mock_context, sample_credit):
+        """An explicit account_id is passed through unchanged."""
+        client = _get_credits_client([sample_credit])
+
+        await _call_get_credits(
+            mock_context, client, start_date=_offset_date(-180), account_id='999888777666'
+        )
+
+        assert client.get_credits.call_args.kwargs['accountId'] == '999888777666'
+
+    @pytest.mark.asyncio
+    async def test_payer_account_flag_passthrough(self, mock_context, sample_credit):
+        """payer_account_flag is forwarded to the API when supplied."""
+        client = _get_credits_client([sample_credit])
+
+        await _call_get_credits(
+            mock_context, client, start_date=_offset_date(-180), payer_account_flag=True
+        )
+
+        assert client.get_credits.call_args.kwargs['payerAccountFlag'] is True
+
+    @pytest.mark.asyncio
+    async def test_omits_unset_optional_parameters(self, mock_context, sample_credit):
+        """Unset optional parameters are absent from the request."""
+        client = _get_credits_client([sample_credit])
+
+        await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        call = client.get_credits.call_args.kwargs
+        assert 'endDate' not in call
+        assert 'payerAccountFlag' not in call
+
+    @pytest.mark.asyncio
+    async def test_open_ended_window_reports_null_end(self, mock_context, sample_credit):
+        """An omitted end_date is reported as a null end in the time range."""
+        client = _get_credits_client([sample_credit])
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        assert result['data']['time_range']['end_date'] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_credits_is_success(self, mock_context):
+        """An account with no credits returns success with an empty list."""
+        client = _get_credits_client([])
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        assert result['status'] == 'success'
+        assert result['data']['credits'] == []
+
+
+class TestGetCreditsValidation:
+    """Input validation for GetCredits, before any API call."""
+
+    @pytest.mark.asyncio
+    async def test_missing_start_date(self, mock_context):
+        """start_date is required."""
+        client = _get_credits_client([])
+
+        result = await _call_get_credits(mock_context, client)
+
+        assert result['status'] == 'error'
+        assert 'start_date is required' in result['data']['message']
+        client.get_credits.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unparseable_date(self, mock_context):
+        """A date that cannot be parsed is rejected without calling the API."""
+        client = _get_credits_client([])
+
+        result = await _call_get_credits(mock_context, client, start_date='not-a-date')
+
+        assert result['status'] == 'error'
+        client.get_credits.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_end_before_start(self, mock_context):
+        """An end date preceding the start is rejected."""
+        client = _get_credits_client([])
+
+        result = await _call_get_credits(
+            mock_context, client, start_date=_offset_date(-30), end_date=_offset_date(-60)
+        )
+
+        assert result['status'] == 'error'
+        assert 'must not precede' in result['data']['message']
+        client.get_credits.assert_not_called()
+
+
+class TestGetCreditsWindow:
+    """Lookback clamping and window rejection for GetCredits.
+
+    GetCredits accepts a start date no more than one year before the current
+    date and no future end date, a tighter limit than the allocation ledger's
+    24-month range.
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_beyond_one_year_is_narrowed(self, mock_context, sample_credit):
+        """A start date older than the lookback is pulled forward to the limit."""
+        client = _get_credits_client([sample_credit])
+        requested = _offset_date(-3 * 365)
+
+        result = await _call_get_credits(mock_context, client, start_date=requested)
+
+        expected_floor = int(datetime.now(timezone.utc).timestamp()) - MAX_CREDITS_LOOKBACK_SECONDS
+        sent = client.get_credits.call_args.kwargs['startDate']
+        assert sent > _epoch_of(requested)
+        assert abs(sent - expected_floor) <= 60
+        assert result['data']['time_range']['narrowed_from_request'] is True
+
+    @pytest.mark.asyncio
+    async def test_narrowing_preserves_requested_window(self, mock_context, sample_credit):
+        """The requested start is reported alongside the effective one."""
+        client = _get_credits_client([sample_credit])
+        requested = _offset_date(-3 * 365)
+
+        result = await _call_get_credits(mock_context, client, start_date=requested)
+
+        time_range = result['data']['time_range']
+        assert time_range['requested_start_date'].startswith(requested)
+        assert time_range['start_date'] != time_range['requested_start_date']
+        assert time_range['requested_end_date'] is None
+        assert time_range['max_lookback_months'] == 12
+
+    @pytest.mark.asyncio
+    async def test_in_range_window_is_not_narrowed(self, mock_context, sample_credit):
+        """A start date inside the lookback is passed through untouched."""
+        client = _get_credits_client([sample_credit])
+        requested = _offset_date(-180)
+
+        result = await _call_get_credits(mock_context, client, start_date=requested)
+
+        assert client.get_credits.call_args.kwargs['startDate'] == _epoch_of(requested)
+        assert result['data']['time_range']['narrowed_from_request'] is False
+
+    @pytest.mark.asyncio
+    async def test_future_end_date_is_clamped(self, mock_context, sample_credit):
+        """An end date in the future is pulled back to now."""
+        client = _get_credits_client([sample_credit])
+
+        result = await _call_get_credits(
+            mock_context, client, start_date=_offset_date(-30), end_date=_offset_date(90)
+        )
+
+        now_epoch = int(datetime.now(timezone.utc).timestamp())
+        assert abs(client.get_credits.call_args.kwargs['endDate'] - now_epoch) <= 60
+        assert result['data']['time_range']['narrowed_from_request'] is True
+
+    @pytest.mark.asyncio
+    async def test_window_start_never_exceeds_end(self, mock_context, sample_credit):
+        """Clamping a window that straddles the lookback cannot invert it."""
+        client = _get_credits_client([sample_credit])
+
+        await _call_get_credits(
+            mock_context, client, start_date=_offset_date(-2 * 365), end_date=_offset_date(-30)
+        )
+
+        call = client.get_credits.call_args.kwargs
+        assert call['startDate'] < call['endDate']
+
+    @pytest.mark.asyncio
+    async def test_future_window_is_rejected(self, mock_context):
+        """A window that has not started yet is refused without an API call."""
+        client = _get_credits_client([])
+
+        result = await _call_get_credits(
+            mock_context, client, start_date=_offset_date(10), end_date=_offset_date(40)
+        )
+
+        assert result['status'] == 'error'
+        assert 'starts in the future' in result['data']['message']
+        client.get_credits.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_window_entirely_before_lookback_is_rejected(self, mock_context):
+        """A window ending before the lookback is refused rather than inverted.
+
+        Clamping the start forward would push it past the end, so a window with
+        no answerable overlap is an error instead of a narrowed result.
+        """
+        client = _get_credits_client([])
+
+        result = await _call_get_credits(
+            mock_context,
+            client,
+            start_date=_offset_date(-3 * 365),
+            end_date=_offset_date(-2 * 365),
+        )
+
+        assert result['status'] == 'error'
+        assert 'within the last year' in result['data']['message']
+        client.get_credits.assert_not_called()
+
+
+class TestGetCreditAllocationHistoryWindow:
+    """Window selection, billing_period expansion and the 24-month clamp."""
+
+    @pytest.mark.asyncio
+    async def test_billing_period_expands_to_month(self, mock_context, sample_allocation):
+        """A YYYY-MM billing period covers the whole calendar month."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        time_range = result['data']['time_range']
+        assert time_range['start_date'].startswith('2026-06-01')
+        assert time_range['end_date'].startswith('2026-06-30')
+
+    @pytest.mark.asyncio
+    async def test_billing_period_handles_leap_year(self, mock_context, sample_allocation):
+        """February in a leap year ends on the 29th."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2024-02'
+        )
+
+        assert result['data']['time_range']['end_date'].startswith('2024-02-29')
+
+    @pytest.mark.asyncio
+    async def test_billing_period_handles_non_leap_year(self, mock_context, sample_allocation):
+        """February in a non-leap year ends on the 28th."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-02'
+        )
+
+        assert result['data']['time_range']['end_date'].startswith('2026-02-28')
+
+    @pytest.mark.asyncio
+    async def test_billing_period_and_dates_are_mutually_exclusive(self, mock_context):
+        """Supplying both window forms is rejected."""
+        client = _get_credit_allocation_history_client([])
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06', start_date='2026-01-01'
+        )
+
+        assert result['status'] == 'error'
+        assert 'mutually exclusive' in result['data']['message']
+        client.get_paginator.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('value', ['2026-13', '2026', 'june', '2026-00', ''])
+    async def test_invalid_billing_period(self, mock_context, value):
+        """A malformed billing period is rejected without calling the API."""
+        client = _get_credit_allocation_history_client([])
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period=value
+        )
+
+        assert result['status'] == 'error'
+        client.get_paginator.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_both_dates_required(self, mock_context):
+        """The date-pair form requires start_date and end_date together."""
+        client = _get_credit_allocation_history_client([])
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, start_date='2026-01-01'
+        )
+
+        assert result['status'] == 'error'
+        client.get_paginator.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_range_over_24_months_is_narrowed(self, mock_context, sample_allocation):
+        """A range longer than 24 months is narrowed to the enforced window."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, start_date='2018-01-01', end_date='2030-01-01'
+        )
+
+        call = _paginate_call(client)
+        assert call['endDate'] - call['startDate'] == MAX_ALLOCATION_HISTORY_SECONDS
+        assert result['data']['time_range']['narrowed_from_request'] is True
+
+    @pytest.mark.asyncio
+    async def test_narrowing_preserves_requested_window(self, mock_context, sample_allocation):
+        """The requested range is reported alongside the effective one."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, start_date='2018-01-01', end_date='2030-01-01'
+        )
+
+        time_range = result['data']['time_range']
+        assert time_range['requested_start_date'].startswith('2018-01-01')
+        assert time_range['requested_end_date'].startswith('2030-01-01')
+        assert time_range['max_range_months'] == 24
+
+    @pytest.mark.asyncio
+    async def test_future_end_date_is_clamped(self, mock_context, sample_allocation):
+        """An end date in the future is clamped to now."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, start_date='2026-01-01', end_date='2099-01-01'
+        )
+
+        now_epoch = int(datetime.now(timezone.utc).timestamp())
+        assert _paginate_call(client)['endDate'] <= now_epoch
+        assert result['data']['time_range']['narrowed_from_request'] is True
+
+    @pytest.mark.asyncio
+    async def test_future_billing_period_is_rejected(self, mock_context):
+        """A billing period that has not started yet is rejected, not clamped."""
+        client = _get_credit_allocation_history_client([])
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2099-01'
+        )
+
+        assert result['status'] == 'error'
+        assert 'starts in the future' in result['data']['message']
+        client.get_paginator.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_future_date_pair_is_rejected(self, mock_context):
+        """A fully future date range is rejected rather than inverted by clamping."""
+        client = _get_credit_allocation_history_client([])
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, start_date='2099-01-01', end_date='2099-06-30'
+        )
+
+        assert result['status'] == 'error'
+        client.get_paginator.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_window_start_never_exceeds_end(self, mock_context, sample_allocation):
+        """Clamping a future end date can never produce an inverted range."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        await _call_get_credit_allocation_history(
+            mock_context, client, start_date='2026-01-01', end_date='2099-01-01'
+        )
+
+        call = _paginate_call(client)
+        assert call['startDate'] < call['endDate']
+
+    @pytest.mark.asyncio
+    async def test_in_range_window_is_not_narrowed(self, mock_context, sample_allocation):
+        """A window inside the limit is passed through unchanged."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert result['data']['time_range']['narrowed_from_request'] is False
+
+
+class TestGetCreditAllocationHistoryPagination:
+    """Page accumulation and pagination metadata."""
+
+    @pytest.mark.asyncio
+    async def test_accumulates_pages(self, mock_context, sample_allocation):
+        """Rows from every page are combined."""
+        client = _get_credit_allocation_history_client(
+            [
+                {'creditAllocationHistoryList': [sample_allocation], 'nextToken': 'page-2'},
+                {'creditAllocationHistoryList': [sample_allocation]},
+            ]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert len(result['data']['credit_allocation_history']) == 2
+        assert result['data']['pagination']['pages_fetched'] == 2
+        assert result['data']['pagination']['has_more'] is False
+        assert result['data']['pagination']['complete_dataset'] is True
+
+    @pytest.mark.asyncio
+    async def test_paging_controls_go_to_the_paginator(self, mock_context, sample_allocation):
+        """Paging controls travel in PaginationConfig, not in the operation parameters."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        await _call_get_credit_allocation_history(
+            mock_context,
+            client,
+            billing_period='2026-06',
+            max_results=50,
+            next_token='resume-here',
+        )
+
+        call = _paginate_call(client)
+        assert call['PaginationConfig'] == {'PageSize': 50, 'StartingToken': 'resume-here'}
+        assert 'maxResults' not in call
+        assert 'nextToken' not in call
+
+    @pytest.mark.asyncio
+    async def test_max_pages_stops_early(self, mock_context, sample_allocation):
+        """max_pages caps the number of requests and reports more remaining."""
+        client = _get_credit_allocation_history_client(
+            [
+                {'creditAllocationHistoryList': [sample_allocation], 'nextToken': 'page-2'},
+                {'creditAllocationHistoryList': [sample_allocation], 'nextToken': 'page-3'},
+            ]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06', max_pages=2
+        )
+
+        pagination = result['data']['pagination']
+        assert pagination['pages_fetched'] == 2
+        assert pagination['has_more'] is True
+        assert pagination['next_token'] == 'page-3'
+        assert pagination['complete_dataset'] is False
+
+    @pytest.mark.asyncio
+    async def test_paginator_selected_by_operation_name(self, mock_context, sample_allocation):
+        """The SDK paginator for the ledger operation is used."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        await _call_get_credit_allocation_history(mock_context, client, billing_period='2026-06')
+
+        client.get_paginator.assert_called_once_with('get_credit_allocation_history')
+
+
+class TestGetCreditAllocationHistoryRealPaginator:
+    """Truncation reporting verified against the real SDK paginator, not a mock."""
+
+    @staticmethod
+    def _stubbed_client(page_tokens):
+        """Build a real billing client with stubbed pages.
+
+        Args:
+            page_tokens: Continuation token for each page, None on the last.
+
+        Returns:
+            Tuple of (client, stubber) with responses queued.
+        """
+        client = boto3.Session(
+            aws_access_key_id='a', aws_secret_access_key='b', region_name='us-east-1'
+        ).client('billing')
+        stubber = Stubber(client)
+        stubber.activate()
+        row = {
+            'creditId': '1',
+            'creditAmount': {'currencyCode': 'USD', 'currencyAmount': '1.00'},
+            'accountId': '123456789012',
+            'appliedServiceName': 'AmazonEC2',
+            'billingMonth': '2026-06',
+            'isEstimatedBill': False,
+        }
+        expected = {'accountId': '123456789012', 'startDate': ANY, 'endDate': ANY}
+        previous = None
+        for token in page_tokens:
+            response = {'creditAllocationHistoryList': [row], 'partialResults': False}
+            if token:
+                response['nextToken'] = token
+            params = dict(expected)
+            if previous:
+                params['nextToken'] = previous
+            stubber.add_response('get_credit_allocation_history', response, params)
+            previous = token
+        return client, stubber
+
+    @pytest.mark.asyncio
+    async def test_truncated_run_reports_more_available(self, mock_context):
+        """Stopping early reports has_more with a usable resume token."""
+        client, stubber = self._stubbed_client(['P2', 'P3', None])
+
+        try:
+            result = await _call_get_credit_allocation_history(
+                mock_context,
+                client,
+                account_id='123456789012',
+                billing_period='2026-06',
+                max_pages=2,
+            )
+        finally:
+            stubber.deactivate()
+
+        pagination = result['data']['pagination']
+        assert pagination['pages_fetched'] == 2
+        assert pagination['has_more'] is True
+        assert pagination['next_token'] == 'P3'
+        assert pagination['complete_dataset'] is False
+
+    @pytest.mark.asyncio
+    async def test_exhausted_run_reports_complete(self, mock_context):
+        """Consuming every page reports a complete dataset with no token."""
+        client, stubber = self._stubbed_client(['P2', None])
+
+        try:
+            result = await _call_get_credit_allocation_history(
+                mock_context, client, account_id='123456789012', billing_period='2026-06'
+            )
+        finally:
+            stubber.deactivate()
+
+        pagination = result['data']['pagination']
+        assert pagination['pages_fetched'] == 2
+        assert pagination['has_more'] is False
+        assert pagination['next_token'] is None
+        assert pagination['complete_dataset'] is True
+
+
+class TestGetCreditAllocationHistoryCompleteness:
+    """partialResults and failedMonths reporting."""
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_complete(self, mock_context, sample_allocation):
+        """A clean response reports complete results and no failed months."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert result['data']['completeness'] == {
+            'partial_results': False,
+            'failed_months': [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_partial_results_from_any_page(self, mock_context, sample_allocation):
+        """A partial flag on any page marks the whole result partial."""
+        client = _get_credit_allocation_history_client(
+            [
+                {'creditAllocationHistoryList': [sample_allocation], 'nextToken': 'page-2'},
+                {
+                    'creditAllocationHistoryList': [sample_allocation],
+                    'partialResults': True,
+                    'failedMonths': ['2026-03'],
+                },
+            ]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert result['data']['completeness']['partial_results'] is True
+        assert result['data']['completeness']['failed_months'] == ['2026-03']
+
+    @pytest.mark.asyncio
+    async def test_failed_months_are_unioned_without_duplicates(
+        self, mock_context, sample_allocation
+    ):
+        """Failed months from every page are combined and de-duplicated."""
+        client = _get_credit_allocation_history_client(
+            [
+                {
+                    'creditAllocationHistoryList': [sample_allocation],
+                    'partialResults': True,
+                    'failedMonths': ['2026-03', '2026-04'],
+                    'nextToken': 'page-2',
+                },
+                {
+                    'creditAllocationHistoryList': [sample_allocation],
+                    'partialResults': True,
+                    'failedMonths': ['2026-04', '2026-05'],
+                },
+            ]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert result['data']['completeness']['failed_months'] == [
+            '2026-03',
+            '2026-04',
+            '2026-05',
+        ]
+
+
+class TestCreditIdConversion:
+    """creditId type handling between the two operations."""
+
+    @pytest.mark.asyncio
+    async def test_string_credit_id_becomes_integer(self, mock_context, sample_allocation):
+        """The string creditId returned by GetCredits is converted to an integer."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06', credit_id='4242'
+        )
+
+        assert _paginate_call(client)['creditId'] == 4242
+
+    @pytest.mark.asyncio
+    async def test_integer_credit_id_passes_through(self, mock_context, sample_allocation):
+        """An integer creditId is forwarded unchanged."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06', credit_id=4242
+        )
+
+        assert _paginate_call(client)['creditId'] == 4242
+
+    @pytest.mark.asyncio
+    async def test_omitted_credit_id_is_absent(self, mock_context, sample_allocation):
+        """No creditId parameter is sent when the caller omits it."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        await _call_get_credit_allocation_history(mock_context, client, billing_period='2026-06')
+
+        assert 'creditId' not in _paginate_call(client)
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_credit_id_is_rejected(self, mock_context):
+        """A non-numeric creditId is rejected with a pointer to get_credits."""
+        client = _get_credit_allocation_history_client([])
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06', credit_id='abc'
+        )
+
+        assert result['status'] == 'error'
+        assert 'must be numeric' in result['data']['message']
+        assert 'get_credits' in result['data']['message']
+        client.get_paginator.assert_not_called()
+
+
+class TestAccessDenied:
+    """Permission failures name the missing IAM action."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('error_code', ['AccessDeniedException', 'AccessDenied'])
+    async def test_get_credits_names_permission(self, mock_context, error_code):
+        """A denied GetCredits call names billing:GetCredits."""
+        client = MagicMock()
+        client.get_credits.side_effect = ClientError(
+            {
+                'Error': {'Code': error_code, 'Message': 'denied'},
+                'ResponseMetadata': {'RequestId': 'req-1', 'HTTPStatusCode': 403},
+            },
+            'GetCredits',
+        )
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        assert result['error_type'] == 'access_denied'
+        assert 'billing:GetCredits' in result['message']
+        assert result['request_id'] == 'req-1'
+        assert result['http_status'] == 403
+
+    @pytest.mark.asyncio
+    async def test_get_credit_allocation_history_names_permission(self, mock_context):
+        """A denied allocation-history call names its own action."""
+        client = _get_credit_allocation_history_client([])
+        client.get_paginator.return_value.paginate.side_effect = ClientError(
+            {
+                'Error': {'Code': 'AccessDeniedException', 'Message': 'denied'},
+                'ResponseMetadata': {'RequestId': 'req-2', 'HTTPStatusCode': 403},
+            },
+            'GetCreditAllocationHistory',
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert result['error_type'] == 'access_denied'
+        assert 'billing:GetCreditAllocationHistory' in result['message']
+        assert 'resolution' in result
+
+    @pytest.mark.asyncio
+    async def test_denial_is_not_reported_as_missing_data(self, mock_context):
+        """The message distinguishes a permission failure from having no credits."""
+        client = MagicMock()
+        client.get_credits.side_effect = ClientError(
+            {
+                'Error': {'Code': 'AccessDeniedException', 'Message': 'denied'},
+                'ResponseMetadata': {'RequestId': 'req-3', 'HTTPStatusCode': 403},
+            },
+            'GetCredits',
+        )
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        assert 'not an absence of credits' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_other_client_errors_fall_through(self, mock_context):
+        """A non-permission error keeps the AWS error code from the shared handler."""
+        client = MagicMock()
+        client.get_credits.side_effect = ClientError(
+            {
+                'Error': {'Code': 'ValidationException', 'Message': 'bad range'},
+                'ResponseMetadata': {'RequestId': 'req-4', 'HTTPStatusCode': 400},
+            },
+            'GetCredits',
+        )
+
+        result = await _call_get_credits(mock_context, client, start_date=_offset_date(-180))
+
+        assert result['error_type'] == 'ValidationException'
+        assert result['status'] == 'error'
+
+
+class TestSessionSqlOffload:
+    """Oversized responses offload to a queryable table, not a single JSON cell."""
+
+    @pytest.mark.asyncio
+    async def test_ledger_offloads_one_row_per_record(self, mock_context, sample_allocation):
+        """A large ledger becomes a table with one row per allocation record."""
+        rows = [dict(sample_allocation, appliedServiceName=f'Service{i}') for i in range(40)]
+        client = _get_credit_allocation_history_client([{'creditAllocationHistoryList': rows}])
+
+        with patch.object(sql_utils, 'SQL_CONVERSION_THRESHOLD', 1):
+            result = await _call_get_credit_allocation_history(
+                mock_context, client, billing_period='2026-06'
+            )
+
+        data = result['data']
+        assert data['data_stored'] is True
+        connection = sqlite3.connect(data['session_db'])
+        try:
+            columns = [
+                row[1] for row in connection.execute(f'PRAGMA table_info({data["table_name"]})')
+            ]
+            count = connection.execute(f'SELECT COUNT(*) FROM {data["table_name"]}').fetchone()[0]
+        finally:
+            connection.close()
+
+        assert count == 40
+        assert 'appliedServiceName' in columns
+        assert 'billingMonth' in columns
+
+    @pytest.mark.asyncio
+    async def test_offload_preserves_guardrail_blocks(self, mock_context, sample_allocation):
+        """time_range and completeness survive an offload."""
+        rows = [dict(sample_allocation) for _ in range(40)]
+        client = _get_credit_allocation_history_client(
+            [
+                {
+                    'creditAllocationHistoryList': rows,
+                    'partialResults': True,
+                    'failedMonths': ['2026-03'],
+                }
+            ]
+        )
+
+        with patch.object(sql_utils, 'SQL_CONVERSION_THRESHOLD', 1):
+            result = await _call_get_credit_allocation_history(
+                mock_context, client, billing_period='2026-06'
+            )
+
+        data = result['data']
+        assert data['completeness'] == {'partial_results': True, 'failed_months': ['2026-03']}
+        assert data['time_range']['start_date'].startswith('2026-06-01')
+        assert data['pagination']['total_results'] == 40
+
+    @pytest.mark.asyncio
+    async def test_credits_offload_preserves_time_range(self, mock_context, sample_credit):
+        """A large credit portfolio keeps its time_range after an offload."""
+        credits = [dict(sample_credit, creditId=str(i)) for i in range(40)]
+        client = _get_credits_client(credits)
+        start = _offset_date(-180)
+
+        with patch.object(sql_utils, 'SQL_CONVERSION_THRESHOLD', 1):
+            result = await _call_get_credits(mock_context, client, start_date=start)
+
+        data = result['data']
+        assert data['data_stored'] is True
+        assert data['time_range']['start_date'].startswith(start)
+
+    @pytest.mark.asyncio
+    async def test_small_response_stays_inline(self, mock_context, sample_allocation):
+        """A response under the threshold keeps its rows inline."""
+        client = _get_credit_allocation_history_client(
+            [{'creditAllocationHistoryList': [sample_allocation]}]
+        )
+
+        result = await _call_get_credit_allocation_history(
+            mock_context, client, billing_period='2026-06'
+        )
+
+        assert result['data']['credit_allocation_history'] == [sample_allocation]
+        assert 'data_stored' not in result['data']

--- a/src/billing-cost-management-mcp-server/tests/tools/test_credits_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_credits_tools.py
@@ -1,0 +1,251 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the credits_tools module."""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.credits_tools import (
+    _credits,
+    credits,
+    credits_server,
+)
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+GET_CREDITS_PATH = 'awslabs.billing_cost_management_mcp_server.tools.credits_tools._get_credits'
+GET_CREDIT_ALLOCATION_HISTORY_PATH = (
+    'awslabs.billing_cost_management_mcp_server.tools.credits_tools._get_credit_allocation_history'
+)
+SUCCESS = {'status': 'success', 'data': {}}
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context with async logging methods."""
+    context = MagicMock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    context.debug = AsyncMock()
+    return context
+
+
+def _await_kwargs(mock):
+    """Return the keyword arguments of a mock's most recent await."""
+    assert mock.await_args is not None
+    return mock.await_args.kwargs
+
+
+async def _registered_tool():
+    """Return the registered credits tool, asserting it exists."""
+    tool = await credits_server.get_tool('credits')
+    assert tool is not None
+    return tool
+
+
+def _handlers():
+    """Patch both operation handlers, yielding the two mocks."""
+    return patch(GET_CREDITS_PATH, new=AsyncMock(return_value=SUCCESS)), patch(
+        GET_CREDIT_ALLOCATION_HISTORY_PATH, new=AsyncMock(return_value=SUCCESS)
+    )
+
+
+class TestOperationRouting:
+    """Each operation reaches its own handler."""
+
+    @pytest.mark.asyncio
+    async def test_get_credits_routes_to_handler(self, mock_context):
+        """The get_credits operation calls the credits handler only."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch as credits_mock, history_patch as history_mock:
+            result = await _credits(mock_context, 'get_credits', start_date='2026-01-01')
+
+        assert result == SUCCESS
+        credits_mock.assert_awaited_once()
+        history_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_credit_allocation_history_routes_to_handler(self, mock_context):
+        """The allocation-history operation calls the ledger handler only."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch as credits_mock, history_patch as history_mock:
+            result = await _credits(
+                mock_context, 'get_credit_allocation_history', billing_period='2026-06'
+            )
+
+        assert result == SUCCESS
+        history_mock.assert_awaited_once()
+        credits_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'operation', ['get_invoices', 'GetCredits', 'delete_credits', '', 'get_credit']
+    )
+    async def test_unknown_operation_is_rejected(self, mock_context, operation):
+        """An unrecognized operation returns an error without calling a handler."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch as credits_mock, history_patch as history_mock:
+            result = await _credits(mock_context, operation)
+
+        assert result['status'] == 'error'
+        credits_mock.assert_not_awaited()
+        history_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_operation_lists_supported_operations(self, mock_context):
+        """The error names both supported operations."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch, history_patch:
+            result = await _credits(mock_context, 'get_invoices')
+
+        message = result['data']['message']
+        assert 'get_credits' in message
+        assert 'get_credit_allocation_history' in message
+
+
+class TestParameterForwarding:
+    """Only the parameters an operation accepts are forwarded to it."""
+
+    @pytest.mark.asyncio
+    async def test_credits_receives_its_own_parameters(self, mock_context):
+        """get_credits receives payer_account_flag and the date window."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch as credits_mock, history_patch:
+            await _credits(
+                mock_context,
+                'get_credits',
+                start_date='2026-01-01',
+                end_date='2026-06-30',
+                account_id='123456789012',
+                payer_account_flag=True,
+            )
+
+        kwargs = _await_kwargs(credits_mock)
+        assert kwargs['start_date'] == '2026-01-01'
+        assert kwargs['end_date'] == '2026-06-30'
+        assert kwargs['account_id'] == '123456789012'
+        assert kwargs['payer_account_flag'] is True
+
+    @pytest.mark.asyncio
+    async def test_credits_does_not_receive_ledger_parameters(self, mock_context):
+        """Ledger-only parameters are never forwarded to get_credits."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch as credits_mock, history_patch:
+            await _credits(
+                mock_context,
+                'get_credits',
+                start_date='2026-01-01',
+                credit_id='4242',
+                billing_period='2026-06',
+                max_results=50,
+                next_token='token',
+                max_pages=2,
+            )
+
+        kwargs = _await_kwargs(credits_mock)
+        for name in ('credit_id', 'billing_period', 'max_results', 'next_token', 'max_pages'):
+            assert name not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_get_credit_allocation_history_receives_its_own_parameters(self, mock_context):
+        """Allocation history receives billing_period, credit_id and paging controls."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch, history_patch as history_mock:
+            await _credits(
+                mock_context,
+                'get_credit_allocation_history',
+                billing_period='2026-06',
+                credit_id='4242',
+                max_results=50,
+                next_token='token',
+                max_pages=3,
+            )
+
+        kwargs = _await_kwargs(history_mock)
+        assert kwargs['billing_period'] == '2026-06'
+        assert kwargs['credit_id'] == '4242'
+        assert kwargs['max_results'] == 50
+        assert kwargs['next_token'] == 'token'
+        assert kwargs['max_pages'] == 3
+
+    @pytest.mark.asyncio
+    async def test_get_credit_allocation_history_does_not_receive_payer_account_flag(
+        self, mock_context
+    ):
+        """payer_account_flag is never forwarded to allocation history."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch, history_patch as history_mock:
+            await _credits(
+                mock_context,
+                'get_credit_allocation_history',
+                billing_period='2026-06',
+                payer_account_flag=True,
+            )
+
+        assert 'payer_account_flag' not in _await_kwargs(history_mock)
+
+
+class TestWrapperDelegation:
+    """The decorated tool delegates to the testable router."""
+
+    @pytest.mark.asyncio
+    async def test_wrapper_forwards_every_parameter(self, mock_context):
+        """The FastMCP wrapper passes all parameters through to the router."""
+        credits_patch, history_patch = _handlers()
+        with credits_patch, history_patch as history_mock:
+            await credits(
+                mock_context,
+                'get_credit_allocation_history',
+                billing_period='2026-06',
+                account_id='123456789012',
+                credit_id='4242',
+                max_results=10,
+                next_token='token',
+                max_pages=1,
+            )
+
+        kwargs = _await_kwargs(history_mock)
+        assert kwargs['billing_period'] == '2026-06'
+        assert kwargs['account_id'] == '123456789012'
+        assert kwargs['credit_id'] == '4242'
+
+
+class TestToolRegistration:
+    """The tool is registered on the sub-server with a usable description."""
+
+    @pytest.mark.asyncio
+    async def test_tool_is_registered(self):
+        """A tool named credits is registered on the sub-server."""
+        tool = await _registered_tool()
+
+        assert tool.name == 'credits'
+
+    @pytest.mark.asyncio
+    async def test_description_documents_both_operations(self):
+        """The description names both operations and their required parameters."""
+        tool = await _registered_tool()
+
+        assert 'get_credits' in (tool.description or '')
+        assert 'get_credit_allocation_history' in (tool.description or '')
+        assert 'billing_period' in (tool.description or '')
+
+    @pytest.mark.asyncio
+    async def test_description_carries_response_guardrails(self):
+        """The description warns about completeness, clamping and precision."""
+        tool = await _registered_tool()
+
+        assert 'partial_results' in (tool.description or '')
+        assert 'narrowed_from_request' in (tool.description or '')
+        assert 'one year before today' in (tool.description or '')
+        assert 'never floats' in (tool.description or '')

--- a/src/billing-cost-management-mcp-server/uv.lock
+++ b/src/billing-cost-management-mcp-server/uv.lock
@@ -127,7 +127,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.42.4" },
+    { name = "boto3", specifier = ">=1.43.41" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
@@ -213,30 +213,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.72"
+version = "1.43.67"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/78/daf8d8950341f4596b2ffa8e69750569a6f567bcae8f2be0a8095a15fc71/boto3-1.42.72.tar.gz", hash = "sha256:932f023ea3b54fd85df453dcfff7d8c5a0f8be144c0ad57568943505c72c1e6a", size = 112782, upload-time = "2026-03-19T21:03:35.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/bf/ef5de9b55523bc2141d072fbe6614627088e3e6f97b47850216e99de6a1c/boto3-1.43.67.tar.gz", hash = "sha256:75fe983b70d39cfdc274dc51f9bb02b8a0a104bdad4fa073c1af85a35e707c91", size = 112665, upload-time = "2026-08-07T19:30:20.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/c7/ac1e8d49b0cb5631410796dd439c621d50d9b241f98a79e38e8d466b8d00/boto3-1.42.72-py3-none-any.whl", hash = "sha256:2b5fdac4f202b2ccb9ed21f8b84229463b15573ea16941c2b1b8db1c69e08b63", size = 140555, upload-time = "2026-03-19T21:03:34.165Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0f/b41f8968452dc6bf3b83f15f5e9f76a27fd93e246906aeb2e0555f494375/boto3-1.43.67-py3-none-any.whl", hash = "sha256:082cf9df068168cb44028a1703822374c1eb7e48fa49470d7e8a76f0c977d0bc", size = 140025, upload-time = "2026-08-07T19:30:18.49Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.72"
+version = "1.43.67"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/ff/36bfa472894648ded83cfe7bb09faabd0db113551dbe920589cfc9cadad7/botocore-1.42.72.tar.gz", hash = "sha256:491b75eb41d46cf99cf8d6cab89f2e2c3602ce8e90d738a1da217a5fb6b2b7ef", size = 15004562, upload-time = "2026-03-19T21:03:24.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/1c/3a75deae60e36bd0ee5c27d040384756b2ea1c90bd7c8c9658335a18b4f5/botocore-1.43.67.tar.gz", hash = "sha256:6fe5cfa0c8676ba809efe505b618ec00f30d1af2d014bf316a7aa4ee86accb20", size = 15889514, upload-time = "2026-08-07T19:30:15.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/50/3297ba278a0d6644396011cc592ee88f628206599fc6cff25f5c83b629e7/botocore-1.42.72-py3-none-any.whl", hash = "sha256:038f34553da68df2ce70edc729f170cc198678daaad43f98649727c59f6404d4", size = 14678727, upload-time = "2026-03-19T21:03:20.575Z" },
+    { url = "https://files.pythonhosted.org/packages/21/be/38af8e96f3d200c9d34eab8e9f69a4468388ed6030ea04ff012974e5af5a/botocore-1.43.67-py3-none-any.whl", hash = "sha256:48ab8e9fac26fbc2a700d57010251003e6a5f731cf74d8540fb796bc8f3fc0ef", size = 15575924, upload-time = "2026-08-07T19:30:12.116Z" },
 ]
 
 [[package]]
@@ -2066,14 +2066,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Notes

- Adds a `credits` tool with two operations, `get_credits` and `get_credit_allocation_history`, covering credit balance, expiration, product applicability, sharing configuration, and the per-service allocation ledger.

- `get_credits` caps lookback at 12 months, `get_credit_allocation_history` caps range width at 24. Both clamp rather than reject and report it in `data.time_range` via `narrowed_from_request`, so a clamped result cannot be mistaken for a complete one. A window with no answerable overlap returns an error instead, since clamping there would invert it.

- `utilities/sql_utils.py` gains a `credits_get_` prefix rule in `_get_specialized_converter`, so a large credit ledger offloads to a queryable per-row table instead of a single JSON blob.

- Raises the `boto3` floor to the first release containing these operations, and refreshes the lock accordingly.

- `get_credit_allocation_history` uses a local paginator rather than `paginate_aws_response`, because the shared helper discards raw pages and this API carries per-page `partialResults` and `failedMonths` that must be unioned across them.

### Testing

- `uv sync --frozen --all-extras --dev`: clean
- `ruff check .` and `ruff format --check .`: pass
- `pyright`: 0 errors
- `pytest --cov --cov-branch --cov-report=term-missing`: full suite passes, 74 new tests

#### Kiro-cli Testing
```
kiro-cli chat --agent credits-mcp-harness --no-interactive --trust-all-tools \
  "What AWS credits do I have on my account, and when do they expire?"

Running tool credits with the param (from mcp server: bcm-credits)
 ⋮  {
 ⋮    "operation": "get_credits",
 ⋮    "start_date": "2025-08-10"
 ⋮  }
 - Completed in 0.642s

> Here's a summary of the AWS credits on account 111122223333:

| # | Description | Initial | Remaining | Expires | Applies To | Status |
|---|---|---|---|---|---|---|
| 1 | Application Signals Free Trial Promotion | $150.00 | $148.10 | 2025-12-15 | AmazonCloudWatch | ⚠️ Expired |
| 2 | Test Credit 1 | $5.00 | $5.00 | 2099-12-31 | Amazon RDS | Active |
| 3 | Test Credit 2 | $5.00 | $5.00 | 2026-01-29 | Amazon RDS | ⚠️ Expired |
| 4 | Test Credit 3 | $5.00 | $5.00 | 2099-12-31 | Amazon RDS | Active |
| 5 | Expired Credit | $5.00 | $5.00 | 2026-01-29 | Amazon RDS | ⚠️ Expired |

Key takeaways:

- **Total remaining balance across all credits:** $168.10
- **Still usable (not expired):** $10.00 — credits #2 and #4 (both RDS-only, expiring 2099-12-31, so effectively no expiration concern)
- **Already expired:** $158.10 — credits #1, #3, and #5 have end dates in the past (before today, 2026-08-10)

The CloudWatch promo credit (#1) had the most value ($148.10 remaining) but expired back in December 2025. The two active credits are small ($5 each) and restricted to Amazon RDS usage only.

All credits are promotional, applied after discounts, and credit sharing is disabled on this account.

 ▸ Credits: 0.32 • Time: 18s

```

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).