### PR TITLE
fix(docusaurus): bump websocket-driver to 0.7.5 (CVE-2026-54466)

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -17659,9 +17659,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
Fixes [Dependabot alert #2694](https://github.com/awslabs/mcp/security/dependabot/2694)

## Summary

### Changes

Bumps the transitive npm dependency `websocket-driver` from `0.7.4` to `0.7.5` in `docusaurus/package-lock.json` to remediate [GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6) / CVE-2026-54466 (**critical**) — *message corruption via abuse of protocol length headers*.

The package is reached transitively at runtime through two parents, both of which already declare ranges satisfied by the patched version, so **no manifest change is required** — only the lockfile pin moves:

| Parent | Declared range | Accepts 0.7.5 |
| --- | --- | --- |
| `sockjs` | `^0.7.4` | yes |
| `faye-websocket` | `>=0.5.1` | yes |

The resulting diff is 3 lines (`version`, `resolved`, `integrity`), and both parents dedupe onto the single hoisted 0.7.5 copy — no second vulnerable copy remains nested in the tree.

### User experience

No user-facing change. `websocket-driver` is only used by the Docusaurus dev server's websocket transport (live reload) and is not part of the published static site output, so rendered documentation is byte-for-byte unaffected. The change removes a critical vulnerability from the dependency tree.

## Verification

* `npm ci` completes cleanly from the updated lockfile — confirms the recomputed `integrity` hash is valid and the install is reproducible.
* `npm ls websocket-driver --all` reports `0.7.5` for all resolution paths (deduped).
* `npm run build` succeeds for both locales (`en`, `ja`).
* The two `[WARNING] Docusaurus found broken anchors!` messages in the build output are **pre-existing on `main`** — a `#installation` TOC link in `docs/servers/healthimaging-mcp-server.md` — and are unrelated to this change.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).