### PR TITLE
fix(aws-documentation-mcp-server): re-validate redirect targets agaist domain allowlist

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws_cn.py
@@ -14,7 +14,6 @@
 """awslabs AWS China Documentation MCP Server implementation."""
 
 import httpx
-import re
 import uuid
 from awslabs.aws_documentation_mcp_server.server_utils import (
     DEFAULT_USER_AGENT,
@@ -23,9 +22,11 @@ from awslabs.aws_documentation_mcp_server.server_utils import (
 
 # Import utility functions
 from awslabs.aws_documentation_mcp_server.util import (
+    enforce_redirect_allowlist,
     extract_content_from_html,
     format_documentation_result,
     is_html_content,
+    url_matches_allowlist,
 )
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
@@ -34,6 +35,9 @@ from typing import Union
 
 
 SESSION_UUID = str(uuid.uuid4())
+
+# China partition domain allowlist
+CN_ALLOWED_DOMAIN_REGEXES = (r'^https?://docs\.amazonaws\.cn/',)
 
 mcp = FastMCP(
     'awslabs.aws-documentation-mcp-server',
@@ -122,7 +126,7 @@ async def read_documentation(
     """
     # Validate that URL is from docs.amazonaws.cn and ends with .html
     url_str = str(url)
-    if not re.match(r'^https?://docs\.amazonaws\.cn/', url_str):
+    if not url_matches_allowlist(url_str, CN_ALLOWED_DOMAIN_REGEXES):
         error_msg = f'Invalid URL: {url_str}. URL must be from the docs.amazonaws.cn domain'
         await ctx.error(error_msg)
         return error_msg
@@ -131,7 +135,9 @@ async def read_documentation(
         await ctx.error(error_msg)
         return error_msg
 
-    return await read_documentation_impl(ctx, url_str, max_length, start_index, SESSION_UUID)
+    return await read_documentation_impl(
+        ctx, url_str, max_length, start_index, SESSION_UUID, CN_ALLOWED_DOMAIN_REGEXES
+    )
 
 
 @mcp.tool()
@@ -163,7 +169,9 @@ async def get_available_services(
 
     toc_url_str = 'https://docs.amazonaws.cn/en_us/aws/latest/userguide/toc-contents.json'
     toc_url_with_session = f'{toc_url_str}?session={SESSION_UUID}'
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(
+        event_hooks={'response': [enforce_redirect_allowlist(CN_ALLOWED_DOMAIN_REGEXES)]}
+    ) as client:
         try:
             response = await client.get(
                 url_with_session,

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -19,6 +19,7 @@ from awslabs.aws_documentation_mcp_server.models import (
     TableResult,
 )
 from awslabs.aws_documentation_mcp_server.util import (
+    enforce_redirect_allowlist,
     extract_content_from_html,
     extract_sections_from_html,
     format_documentation_result,
@@ -29,8 +30,22 @@ from collections import deque
 from importlib.metadata import version
 from loguru import logger
 from mcp.server.fastmcp import Context
-from typing import Optional
+from typing import Optional, Sequence
 from urllib.parse import quote
+
+
+# Commercial partition domain allowlist
+COMMERCIAL_ALLOWED_DOMAIN_REGEXES = (
+    r'^https?://docs\.aws\.amazon\.com/',
+    r'^https?://awsdocs-neuron\.readthedocs-hosted\.com/',
+)
+
+
+def _docs_client(allowed_domain_regexes: Sequence[str]) -> httpx.AsyncClient:
+    """Build an AsyncClient that re-validates every redirect hop against the allowlist."""
+    return httpx.AsyncClient(
+        event_hooks={'response': [enforce_redirect_allowlist(allowed_domain_regexes)]}
+    )
 
 
 try:
@@ -55,6 +70,7 @@ async def read_documentation_impl(
     max_length: int,
     start_index: int,
     session_uuid: str,
+    allowed_domain_regexes: Sequence[str] = COMMERCIAL_ALLOWED_DOMAIN_REGEXES,
 ) -> str:
     """The implementation of the read_documentation tool."""
     logger.debug(f'Fetching documentation from {url_str}')
@@ -66,7 +82,7 @@ async def read_documentation_impl(
         url_with_session += f'&query_id={query_id}'
         logger.debug(f'Using query_id {query_id}')
 
-    async with httpx.AsyncClient() as client:
+    async with _docs_client(allowed_domain_regexes) as client:
         try:
             response = await client.get(
                 url_with_session,
@@ -156,6 +172,7 @@ async def read_sections_impl(
     url_str: str,
     section_titles: list[str],
     session_uuid: str,
+    allowed_domain_regexes: Sequence[str] = COMMERCIAL_ALLOWED_DOMAIN_REGEXES,
 ) -> str:
     """The implementation of the read_sections tool."""
     logger.debug(f'Fetching sections {section_titles} from {url_str}')
@@ -169,7 +186,7 @@ async def read_sections_impl(
         url_with_session += f'&query_id={query_id}'
         logger.debug(f'Using query_id {query_id}')
 
-    async with httpx.AsyncClient() as client:
+    async with _docs_client(allowed_domain_regexes) as client:
         try:
             response = await client.get(
                 url_with_session,
@@ -232,6 +249,7 @@ async def search_table_impl(
     query: str,
     max_rows: int,
     session_uuid: str,
+    allowed_domain_regexes: Sequence[str] = COMMERCIAL_ALLOWED_DOMAIN_REGEXES,
 ) -> SearchTableResponse:
     """The implementation of the search_table tool."""
     from awslabs.aws_documentation_mcp_server.table_utils import (  # noqa: E402
@@ -251,7 +269,7 @@ async def search_table_impl(
     if query_id:
         url_with_session += f'&query_id={query_id}'
 
-    async with httpx.AsyncClient() as client:
+    async with _docs_client(allowed_domain_regexes) as client:
         try:
             response = await client.get(
                 url_with_session,

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 """Utility functions for AWS Documentation MCP Server."""
 
+import httpx
 import markdownify
 import re
 from awslabs.aws_documentation_mcp_server.models import RecommendationResult
-from typing import Any, Dict, List
-from urllib.parse import quote_plus
+from typing import Any, Dict, List, Sequence
+from urllib.parse import quote_plus, urljoin
 
 
 def extract_content_from_html(html: str) -> str:
@@ -154,6 +155,35 @@ def is_html_content(page_raw: str, content_type: str) -> bool:
         True if content is HTML, False otherwise
     """
     return '<html' in page_raw[:100] or 'text/html' in content_type or not content_type
+
+
+def url_matches_allowlist(url: str, allowed_domain_regexes: Sequence[str]) -> bool:
+    """Return True if the URL's host matches an allowed domain regex (extension not checked)."""
+    return any(re.match(pattern, url) for pattern in allowed_domain_regexes)
+
+
+def enforce_redirect_allowlist(allowed_domain_regexes: Sequence[str]):
+    """Build an httpx response event hook that rejects redirects to off-allowlist hosts.
+
+    Without this, ``follow_redirects=True`` follows a 3xx from an allow-listed page to any
+    host, including link-local metadata. The hook resolves each ``Location`` (including
+    relative redirects) against the request URL and raises if the target is not allow-listed.
+    """
+
+    async def _hook(response: httpx.Response) -> None:
+        if not response.is_redirect:
+            return
+        location = response.headers.get('location')
+        if not location:
+            return
+        target = urljoin(str(response.request.url), location)
+        if not url_matches_allowlist(target, allowed_domain_regexes):
+            raise httpx.RequestError(
+                f'Refusing to follow redirect to non-allowlisted URL: {target}',
+                request=response.request,
+            )
+
+    return _hook
 
 
 def format_documentation_result(url: str, content: str, start_index: int, max_length: int) -> str:

--- a/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
@@ -16,12 +16,14 @@
 import httpx
 import pytest
 from awslabs.aws_documentation_mcp_server.server_aws_cn import (
+    CN_ALLOWED_DOMAIN_REGEXES,
     get_available_services,
     main,
 )
 from awslabs.aws_documentation_mcp_server.server_aws_cn import (
     read_documentation as read_documentation_china,
 )
+from awslabs.aws_documentation_mcp_server.util import url_matches_allowlist
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -278,6 +280,109 @@ class TestGetAvailableServices:
                 mock_extract.assert_not_called()
                 called_url = mock_get.call_args[0][0]
                 assert '?session=' in called_url
+
+
+def _install_cn_mock_transport(monkeypatch, routes, target_module):
+    """Force AsyncClient in target_module to use a MockTransport, preserving real event_hooks.
+
+    Preserving the real hooks means a regression that dropped the redirect guard would leak
+    the redirect body and fail these tests.
+    """
+    real_async_client = httpx.AsyncClient
+
+    def patched(*args, **kwargs):
+        kwargs['transport'] = httpx.MockTransport(routes)
+        kwargs.setdefault('follow_redirects', True)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(f'{target_module}.httpx.AsyncClient', patched)
+
+
+def _cn_imds_redirect_routes(request: httpx.Request) -> httpx.Response:
+    """docs.amazonaws.cn 302s to IMDS; IMDS would leak a marker if the redirect were followed."""
+    if request.url.host == 'docs.amazonaws.cn':
+        return httpx.Response(
+            302, headers={'location': 'http://169.254.169.254/latest/meta-data/'}
+        )
+    return httpx.Response(200, text='SENSITIVE-IMDS-DATA')
+
+
+class TestCnAllowlist:
+    """The CN allowlist gates only docs.amazonaws.cn."""
+
+    def test_cn_host_allowed(self):
+        """docs.amazonaws.cn is on the CN allowlist."""
+        assert url_matches_allowlist(
+            'https://docs.amazonaws.cn/en_us/x.html', CN_ALLOWED_DOMAIN_REGEXES
+        )
+
+    def test_commercial_host_rejected(self):
+        """The commercial docs host is not on the CN allowlist."""
+        assert not url_matches_allowlist(
+            'https://docs.aws.amazon.com/x.html', CN_ALLOWED_DOMAIN_REGEXES
+        )
+
+    def test_imds_rejected(self):
+        """IMDS is not on the CN allowlist."""
+        assert not url_matches_allowlist(
+            'http://169.254.169.254/latest/meta-data/', CN_ALLOWED_DOMAIN_REGEXES
+        )
+
+
+class TestCnRedirectEnforcement:
+    """Both CN fetch sites re-validate redirect targets against CN_ALLOWED_DOMAIN_REGEXES."""
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_offsite_redirect_blocked(self, monkeypatch):
+        """read_documentation (via read_documentation_impl) refuses an IMDS redirect."""
+        ctx = MockContext()
+        _install_cn_mock_transport(
+            monkeypatch,
+            _cn_imds_redirect_routes,
+            'awslabs.aws_documentation_mcp_server.server_utils',
+        )
+        result = await read_documentation_china(
+            ctx, url='https://docs.amazonaws.cn/en_us/test.html', max_length=1000, start_index=0
+        )
+        assert 'SENSITIVE-IMDS-DATA' not in result
+        assert 'Failed to fetch' in result
+
+    @pytest.mark.asyncio
+    async def test_get_available_services_offsite_redirect_blocked(self, monkeypatch):
+        """get_available_services (its own inline client) refuses an IMDS redirect."""
+        ctx = MockContext()
+        _install_cn_mock_transport(
+            monkeypatch,
+            _cn_imds_redirect_routes,
+            'awslabs.aws_documentation_mcp_server.server_aws_cn',
+        )
+        result = await get_available_services(ctx)
+        assert 'SENSITIVE-IMDS-DATA' not in result
+        assert 'Failed to fetch' in result
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_onsite_redirect_followed(self, monkeypatch):
+        """A same-domain (docs.amazonaws.cn) redirect is followed and content returned."""
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/en_us/test.html':
+                return httpx.Response(
+                    301, headers={'location': 'https://docs.amazonaws.cn/en_us/final.html'}
+                )
+            return httpx.Response(
+                200,
+                text='<html><body><h1>Final CN</h1></body></html>',
+                headers={'content-type': 'text/html'},
+            )
+
+        ctx = MockContext()
+        _install_cn_mock_transport(
+            monkeypatch, routes, 'awslabs.aws_documentation_mcp_server.server_utils'
+        )
+        result = await read_documentation_china(
+            ctx, url='https://docs.amazonaws.cn/en_us/test.html', max_length=1000, start_index=0
+        )
+        assert 'Final CN' in result
 
 
 class TestMain:

--- a/src/aws-documentation-mcp-server/tests/test_server_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_utils.py
@@ -17,11 +17,15 @@ import httpx
 import pytest
 from awslabs.aws_documentation_mcp_server.models import SearchResponse, SearchResult
 from awslabs.aws_documentation_mcp_server.server_utils import (
+    COMMERCIAL_ALLOWED_DOMAIN_REGEXES,
     DEFAULT_USER_AGENT,
     SEARCH_RESULT_CACHE,
+    _docs_client,
     add_search_result_cache_item,
     get_query_id_from_cache,
     read_documentation_impl,
+    read_sections_impl,
+    search_table_impl,
 )
 from mcp.server.fastmcp.server import Context
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -409,6 +413,131 @@ class TestReadDocumentationImpl:
             # The large table should have been truncated
             assert 'Table truncated' in result
             assert 'search_table' in result
+
+
+def _install_mock_transport(monkeypatch, routes, target_module):
+    """Force AsyncClient in target_module to use a MockTransport, preserving real event_hooks.
+
+    The impl builds its client via the real _docs_client (which attaches the redirect hook);
+    we only swap in a MockTransport so no network call happens. Because the real hook is
+    preserved, a regression that reverted the impl to a plain httpx.AsyncClient() (no hook)
+    would leak the redirect body and fail these tests.
+    """
+    real_async_client = httpx.AsyncClient
+
+    def patched(*args, **kwargs):
+        kwargs['transport'] = httpx.MockTransport(routes)
+        kwargs.setdefault('follow_redirects', True)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(f'{target_module}.httpx.AsyncClient', patched)
+
+
+def _imds_redirect_routes(docs_host):
+    """Routes where the docs host 302s to IMDS; IMDS would leak a marker if wrongly followed."""
+
+    def routes(request: httpx.Request) -> httpx.Response:
+        if request.url.host == docs_host:
+            return httpx.Response(
+                302, headers={'location': 'http://169.254.169.254/latest/meta-data/'}
+            )
+        return httpx.Response(200, text='SENSITIVE-IMDS-DATA')
+
+    return routes
+
+
+def _onsite_redirect_routes(docs_host):
+    """Routes where the docs host 301s to another same-host page that returns real content."""
+
+    def routes(request: httpx.Request) -> httpx.Response:
+        if request.url.path == '/test.html':
+            return httpx.Response(301, headers={'location': f'https://{docs_host}/final.html'})
+        return httpx.Response(
+            200,
+            text='<html><body><h1>Final</h1><table><tr><td>x</td></tr></table></body></html>',
+            headers={'content-type': 'text/html'},
+        )
+
+    return routes
+
+
+class TestRedirectAllowlistEnforcement:
+    """End-to-end tests that all three read impls re-validate redirect targets (SSRF-class fix).
+
+    These use httpx.MockTransport with the real _docs_client + redirect event hook, so they
+    exercise the actual follow-redirects path and would fail if an impl stopped routing its
+    fetch through the guarded client.
+    """
+
+    def test_docs_client_wires_the_redirect_hook(self):
+        """_docs_client must attach a response event hook; catches a dropped-hook regression."""
+        client = _docs_client(COMMERCIAL_ALLOWED_DOMAIN_REGEXES)
+        assert client.event_hooks.get('response'), (
+            '_docs_client must register a response event hook to re-validate redirects'
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_offsite_redirect_blocked(self, monkeypatch):
+        """read_documentation: a docs page that 302s to IMDS is refused, body never leaks."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        _install_mock_transport(
+            monkeypatch,
+            _imds_redirect_routes('docs.aws.amazon.com'),
+            'awslabs.aws_documentation_mcp_server.server_utils',
+        )
+        result = await read_documentation_impl(
+            ctx, 'https://docs.aws.amazon.com/test.html', 1000, 0, 'uuid'
+        )
+        assert 'SENSITIVE-IMDS-DATA' not in result
+        assert 'Failed to fetch' in result
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_onsite_redirect_followed(self, monkeypatch):
+        """read_documentation: a same-domain redirect is followed and content returned."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        _install_mock_transport(
+            monkeypatch,
+            _onsite_redirect_routes('docs.aws.amazon.com'),
+            'awslabs.aws_documentation_mcp_server.server_utils',
+        )
+        result = await read_documentation_impl(
+            ctx, 'https://docs.aws.amazon.com/test.html', 1000, 0, 'uuid'
+        )
+        assert 'Final' in result
+
+    @pytest.mark.asyncio
+    async def test_read_sections_offsite_redirect_blocked(self, monkeypatch):
+        """read_sections: an IMDS redirect is refused and the body never leaks."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        _install_mock_transport(
+            monkeypatch,
+            _imds_redirect_routes('docs.aws.amazon.com'),
+            'awslabs.aws_documentation_mcp_server.server_utils',
+        )
+        result = await read_sections_impl(
+            ctx, 'https://docs.aws.amazon.com/test.html', ['Intro'], 'uuid'
+        )
+        assert 'SENSITIVE-IMDS-DATA' not in result
+        assert 'Failed to fetch' in result
+
+    @pytest.mark.asyncio
+    async def test_search_table_offsite_redirect_blocked(self, monkeypatch):
+        """search_table: an IMDS redirect is refused and the body never leaks."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        _install_mock_transport(
+            monkeypatch,
+            _imds_redirect_routes('docs.aws.amazon.com'),
+            'awslabs.aws_documentation_mcp_server.server_utils',
+        )
+        result = await search_table_impl(
+            ctx, 'https://docs.aws.amazon.com/test.html', None, 'query', 20, 'uuid'
+        )
+        assert 'SENSITIVE-IMDS-DATA' not in (result.error or '')
+        assert result.error and 'Failed to fetch' in result.error
 
 
 class TestUserAgentCustomization:

--- a/src/aws-documentation-mcp-server/tests/test_util.py
+++ b/src/aws-documentation-mcp-server/tests/test_util.py
@@ -13,17 +13,109 @@
 # limitations under the License.
 """Tests for utility functions in the AWS Documentation MCP Server."""
 
+import httpx
 import os
 import pytest
 from awslabs.aws_documentation_mcp_server.util import (
     add_search_intent_to_search_request,
+    enforce_redirect_allowlist,
     extract_content_from_html,
     extract_sections_from_html,
     format_documentation_result,
     is_html_content,
     parse_recommendation_results,
+    url_matches_allowlist,
 )
 from unittest.mock import MagicMock, patch
+
+
+ALLOWLIST = (
+    r'^https?://docs\.aws\.amazon\.com/',
+    r'^https?://awsdocs-neuron\.readthedocs-hosted\.com/',
+)
+
+
+class TestUrlMatchesAllowlist:
+    """Tests for url_matches_allowlist (domain-only, no extension check)."""
+
+    def test_docs_host_allowed(self):
+        """docs.aws.amazon.com is on the allowlist."""
+        assert url_matches_allowlist('https://docs.aws.amazon.com/s3/latest/x.html', ALLOWLIST)
+
+    def test_neuron_host_allowed(self):
+        """The third-party Neuron docs host is on the allowlist."""
+        assert url_matches_allowlist(
+            'https://awsdocs-neuron.readthedocs-hosted.com/x.html', ALLOWLIST
+        )
+
+    def test_directory_url_without_html_allowed(self):
+        """Redirect targets are often directory URLs (no .html); the domain check must pass them."""
+        assert url_matches_allowlist(
+            'https://docs.aws.amazon.com/powershell/v4/reference/', ALLOWLIST
+        )
+
+    def test_imds_blocked(self):
+        """The link-local IMDS endpoint is not on the allowlist."""
+        assert not url_matches_allowlist('http://169.254.169.254/latest/meta-data/', ALLOWLIST)
+
+    def test_arbitrary_host_blocked(self):
+        """An arbitrary external host is not on the allowlist."""
+        assert not url_matches_allowlist('https://evil.example.com/x', ALLOWLIST)
+
+    def test_lookalike_host_blocked(self):
+        """A host that merely contains the allowed domain as a substring is not allowed."""
+        assert not url_matches_allowlist('https://docs.aws.amazon.com.evil.com/x', ALLOWLIST)
+
+
+class TestEnforceRedirectAllowlist:
+    """Tests for the redirect-revalidation event hook."""
+
+    def _response(self, status, location=None, req_url='https://docs.aws.amazon.com/foo.html'):
+        """Build an httpx.Response with an optional Location header for hook testing."""
+        headers = {'location': location} if location else {}
+        return httpx.Response(status, headers=headers, request=httpx.Request('GET', req_url))
+
+    @pytest.mark.asyncio
+    async def test_off_allowlist_redirect_blocked(self):
+        """A redirect whose target is off the allowlist (IMDS) is rejected."""
+        hook = enforce_redirect_allowlist(ALLOWLIST)
+        resp = self._response(302, 'http://169.254.169.254/latest/meta-data/')
+        with pytest.raises(httpx.RequestError, match='non-allowlisted'):
+            await hook(resp)
+
+    @pytest.mark.asyncio
+    async def test_on_allowlist_redirect_allowed(self):
+        """A same-domain canonicalization redirect is allowed."""
+        hook = enforce_redirect_allowlist(ALLOWLIST)
+        resp = self._response(301, 'https://docs.aws.amazon.com/lambda/latest/dg/')
+        await hook(resp)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_relative_redirect_resolved_against_request(self):
+        """A relative Location resolves against the request URL and stays on the allowlist."""
+        hook = enforce_redirect_allowlist(ALLOWLIST)
+        resp = self._response(301, '/lambda/latest/dg/')
+        await hook(resp)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_relative_redirect_cannot_escape_host(self):
+        """A protocol-relative Location to another host is rejected."""
+        hook = enforce_redirect_allowlist(ALLOWLIST)
+        resp = self._response(302, '//169.254.169.254/latest/meta-data/')
+        with pytest.raises(httpx.RequestError, match='non-allowlisted'):
+            await hook(resp)
+
+    @pytest.mark.asyncio
+    async def test_non_redirect_response_is_noop(self):
+        """A 200 response is not a redirect and passes through untouched."""
+        hook = enforce_redirect_allowlist(ALLOWLIST)
+        await hook(self._response(200))  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_redirect_without_location_is_noop(self):
+        """A 3xx with no Location header has nothing to validate and passes through."""
+        hook = enforce_redirect_allowlist(ALLOWLIST)
+        await hook(self._response(302))  # no Location header -> nothing to validate
 
 
 class TestIsHtmlContent:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

`read_documentation`, `read_sections`, and `search_table` validate the initial URL against the AWS-docs allowlist, then fetch with `follow_redirects=True` without re-validating redirect targets. A 3xx from an allow-listed page was followed to any host, including link-local metadata, with the body returned to the caller.

This change re-validates **every redirect hop** against the same allowlist:

* **`util.py`**: add `url_matches_allowlist()` (domain-only check) and `enforce_redirect_allowlist()` — an httpx response event hook that resolves each redirect's `Location` (including relative redirects) against the request URL and refuses any hop whose target is not allow-listed.
* **`server_utils.py`**: add `_docs_client()` that attaches the hook, plus `DEFAULT_ALLOWED_DOMAIN_REGEXES` (commercial partition). All three read impls now fetch through this client and accept an `allowed_domain_regexes` argument (defaulted, so callers are unchanged).
* **`server_aws_cn.py`**: apply the same hook to both China-partition fetch sites (`read_documentation` and `get_available_services`) with `CN_ALLOWED_DOMAIN_REGEXES`.
* **Tests**: unit tests for the allowlist check and the redirect hook (off-allowlist/IMDS blocked, on-allowlist and relative redirects allowed, protocol-relative escape blocked, non-redirect and no-`Location` no-ops), plus end-to-end `httpx.MockTransport` tests confirming a read that 302s to IMDS returns a fetch error and never leaks the redirect body, while a same-domain redirect is followed.

`follow_redirects=True` is retained — legitimate AWS-docs pages rely on same-domain canonicalization redirects (verified: ~4.3% of doc reads are 3xx, all staying on the docs host).

### User experience

No change for legitimate usage. Direct 200 responses and same-domain redirects behave exactly as before. Only a redirect whose target leaves the allowlist changes: previously followed silently (with the off-host body returned), now refused and surfaced as a normal "Failed to fetch" error.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
