### PR TITLE
fix(docusaurus): bump express to 4.22.2 to clear qs DoS GHSA-q8mj-m7cp-5q26

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -6204,22 +6204,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/body-parser/node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8371,14 +8355,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -8397,7 +8381,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -15080,12 +15064,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

Fixes GHSA-q8mj-m7cp-5q26 (moderate) — unblocks the `dependency-review` gate on #4455

## Summary

The `dependency-review` job on #4455 fails with a single finding:

```
docusaurus/package-lock.json » qs@6.14.2 – qs has a remotely triggerable DoS:
  qs.stringify crashes with TypeError on null/undefined entries in comma-format
  arrays when encodeValuesOnly is set (moderate severity)
```

`qs` cannot be fixed by bumping `qs`. GHSA-q8mj-m7cp-5q26 covers `>= 6.11.1, <= 6.15.1` and is first patched in **6.15.2**, but the dependency chain pins it below that:

```
webpack-dev-server → express ^4.21.2 → express@4.22.1 → qs ~6.14.0
```

`~6.14.0` admits only `6.14.x`, and every `6.14.x` release is inside the vulnerable range. `express@4.22.2` relaxes its constraint to `~6.15.1`, which lets `qs` resolve to the patched `6.15.3`.

### Changes

Lockfile-only (`docusaurus/package-lock.json`). `package.json` is unchanged — both `express` and `qs` are transitive, so there is no declared constraint to edit.

| package | before | after |
|---|---|---|
| `express` | 4.22.1 | 4.22.2 |
| `qs` | 6.14.1 | 6.15.3 |
| `body-parser/node_modules/qs` | 6.15.3 (nested dup) | removed (deduped) |

Net diff is 10 insertions / 25 deletions — the nested duplicate `qs` collapses into the hoisted copy now that both resolve to 6.15.3.

`express@4.22.2` satisfies the existing `webpack-dev-server` requirement of `express ^4.21.2`, so this needs no major bump and no override.

### User experience

No user-facing change. `express`/`qs` reach the tree only via `webpack-dev-server` (local dev server), and are not part of the built static site.

## Verification

* `npm ci --ignore-scripts` — succeeds, lockfile is internally consistent
* `npm ls qs express --all` — confirms `express@4.22.2` → `qs@6.15.3 deduped`
* `npm run build` — succeeds for both `en` and `ja` locales (the broken-anchor warning on `healthimaging-mcp-server#installation` is pre-existing on `main` and non-fatal)
* `npm audit` — no remaining `qs` advisory; all other findings are pre-existing on `main` and untouched by this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)