### PR TITLE
feat(redshift-mcp-server): add read-only tool annotations (OpenAI plugin requirements)

### DIFF
--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -39,6 +39,7 @@ from awslabs.redshift_mcp_server.review.executor import review_cluster
 from awslabs.redshift_mcp_server.review.models import ReviewResult
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -137,7 +138,21 @@ The server reuses one Redshift Data API session per `cluster:database`:
 )
 
 
-@mcp.tool(name='list_clusters')
+def _read_only_annotations(title: str) -> ToolAnnotations:
+    """Return annotations for tools that only read the caller's AWS environment."""
+    return ToolAnnotations(
+        title=title,
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
+
+@mcp.tool(
+    name='list_clusters',
+    annotations=_read_only_annotations('List Redshift clusters and workgroups'),
+)
 async def list_clusters_tool(ctx: Context) -> list[RedshiftCluster]:
     """List all available Amazon Redshift clusters and serverless workgroups.
 
@@ -196,7 +211,10 @@ async def list_clusters_tool(ctx: Context) -> list[RedshiftCluster]:
         raise
 
 
-@mcp.tool(name='list_databases')
+@mcp.tool(
+    name='list_databases',
+    annotations=_read_only_annotations('List Redshift databases'),
+)
 async def list_databases_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -270,7 +288,10 @@ async def list_databases_tool(
         raise
 
 
-@mcp.tool(name='list_schemas')
+@mcp.tool(
+    name='list_schemas',
+    annotations=_read_only_annotations('List Redshift schemas'),
+)
 async def list_schemas_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -352,7 +373,10 @@ async def list_schemas_tool(
         raise
 
 
-@mcp.tool(name='list_tables')
+@mcp.tool(
+    name='list_tables',
+    annotations=_read_only_annotations('List Redshift tables'),
+)
 async def list_tables_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -441,7 +465,10 @@ async def list_tables_tool(
         raise
 
 
-@mcp.tool(name='list_columns')
+@mcp.tool(
+    name='list_columns',
+    annotations=_read_only_annotations('List Redshift columns'),
+)
 async def list_columns_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -544,7 +571,10 @@ async def list_columns_tool(
         raise
 
 
-@mcp.tool(name='execute_query')
+@mcp.tool(
+    name='execute_query',
+    annotations=_read_only_annotations('Execute read-only Redshift query'),
+)
 async def execute_query_tool(
     ctx: Context,
     cluster_identifier: str = Field(
@@ -635,7 +665,10 @@ async def execute_query_tool(
         raise
 
 
-@mcp.tool(name='review_cluster')
+@mcp.tool(
+    name='review_cluster',
+    annotations=_read_only_annotations('Review Redshift cluster'),
+)
 async def review_cluster_tool(
     ctx: Context,
     cluster_identifier: str = Field(

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -35,10 +35,37 @@ from awslabs.redshift_mcp_server.server import (
     list_databases_tool,
     list_schemas_tool,
     list_tables_tool,
+    mcp,
     review_cluster_tool,
 )
 from datetime import datetime
 from mcp.server.fastmcp import Context
+
+
+@pytest.mark.asyncio
+async def test_tool_annotations():
+    """Test that every tool advertises its read-only behavior to MCP clients."""
+    expected_titles = {
+        'list_clusters': 'List Redshift clusters and workgroups',
+        'list_databases': 'List Redshift databases',
+        'list_schemas': 'List Redshift schemas',
+        'list_tables': 'List Redshift tables',
+        'list_columns': 'List Redshift columns',
+        'execute_query': 'Execute read-only Redshift query',
+        'review_cluster': 'Review Redshift cluster',
+    }
+
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+
+    assert tools.keys() == expected_titles.keys()
+    for name, title in expected_titles.items():
+        annotations = tools[name].annotations
+        assert annotations is not None
+        assert annotations.title == title
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint is False
+        assert annotations.idempotentHint is True
+        assert annotations.openWorldHint is True
 
 
 class TestListClustersTool:


### PR DESCRIPTION
Fixes: N/A

## Summary

Adds standard MCP tool annotations to every tool exposed by the Redshift MCP server.

### Changes

- Advertise all seven Redshift tools as read-only, non-destructive, idempotent interactions with the caller's external AWS environment.
- Add human-readable titles for each tool.
- Add a contract test over `mcp.list_tools()` so future tools cannot silently ship without the expected annotations.
- Preserve all existing handlers, SQL guards, AWS calls, inputs, outputs, and tool names.

### User experience

Before this change, MCP clients received no safety metadata for Redshift tools and could not distinguish the server's guarded read-only operations from unannotated actions. After this change, clients can use the server-advertised annotations when presenting or reviewing tool calls.

## Testing

- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing` (197 passed; 99% branch coverage)
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pyright`

The monorepo pre-commit bootstrap could not download the Go-based gitleaks dependencies because `proxy.golang.org` DNS timed out locally; upstream CI can rerun that repository-level hook.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented (not applicable)
* [ ] Implement warnings (not applicable)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
