### PR TITLE
fix(billing-cost-management): Fix tool parameter in get_recommendation API

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_helpers.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_helpers.py
@@ -220,15 +220,14 @@ async def list_recommendations(
 
 
 async def get_recommendation(
-    ctx: Context, coh_client: Any, resource_id: str, resource_type: str
+    ctx: Context, coh_client: Any, recommendation_id: str
 ) -> Dict[str, Any]:
     """Get detailed information about a specific recommendation.
 
     Args:
         ctx: MCP context
         coh_client: Cost Optimization Hub client
-        resource_id: Recommendation ID to retrieve
-        resource_type: Resource type (for compatibility, not used in API call)
+        recommendation_id: Recommendation ID to retrieve
 
     Returns:
         Dict containing detailed recommendation information
@@ -238,10 +237,10 @@ async def get_recommendation(
 
     try:
         # Prepare the request parameters
-        request_params = {'recommendationId': resource_id}
+        request_params = {'recommendationId': recommendation_id}
 
         # Make the API call
-        await ctx_logger.info(f'Fetching recommendation {resource_id}')
+        await ctx_logger.info(f'Fetching recommendation {recommendation_id}')
         response = coh_client.get_recommendation(**request_params)
 
         # The response IS the recommendation data
@@ -249,16 +248,15 @@ async def get_recommendation(
 
         if not recommendation:
             await ctx_logger.warning(
-                f'No recommendation found for resource {resource_id} of type {resource_type}'
+                f'No recommendation found for recommendation {recommendation_id}'
             )
             return format_response(
                 'warning',
                 {
-                    'resource_id': resource_id,
-                    'resource_type': resource_type,
-                    'message': 'No recommendation found for the specified resource.',
+                    'recommendation_id': recommendation_id,
+                    'message': 'No recommendation found for the specified recommendation.',
                 },
-                'No recommendation found. The resource may not have optimization opportunities, or the resource ID/type may be incorrect.',
+                'No recommendation found. The recommendation may not have optimization opportunities, or the recommendation ID may be incorrect.',
             )
 
         # Build response using actual API fields
@@ -324,10 +322,9 @@ async def get_recommendation(
                 'warning',
                 {
                     'error_code': error_code,
-                    'resource_id': resource_id,
-                    'resource_type': resource_type,
+                    'recommendation_id': recommendation_id,
                 },
-                f'Resource {resource_id} of type {resource_type} not found in Cost Optimization Hub.',
+                f'Recommendation {recommendation_id} not found in Cost Optimization Hub.',
             )
         else:
             # Re-raise for other errors

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_optimization_hub_tools.py
@@ -72,7 +72,7 @@ Valid 'group_by' values: AccountId, Region, ActionType, ResourceType, RestartNee
 CRITICAL PARAMETER REQUIREMENTS:
 - 'filters' parameter must be passed as JSON string format
 - 'max_results' must be integer (not string)
-- 'get_recommendation' requires both 'resource_id' AND 'resource_type' parameters
+- 'get_recommendation' requires only 'recommendation_id' (mapped to the API's recommendationId)
 - Service only available in us-east-1 region
 
 Available Filter Parameters (pass as JSON string):
@@ -102,8 +102,7 @@ Each recommendation includes:
 async def cost_optimization_hub(
     ctx: Context,
     operation: str,
-    resource_id: Optional[str] = None,
-    resource_type: Optional[str] = None,
+    recommendation_id: Optional[str] = None,
     max_results: Optional[int] = None,
     filters: Optional[str] = None,
     group_by: Optional[str] = None,
@@ -114,8 +113,7 @@ async def cost_optimization_hub(
     Args:
         ctx: The MCP context
         operation: The operation to perform ('list_recommendations', 'get_recommendation', or 'list_recommendation_summaries')
-        resource_id: Resource ID for get_recommendation operation
-        resource_type: Resource type for get_recommendation operation
+        recommendation_id: Recommendation ID for get_recommendation operation (mapped to the API's recommendationId)
         max_results: Maximum total results to return across all pages; None means all available results
         filters: Optional filter expression as JSON string
         group_by: Optional grouping parameter for list_recommendation_summaries
@@ -157,11 +155,11 @@ async def cost_optimization_hub(
                 )
 
         elif operation == OPERATION_GET_RECOMMENDATION:
-            if not resource_id or not resource_type:
+            if not recommendation_id:
                 return format_response(
                     'error',
                     {},
-                    'Both resource_id and resource_type are required for get_recommendation operation',
+                    'recommendation_id is required for get_recommendation operation',
                 )
 
         # Execute the appropriate operation
@@ -244,14 +242,8 @@ async def cost_optimization_hub(
                 )
 
         elif operation == OPERATION_GET_RECOMMENDATION:
-            if not resource_id or not resource_type:
-                return format_response(
-                    'error',
-                    {
-                        'message': 'Both resource_id and resource_type are required for get_recommendation operation'
-                    },
-                )
-            return await get_recommendation(ctx, coh_client, str(resource_id), str(resource_type))
+            # recommendation_id is already validated above
+            return await get_recommendation(ctx, coh_client, str(recommendation_id))
 
         else:
             # Return error for unsupported operations

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_optimization_hub_helpers.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_optimization_hub_helpers.py
@@ -226,14 +226,16 @@ class TestGetRecommendation:
         result = await get_recommendation(
             mock_context,
             mock_coh_client,
-            resource_id='i-1234567890abcdef0',
-            resource_type='EC2_INSTANCE',
+            recommendation_id='i-1234567890abcdef0',
         )
 
         # Verify the client was called correctly
         mock_coh_client.get_recommendation.assert_called_once()
         call_kwargs = mock_coh_client.get_recommendation.call_args[1]
         assert call_kwargs['recommendationId'] == 'i-1234567890abcdef0'
+        # resource_type is not part of the API contract and must not be sent
+        assert 'resource_type' not in call_kwargs
+        assert 'resourceType' not in call_kwargs
 
         # Verify the context was informed
         mock_context.info.assert_called_once()
@@ -509,9 +511,7 @@ class TestGetRecommendationErrorHandling:
         """Test get_recommendation with empty recommendation in response."""
         mock_coh_client.get_recommendation.return_value = {}
 
-        result = await get_recommendation(
-            mock_context, mock_coh_client, 'i-1234567890abcdef0', 'EC2_INSTANCE'
-        )
+        result = await get_recommendation(mock_context, mock_coh_client, 'i-1234567890abcdef0')
 
         assert result['status'] == 'warning'
 
@@ -519,9 +519,7 @@ class TestGetRecommendationErrorHandling:
         """Test get_recommendation with no recommendation key in response."""
         mock_coh_client.get_recommendation.return_value = {}
 
-        result = await get_recommendation(
-            mock_context, mock_coh_client, 'i-1234567890abcdef0', 'EC2_INSTANCE'
-        )
+        result = await get_recommendation(mock_context, mock_coh_client, 'i-1234567890abcdef0')
 
         assert result['status'] == 'warning'
         assert 'No recommendation found' in result['message']
@@ -537,9 +535,7 @@ class TestGetRecommendationErrorHandling:
             operation_name='GetRecommendation',
         )
 
-        result = await get_recommendation(
-            mock_context, mock_coh_client, 'invalid-id', 'EC2_INSTANCE'
-        )
+        result = await get_recommendation(mock_context, mock_coh_client, 'invalid-id')
 
         assert result['status'] == 'error'
         assert result['data']['error_code'] == 'ValidationException'
@@ -556,9 +552,7 @@ class TestGetRecommendationErrorHandling:
             operation_name='GetRecommendation',
         )
 
-        result = await get_recommendation(
-            mock_context, mock_coh_client, 'i-1234567890abcdef0', 'EC2_INSTANCE'
-        )
+        result = await get_recommendation(mock_context, mock_coh_client, 'i-1234567890abcdef0')
 
         assert result['status'] == 'error'
         assert result['data']['error_code'] == 'AccessDeniedException'
@@ -575,9 +569,7 @@ class TestGetRecommendationErrorHandling:
             operation_name='GetRecommendation',
         )
 
-        result = await get_recommendation(
-            mock_context, mock_coh_client, 'i-nonexistent', 'EC2_INSTANCE'
-        )
+        result = await get_recommendation(mock_context, mock_coh_client, 'i-nonexistent')
 
         assert result['status'] == 'warning'
         assert result['data']['error_code'] == 'ResourceNotFoundException'
@@ -594,9 +586,7 @@ class TestGetRecommendationErrorHandling:
         mock_coh_client.get_recommendation.side_effect = error
 
         with pytest.raises(ClientError):
-            await get_recommendation(
-                mock_context, mock_coh_client, 'i-1234567890abcdef0', 'EC2_INSTANCE'
-            )
+            await get_recommendation(mock_context, mock_coh_client, 'i-1234567890abcdef0')
 
     async def test_non_client_error_reraise(self, mock_context, mock_coh_client):
         """Test get_recommendation non-ClientError gets re-raised."""
@@ -604,9 +594,7 @@ class TestGetRecommendationErrorHandling:
         mock_coh_client.get_recommendation.side_effect = error
 
         with pytest.raises(ValueError):
-            await get_recommendation(
-                mock_context, mock_coh_client, 'i-1234567890abcdef0', 'EC2_INSTANCE'
-            )
+            await get_recommendation(mock_context, mock_coh_client, 'i-1234567890abcdef0')
 
 
 @pytest.mark.asyncio
@@ -786,9 +774,7 @@ class TestRecommendationFormatting:
             # Missing optional fields: source, lookbackPeriodInDays, estimatedMonthlySavings
         }
 
-        result = await get_recommendation(
-            mock_context, mock_coh_client, 'i-minimal', 'EC2_INSTANCE'
-        )
+        result = await get_recommendation(mock_context, mock_coh_client, 'i-minimal')
 
         assert result['status'] == 'success'
         rec = result['data']
@@ -811,7 +797,7 @@ class TestRecommendationFormatting:
             # Missing implementationEffort
         }
 
-        result = await get_recommendation(mock_context, mock_coh_client, 'i-test', 'EC2_INSTANCE')
+        result = await get_recommendation(mock_context, mock_coh_client, 'i-test')
 
         assert result['status'] == 'success'
         rec = result['data']

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_optimization_hub_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_optimization_hub_tools.py
@@ -88,19 +88,18 @@ async def cost_optimization_hub(ctx, operation, **kwargs):
         }
 
     elif operation == 'get_recommendation':
-        if not kwargs.get('resource_id') or not kwargs.get('resource_type'):
+        if not kwargs.get('recommendation_id'):
             return format_response(
                 'error',
                 {},
-                'Both resource_id and resource_type are required for get_recommendation operation',
+                'recommendation_id is required for get_recommendation operation',
             )
 
         return {
             'status': 'success',
             'data': {
-                'id': kwargs.get('recommendation_id'),
-                'resource_id': kwargs.get('resource_id'),
-                'resource_type': 'EC2_INSTANCE',
+                'recommendation_id': kwargs.get('recommendation_id'),
+                'resource_id': 'i-12345',
                 'current_instance_type': 't3.xlarge',
                 'recommended_instance_type': 't3.large',
                 'estimated_monthly_savings': 50.0,
@@ -222,11 +221,11 @@ async def test_missing_group_by_for_summaries(mock_context):
 
 @pytest.mark.asyncio
 async def test_missing_resource_params_for_get_recommendation(mock_context):
-    """Test missing resource parameters for get_recommendation."""
+    """Test missing recommendation_id for get_recommendation."""
     result = await cost_optimization_hub(mock_context, operation='get_recommendation')
 
     assert result['status'] == 'error'
-    assert 'resource_id and resource_type are required' in result['message']
+    assert 'recommendation_id is required' in result['message']
 
 
 @pytest.mark.asyncio
@@ -255,18 +254,15 @@ async def test_list_recommendations_success(mock_context):
 
 @pytest.mark.asyncio
 async def test_get_recommendation_success(mock_context):
-    """Test successful get_recommendation."""
+    """Test successful get_recommendation with recommendation_id."""
     result = await cost_optimization_hub(
         mock_context,
         operation='get_recommendation',
-        resource_id='i-12345',
-        resource_type='EC2_INSTANCE',
         recommendation_id='rec-1',
     )
 
     assert result['status'] == 'success'
-    assert result['data']['resource_id'] == 'i-12345'
-    assert result['data']['resource_type'] == 'EC2_INSTANCE'
+    assert result['data']['recommendation_id'] == 'rec-1'
 
 
 def _reload_coh_with_identity_decorator():
@@ -388,15 +384,14 @@ async def test_coh_real_get_recommendation_success_reload_identity_decorator(moc
         res = await real_fn(  # type: ignore
             mock_context,
             operation='get_recommendation',
-            resource_id='i-abc',
-            resource_type='EC2_INSTANCE',
+            recommendation_id='i-abc',
         )
 
         assert res['status'] == 'success'
         mock_create_client.assert_called_once_with(
             'cost-optimization-hub', region_name='us-east-1'
         )
-        mock_get_rec.assert_awaited_once_with(mock_context, fake_client, 'i-abc', 'EC2_INSTANCE')
+        mock_get_rec.assert_awaited_once_with(mock_context, fake_client, 'i-abc')
 
 
 @pytest.mark.asyncio
@@ -408,12 +403,11 @@ async def test_coh_real_get_recommendation_missing_params_reload_identity_decora
     res = await real_fn(  # type: ignore
         mock_context,
         operation='get_recommendation',
-        # missing resource_id/resource_type
+        # missing recommendation_id
     )
     assert res['status'] == 'error'
     blob = json.dumps(res)
-    assert 'resource_id' in blob
-    assert 'resource_type' in blob
+    assert 'recommendation_id' in blob
 
 
 @pytest.mark.asyncio
@@ -560,12 +554,11 @@ async def test_coh_real_get_recommendation_missing_resource_id_reload_identity_d
     res = await real_fn(  # type: ignore
         mock_context,
         operation='get_recommendation',
-        resource_type='EC2_INSTANCE',
-        # missing resource_id
+        # missing recommendation_id
     )
 
     assert res['status'] == 'error'
-    assert 'resource_id and resource_type are required' in res['message']
+    assert 'recommendation_id is required' in res['message']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The Cost Optimization Hub GetRecommendation API only accepts recommendationId, but the tool description and validation gates wrongly required a resource_type parameter that was never sent to the API. 

### Changes

- Remove resource_type entirely and rename resource_id to recommendation_id to match the API contract.
- Update the tool description, validation gates, helper signature, and unit tests; 

### User experience

The agent can get recommendation successfully

```
  I'll grab a recommendation from a different category (Delete) to exercise get_recommendation on a different resource type, then look it
  up.
● cost-optimization
    ╰ filters={"actionTypes": ["Delete"]}, max_results=1, operation=list_recommendations
● cost-optimization
    ╰ operation=get_recommendation, recommendation_id=xxx
    ╰ output:
        {
          "content": [
            {
              "type": "text",
              "text":
xxx
            }
          ],
          "isError": false
        }

● Thought for 1s...
    ╰ I need to present the Delete recommendation through the get_recommendation function, making sure to set rollback_possible to false
      since deletions can't be undone.
  Here's the get_recommendation result for a Delete recommendation — a different resource type (xxx) this time:

```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
