### PR TITLE
docs: Fix argument in README for well-architected-security-mcp-server

### DIFF
--- a/src/well-architected-security-mcp-server/README.md
+++ b/src/well-architected-security-mcp-server/README.md
@@ -89,7 +89,7 @@ Add the AWS Well-Architected Security Assessment Tool MCP Server to your MCP cli
   "mcpServers": {
     "well-architected-security-mcp-server": {
       "command": "uvx",
-      "args": ["--from", "awslabs.well-architected-security-mcp-server", "well-architected-security-mcp-server"],
+      "args": ["--from", "awslabs.well-architected-security-mcp-server", "awslabs.well-architected-security-mcp-server"],
       "env": {
         "AWS_PROFILE": "your-aws-profile", // Optional - uses your local AWS configuration if not specified
         "AWS_REGION": "your-aws-region", // Optional - uses your local AWS configuration if not specified


### PR DESCRIPTION
## Summary

### Changes

The README for `well-architected-security-mcp-server` documents the `args` for the MCP configuration as:

```json
"args": ["--from", "awslabs.well-architected-security-mcp-server", "well-architected-security-mcp-server"]
```

The correct entry point provided by the package is `awslabs.well-architected-security-mcp-server`, not `well-architected-security-mcp-server`. This PR updates the documented configuration to:

```json
"args": ["--from", "awslabs.well-architected-security-mcp-server", "awslabs.well-architected-security-mcp-server"]
```

### User experience

**Before:** Users copying the configuration from the README get a connection failure:

```
An executable named `well-architected-security-mcp-server` is not provided by package `awslabs-well-architected-security-mcp-server`.
The following executables are available:
- awslabs.well-architected-security-mcp-server
```

**After:** The MCP server connects successfully using the correct executable name.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)

* [x] I have performed a self-review of this change

* [x] Changes have been tested

* [x] Changes are documented

Is this a breaking change? **N**

**RFC issue number**: N/A

Checklist:

* [x] Migration process documented

* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
