### PR TITLE
fix(billing-cost-management): normalize Compute Optimizer timestamps to UTC

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/compute_optimizer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/compute_optimizer_tools.py
@@ -25,6 +25,7 @@ from ..utilities.aws_service_base import (
     parse_json,
 )
 from ..utilities.logging_utils import get_context_logger
+from ..utilities.time_utils import timestamp_to_utc_iso_string
 from botocore.exceptions import ClientError
 from fastmcp import Context, FastMCP
 from typing import Any, Dict, Optional
@@ -806,8 +807,8 @@ def format_savings_opportunity(savings_opportunity):
 
 
 def format_timestamp(timestamp):
-    """Format a timestamp to ISO format string."""
-    if not timestamp:
+    """Format a timestamp to an ISO 8601 UTC string."""
+    if timestamp is None:
         return None
 
-    return timestamp.isoformat() if hasattr(timestamp, 'isoformat') else str(timestamp)
+    return timestamp_to_utc_iso_string(timestamp)

--- a/src/billing-cost-management-mcp-server/tests/tools/test_compute_optimizer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_compute_optimizer_tools.py
@@ -37,7 +37,7 @@ from awslabs.billing_cost_management_mcp_server.tools.compute_optimizer_tools im
     get_lambda_function_recommendations,
     get_rds_recommendations,
 )
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from fastmcp import Context, FastMCP
 from typing import Any, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -673,6 +673,19 @@ class TestHelperFunctions:
         # Test with None
         result = format_timestamp(None)
         assert result is None
+
+    def test_format_timestamp_normalizes_aware_datetime_to_utc(self):
+        """Test format_timestamp converts timezone-aware input to UTC."""
+        aware = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
+        assert format_timestamp(aware) == '2023-01-01T17:00:00'
+
+    def test_format_timestamp_accepts_epoch_seconds(self):
+        """Test format_timestamp accepts epoch seconds."""
+        assert format_timestamp(1672574400) == '2023-01-01T12:00:00'
+
+    def test_format_timestamp_preserves_epoch_zero(self):
+        """Test format_timestamp treats epoch 0 as a value, not as absent."""
+        assert format_timestamp(0) == '1970-01-01T00:00:00'
 
 
 def test_compute_optimizer_server_initialization():


### PR DESCRIPTION
## Summary

### Changes

`format_timestamp` in the Compute Optimizer tool called `.isoformat()` directly on the value returned by boto3. botocore returns timezone-aware datetimes in the **host's local zone**, so `last_refresh_timestamp` varied with wherever the server happened to be running.

The server is also inconsistent with itself: `compute_optimizer_automation_operations._format_timestamp` already uses `time_utils.timestamp_to_utc_iso_string` and emits UTC, while `compute_optimizer_tools.format_timestamp` emitted host-local. Two Compute Optimizer tools, same field name, different timezones.

This delegates to that existing helper so both tools produce the same representation:

```diff
-    return timestamp.isoformat() if hasattr(timestamp, 'isoformat') else str(timestamp)
+    return timestamp_to_utc_iso_string(timestamp)
```

### User experience

Before, the same recommendation rendered differently depending on the host's timezone:

```
2026-08-06T14:00:00-04:00     # server in us-east-1
2026-08-06T18:00:00+00:00     # server with TZ=UTC
```

After, it is always the same instant in UTC, matching what the Compute Optimizer Automation tool already returns:

```
2026-08-06T18:00:00
```

The helper also accepts epoch seconds, so a caller passing a raw numeric timestamp now gets an ISO string instead of `str()` of the number.

Note the output is naive UTC rather than offset-bearing, because that is what `timestamp_to_utc_iso_string` produces. Happy to emit `+00:00` instead if maintainers prefer the offset retained — that would be a change to the shared helper and would also affect the Automation tool, so I have left it alone here.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N** — no API or signature change. The timestamp *string format* does change as described above.

**RFC issue number**: n/a

### Testing

* Full suite passes (1156 tests).
* Two tests added: timezone-aware input normalizes to UTC, and epoch seconds are accepted.
* The existing `test_format_timestamp` is unchanged and still passes — naive datetimes are unaffected.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
