### PR TITLE
fix(billing-cost-management): migrate import_server to mount for fastmcp 4.x compat

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -18,7 +18,6 @@ A Model Context Protocol (MCP) server that provides tools for Billing and Cost M
 by wrapping boto3 SDK functions for AWS Billing and Cost Management services.
 """
 
-import asyncio
 import os
 import sys
 
@@ -192,7 +191,7 @@ For multi-account environments:
 mcp.add_middleware(ErrorSignalingMiddleware())
 
 
-async def register_prompts():
+def register_prompts():
     """Register all prompts with the MCP server."""
     try:
         from awslabs.billing_cost_management_mcp_server.prompts import register_all_prompts
@@ -203,32 +202,32 @@ async def register_prompts():
         logger.error(f'Error registering prompts: {e}')
 
 
-async def setup():
-    """Initialize the MCP server by importing all tool servers."""
-    await mcp.import_server(cost_explorer_server)
-    await mcp.import_server(compute_optimizer_server)
-    await mcp.import_server(compute_optimizer_automation_server)
-    await mcp.import_server(cost_optimization_hub_server)
-    await mcp.import_server(storage_lens_server)
-    await mcp.import_server(aws_pricing_server)
-    await mcp.import_server(bcm_pricing_calculator_server)
-    await mcp.import_server(budget_server)
-    await mcp.import_server(cost_anomaly_server)
-    await mcp.import_server(cost_comparison_server)
-    await mcp.import_server(free_tier_usage_server)
-    await mcp.import_server(recommendation_details_server)
-    await mcp.import_server(ri_performance_server)
-    await mcp.import_server(sp_performance_server)
-    await mcp.import_server(unified_sql_server)
-    await mcp.import_server(billing_conductor_server)
-    await mcp.import_server(bvs_server)
-    await mcp.import_server(cost_allocation_tags_server)
-    await mcp.import_server(cost_category_server)
-    await mcp.import_server(invoicing_server)
-    await mcp.import_server(invoice_units_server)
-    await mcp.import_server(procurement_preferences_server)
+def setup():
+    """Initialize the MCP server by mounting all tool servers."""
+    mcp.mount(cost_explorer_server)
+    mcp.mount(compute_optimizer_server)
+    mcp.mount(compute_optimizer_automation_server)
+    mcp.mount(cost_optimization_hub_server)
+    mcp.mount(storage_lens_server)
+    mcp.mount(aws_pricing_server)
+    mcp.mount(bcm_pricing_calculator_server)
+    mcp.mount(budget_server)
+    mcp.mount(cost_anomaly_server)
+    mcp.mount(cost_comparison_server)
+    mcp.mount(free_tier_usage_server)
+    mcp.mount(recommendation_details_server)
+    mcp.mount(ri_performance_server)
+    mcp.mount(sp_performance_server)
+    mcp.mount(unified_sql_server)
+    mcp.mount(billing_conductor_server)
+    mcp.mount(bvs_server)
+    mcp.mount(cost_allocation_tags_server)
+    mcp.mount(cost_category_server)
+    mcp.mount(invoicing_server)
+    mcp.mount(invoice_units_server)
+    mcp.mount(procurement_preferences_server)
 
-    await register_prompts()
+    register_prompts()
 
     logger.info('AWS Billing and Cost Management MCP Server initialized successfully')
 
@@ -282,7 +281,7 @@ async def setup():
 def main():
     """Main entry point for the server."""
     # Run the setup function to initialize the server
-    asyncio.run(setup())
+    setup()
 
     # Start the MCP server
     mcp.run()

--- a/src/billing-cost-management-mcp-server/tests/test_server.py
+++ b/src/billing-cost-management-mcp-server/tests/test_server.py
@@ -15,7 +15,7 @@
 """Tests for server.py."""
 
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 
 def test_server_imports():
@@ -32,7 +32,6 @@ def test_server_module_attributes():
     # Check that the module has the expected functions and imports
     assert hasattr(server, 'main')
     assert hasattr(server, 'mcp')
-    assert hasattr(server, 'asyncio')
 
 
 def test_path_modification():
@@ -89,47 +88,48 @@ def test_server_registration_logic():
 
 @patch('awslabs.billing_cost_management_mcp_server.server.mcp')
 @patch('awslabs.billing_cost_management_mcp_server.server.register_prompts')
-async def test_setup_function(mock_register_prompts, mock_mcp):
+def test_setup_function(mock_register_prompts, mock_mcp):
     """Test the setup function execution path."""
     from awslabs.billing_cost_management_mcp_server.server import setup
 
-    mock_mcp.import_server = AsyncMock()
+    mock_mcp.mount = MagicMock()
     mock_register_prompts.return_value = None
 
-    await setup()
+    setup()
 
-    assert mock_mcp.import_server.call_count >= 10
+    assert mock_mcp.mount.call_count == 22
+    mock_register_prompts.assert_called_once()
 
 
 @patch('awslabs.billing_cost_management_mcp_server.prompts.register_all_prompts')
-async def test_register_prompts_success(mock_register_all_prompts):
+def test_register_prompts_success(mock_register_all_prompts):
     """Test successful prompt registration."""
     from awslabs.billing_cost_management_mcp_server.server import register_prompts
 
     mock_register_all_prompts.return_value = None
 
-    await register_prompts()
+    register_prompts()
 
     mock_register_all_prompts.assert_called_once()
 
 
 @patch('awslabs.billing_cost_management_mcp_server.prompts.register_all_prompts')
-async def test_register_prompts_error(mock_register_all_prompts):
+def test_register_prompts_error(mock_register_all_prompts):
     """Test prompt registration error handling."""
     from awslabs.billing_cost_management_mcp_server.server import register_prompts
 
     mock_register_all_prompts.side_effect = Exception('Test error')
 
-    await register_prompts()
+    register_prompts()
 
 
-@patch('awslabs.billing_cost_management_mcp_server.server.asyncio.run')
+@patch('awslabs.billing_cost_management_mcp_server.server.setup')
 @patch('awslabs.billing_cost_management_mcp_server.server.mcp.run')
-def test_main_function(mock_mcp_run, mock_asyncio_run):
+def test_main_function(mock_mcp_run, mock_setup):
     """Test main function execution."""
     from awslabs.billing_cost_management_mcp_server.server import main
 
     main()
 
-    mock_asyncio_run.assert_called_once()
+    mock_setup.assert_called_once()
     mock_mcp_run.assert_called_once()


### PR DESCRIPTION
## Problem

The `billing-cost-management-mcp-server` pins `fastmcp>=3.2.0` with no upper bound. fastmcp 4.x removes `import_server()`, so when pip/uv resolves a 4.x prerelease the server crashes at startup:

```
AttributeError: 'FastMCP' object has no attribute 'import_server'
```

## Fix

- Replace all 22 `await mcp.import_server(X)` calls with `mcp.mount(X)` in `server.py`
- Convert `async def setup()` → `def setup()` and `async def register_prompts()` → `def register_prompts()` (no longer awaited)
- Remove `asyncio.run(setup())` in `main()`; call `setup()` directly
- Remove unused `import asyncio`
- Update `tests/test_server.py`: repoint mocks from `import_server` to `mount`, convert affected tests from async to sync, drop `AsyncMock` where targets are now synchronous

## Why no pin change

`mcp.mount(child)` (no `namespace=`) is valid and identical in tool names and semantics across the entire supported range:

| fastmcp | `mount()` signature | bare `mount(child)` | sync/async | tool names | `import_server` |
|---|---|---|---|---|---|
| 3.2.0 | `(self, server, namespace=None, ...)` | ✓ works | sync | unprefixed | present |
| 3.4.6 | `(self, server, namespace=None, ...)` | ✓ works | sync | unprefixed | present |
| 4.0.0b2 | `(self, server, namespace=None, tool_names=None)` | ✓ works | sync | unprefixed | **absent** |

No tool renaming or prefixing occurs. None of the 22 original calls passed `prefix=` or `namespace=`, and none of the sub-servers define lifespan/startup hooks (boto3 clients are created lazily). The existing `fastmcp>=3.2.0` pin remains correct without modification.

## Performance

Measured on fastmcp 3.4.6 for both code paths (22 sub-servers, 37 tools):

| Metric | `import_server` | `mount` | Delta |
|---|---|---|---|
| `setup()` startup, median of 10 fresh processes | 32.0 ms | 6.3 ms | −25.7 ms |
| `list_tools()`, median of 100 calls | 0.473 ms | 3.264 ms | +2.8 ms |
| `get_tool(name)`, median of 100 calls | 0.145 ms | 1.087 ms | +0.94 ms |

`import_server` copied all 37 tools into a single flat provider, so lookup was one
dict hit. `mount` leaves 23 providers (1 local + 22 sub-servers) that are queried
sequentially, which accounts for the per-call delta. Listing cost does not grow
across repeated calls.

The per-call overhead is not material in context: tool invocations are dominated by
AWS API latency (50–500 ms), so +0.94 ms is well under 2% of end-to-end time, and
`list_tools()` runs on session init rather than per request. Startup is ~5× faster.

Note that `mount()` is the only composition API available on fastmcp 4.x, so this
overhead is inherent to 4.x compatibility rather than a choice between two viable
options. The bare `mount(server)` call does not wrap sub-servers in a proxy
(`as_proxy` defaults to no proxy, and the parameter is removed entirely in 4.x).


## Relationship to #4452 / #4448

PR #4452 migrates 43 servers from `mcp[cli]` v1 to v2 but explicitly defers this package because fastmcp 3.x pins `mcp<2.0`. This PR is orthogonal — it makes the server fastmcp-4-ready ahead of the 4.0 stable release (prerequisite groundwork for the migration #4452 is deferring) while also fixing a crash reachable today via prerelease resolution. There is no file overlap or textual conflict with #4452.

## Testing

Verified 2026-08-09 in isolated venvs (one per fastmcp version):

| fastmcp version | setup() | pytest | tools exposed |
|---|---|---|---|
| 3.2.0 (pinned floor) | completed, no error | 1161 passed | 37 |
| 3.4.6 (latest stable) | completed, no error | 1161 passed | 37 |
| 4.0.0b2 (latest 4.x prerelease) | completed, no error | 1161 passed (2 warnings) | 37 |

**Tool-name parity**: diffed the sorted tool-name list from the new `mount()` code against the list from the pre-change `import_server()` code on `main` (same fastmcp 3.4.6, isolated git worktree). The diff is empty — all 37 tools across the 22 sub-servers are identical. No prefixing, no renaming.

`ruff check` and `ruff format --check` both clean; branch coverage 95%.

CI (`python.yml`) has not run yet — pending.

## References

- [fastmcp 4.x migration guide](https://gofastmcp.com/getting-started/upgrading)
- #4448 — tracking issue for fastmcp 4.x migration
- #4452 — mcp v1→v2 migration (defers this package)


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

