### PR TITLE
feat(timestream-for-influxdb-mcp-server): Add InfluxDB v2 write mode

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1251,10 +1251,10 @@
         "filename": "src/timestream-for-influxdb-mcp-server/tests/test_server.py",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 619,
+        "line_number": 620,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-16T18:42:37Z"
+  "generated_at": "2026-08-10T16:13:08Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1251,10 +1251,10 @@
         "filename": "src/timestream-for-influxdb-mcp-server/tests/test_server.py",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 621,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-08-10T16:13:08Z"
+  "generated_at": "2026-08-12T23:21:47Z"
 }

--- a/src/timestream-for-influxdb-mcp-server/README.md
+++ b/src/timestream-for-influxdb-mcp-server/README.md
@@ -40,6 +40,7 @@ You can modify the settings of your MCP client to run your local server (e.g. fo
         "INFLUXDB_URL": "https://your-influxdb-endpoint:8086",
         "INFLUXDB_TOKEN": "your-influxdb-token",
         "INFLUXDB_ORG": "your-influxdb-org",
+        "INFLUXDB_WRITE_MODE": "false",
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
       "disabled": false,
@@ -73,6 +74,7 @@ For Windows users, the MCP server configuration format is slightly different:
         "INFLUXDB_URL": "https://your-influxdb-endpoint:8086",
         "INFLUXDB_TOKEN": "your-influxdb-token",
         "INFLUXDB_ORG": "your-influxdb-org",
+        "INFLUXDB_WRITE_MODE": "false",
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     }
@@ -152,3 +154,32 @@ The Timestream for InfluxDB MCP server provides the following tools:
 ##### Organization Management
 - `InfluxDBListOrgs`: List all organizations in InfluxDB
 - `InfluxDBCreateOrg`: Create a new organization in InfluxDB
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AWS_PROFILE` | No | — | AWS profile for control-plane operations |
+| `AWS_REGION` | No | `us-east-1` | AWS region |
+| `INFLUXDB_URL` | No | — | InfluxDB v2 endpoint URL (e.g. `https://host:8086`) |
+| `INFLUXDB_TOKEN` | No | — | InfluxDB v2 authentication token |
+| `INFLUXDB_ORG` | No | — | InfluxDB v2 organization name |
+| `INFLUXDB_ALLOWED_URLS` | No | — | Comma-separated list of additional approved InfluxDB URLs |
+| `INFLUXDB_WRITE_MODE` | No | `false` | Enable write-producing Flux operations in queries (see below) |
+| `FASTMCP_LOG_LEVEL` | No | — | Logging level (`ERROR`, `WARNING`, `INFO`, `DEBUG`) |
+
+### Write Mode
+
+By default, the `InfluxDBQuery` tool rejects Flux queries that contain write-producing operations such as `to()`, `experimental.to()`, and `wideTo()`. This ensures that the query tool behaves as read-only, even when the configured InfluxDB token has write permissions.
+
+To enable write-producing Flux operations through the query tool, set:
+
+```
+INFLUXDB_WRITE_MODE=true
+```
+
+This setting is operator-controlled and cannot be overridden by tool callers.
+
+> **Best practice:** For deployments that need both read and write capabilities, configure a **read-only InfluxDB token** for general use and enable the explicit write tools (`InfluxDBWritePoints`, `InfluxDBWriteLP`) with `tool_write_mode=True` only when needed. This provides the strongest data integrity guarantee regardless of the MCP server's write-mode setting.

--- a/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/server.py
+++ b/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/server.py
@@ -17,6 +17,7 @@
 
 import boto3
 import os
+import re
 from awslabs.timestream_for_influxdb_mcp_server import __version__
 from botocore.config import Config
 from influxdb_client.client.influxdb_client import InfluxDBClient
@@ -40,6 +41,7 @@ INFLUXDB_TOKEN = os.environ.get('INFLUXDB_TOKEN')
 INFLUXDB_URL = os.environ.get('INFLUXDB_URL')
 INFLUXDB_ORG = os.environ.get('INFLUXDB_ORG')
 INFLUXDB_ALLOWED_URLS = os.environ.get('INFLUXDB_ALLOWED_URLS', '')
+INFLUXDB_WRITE_MODE = os.environ.get('INFLUXDB_WRITE_MODE', 'false').lower() == 'true'
 
 # Define Field parameters as global variables to avoid duplication
 # Common fields
@@ -435,6 +437,63 @@ def get_influxdb_client(url, token, org=None, timeout=10000, verify_ssl: bool = 
     return InfluxDBClient(
         url=url, token=token, org=org_param, timeout=timeout, verify_ssl=verify_ssl
     )
+
+
+def validate_flux_query(query: str) -> None:
+    """Validate that a Flux query does not contain write-producing operations.
+
+    When INFLUXDB_WRITE_MODE is disabled (default), this function rejects Flux
+    queries that contain functions capable of writing data to InfluxDB. This
+    provides defense-in-depth protection against data modification through
+    the query interface.
+
+    The following write-producing Flux functions are blocked:
+    - to() — standard write function (influxdata/influxdb/to)
+    - experimental.to() — experimental write function
+    - wideTo() / influxdb.wideTo() — writes wide/pivoted data
+
+    Args:
+        query: The Flux query string to validate.
+
+    Raises:
+        ValueError: If the query contains write-producing operations and
+            INFLUXDB_WRITE_MODE is not enabled.
+    """
+    if INFLUXDB_WRITE_MODE:
+        return
+
+    # Strip single-line comments (// ...) to avoid false positives from commented-out code.
+    # Preserve line structure so that multi-line patterns still work.
+    stripped = re.sub(r'//[^\n]*', '', query)
+
+    # Patterns to detect write-producing Flux functions.
+    # These cover:
+    #   - Pipe-forward to `to(` — e.g. `|> to(bucket: "x")`
+    #   - Standalone or qualified calls — e.g. `to(bucket: "x")`,
+    #     `experimental.to(`, `influxdb.wideTo(`
+    #   - Aliased imports — e.g. `import ex "experimental"` then `ex.to(`
+    # The word-boundary and parenthesis requirements minimize false positives
+    # from identifiers like `toString` or field names containing "to".
+    write_patterns = [
+        # Pipe-forward into to(): |> to(
+        r'\|>\s*to\s*\(',
+        # Qualified calls: experimental.to( or <alias>.to( preceded by word char + dot
+        r'\w+\.to\s*\(',
+        # wideTo as standalone or qualified: wideTo( or <qualifier>.wideTo(
+        r'(?:\w+\.)?wideTo\s*\(',
+        # Standalone to() at statement level — preceded by start-of-line or semicolon
+        # but NOT preceded by a dot (which would be a method on something else).
+        r'(?:^|;\s*)to\s*\(',
+    ]
+
+    for pattern in write_patterns:
+        if re.search(pattern, stripped, re.MULTILINE):
+            raise ValueError(
+                'Query contains a write-producing Flux operation (to(), experimental.to(), '
+                'or wideTo()) which is not allowed when INFLUXDB_WRITE_MODE is not enabled. '
+                'Set the INFLUXDB_WRITE_MODE=true environment variable to allow write '
+                'operations through Flux queries.'
+            )
 
 
 @mcp.tool(
@@ -1365,6 +1424,9 @@ async def influxdb_query(
     Returns:
         Query results in the specified format.
     """
+    # Validate query does not contain write-producing operations in read-only mode
+    validate_flux_query(query)
+
     resolved_url, resolved_token, resolved_org = resolve_influxdb_config(url, token, org)
 
     try:

--- a/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/server.py
+++ b/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/server.py
@@ -439,18 +439,105 @@ def get_influxdb_client(url, token, org=None, timeout=10000, verify_ssl: bool = 
     )
 
 
+# Names of Flux functions capable of writing data back to a bucket.
+FLUX_WRITE_FUNCTION_NAMES = ('to', 'wideTo')
+
+# A write function referenced as a whole identifier, in any position and with or
+# without a package qualifier: `to(...)`, `result = to(...)`, `writer = to`,
+# `experimental.to(...)`, `influxdb.wideTo(...)`. Word boundaries keep
+# identifiers that merely contain the name, such as `toString`, from matching.
+_WRITE_REFERENCE_RE = re.compile(r'\b(?:' + '|'.join(FLUX_WRITE_FUNCTION_NAMES) + r')\b')
+
+_WRITE_BLOCKED_MESSAGE = (
+    'Query contains a write-producing Flux operation (to(), experimental.to(), '
+    'or wideTo()) which is not allowed when INFLUXDB_WRITE_MODE is not enabled. '
+    'Set the INFLUXDB_WRITE_MODE=true environment variable to allow write '
+    'operations through Flux queries.'
+)
+
+
+def mask_flux_comments_and_strings(query: str) -> str:
+    r"""Blank out comment and string-literal content in a Flux query.
+
+    Replaces the contents of `// ...` comments and `"..."` string literals with
+    spaces, leaving all other characters in place. Offsets and newlines are
+    preserved so that reported positions and multi-line patterns still line up
+    with the original query.
+
+    Scanning left to right is what distinguishes code from data. A plain regex
+    substitution cannot: `re.sub(r'//[^\n]*', '', query)` treats the `//` in
+    `"http://example"` as the start of a comment and deletes the remainder of
+    the line, which can hide a trailing write call. Conversely, a string literal
+    such as `"experimental.to("` is data and must not be scanned as code.
+
+    Args:
+        query: The Flux query string to mask.
+
+    Returns:
+        A string of the same length as the input, with comment and string
+        contents replaced by spaces (newlines preserved).
+    """
+    masked: list[str] = []
+    index = 0
+    length = len(query)
+    while index < length:
+        char = query[index]
+        # Line comment: blank to end of line, leaving the newline itself.
+        if char == '/' and index + 1 < length and query[index + 1] == '/':
+            while index < length and query[index] != '\n':
+                masked.append(' ')
+                index += 1
+            continue
+        # String literal: blank the quotes and everything between them.
+        if char == '"':
+            masked.append(' ')
+            index += 1
+            while index < length:
+                # Escape sequence: consume both characters so that an escaped
+                # quote does not terminate the literal early.
+                if query[index] == '\\' and index + 1 < length:
+                    masked.append('  ')
+                    index += 2
+                    continue
+                if query[index] == '"':
+                    masked.append(' ')
+                    index += 1
+                    break
+                masked.append('\n' if query[index] == '\n' else ' ')
+                index += 1
+            continue
+        masked.append(char)
+        index += 1
+    return ''.join(masked)
+
+
 def validate_flux_query(query: str) -> None:
     """Validate that a Flux query does not contain write-producing operations.
 
     When INFLUXDB_WRITE_MODE is disabled (default), this function rejects Flux
-    queries that contain functions capable of writing data to InfluxDB. This
-    provides defense-in-depth protection against data modification through
-    the query interface.
+    queries that contain functions capable of writing data to InfluxDB.
 
     The following write-producing Flux functions are blocked:
     - to() — standard write function (influxdata/influxdb/to)
     - experimental.to() — experimental write function
     - wideTo() / influxdb.wideTo() — writes wide/pivoted data
+
+    Detection operates on the query with comments and string literals masked,
+    and matches write functions as whole identifiers in any position rather than
+    only in specific call syntax. Matching the identifier rather than the call
+    form is what rejects indirection such as `writer = to` followed by
+    `|> writer(...)`, and matching regardless of qualifier is what rejects
+    aliased package imports such as `import e "experimental"` then `e.to(...)`.
+
+    The check is deliberately biased towards rejection: record field access on a
+    column literally named `to` (`r.to`) is refused, because a qualifier cannot
+    be distinguished from a package alias without resolving the whole query.
+    Operators who need such a query can set INFLUXDB_WRITE_MODE=true.
+
+    This is a defense-in-depth control, not a complete one. Flux has
+    first-class functions, so no static inspection of query text can be
+    exhaustive. The authoritative control is a read-scoped InfluxDB token, so
+    that a write is refused by InfluxDB even if it reaches the server.
 
     Args:
         query: The Flux query string to validate.
@@ -462,38 +549,21 @@ def validate_flux_query(query: str) -> None:
     if INFLUXDB_WRITE_MODE:
         return
 
-    # Strip single-line comments (// ...) to avoid false positives from commented-out code.
-    # Preserve line structure so that multi-line patterns still work.
-    stripped = re.sub(r'//[^\n]*', '', query)
+    # Interpolation is checked on the raw query, because masking blanks the
+    # string contents in which `${...}` appears. Nested quotes inside an
+    # interpolated expression can desynchronize masking, so interpolation is
+    # refused rather than analyzed. It is rare in a read query.
+    if '${' in query:
+        raise ValueError(
+            'Flux string interpolation is not permitted when INFLUXDB_WRITE_MODE '
+            'is not enabled, because the query cannot be reliably inspected for '
+            'write operations. Set INFLUXDB_WRITE_MODE=true to allow it.'
+        )
 
-    # Patterns to detect write-producing Flux functions.
-    # These cover:
-    #   - Pipe-forward to `to(` — e.g. `|> to(bucket: "x")`
-    #   - Standalone or qualified calls — e.g. `to(bucket: "x")`,
-    #     `experimental.to(`, `influxdb.wideTo(`
-    #   - Aliased imports — e.g. `import ex "experimental"` then `ex.to(`
-    # The word-boundary and parenthesis requirements minimize false positives
-    # from identifiers like `toString` or field names containing "to".
-    write_patterns = [
-        # Pipe-forward into to(): |> to(
-        r'\|>\s*to\s*\(',
-        # Qualified calls: experimental.to( or <alias>.to( preceded by word char + dot
-        r'\w+\.to\s*\(',
-        # wideTo as standalone or qualified: wideTo( or <qualifier>.wideTo(
-        r'(?:\w+\.)?wideTo\s*\(',
-        # Standalone to() at statement level — preceded by start-of-line or semicolon
-        # but NOT preceded by a dot (which would be a method on something else).
-        r'(?:^|;\s*)to\s*\(',
-    ]
+    code = mask_flux_comments_and_strings(query)
 
-    for pattern in write_patterns:
-        if re.search(pattern, stripped, re.MULTILINE):
-            raise ValueError(
-                'Query contains a write-producing Flux operation (to(), experimental.to(), '
-                'or wideTo()) which is not allowed when INFLUXDB_WRITE_MODE is not enabled. '
-                'Set the INFLUXDB_WRITE_MODE=true environment variable to allow write '
-                'operations through Flux queries.'
-            )
+    if _WRITE_REFERENCE_RE.search(code):
+        raise ValueError(_WRITE_BLOCKED_MESSAGE)
 
 
 @mcp.tool(

--- a/src/timestream-for-influxdb-mcp-server/tests/test_server.py
+++ b/src/timestream-for-influxdb-mcp-server/tests/test_server.py
@@ -41,6 +41,7 @@ from awslabs.timestream_for_influxdb_mcp_server.server import (
     list_db_instances_for_cluster,
     list_db_parameter_groups,
     list_tags_for_resource,
+    mask_flux_comments_and_strings,
     tag_resource,
     untag_resource,
     update_db_cluster,
@@ -3027,3 +3028,134 @@ class TestValidateFluxQueryUnit:
         query = '// This is a comment\nfrom(bucket: "b") |> to(bucket: "x")'
         with pytest.raises(ValueError):
             validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_to_in_assignment_position(self):
+        """Test that to() called as an assignment right-hand side is caught."""
+        query = 'data = from(bucket: "src")\nresult = to(bucket: "dst", tables: data)'
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_write_function_bound_to_another_name(self):
+        """Test that binding to() to another name and piping into it is caught."""
+        query = 'writer = to\nfrom(bucket: "src") |> writer(bucket: "dst")'
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_write_wrapped_in_user_defined_function(self):
+        """Test that a write hidden inside a user-defined function is caught."""
+        query = 'f = (tables=<-) => tables |> to(bucket: "dst")\nfrom(bucket: "src") |> f()'
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_write_through_aliased_package_import(self):
+        """Test that an aliased package import does not hide a qualified write."""
+        query = 'import e "experimental"\ndata |> e.to(bucket: "dst")'
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_write_split_across_lines(self):
+        """Test that a newline between to() and its parenthesis is still a write."""
+        query = 'from(bucket: "src") |> to\n(bucket: "dst")'
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_write_hidden_behind_url_in_string(self):
+        """Test that a URL in a string does not hide a later to() on the same line."""
+        query = (
+            'from(bucket: "src") '
+            + '|> map(fn: (r) => ({r with url: "http://example"})) |> to(bucket: "dst")'
+        )
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_write_after_escaped_quote(self):
+        """Test that an escaped quote does not end the literal early and hide a write."""
+        query = 'from(bucket: "src") |> filter(fn: (r) => r.m == "a\\"b") |> to(bucket: "dst")'
+        with pytest.raises(ValueError, match='write-producing'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_string_interpolation(self):
+        """Test that interpolation is refused, since masking cannot be trusted."""
+        query = 'b = "dst"\nfrom(bucket: "src") |> to(bucket: "${b}")'
+        with pytest.raises(ValueError, match='interpolation is not permitted'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_interpolation_without_any_write_function(self):
+        """Test that interpolation is refused on its own merits, not via to().
+
+        The interpolation guard must run against the raw query. Checking the
+        masked query instead makes it dead code, because masking blanks the
+        string contents in which the interpolation appears.
+        """
+        query = 'b = "src"\nfrom(bucket: "${b}") |> range(start: -1h)'
+        with pytest.raises(ValueError, match='interpolation is not permitted'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_interpolation_with_nested_quotes(self):
+        """Test that interpolation containing nested quotes cannot smuggle a write."""
+        query = 'from(bucket: "${x + "y"}") |> to(bucket: "dst")'
+        with pytest.raises(ValueError, match='interpolation is not permitted'):
+            validate_flux_query(query)
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_allows_write_function_name_inside_string_literal(self):
+        """Test that a string literal resembling a call is data, not code."""
+        # Should not raise — the text is a string literal, not an invocation
+        validate_flux_query(
+            'from(bucket: "src")\n  |> filter(fn: (r) => r.message == "experimental.to(")'
+        )
+
+    @pytest.mark.parametrize(
+        'expression',
+        [
+            'toString(v: r._value)',
+            'toFloat(v: r._value)',
+            'toInt(v: r._value)',
+            'toBool(v: r._value)',
+            'toTime(v: r._value)',
+            'toUInt(v: r._value)',
+        ],
+    )
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_allows_to_prefixed_conversion_functions(self, expression):
+        """Test that the toX() conversion family are reads and are not rejected."""
+        # Should not raise — these are read-only type conversions
+        validate_flux_query(f'from(bucket: "b") |> map(fn: (r) => ({{r with s: {expression}}}))')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_allows_double_slash_inside_string_on_earlier_line(self):
+        """Test that // inside a string literal does not consume later lines."""
+        # Should not raise, and the trailing range() must remain visible
+        validate_flux_query(
+            'from(bucket: "b")\n'
+            + '  |> filter(fn: (r) => r.u == "http://a//b")\n'
+            + '  |> range(start: -1h)'
+        )
+
+    def test_masking_preserves_length_and_line_structure(self):
+        """Test that masking keeps offsets and newlines aligned with the input."""
+        query = 'from(bucket: "src") // note\n|> range(start: -1h)'
+        masked = mask_flux_comments_and_strings(query)
+        assert len(masked) == len(query)
+        assert masked.count('\n') == query.count('\n')
+
+    def test_masking_blanks_string_contents_but_keeps_code(self):
+        """Test that string contents are blanked while surrounding code remains."""
+        masked = mask_flux_comments_and_strings('from(bucket: "to(")')
+        assert masked.startswith('from(bucket:')
+        assert 'to(' not in masked.replace('from(', '')
+
+    def test_masking_does_not_treat_slashes_in_strings_as_comments(self):
+        """Test that // inside a literal is data, so following code stays visible."""
+        masked = mask_flux_comments_and_strings('a = "http://x" |> range()')
+        assert '|> range()' in masked

--- a/src/timestream-for-influxdb-mcp-server/tests/test_server.py
+++ b/src/timestream-for-influxdb-mcp-server/tests/test_server.py
@@ -2733,10 +2733,10 @@ class TestFluxQueryWriteGuard:
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
     async def test_rejects_experimental_to(self, mock_get_client):
         """Test that experimental.to() is rejected in read-only mode."""
-        query = '''import "experimental"
+        query = """import "experimental"
 from(bucket: "source")
   |> range(start: -1h)
-  |> experimental.to(bucket: "dest", org: "my-org")'''
+  |> experimental.to(bucket: "dest", org: "my-org")"""
 
         with pytest.raises(ValueError) as excinfo:
             await influxdb_query(
@@ -2754,11 +2754,11 @@ from(bucket: "source")
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
     async def test_rejects_wideTo(self, mock_get_client):
         """Test that wideTo() is rejected in read-only mode."""
-        query = '''import "influxdata/influxdb"
+        query = """import "influxdata/influxdb"
 from(bucket: "source")
   |> range(start: -1h)
   |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
-  |> wideTo(bucket: "dest")'''
+  |> wideTo(bucket: "dest")"""
 
         with pytest.raises(ValueError) as excinfo:
             await influxdb_query(
@@ -2776,10 +2776,10 @@ from(bucket: "source")
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
     async def test_rejects_influxdb_wideTo(self, mock_get_client):
         """Test that influxdb.wideTo() is rejected in read-only mode."""
-        query = '''import "influxdata/influxdb"
+        query = """import "influxdata/influxdb"
 from(bucket: "source")
   |> range(start: -1h)
-  |> influxdb.wideTo(bucket: "dest", org: "my-org")'''
+  |> influxdb.wideTo(bucket: "dest", org: "my-org")"""
 
         with pytest.raises(ValueError) as excinfo:
             await influxdb_query(
@@ -2797,10 +2797,10 @@ from(bucket: "source")
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
     async def test_rejects_aliased_experimental_to(self, mock_get_client):
         """Test that aliased experimental import with to() is rejected."""
-        query = '''import ex "experimental"
+        query = """import ex "experimental"
 from(bucket: "source")
   |> range(start: -1h)
-  |> ex.to(bucket: "dest")'''
+  |> ex.to(bucket: "dest")"""
 
         with pytest.raises(ValueError) as excinfo:
             await influxdb_query(
@@ -2836,8 +2836,8 @@ from(bucket: "source")
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
     async def test_rejects_standalone_to_at_line_start(self, mock_get_client):
         """Test that standalone to() at line start is rejected."""
-        query = '''from(bucket: "source") |> range(start: -1h)
-to(bucket: "dest", org: "my-org")'''
+        query = """from(bucket: "source") |> range(start: -1h)
+to(bucket: "dest", org: "my-org")"""
 
         with pytest.raises(ValueError) as excinfo:
             await influxdb_query(
@@ -2930,9 +2930,9 @@ to(bucket: "dest", org: "my-org")'''
         mock_client.query_api.return_value = mock_query_api
         mock_query_api.query.return_value = []
 
-        query = '''from(bucket: "b") |> range(start: -1h)
+        query = """from(bucket: "b") |> range(start: -1h)
 // |> to(bucket: "dest")
-|> yield()'''
+|> yield()"""
 
         result = await influxdb_query(
             url='https://influxdb-example.aws:8086',
@@ -2949,7 +2949,7 @@ to(bucket: "dest", org: "my-org")'''
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
     async def test_rejects_to_in_multiline_query(self, mock_get_client):
         """Test that to() in a complex multi-line query is caught."""
-        query = '''import "influxdata/influxdb"
+        query = """import "influxdata/influxdb"
 
 data = from(bucket: "source")
   |> range(start: -1h)
@@ -2960,7 +2960,7 @@ data
   |> to(
     bucket: "destination",
     org: "my-org"
-  )'''
+  )"""
 
         with pytest.raises(ValueError) as excinfo:
             await influxdb_query(
@@ -3017,7 +3017,9 @@ class TestValidateFluxQueryUnit:
     def test_ignores_single_line_comment(self):
         """Test that single-line comments with to() don't trigger rejection."""
         # Should not raise — the to() is in a comment
-        validate_flux_query('from(bucket: "b") |> range(start: -1h)\n// |> to(bucket: "x")\n|> yield()')
+        validate_flux_query(
+            'from(bucket: "b") |> range(start: -1h)\n// |> to(bucket: "x")\n|> yield()'
+        )
 
     @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
     def test_rejects_to_after_comment(self):

--- a/src/timestream-for-influxdb-mcp-server/tests/test_server.py
+++ b/src/timestream-for-influxdb-mcp-server/tests/test_server.py
@@ -45,6 +45,7 @@ from awslabs.timestream_for_influxdb_mcp_server.server import (
     untag_resource,
     update_db_cluster,
     update_db_instance,
+    validate_flux_query,
 )
 from unittest.mock import MagicMock, patch
 
@@ -2695,3 +2696,332 @@ class TestInfluxDBCreateBucketWithRetention:
 
         assert result['status'] == 'error'
         assert 'not found' in result['message']
+
+
+@patch(
+    'awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_ALLOWED_URLS',
+    'https://influxdb-example.aws:8086',
+)
+class TestFluxQueryWriteGuard:
+    """Tests proving write-shaped Flux is rejected in read-only mode (default).
+
+    These tests validate the defense-in-depth fix for the security vulnerability
+    where InfluxDBQuery could execute Flux write primitives (to(), experimental.to(),
+    influxdb.wideTo()) without a write-mode guard.
+    """
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_pipe_forward_to(self, mock_get_client):
+        """Test that pipe-forward to() is rejected in read-only mode."""
+        query = 'from(bucket: "source") |> range(start: -1h) |> to(bucket: "dest")'
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_experimental_to(self, mock_get_client):
+        """Test that experimental.to() is rejected in read-only mode."""
+        query = '''import "experimental"
+from(bucket: "source")
+  |> range(start: -1h)
+  |> experimental.to(bucket: "dest", org: "my-org")'''
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_wideTo(self, mock_get_client):
+        """Test that wideTo() is rejected in read-only mode."""
+        query = '''import "influxdata/influxdb"
+from(bucket: "source")
+  |> range(start: -1h)
+  |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+  |> wideTo(bucket: "dest")'''
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_influxdb_wideTo(self, mock_get_client):
+        """Test that influxdb.wideTo() is rejected in read-only mode."""
+        query = '''import "influxdata/influxdb"
+from(bucket: "source")
+  |> range(start: -1h)
+  |> influxdb.wideTo(bucket: "dest", org: "my-org")'''
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_aliased_experimental_to(self, mock_get_client):
+        """Test that aliased experimental import with to() is rejected."""
+        query = '''import ex "experimental"
+from(bucket: "source")
+  |> range(start: -1h)
+  |> ex.to(bucket: "dest")'''
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_to_with_extra_whitespace(self, mock_get_client):
+        """Test that to() with extra whitespace is still caught."""
+        query = 'from(bucket: "source") |>   to  (bucket: "dest")'
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_standalone_to_at_line_start(self, mock_get_client):
+        """Test that standalone to() at line start is rejected."""
+        query = '''from(bucket: "source") |> range(start: -1h)
+to(bucket: "dest", org: "my-org")'''
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', True)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_allows_to_when_write_mode_enabled(self, mock_get_client):
+        """Test that to() is allowed when INFLUXDB_WRITE_MODE is True."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_query_api = MagicMock()
+        mock_client.query_api.return_value = mock_query_api
+        mock_query_api.query.return_value = []
+
+        query = 'from(bucket: "source") |> range(start: -1h) |> to(bucket: "dest")'
+
+        result = await influxdb_query(
+            url='https://influxdb-example.aws:8086',
+            token='test-token',
+            org='test-org',
+            query=query,
+        )
+
+        assert result['status'] == 'success'
+        mock_get_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_allows_normal_read_query(self, mock_get_client):
+        """Test that normal read queries are not blocked."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_query_api = MagicMock()
+        mock_client.query_api.return_value = mock_query_api
+        mock_query_api.query.return_value = []
+
+        query = 'from(bucket: "my-bucket") |> range(start: -1h) |> filter(fn: (r) => r._measurement == "cpu")'
+
+        result = await influxdb_query(
+            url='https://influxdb-example.aws:8086',
+            token='test-token',
+            org='test-org',
+            query=query,
+        )
+
+        assert result['status'] == 'success'
+        mock_get_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_allows_toString_function(self, mock_get_client):
+        """Test that toString() is not falsely blocked (no false positive)."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_query_api = MagicMock()
+        mock_client.query_api.return_value = mock_query_api
+        mock_query_api.query.return_value = []
+
+        query = 'from(bucket: "b") |> range(start: -1h) |> map(fn: (r) => ({r with _value: string(v: r._value)}))'
+
+        result = await influxdb_query(
+            url='https://influxdb-example.aws:8086',
+            token='test-token',
+            org='test-org',
+            query=query,
+        )
+
+        assert result['status'] == 'success'
+        mock_get_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_ignores_commented_out_to(self, mock_get_client):
+        """Test that commented-out to() is not blocked."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_query_api = MagicMock()
+        mock_client.query_api.return_value = mock_query_api
+        mock_query_api.query.return_value = []
+
+        query = '''from(bucket: "b") |> range(start: -1h)
+// |> to(bucket: "dest")
+|> yield()'''
+
+        result = await influxdb_query(
+            url='https://influxdb-example.aws:8086',
+            token='test-token',
+            org='test-org',
+            query=query,
+        )
+
+        assert result['status'] == 'success'
+        mock_get_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.get_influxdb_client')
+    async def test_rejects_to_in_multiline_query(self, mock_get_client):
+        """Test that to() in a complex multi-line query is caught."""
+        query = '''import "influxdata/influxdb"
+
+data = from(bucket: "source")
+  |> range(start: -1h)
+  |> filter(fn: (r) => r._measurement == "cpu")
+  |> aggregateWindow(every: 5m, fn: mean)
+
+data
+  |> to(
+    bucket: "destination",
+    org: "my-org"
+  )'''
+
+        with pytest.raises(ValueError) as excinfo:
+            await influxdb_query(
+                url='https://influxdb-example.aws:8086',
+                token='test-token',
+                org='test-org',
+                query=query,
+            )
+
+        assert 'write-producing Flux operation' in str(excinfo.value)
+        mock_get_client.assert_not_called()
+
+
+class TestValidateFluxQueryUnit:
+    """Unit tests for validate_flux_query function directly."""
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_simple_to(self):
+        """Test simple pipe-forward to()."""
+        with pytest.raises(ValueError):
+            validate_flux_query('from(bucket: "b") |> to(bucket: "x")')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_experimental_to(self):
+        """Test experimental.to()."""
+        with pytest.raises(ValueError):
+            validate_flux_query('data |> experimental.to(bucket: "x")')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_wideTo(self):
+        """Test wideTo()."""
+        with pytest.raises(ValueError):
+            validate_flux_query('data |> wideTo(bucket: "x")')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_influxdb_wideTo(self):
+        """Test influxdb.wideTo()."""
+        with pytest.raises(ValueError):
+            validate_flux_query('data |> influxdb.wideTo(bucket: "x")')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_allows_safe_query(self):
+        """Test that a safe query passes validation."""
+        # Should not raise
+        validate_flux_query('from(bucket: "b") |> range(start: -1h) |> yield()')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', True)
+    def test_allows_write_when_enabled(self):
+        """Test that write is allowed when INFLUXDB_WRITE_MODE is True."""
+        # Should not raise even with to()
+        validate_flux_query('from(bucket: "b") |> to(bucket: "x")')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_ignores_single_line_comment(self):
+        """Test that single-line comments with to() don't trigger rejection."""
+        # Should not raise — the to() is in a comment
+        validate_flux_query('from(bucket: "b") |> range(start: -1h)\n// |> to(bucket: "x")\n|> yield()')
+
+    @patch('awslabs.timestream_for_influxdb_mcp_server.server.INFLUXDB_WRITE_MODE', False)
+    def test_rejects_to_after_comment(self):
+        """Test that to() on a line after a comment is still caught."""
+        query = '// This is a comment\nfrom(bucket: "b") |> to(bucket: "x")'
+        with pytest.raises(ValueError):
+            validate_flux_query(query)


### PR DESCRIPTION
## Summary

Adds an operator-controlled INFLUXDB_WRITE_MODE environment variable that governs whether write-producing Flux operations (to(), experimental.to(), wideTo()) are permitted through the InfluxDBQuery tool. When disabled (the default), queries containing these functions are rejected before reaching InfluxDB.

### Changes

- New INFLUXDB_WRITE_MODE environment variable (default: false). Operator-controlled and not overridable by tool callers.
- validate_flux_query() function that detects write-producing Flux patterns and rejects them when write mode is disabled. Handles pipe-forward syntax, qualified calls, aliased imports, and ignores commented-out code.
- Validation integrated into InfluxDBQuery before any network call is made.
- 21 new tests covering blocked patterns, false-positive avoidance, write-mode opt-in, and normal read queries passing through.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
