### PR TITLE
feat: add pricing scenario forecasts

### DIFF
--- a/src/aws-pricing-mcp-server/CHANGELOG.md
+++ b/src/aws-pricing-mcp-server/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project setup
+- Add deterministic fixed-versus-usage scenario forecasting.

--- a/src/aws-pricing-mcp-server/README.md
+++ b/src/aws-pricing-mcp-server/README.md
@@ -20,7 +20,7 @@ MCP server for accessing real-time AWS pricing information and providing cost an
 - **Infrastructure project analysis**: Scan CDK and Terraform projects to automatically identify AWS services and their configurations
 - **Architecture pattern guidance**: Get detailed architecture patterns and cost considerations, especially for Amazon Bedrock services
 - **Cost optimization recommendations**: Receive AWS Well-Architected Framework aligned suggestions for cost optimization
-- **Scenario forecasting**: Model independent growth ramps while keeping fixed architecture costs separate from usage-driven costs
+- **Scenario forecasting**: Model independent growth ramps while keeping fixed architecture costs separate from usage-driven costs, with auditable fixed-precision monetary output
 
 ### Query pricing data with natural language
 

--- a/src/aws-pricing-mcp-server/README.md
+++ b/src/aws-pricing-mcp-server/README.md
@@ -20,6 +20,7 @@ MCP server for accessing real-time AWS pricing information and providing cost an
 - **Infrastructure project analysis**: Scan CDK and Terraform projects to automatically identify AWS services and their configurations
 - **Architecture pattern guidance**: Get detailed architecture patterns and cost considerations, especially for Amazon Bedrock services
 - **Cost optimization recommendations**: Receive AWS Well-Architected Framework aligned suggestions for cost optimization
+- **Scenario forecasting**: Model independent growth ramps while keeping fixed architecture costs separate from usage-driven costs
 
 ### Query pricing data with natural language
 

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
@@ -133,7 +133,7 @@ def calculate_forecast(
             }
         )
 
-    annual_total = sum(unrounded_monthly_totals, Decimal('0'))
+    forecast_total = sum(unrounded_monthly_totals, Decimal('0'))
     return {
         'status': 'success',
         'currency': currency,
@@ -143,8 +143,8 @@ def calculate_forecast(
         'summary': {
             'forecast_months': months,
             'baseline_monthly_cost': _money(unrounded_monthly_totals[0]),
-            'average_monthly_cost': _money(annual_total / Decimal(months)),
-            'forecast_total': _money(annual_total),
+            'average_monthly_cost': _money(forecast_total / Decimal(months)),
+            'forecast_total': _money(forecast_total),
             'ending_monthly_cost': _money(unrounded_monthly_totals[-1]),
         },
     }

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
@@ -14,20 +14,23 @@
 
 """Deterministic scenario forecasting for fixed and usage-scaled costs."""
 
+import json
 import re
 from decimal import ROUND_HALF_UP, Decimal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing import Dict, List, Literal, Optional
 
 
-MONEY = Decimal('0.01')
 MAX_COMPONENTS = 100
+MAX_DECIMAL_PLACES = 6
+MAX_MONTHLY_COST = 1_000_000_000
 MAX_MONTHS = 120
+MAX_RESPONSE_CHARACTERS = 100_000
 
 
-def _money(value: Decimal) -> float:
-    """Round a decimal monetary value to cents for JSON output."""
-    return float(value.quantize(MONEY, rounding=ROUND_HALF_UP))
+def _round_money(value: Decimal, quantum: Decimal) -> Decimal:
+    """Round a decimal monetary value to the requested minor unit."""
+    return value.quantize(quantum, rounding=ROUND_HALF_UP)
 
 
 class ForecastCostComponent(BaseModel):
@@ -40,7 +43,11 @@ class ForecastCostComponent(BaseModel):
         None, min_length=1, max_length=100, description='Optional grouping label'
     )
     monthly_cost: float = Field(
-        ..., ge=0, allow_inf_nan=False, description='Baseline monthly cost'
+        ...,
+        ge=0,
+        le=MAX_MONTHLY_COST,
+        allow_inf_nan=False,
+        description='Baseline monthly cost',
     )
     scaling_behavior: Literal['fixed', 'linear'] = Field(
         ...,
@@ -63,7 +70,10 @@ class ForecastCostComponent(BaseModel):
 
 
 def calculate_forecast(
-    components: List[ForecastCostComponent], months: int, currency: str
+    components: List[ForecastCostComponent],
+    months: int,
+    currency: str,
+    decimal_places: int = 2,
 ) -> Dict:
     """Calculate a linear scenario forecast without querying external services."""
     if not 2 <= months <= MAX_MONTHS:
@@ -71,15 +81,21 @@ def calculate_forecast(
     if not 1 <= len(components) <= MAX_COMPONENTS:
         raise ValueError(f'components must contain between 1 and {MAX_COMPONENTS} items')
     if not re.fullmatch(r'[A-Z]{3}', currency):
-        raise ValueError('currency must be a three-letter uppercase ISO 4217 code')
+        raise ValueError('currency must be a three-letter uppercase display label')
+    if not 0 <= decimal_places <= MAX_DECIMAL_PLACES:
+        raise ValueError(f'decimal_places must be between 0 and {MAX_DECIMAL_PLACES}')
 
     component_names = [component.name for component in components]
     if len(component_names) != len(set(component_names)):
         raise ValueError('component names must be unique')
 
+    quantum = Decimal(1).scaleb(-decimal_places)
     component_rows = []
     monthly_rows = []
-    unrounded_monthly_totals = []
+    monthly_totals = []
+    component_totals = {component.name: Decimal('0') for component in components}
+    component_first_costs: Dict[str, Decimal] = {}
+    component_last_costs: Dict[str, Decimal] = {}
 
     for month_index in range(months):
         progress = Decimal(month_index) / Decimal(months - 1)
@@ -95,56 +111,68 @@ def calculate_forecast(
                 if component.scaling_behavior == 'fixed'
                 else Decimal('1') + (end_multiplier - Decimal('1')) * progress
             )
-            cost = baseline * factor
-            component_costs[component.name] = _money(cost)
+            cost = _round_money(baseline * factor, quantum)
+            component_costs[component.name] = float(cost)
             category = component.category or 'uncategorized'
             category_costs[category] = category_costs.get(category, Decimal('0')) + cost
             month_total += cost
+            component_totals[component.name] += cost
+            component_first_costs.setdefault(component.name, cost)
+            component_last_costs[component.name] = cost
 
-        unrounded_monthly_totals.append(month_total)
+        monthly_totals.append(month_total)
         monthly_rows.append(
             {
                 'month': month_index + 1,
-                'total': _money(month_total),
+                'total': float(month_total),
                 'by_category': {
-                    category: _money(cost) for category, cost in sorted(category_costs.items())
+                    category: float(cost) for category, cost in sorted(category_costs.items())
                 },
                 'by_component': component_costs,
             }
         )
 
     for component in components:
-        baseline = Decimal(str(component.monthly_cost))
         end_multiplier = Decimal(str(component.end_multiplier))
-        average_factor = (
-            Decimal('1')
-            if component.scaling_behavior == 'fixed'
-            else (Decimal('1') + end_multiplier) / Decimal('2')
-        )
         component_rows.append(
             {
                 'name': component.name,
                 'category': component.category or 'uncategorized',
                 'scaling_behavior': component.scaling_behavior,
-                'baseline_monthly_cost': _money(baseline),
+                'baseline_monthly_cost': float(component_first_costs[component.name]),
                 'end_multiplier': float(end_multiplier),
-                'average_monthly_cost': _money(baseline * average_factor),
-                'ending_monthly_cost': _money(baseline * end_multiplier),
+                'average_monthly_cost': float(
+                    _round_money(component_totals[component.name] / Decimal(months), quantum)
+                ),
+                'ending_monthly_cost': float(component_last_costs[component.name]),
             }
         )
 
-    forecast_total = sum(unrounded_monthly_totals, Decimal('0'))
-    return {
+    forecast_total = sum(monthly_totals, Decimal('0'))
+    response = {
         'status': 'success',
         'currency': currency,
-        'assumption': 'Each linear component ramps independently from 1x to its end multiplier.',
+        'decimal_places': decimal_places,
+        'assumption': (
+            'Each linear component ramps independently from 1x to its end multiplier using '
+            'a constant effective rate; tiering, free allowances, commitments, capacity steps, '
+            'and price changes must be modeled separately.'
+        ),
         'months': monthly_rows,
         'components': component_rows,
         'summary': {
             'forecast_months': months,
-            'baseline_monthly_cost': _money(unrounded_monthly_totals[0]),
-            'average_monthly_cost': _money(forecast_total / Decimal(months)),
-            'forecast_total': _money(forecast_total),
-            'ending_monthly_cost': _money(unrounded_monthly_totals[-1]),
+            'baseline_monthly_cost': float(monthly_totals[0]),
+            'average_monthly_cost': float(_round_money(forecast_total / Decimal(months), quantum)),
+            'forecast_total': float(forecast_total),
+            'ending_monthly_cost': float(monthly_totals[-1]),
         },
     }
+    response_characters = len(json.dumps(response, indent=2))
+    if response_characters > MAX_RESPONSE_CHARACTERS:
+        raise ValueError(
+            f'forecast response would contain {response_characters:,} characters, exceeding '
+            f'the {MAX_RESPONSE_CHARACTERS:,}-character limit; reduce components, months, or '
+            'label lengths'
+        )
+    return response

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
@@ -27,15 +27,25 @@ MAX_MONTHLY_COST = 1_000_000_000
 MAX_MONTHS = 120
 MAX_RESPONSE_CHARACTERS = 100_000
 
-# Monetary values are published as JSON numbers, so every emitted amount must survive the
-# round trip through a float. Keeping the largest emitted value below 10**15 minor units
-# holds the whole payload within float64's 15-significant-digit exact range.
-MAX_EXACT_MINOR_UNITS = 10**15
-
 
 def _round_money(value: Decimal, quantum: Decimal) -> Decimal:
     """Round a decimal monetary value to the requested minor unit."""
     return value.quantize(quantum, rounding=ROUND_HALF_UP)
+
+
+def _format_money(value: Decimal, decimal_places: int) -> str:
+    """Preserve a rounded monetary value as a fixed-precision decimal string."""
+    return f'{value:.{decimal_places}f}'
+
+
+def _fits_response_budget(value: Dict) -> bool:
+    """Count encoded characters without allocating an oversized JSON string."""
+    encoded_characters = 0
+    for chunk in json.JSONEncoder(indent=2).iterencode(value):
+        encoded_characters += len(chunk)
+        if encoded_characters > MAX_RESPONSE_CHARACTERS:
+            return False
+    return True
 
 
 class ForecastCostComponent(BaseModel):
@@ -104,7 +114,7 @@ def calculate_forecast(
 
     for month_index in range(months):
         progress = Decimal(month_index) / Decimal(months - 1)
-        component_costs: Dict[str, float] = {}
+        component_costs: Dict[str, str] = {}
         category_costs: Dict[str, Decimal] = {}
         month_total = Decimal('0')
 
@@ -117,7 +127,7 @@ def calculate_forecast(
                 else Decimal('1') + (end_multiplier - Decimal('1')) * progress
             )
             cost = _round_money(baseline * factor, quantum)
-            component_costs[component.name] = float(cost)
+            component_costs[component.name] = _format_money(cost, decimal_places)
             category = component.category or 'uncategorized'
             category_costs[category] = category_costs.get(category, Decimal('0')) + cost
             month_total += cost
@@ -129,9 +139,10 @@ def calculate_forecast(
         monthly_rows.append(
             {
                 'month': month_index + 1,
-                'total': float(month_total),
+                'total': _format_money(month_total, decimal_places),
                 'by_category': {
-                    category: float(cost) for category, cost in sorted(category_costs.items())
+                    category: _format_money(cost, decimal_places)
+                    for category, cost in sorted(category_costs.items())
                 },
                 'by_component': component_costs,
             }
@@ -144,25 +155,21 @@ def calculate_forecast(
                 'name': component.name,
                 'category': component.category or 'uncategorized',
                 'scaling_behavior': component.scaling_behavior,
-                'baseline_monthly_cost': float(component_first_costs[component.name]),
-                'end_multiplier': float(end_multiplier),
-                'average_monthly_cost': float(
-                    _round_money(component_totals[component.name] / Decimal(months), quantum)
+                'baseline_monthly_cost': _format_money(
+                    component_first_costs[component.name], decimal_places
                 ),
-                'ending_monthly_cost': float(component_last_costs[component.name]),
+                'end_multiplier': float(end_multiplier),
+                'average_monthly_cost': _format_money(
+                    _round_money(component_totals[component.name] / Decimal(months), quantum),
+                    decimal_places,
+                ),
+                'ending_monthly_cost': _format_money(
+                    component_last_costs[component.name], decimal_places
+                ),
             }
         )
 
     forecast_total = sum(monthly_totals, Decimal('0'))
-
-    # forecast_total is the largest emitted amount, so bounding it bounds every published value.
-    emitted_minor_units = forecast_total.scaleb(decimal_places)
-    if emitted_minor_units > MAX_EXACT_MINOR_UNITS:
-        raise ValueError(
-            f'forecast total {forecast_total} cannot be represented exactly at '
-            f'{decimal_places} decimal places; reduce component costs, multipliers, months, '
-            'or decimal_places'
-        )
 
     response = {
         'status': 'success',
@@ -177,17 +184,17 @@ def calculate_forecast(
         'components': component_rows,
         'summary': {
             'forecast_months': months,
-            'baseline_monthly_cost': float(monthly_totals[0]),
-            'average_monthly_cost': float(_round_money(forecast_total / Decimal(months), quantum)),
-            'forecast_total': float(forecast_total),
-            'ending_monthly_cost': float(monthly_totals[-1]),
+            'baseline_monthly_cost': _format_money(monthly_totals[0], decimal_places),
+            'average_monthly_cost': _format_money(
+                _round_money(forecast_total / Decimal(months), quantum), decimal_places
+            ),
+            'forecast_total': _format_money(forecast_total, decimal_places),
+            'ending_monthly_cost': _format_money(monthly_totals[-1], decimal_places),
         },
     }
-    response_characters = len(json.dumps(response, indent=2))
-    if response_characters > MAX_RESPONSE_CHARACTERS:
+    if not _fits_response_budget(response):
         raise ValueError(
-            f'forecast response would contain {response_characters:,} characters, exceeding '
-            f'the {MAX_RESPONSE_CHARACTERS:,}-character limit; reduce components, months, or '
-            'label lengths'
+            f'forecast response exceeds the {MAX_RESPONSE_CHARACTERS:,}-character limit; '
+            'reduce components, months, or label lengths'
         )
     return response

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
@@ -39,9 +39,9 @@ def _format_money(value: Decimal, decimal_places: int) -> str:
 
 
 def _fits_response_budget(value: Dict) -> bool:
-    """Count encoded characters without allocating an oversized JSON string."""
+    """Count emitted characters without allocating an oversized JSON string."""
     encoded_characters = 0
-    for chunk in json.JSONEncoder(indent=2).iterencode(value):
+    for chunk in json.JSONEncoder(indent=2, ensure_ascii=False).iterencode(value):
         encoded_characters += len(chunk)
         if encoded_characters > MAX_RESPONSE_CHARACTERS:
             return False

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic scenario forecasting for fixed and usage-scaled costs."""
+
+import re
+from decimal import ROUND_HALF_UP, Decimal
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing import Dict, List, Literal, Optional
+
+
+MONEY = Decimal('0.01')
+MAX_COMPONENTS = 100
+MAX_MONTHS = 120
+
+
+def _money(value: Decimal) -> float:
+    """Round a decimal monetary value to cents for JSON output."""
+    return float(value.quantize(MONEY, rounding=ROUND_HALF_UP))
+
+
+class ForecastCostComponent(BaseModel):
+    """A baseline monthly cost and its behavior over a forecast horizon."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(..., min_length=1, max_length=200, description='Component name')
+    category: Optional[str] = Field(
+        None, min_length=1, max_length=100, description='Optional grouping label'
+    )
+    monthly_cost: float = Field(
+        ..., ge=0, allow_inf_nan=False, description='Baseline monthly cost'
+    )
+    scaling_behavior: Literal['fixed', 'linear'] = Field(
+        ...,
+        description='fixed holds cost constant; linear ramps from 1x to end_multiplier',
+    )
+    end_multiplier: float = Field(
+        1,
+        ge=0,
+        le=1_000_000,
+        allow_inf_nan=False,
+        description='Final-month multiplier for a linear component',
+    )
+
+    @model_validator(mode='after')
+    def validate_fixed_multiplier(self):
+        """Reject contradictory fixed-component configuration."""
+        if self.scaling_behavior == 'fixed' and self.end_multiplier != 1:
+            raise ValueError('fixed components must use end_multiplier=1')
+        return self
+
+
+def calculate_forecast(
+    components: List[ForecastCostComponent], months: int, currency: str
+) -> Dict:
+    """Calculate a linear scenario forecast without querying external services."""
+    if not 2 <= months <= MAX_MONTHS:
+        raise ValueError(f'months must be between 2 and {MAX_MONTHS}')
+    if not 1 <= len(components) <= MAX_COMPONENTS:
+        raise ValueError(f'components must contain between 1 and {MAX_COMPONENTS} items')
+    if not re.fullmatch(r'[A-Z]{3}', currency):
+        raise ValueError('currency must be a three-letter uppercase ISO 4217 code')
+
+    component_names = [component.name for component in components]
+    if len(component_names) != len(set(component_names)):
+        raise ValueError('component names must be unique')
+
+    component_rows = []
+    monthly_rows = []
+    unrounded_monthly_totals = []
+
+    for month_index in range(months):
+        progress = Decimal(month_index) / Decimal(months - 1)
+        component_costs: Dict[str, float] = {}
+        category_costs: Dict[str, Decimal] = {}
+        month_total = Decimal('0')
+
+        for component in components:
+            baseline = Decimal(str(component.monthly_cost))
+            end_multiplier = Decimal(str(component.end_multiplier))
+            factor = (
+                Decimal('1')
+                if component.scaling_behavior == 'fixed'
+                else Decimal('1') + (end_multiplier - Decimal('1')) * progress
+            )
+            cost = baseline * factor
+            component_costs[component.name] = _money(cost)
+            category = component.category or 'uncategorized'
+            category_costs[category] = category_costs.get(category, Decimal('0')) + cost
+            month_total += cost
+
+        unrounded_monthly_totals.append(month_total)
+        monthly_rows.append(
+            {
+                'month': month_index + 1,
+                'total': _money(month_total),
+                'by_category': {
+                    category: _money(cost) for category, cost in sorted(category_costs.items())
+                },
+                'by_component': component_costs,
+            }
+        )
+
+    for component in components:
+        baseline = Decimal(str(component.monthly_cost))
+        end_multiplier = Decimal(str(component.end_multiplier))
+        average_factor = (
+            Decimal('1')
+            if component.scaling_behavior == 'fixed'
+            else (Decimal('1') + end_multiplier) / Decimal('2')
+        )
+        component_rows.append(
+            {
+                'name': component.name,
+                'category': component.category or 'uncategorized',
+                'scaling_behavior': component.scaling_behavior,
+                'baseline_monthly_cost': _money(baseline),
+                'end_multiplier': float(end_multiplier),
+                'average_monthly_cost': _money(baseline * average_factor),
+                'ending_monthly_cost': _money(baseline * end_multiplier),
+            }
+        )
+
+    annual_total = sum(unrounded_monthly_totals, Decimal('0'))
+    return {
+        'status': 'success',
+        'currency': currency,
+        'assumption': 'Each linear component ramps independently from 1x to its end multiplier.',
+        'months': monthly_rows,
+        'components': component_rows,
+        'summary': {
+            'forecast_months': months,
+            'baseline_monthly_cost': _money(unrounded_monthly_totals[0]),
+            'average_monthly_cost': _money(annual_total / Decimal(months)),
+            'forecast_total': _money(annual_total),
+            'ending_monthly_cost': _money(unrounded_monthly_totals[-1]),
+        },
+    }

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/forecast.py
@@ -27,6 +27,11 @@ MAX_MONTHLY_COST = 1_000_000_000
 MAX_MONTHS = 120
 MAX_RESPONSE_CHARACTERS = 100_000
 
+# Monetary values are published as JSON numbers, so every emitted amount must survive the
+# round trip through a float. Keeping the largest emitted value below 10**15 minor units
+# holds the whole payload within float64's 15-significant-digit exact range.
+MAX_EXACT_MINOR_UNITS = 10**15
+
 
 def _round_money(value: Decimal, quantum: Decimal) -> Decimal:
     """Round a decimal monetary value to the requested minor unit."""
@@ -149,6 +154,16 @@ def calculate_forecast(
         )
 
     forecast_total = sum(monthly_totals, Decimal('0'))
+
+    # forecast_total is the largest emitted amount, so bounding it bounds every published value.
+    emitted_minor_units = forecast_total.scaleb(decimal_places)
+    if emitted_minor_units > MAX_EXACT_MINOR_UNITS:
+        raise ValueError(
+            f'forecast total {forecast_total} cannot be represented exactly at '
+            f'{decimal_places} decimal places; reduce component costs, multipliers, months, '
+            'or decimal_places'
+        )
+
     response = {
         'status': 'success',
         'currency': currency,

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -183,12 +183,15 @@ planes, proxy capacity, gateway hours, keys, and subscriptions. Use linear compo
 when the baseline cost's effective rate is expected to remain constant over the modeled range.
 Tiering, free allowances, commitments, capacity steps, and price changes must be modeled
 separately. Each linear component can have its own final-month multiplier.
+Monetary amounts are returned as fixed-precision decimal strings so every breakdown remains
+exactly auditable at decimal_places.
 
 This tool performs arithmetic only. It does not retrieve account data, query AWS pricing, or
 create an AWS Pricing Calculator estimate. Obtain baseline costs and current unit prices with
 the appropriate pricing or billing tools first.
 """,
     annotations=ToolAnnotations(readOnlyHint=True),
+    structured_output=False,
 )
 async def calculate_cost_scenario(
     components: List[ForecastCostComponent] = Field(

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -22,6 +22,12 @@ import sys
 from awslabs.aws_pricing_mcp_server import consts
 from awslabs.aws_pricing_mcp_server.alternative_pricing import get_pricing_alternatives
 from awslabs.aws_pricing_mcp_server.cdk_analyzer import analyze_cdk_project
+from awslabs.aws_pricing_mcp_server.forecast import (
+    MAX_COMPONENTS,
+    MAX_MONTHS,
+    ForecastCostComponent,
+    calculate_forecast,
+)
 from awslabs.aws_pricing_mcp_server.models import (
     ATTRIBUTE_NAMES_FIELD,
     ATTRIBUTE_VALUES_FILTERS_FIELD,
@@ -143,6 +149,12 @@ mcp = FastMCP(
        - Source of the data (web scraping, API, or websearch)
        - List of attempted data retrieval methods
 
+    # USE CASE 3: MULTI-PERIOD SCENARIO FORECASTING
+    Use calculate_cost_scenario() after gathering baseline costs and current prices.
+    Classify architecture units that do not grow with demand as fixed. Classify usage-driven
+    costs as linear and assign each its own final-month multiplier. Do not apply a single
+    growth multiplier to the entire bill.
+
     ACCURACY GUIDELINES:
     - When uncertain about service compatibility or pricing details, EXCLUDE them rather than making assumptions
     - For database compatibility, only include CONFIRMED supported databases
@@ -157,6 +169,41 @@ mcp = FastMCP(
     serverless services and pay-as-you-go pricing models.""",
     dependencies=['pydantic', 'loguru', 'boto3', 'beautifulsoup4', 'websearch'],
 )
+
+
+@mcp.tool(
+    name='calculate_cost_scenario',
+    description="""Calculate a deterministic month-by-month cost scenario from classified components.
+
+Use fixed components for architecture units that do not grow with demand, such as control
+planes, proxy capacity, gateway hours, keys, and subscriptions. Use linear components for
+usage-driven costs such as compute, database consumption, requests, storage, data transfer,
+logs, and AI tokens. Each linear component can have its own final-month multiplier.
+
+This tool performs arithmetic only. It does not retrieve account data, query AWS pricing, or
+create an AWS Pricing Calculator estimate. Obtain baseline costs and current unit prices with
+the appropriate pricing or billing tools first.
+""",
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
+async def calculate_cost_scenario(
+    components: List[ForecastCostComponent] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_COMPONENTS,
+        description='Baseline monthly cost components with explicit scaling behavior',
+    ),
+    months: int = Field(12, ge=2, le=MAX_MONTHS, description='Forecast horizon in months'),
+    currency: str = Field(
+        'USD',
+        min_length=3,
+        max_length=3,
+        pattern=r'^[A-Z]{3}$',
+        description='ISO 4217 currency code',
+    ),
+) -> Dict:
+    """Calculate a cost scenario while preserving fixed and usage-scaled boundaries."""
+    return calculate_forecast(components=components, months=months, currency=currency)
 
 
 @mcp.tool(

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -24,6 +24,7 @@ from awslabs.aws_pricing_mcp_server.alternative_pricing import get_pricing_alter
 from awslabs.aws_pricing_mcp_server.cdk_analyzer import analyze_cdk_project
 from awslabs.aws_pricing_mcp_server.forecast import (
     MAX_COMPONENTS,
+    MAX_DECIMAL_PLACES,
     MAX_MONTHS,
     ForecastCostComponent,
     calculate_forecast,
@@ -87,7 +88,7 @@ async def create_error_response(
 
 mcp = FastMCP(
     name='awslabs.aws-pricing-mcp-server',
-    instructions="""This server provides two primary functionalities:
+    instructions="""This server provides three primary functionalities:
 
     # USE CASE 1: AWS SERVICE CATALOG & PRICING DISCOVERY
     Access AWS service catalog information and pricing details through a structured workflow:
@@ -151,9 +152,11 @@ mcp = FastMCP(
 
     # USE CASE 3: MULTI-PERIOD SCENARIO FORECASTING
     Use calculate_cost_scenario() after gathering baseline costs and current prices.
-    Classify architecture units that do not grow with demand as fixed. Classify usage-driven
-    costs as linear and assign each its own final-month multiplier. Do not apply a single
-    growth multiplier to the entire bill.
+    Classify architecture units that do not grow with demand as fixed. Classify a usage-driven
+    cost as linear only when its effective rate is expected to remain constant over the modeled
+    range, and assign each such component its own final-month multiplier. Keep tiered, stepped,
+    commitment-sensitive, or otherwise nonlinear costs separate. Do not apply a single growth
+    multiplier to the entire bill.
 
     ACCURACY GUIDELINES:
     - When uncertain about service compatibility or pricing details, EXCLUDE them rather than making assumptions
@@ -176,9 +179,10 @@ mcp = FastMCP(
     description="""Calculate a deterministic month-by-month cost scenario from classified components.
 
 Use fixed components for architecture units that do not grow with demand, such as control
-planes, proxy capacity, gateway hours, keys, and subscriptions. Use linear components for
-usage-driven costs such as compute, database consumption, requests, storage, data transfer,
-logs, and AI tokens. Each linear component can have its own final-month multiplier.
+planes, proxy capacity, gateway hours, keys, and subscriptions. Use linear components only
+when the baseline cost's effective rate is expected to remain constant over the modeled range.
+Tiering, free allowances, commitments, capacity steps, and price changes must be modeled
+separately. Each linear component can have its own final-month multiplier.
 
 This tool performs arithmetic only. It does not retrieve account data, query AWS pricing, or
 create an AWS Pricing Calculator estimate. Obtain baseline costs and current unit prices with
@@ -199,11 +203,22 @@ async def calculate_cost_scenario(
         min_length=3,
         max_length=3,
         pattern=r'^[A-Z]{3}$',
-        description='ISO 4217 currency code',
+        description='Three-letter uppercase currency display label',
+    ),
+    decimal_places: int = Field(
+        2,
+        ge=0,
+        le=MAX_DECIMAL_PLACES,
+        description='Number of decimal places used for monetary output',
     ),
 ) -> Dict:
     """Calculate a cost scenario while preserving fixed and usage-scaled boundaries."""
-    return calculate_forecast(components=components, months=months, currency=currency)
+    return calculate_forecast(
+        components=components,
+        months=months,
+        currency=currency,
+        decimal_places=decimal_places,
+    )
 
 
 @mcp.tool(

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/server.py
@@ -213,6 +213,13 @@ async def calculate_cost_scenario(
     ),
 ) -> Dict:
     """Calculate a cost scenario while preserving fixed and usage-scaled boundaries."""
+    if isinstance(months, FieldInfo):
+        months = months.default
+    if isinstance(currency, FieldInfo):
+        currency = currency.default
+    if isinstance(decimal_places, FieldInfo):
+        decimal_places = decimal_places.default
+
     return calculate_forecast(
         components=components,
         months=months,

--- a/src/aws-pricing-mcp-server/tests/test_forecast.py
+++ b/src/aws-pricing-mcp-server/tests/test_forecast.py
@@ -21,6 +21,7 @@ from awslabs.aws_pricing_mcp_server.forecast import (
     calculate_forecast,
 )
 from awslabs.aws_pricing_mcp_server.server import calculate_cost_scenario
+from decimal import Decimal
 from pydantic import ValidationError
 
 
@@ -91,6 +92,27 @@ async def test_mcp_tool_returns_forecast():
     assert [month['total'] for month in result['months']] == [172.0, 272.0, 372.0]
 
 
+@pytest.mark.asyncio
+async def test_mcp_tool_applies_field_defaults_on_direct_calls():
+    """Unwrap Field defaults so non-MCP callers get a forecast, not a FieldInfo."""
+    components = [
+        ForecastCostComponent(
+            name='Control plane',
+            category=None,
+            monthly_cost=10,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        )
+    ]
+
+    result = await calculate_cost_scenario(components)
+
+    assert result['summary']['forecast_months'] == 12
+    assert result['currency'] == 'USD'
+    assert result['decimal_places'] == 2
+    assert result['summary']['forecast_total'] == 120.0
+
+
 def test_linear_component_can_scale_down():
     """Support planned reductions as well as growth."""
     component = ForecastCostComponent(
@@ -128,10 +150,105 @@ def test_rounded_breakdowns_reconcile_with_forecast_total():
 
     result = calculate_forecast(components, months=3, currency='USD')
 
+    # Published values are JSON numbers, so reconcile at the stated precision rather than
+    # asserting exact float equality, which holds only for float-friendly inputs.
+    def at_precision(value):
+        return round(value, result['decimal_places'])
+
     for month in result['months']:
-        assert sum(month['by_component'].values()) == month['total']
-        assert sum(month['by_category'].values()) == month['total']
-    assert sum(month['total'] for month in result['months']) == result['summary']['forecast_total']
+        assert at_precision(sum(month['by_component'].values())) == month['total']
+        assert at_precision(sum(month['by_category'].values())) == month['total']
+    assert (
+        at_precision(sum(month['total'] for month in result['months']))
+        == result['summary']['forecast_total']
+    )
+
+
+def test_fractional_cent_breakdowns_reconcile_at_stated_precision():
+    """Reconcile a component set whose published floats do not sum exactly."""
+    components = [
+        ForecastCostComponent(
+            name=name,
+            category=category,
+            monthly_cost=cost,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        )
+        for name, category, cost in (
+            ('Compute', 'hosting', 10.10),
+            ('Storage', 'hosting', 20.20),
+            ('Requests', 'usage', 0.30),
+        )
+    ]
+
+    result = calculate_forecast(components, months=3, currency='USD')
+
+    # Guard the regression directly: raw float summation misses the published total.
+    first_month = result['months'][0]
+    assert sum(first_month['by_component'].values()) != first_month['total']
+
+    for month in result['months']:
+        assert round(sum(month['by_component'].values()), 2) == month['total']
+        assert round(sum(month['by_category'].values()), 2) == month['total']
+    assert (
+        round(sum(month['total'] for month in result['months']), 2)
+        == result['summary']['forecast_total']
+    )
+
+
+def test_forecast_total_beyond_exact_float_range_is_rejected():
+    """Reject magnitudes whose published values would silently lose significant digits."""
+    components = [
+        ForecastCostComponent(
+            name=f'Component {index}',
+            category=None,
+            monthly_cost=MAX_MONTHLY_COST,
+            scaling_behavior='linear',
+            end_multiplier=1_000_000,
+        )
+        for index in range(4)
+    ]
+
+    with pytest.raises(ValueError, match='cannot be represented exactly'):
+        calculate_forecast(components, months=12, currency='USD', decimal_places=6)
+
+
+def test_every_published_value_round_trips_to_its_decimal():
+    """Keep each accepted forecast's published floats exact at the requested precision."""
+    components = [
+        ForecastCostComponent(
+            name='Compute',
+            category='hosting',
+            monthly_cost=1234.567891,
+            scaling_behavior='linear',
+            end_multiplier=7.5,
+        ),
+        ForecastCostComponent(
+            name='Tokens',
+            category='ai',
+            monthly_cost=98.765432,
+            scaling_behavior='linear',
+            end_multiplier=40,
+        ),
+    ]
+
+    result = calculate_forecast(components, months=12, currency='USD', decimal_places=6)
+
+    quantum = Decimal('1').scaleb(-6)
+    published = [
+        value
+        for month in result['months']
+        for value in [
+            month['total'],
+            *month['by_category'].values(),
+            *month['by_component'].values(),
+        ]
+    ]
+    published.extend(result['summary'][key] for key in ('forecast_total', 'average_monthly_cost'))
+
+    for value in published:
+        exact = Decimal(repr(value))
+        assert exact == exact.quantize(quantum)
 
 
 @pytest.mark.parametrize(
@@ -205,7 +322,7 @@ def test_non_finite_costs_are_rejected(value):
 
 
 def test_monthly_cost_boundary_is_safe_for_maximum_multiplier():
-    """Keep every schema-valid cost within the supported Decimal range."""
+    """Reject the largest schema-valid input cleanly instead of failing inside Decimal."""
     component = ForecastCostComponent(
         name='Maximum',
         category=None,
@@ -214,9 +331,26 @@ def test_monthly_cost_boundary_is_safe_for_maximum_multiplier():
         end_multiplier=1_000_000,
     )
 
+    # Decimal quantization still succeeds at this magnitude; the exactness guard is what
+    # rejects it, so the caller gets actionable guidance rather than InvalidOperation.
+    with pytest.raises(ValueError, match='cannot be represented exactly'):
+        calculate_forecast([component], months=120, currency='USD')
+
+
+def test_maximum_monthly_cost_is_accepted_without_a_multiplier():
+    """Keep realistic large baselines inside the publishable range."""
+    component = ForecastCostComponent(
+        name='Maximum',
+        category=None,
+        monthly_cost=MAX_MONTHLY_COST,
+        scaling_behavior='fixed',
+        end_multiplier=1,
+    )
+
     result = calculate_forecast([component], months=120, currency='USD')
 
-    assert result['months'][-1]['total'] == 1e15
+    assert result['months'][-1]['total'] == float(MAX_MONTHLY_COST)
+    assert result['summary']['forecast_total'] == float(MAX_MONTHLY_COST) * 120
 
 
 def test_monthly_cost_above_supported_bound_is_rejected():

--- a/src/aws-pricing-mcp-server/tests/test_forecast.py
+++ b/src/aws-pricing-mcp-server/tests/test_forecast.py
@@ -17,6 +17,7 @@
 import pytest
 from awslabs.aws_pricing_mcp_server.forecast import (
     MAX_MONTHLY_COST,
+    MAX_RESPONSE_CHARACTERS,
     ForecastCostComponent,
     calculate_forecast,
 )
@@ -392,6 +393,29 @@ def test_oversized_forecast_response_is_rejected():
 
     with pytest.raises(ValueError, match='100,000-character limit'):
         calculate_forecast(components, months=120, currency='USD')
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_labels_are_budgeted_as_emitted():
+    """Budget non-ASCII labels by emitted characters, not by escaped ones."""
+    components = [
+        {
+            'name': f'{index:02d}' + ('🧾' * 98),
+            'category': f'{index:02d}' + ('💰' * 48),
+            'monthly_cost': 1,
+            'scaling_behavior': 'fixed',
+        }
+        for index in range(3)
+    ]
+
+    content = await mcp.call_tool(
+        'calculate_cost_scenario', {'components': components, 'months': 12}
+    )
+
+    assert isinstance(content, list)
+    assert len(content) == 1
+    assert isinstance(content[0], TextContent)
+    assert len(content[0].text) < MAX_RESPONSE_CHARACTERS // 4
 
 
 @pytest.mark.asyncio

--- a/src/aws-pricing-mcp-server/tests/test_forecast.py
+++ b/src/aws-pricing-mcp-server/tests/test_forecast.py
@@ -1,0 +1,209 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for deterministic scenario forecasting."""
+
+import pytest
+from awslabs.aws_pricing_mcp_server.forecast import (
+    ForecastCostComponent,
+    calculate_forecast,
+)
+from awslabs.aws_pricing_mcp_server.server import calculate_cost_scenario
+from pydantic import ValidationError
+
+
+def test_mixed_fixed_and_independent_growth_components():
+    """Keep fixed architecture flat while hosting and AI use different ramps."""
+    components = [
+        ForecastCostComponent(
+            name='Fixed architecture',
+            category='hosting',
+            monthly_cost=827.09,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        ),
+        ForecastCostComponent(
+            name='Usage-driven hosting',
+            category='hosting',
+            monthly_cost=1074.42,
+            scaling_behavior='linear',
+            end_multiplier=5,
+        ),
+        ForecastCostComponent(
+            name='AI tokens',
+            category='ai',
+            monthly_cost=98.130498,
+            scaling_behavior='linear',
+            end_multiplier=150,
+        ),
+    ]
+
+    result = calculate_forecast(components, months=12, currency='USD')
+
+    assert result['summary'] == {
+        'forecast_months': 12,
+        'baseline_monthly_cost': 1999.64,
+        'average_monthly_cost': 11459.2,
+        'forecast_total': 137510.43,
+        'ending_monthly_cost': 20918.76,
+    }
+    assert result['months'][0]['by_category'] == {'ai': 98.13, 'hosting': 1901.51}
+    assert result['months'][-1]['by_category'] == {'ai': 14719.57, 'hosting': 6199.19}
+    assert result['months'][0]['by_component']['Fixed architecture'] == 827.09
+    assert result['months'][-1]['by_component']['Fixed architecture'] == 827.09
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_returns_forecast():
+    """Expose the deterministic calculation through the MCP tool wrapper."""
+    components = [
+        ForecastCostComponent(
+            name='Control plane',
+            category='hosting',
+            monthly_cost=72,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        ),
+        ForecastCostComponent(
+            name='Compute',
+            category='hosting',
+            monthly_cost=100,
+            scaling_behavior='linear',
+            end_multiplier=3,
+        ),
+    ]
+
+    result = await calculate_cost_scenario(components, months=3, currency='USD')
+
+    assert result['summary']['forecast_total'] == 816.0
+    assert [month['total'] for month in result['months']] == [172.0, 272.0, 372.0]
+
+
+def test_linear_component_can_scale_down():
+    """Support planned reductions as well as growth."""
+    component = ForecastCostComponent(
+        name='Legacy workload',
+        category=None,
+        monthly_cost=100,
+        scaling_behavior='linear',
+        end_multiplier=0,
+    )
+
+    result = calculate_forecast([component], months=3, currency='USD')
+
+    assert [month['total'] for month in result['months']] == [100.0, 50.0, 0.0]
+    assert result['summary']['forecast_total'] == 150.0
+
+
+def test_duplicate_component_names_are_rejected():
+    """Reject duplicate names that would make component output ambiguous."""
+    components = [
+        ForecastCostComponent(
+            name='Compute',
+            category=None,
+            monthly_cost=10,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        ),
+        ForecastCostComponent(
+            name='Compute',
+            category=None,
+            monthly_cost=20,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match='component names must be unique'):
+        calculate_forecast(components, months=2, currency='USD')
+
+
+def test_fixed_component_rejects_non_one_multiplier():
+    """Reject contradictory fixed-component input."""
+    with pytest.raises(ValidationError, match='fixed components must use end_multiplier=1'):
+        ForecastCostComponent(
+            name='Control plane',
+            category=None,
+            monthly_cost=72,
+            scaling_behavior='fixed',
+            end_multiplier=5,
+        )
+
+
+@pytest.mark.parametrize('value', [float('inf'), float('-inf'), float('nan')])
+def test_non_finite_costs_are_rejected(value):
+    """Reject values that cannot produce a meaningful financial forecast."""
+    with pytest.raises(ValidationError):
+        ForecastCostComponent(
+            name='Invalid',
+            category=None,
+            monthly_cost=value,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ('components', 'months', 'currency', 'message'),
+    [
+        ([], 12, 'USD', 'components must contain'),
+        (
+            [
+                ForecastCostComponent(
+                    name=f'Compute {index}',
+                    category=None,
+                    monthly_cost=1,
+                    scaling_behavior='fixed',
+                    end_multiplier=1,
+                )
+                for index in range(101)
+            ],
+            12,
+            'USD',
+            'components must contain',
+        ),
+        (
+            [
+                ForecastCostComponent(
+                    name='Compute',
+                    category=None,
+                    monthly_cost=1,
+                    scaling_behavior='fixed',
+                    end_multiplier=1,
+                )
+            ],
+            1,
+            'USD',
+            'months must be',
+        ),
+        (
+            [
+                ForecastCostComponent(
+                    name='Compute',
+                    category=None,
+                    monthly_cost=1,
+                    scaling_behavior='fixed',
+                    end_multiplier=1,
+                )
+            ],
+            12,
+            'usd',
+            'currency must be',
+        ),
+    ],
+)
+def test_calculate_forecast_rejects_invalid_direct_calls(components, months, currency, message):
+    """Keep the pure calculation boundary safe outside MCP validation."""
+    with pytest.raises(ValueError, match=message):
+        calculate_forecast(components, months=months, currency=currency)

--- a/src/aws-pricing-mcp-server/tests/test_forecast.py
+++ b/src/aws-pricing-mcp-server/tests/test_forecast.py
@@ -20,8 +20,9 @@ from awslabs.aws_pricing_mcp_server.forecast import (
     ForecastCostComponent,
     calculate_forecast,
 )
-from awslabs.aws_pricing_mcp_server.server import calculate_cost_scenario
+from awslabs.aws_pricing_mcp_server.server import calculate_cost_scenario, mcp
 from decimal import Decimal
+from mcp.types import TextContent
 from pydantic import ValidationError
 
 
@@ -55,15 +56,15 @@ def test_mixed_fixed_and_independent_growth_components():
 
     assert result['summary'] == {
         'forecast_months': 12,
-        'baseline_monthly_cost': 1999.64,
-        'average_monthly_cost': 11459.2,
-        'forecast_total': 137510.42,
-        'ending_monthly_cost': 20918.76,
+        'baseline_monthly_cost': '1999.64',
+        'average_monthly_cost': '11459.20',
+        'forecast_total': '137510.42',
+        'ending_monthly_cost': '20918.76',
     }
-    assert result['months'][0]['by_category'] == {'ai': 98.13, 'hosting': 1901.51}
-    assert result['months'][-1]['by_category'] == {'ai': 14719.57, 'hosting': 6199.19}
-    assert result['months'][0]['by_component']['Fixed architecture'] == 827.09
-    assert result['months'][-1]['by_component']['Fixed architecture'] == 827.09
+    assert result['months'][0]['by_category'] == {'ai': '98.13', 'hosting': '1901.51'}
+    assert result['months'][-1]['by_category'] == {'ai': '14719.57', 'hosting': '6199.19'}
+    assert result['months'][0]['by_component']['Fixed architecture'] == '827.09'
+    assert result['months'][-1]['by_component']['Fixed architecture'] == '827.09'
 
 
 @pytest.mark.asyncio
@@ -88,8 +89,8 @@ async def test_mcp_tool_returns_forecast():
 
     result = await calculate_cost_scenario(components, months=3, currency='USD', decimal_places=2)
 
-    assert result['summary']['forecast_total'] == 816.0
-    assert [month['total'] for month in result['months']] == [172.0, 272.0, 372.0]
+    assert result['summary']['forecast_total'] == '816.00'
+    assert [month['total'] for month in result['months']] == ['172.00', '272.00', '372.00']
 
 
 @pytest.mark.asyncio
@@ -110,7 +111,7 @@ async def test_mcp_tool_applies_field_defaults_on_direct_calls():
     assert result['summary']['forecast_months'] == 12
     assert result['currency'] == 'USD'
     assert result['decimal_places'] == 2
-    assert result['summary']['forecast_total'] == 120.0
+    assert result['summary']['forecast_total'] == '120.00'
 
 
 def test_linear_component_can_scale_down():
@@ -125,8 +126,8 @@ def test_linear_component_can_scale_down():
 
     result = calculate_forecast([component], months=3, currency='USD')
 
-    assert [month['total'] for month in result['months']] == [100.0, 50.0, 0.0]
-    assert result['summary']['forecast_total'] == 150.0
+    assert [month['total'] for month in result['months']] == ['100.00', '50.00', '0.00']
+    assert result['summary']['forecast_total'] == '150.00'
 
 
 def test_rounded_breakdowns_reconcile_with_forecast_total():
@@ -150,22 +151,16 @@ def test_rounded_breakdowns_reconcile_with_forecast_total():
 
     result = calculate_forecast(components, months=3, currency='USD')
 
-    # Published values are JSON numbers, so reconcile at the stated precision rather than
-    # asserting exact float equality, which holds only for float-friendly inputs.
-    def at_precision(value):
-        return round(value, result['decimal_places'])
-
     for month in result['months']:
-        assert at_precision(sum(month['by_component'].values())) == month['total']
-        assert at_precision(sum(month['by_category'].values())) == month['total']
-    assert (
-        at_precision(sum(month['total'] for month in result['months']))
-        == result['summary']['forecast_total']
+        assert sum(map(Decimal, month['by_component'].values())) == Decimal(month['total'])
+        assert sum(map(Decimal, month['by_category'].values())) == Decimal(month['total'])
+    assert sum(Decimal(month['total']) for month in result['months']) == Decimal(
+        result['summary']['forecast_total']
     )
 
 
-def test_fractional_cent_breakdowns_reconcile_at_stated_precision():
-    """Reconcile a component set whose published floats do not sum exactly."""
+def test_fixed_precision_breakdowns_reconcile_exactly():
+    """Keep component arithmetic exact for decimal values that floats cannot sum."""
     components = [
         ForecastCostComponent(
             name=name,
@@ -183,21 +178,16 @@ def test_fractional_cent_breakdowns_reconcile_at_stated_precision():
 
     result = calculate_forecast(components, months=3, currency='USD')
 
-    # Guard the regression directly: raw float summation misses the published total.
-    first_month = result['months'][0]
-    assert sum(first_month['by_component'].values()) != first_month['total']
-
     for month in result['months']:
-        assert round(sum(month['by_component'].values()), 2) == month['total']
-        assert round(sum(month['by_category'].values()), 2) == month['total']
-    assert (
-        round(sum(month['total'] for month in result['months']), 2)
-        == result['summary']['forecast_total']
+        assert sum(map(Decimal, month['by_component'].values())) == Decimal(month['total'])
+        assert sum(map(Decimal, month['by_category'].values())) == Decimal(month['total'])
+    assert sum(Decimal(month['total']) for month in result['months']) == Decimal(
+        result['summary']['forecast_total']
     )
 
 
-def test_forecast_total_beyond_exact_float_range_is_rejected():
-    """Reject magnitudes whose published values would silently lose significant digits."""
+def test_large_forecast_is_preserved_as_fixed_precision_strings():
+    """Preserve significant digits at the schema ceiling without float conversion."""
     components = [
         ForecastCostComponent(
             name=f'Component {index}',
@@ -209,12 +199,16 @@ def test_forecast_total_beyond_exact_float_range_is_rejected():
         for index in range(4)
     ]
 
-    with pytest.raises(ValueError, match='cannot be represented exactly'):
-        calculate_forecast(components, months=12, currency='USD', decimal_places=6)
+    result = calculate_forecast(components, months=12, currency='USD', decimal_places=6)
+
+    assert result['months'][-1]['total'] == '4000000000000000.000000'
+    assert Decimal(result['summary']['forecast_total']) == sum(
+        Decimal(month['total']) for month in result['months']
+    )
 
 
-def test_every_published_value_round_trips_to_its_decimal():
-    """Keep each accepted forecast's published floats exact at the requested precision."""
+def test_every_published_value_has_fixed_decimal_precision():
+    """Publish every monetary amount with the requested fixed precision."""
     components = [
         ForecastCostComponent(
             name='Compute',
@@ -234,7 +228,6 @@ def test_every_published_value_round_trips_to_its_decimal():
 
     result = calculate_forecast(components, months=12, currency='USD', decimal_places=6)
 
-    quantum = Decimal('1').scaleb(-6)
     published = [
         value
         for month in result['months']
@@ -247,13 +240,33 @@ def test_every_published_value_round_trips_to_its_decimal():
     published.extend(result['summary'][key] for key in ('forecast_total', 'average_monthly_cost'))
 
     for value in published:
-        exact = Decimal(repr(value))
-        assert exact == exact.quantize(quantum)
+        assert isinstance(value, str)
+        assert len(value.rpartition('.')[2]) == 6
+
+
+def test_many_large_components_reconcile_at_six_decimal_places():
+    """Keep aggregate arithmetic exact near the former float guard."""
+    components = [
+        ForecastCostComponent(
+            name=f'Component {index}',
+            category='hosting',
+            monthly_cost=9_990_491.047545,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        )
+        for index in range(50)
+    ]
+
+    result = calculate_forecast(components, months=2, currency='USD', decimal_places=6)
+    month = result['months'][0]
+
+    assert sum(map(Decimal, month['by_component'].values())) == Decimal(month['total'])
+    assert Decimal(month['by_category']['hosting']) == Decimal(month['total'])
 
 
 @pytest.mark.parametrize(
     ('currency', 'decimal_places', 'expected'),
-    [('JPY', 0, 1.0), ('KWD', 3, 1.234)],
+    [('JPY', 0, '1'), ('KWD', 3, '1.234')],
 )
 def test_currency_labels_use_explicit_decimal_places(currency, decimal_places, expected):
     """Do not assume that every currency uses two decimal places."""
@@ -322,7 +335,7 @@ def test_non_finite_costs_are_rejected(value):
 
 
 def test_monthly_cost_boundary_is_safe_for_maximum_multiplier():
-    """Reject the largest schema-valid input cleanly instead of failing inside Decimal."""
+    """Keep the largest schema-valid input inside the supported Decimal range."""
     component = ForecastCostComponent(
         name='Maximum',
         category=None,
@@ -331,10 +344,9 @@ def test_monthly_cost_boundary_is_safe_for_maximum_multiplier():
         end_multiplier=1_000_000,
     )
 
-    # Decimal quantization still succeeds at this magnitude; the exactness guard is what
-    # rejects it, so the caller gets actionable guidance rather than InvalidOperation.
-    with pytest.raises(ValueError, match='cannot be represented exactly'):
-        calculate_forecast([component], months=120, currency='USD')
+    result = calculate_forecast([component], months=120, currency='USD')
+
+    assert result['months'][-1]['total'] == '1000000000000000.00'
 
 
 def test_maximum_monthly_cost_is_accepted_without_a_multiplier():
@@ -349,8 +361,8 @@ def test_maximum_monthly_cost_is_accepted_without_a_multiplier():
 
     result = calculate_forecast([component], months=120, currency='USD')
 
-    assert result['months'][-1]['total'] == float(MAX_MONTHLY_COST)
-    assert result['summary']['forecast_total'] == float(MAX_MONTHLY_COST) * 120
+    assert result['months'][-1]['total'] == '1000000000.00'
+    assert result['summary']['forecast_total'] == '120000000000.00'
 
 
 def test_monthly_cost_above_supported_bound_is_rejected():
@@ -366,11 +378,11 @@ def test_monthly_cost_above_supported_bound_is_rejected():
 
 
 def test_oversized_forecast_response_is_rejected():
-    """Keep valid caller-controlled labels from exhausting client context."""
+    """Reject worst-case encoded labels without allocating the complete JSON string."""
     components = [
         ForecastCostComponent(
-            name=('n' * 196) + f'{index:04d}',
-            category=('c' * 96) + f'{index:04d}',
+            name=('🧾' * 196) + f'{index:04d}',
+            category=('💰' * 96) + f'{index:04d}',
             monthly_cost=1,
             scaling_behavior='fixed',
             end_multiplier=1,
@@ -380,6 +392,29 @@ def test_oversized_forecast_response_is_rejected():
 
     with pytest.raises(ValueError, match='100,000-character limit'):
         calculate_forecast(components, months=120, currency='USD')
+
+
+@pytest.mark.asyncio
+async def test_mcp_response_budget_counts_the_only_emitted_representation():
+    """Avoid duplicating a near-limit result as text and structured content."""
+    components = [
+        {
+            'name': f'{index:02d}' + ('n' * 98),
+            'category': f'{index:02d}' + ('c' * 98),
+            'monthly_cost': 1,
+            'scaling_behavior': 'fixed',
+        }
+        for index in range(10)
+    ]
+
+    content = await mcp.call_tool(
+        'calculate_cost_scenario', {'components': components, 'months': 37}
+    )
+
+    assert isinstance(content, list)
+    assert len(content) == 1
+    assert isinstance(content[0], TextContent)
+    assert len(content[0].text) <= 100_000
 
 
 def test_decimal_places_outside_supported_range_is_rejected():

--- a/src/aws-pricing-mcp-server/tests/test_forecast.py
+++ b/src/aws-pricing-mcp-server/tests/test_forecast.py
@@ -16,6 +16,7 @@
 
 import pytest
 from awslabs.aws_pricing_mcp_server.forecast import (
+    MAX_MONTHLY_COST,
     ForecastCostComponent,
     calculate_forecast,
 )
@@ -55,7 +56,7 @@ def test_mixed_fixed_and_independent_growth_components():
         'forecast_months': 12,
         'baseline_monthly_cost': 1999.64,
         'average_monthly_cost': 11459.2,
-        'forecast_total': 137510.43,
+        'forecast_total': 137510.42,
         'ending_monthly_cost': 20918.76,
     }
     assert result['months'][0]['by_category'] == {'ai': 98.13, 'hosting': 1901.51}
@@ -84,7 +85,7 @@ async def test_mcp_tool_returns_forecast():
         ),
     ]
 
-    result = await calculate_cost_scenario(components, months=3, currency='USD')
+    result = await calculate_cost_scenario(components, months=3, currency='USD', decimal_places=2)
 
     assert result['summary']['forecast_total'] == 816.0
     assert [month['total'] for month in result['months']] == [172.0, 272.0, 372.0]
@@ -104,6 +105,55 @@ def test_linear_component_can_scale_down():
 
     assert [month['total'] for month in result['months']] == [100.0, 50.0, 0.0]
     assert result['summary']['forecast_total'] == 150.0
+
+
+def test_rounded_breakdowns_reconcile_with_forecast_total():
+    """Derive every monetary view from the same rounded component ledger."""
+    components = [
+        ForecastCostComponent(
+            name='Requests',
+            category='usage',
+            monthly_cost=0.005,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        ),
+        ForecastCostComponent(
+            name='Storage',
+            category='usage',
+            monthly_cost=0.005,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        ),
+    ]
+
+    result = calculate_forecast(components, months=3, currency='USD')
+
+    for month in result['months']:
+        assert sum(month['by_component'].values()) == month['total']
+        assert sum(month['by_category'].values()) == month['total']
+    assert sum(month['total'] for month in result['months']) == result['summary']['forecast_total']
+
+
+@pytest.mark.parametrize(
+    ('currency', 'decimal_places', 'expected'),
+    [('JPY', 0, 1.0), ('KWD', 3, 1.234)],
+)
+def test_currency_labels_use_explicit_decimal_places(currency, decimal_places, expected):
+    """Do not assume that every currency uses two decimal places."""
+    component = ForecastCostComponent(
+        name='Usage',
+        category=None,
+        monthly_cost=1.234,
+        scaling_behavior='fixed',
+        end_multiplier=1,
+    )
+
+    result = calculate_forecast(
+        [component], months=2, currency=currency, decimal_places=decimal_places
+    )
+
+    assert result['decimal_places'] == decimal_places
+    assert result['months'][0]['total'] == expected
 
 
 def test_duplicate_component_names_are_rejected():
@@ -152,6 +202,64 @@ def test_non_finite_costs_are_rejected(value):
             scaling_behavior='fixed',
             end_multiplier=1,
         )
+
+
+def test_monthly_cost_boundary_is_safe_for_maximum_multiplier():
+    """Keep every schema-valid cost within the supported Decimal range."""
+    component = ForecastCostComponent(
+        name='Maximum',
+        category=None,
+        monthly_cost=MAX_MONTHLY_COST,
+        scaling_behavior='linear',
+        end_multiplier=1_000_000,
+    )
+
+    result = calculate_forecast([component], months=120, currency='USD')
+
+    assert result['months'][-1]['total'] == 1e15
+
+
+def test_monthly_cost_above_supported_bound_is_rejected():
+    """Reject large finite inputs before Decimal quantization can fail."""
+    with pytest.raises(ValidationError):
+        ForecastCostComponent(
+            name='Too large',
+            category=None,
+            monthly_cost=MAX_MONTHLY_COST + 1,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        )
+
+
+def test_oversized_forecast_response_is_rejected():
+    """Keep valid caller-controlled labels from exhausting client context."""
+    components = [
+        ForecastCostComponent(
+            name=('n' * 196) + f'{index:04d}',
+            category=('c' * 96) + f'{index:04d}',
+            monthly_cost=1,
+            scaling_behavior='fixed',
+            end_multiplier=1,
+        )
+        for index in range(100)
+    ]
+
+    with pytest.raises(ValueError, match='100,000-character limit'):
+        calculate_forecast(components, months=120, currency='USD')
+
+
+def test_decimal_places_outside_supported_range_is_rejected():
+    """Keep direct calls within the advertised monetary precision range."""
+    component = ForecastCostComponent(
+        name='Compute',
+        category=None,
+        monthly_cost=1,
+        scaling_behavior='fixed',
+        end_multiplier=1,
+    )
+
+    with pytest.raises(ValueError, match='decimal_places must be'):
+        calculate_forecast([component], months=2, currency='USD', decimal_places=7)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #4473

## Summary

Add deterministic multi-period scenario forecasting to the AWS Pricing MCP Server without querying account data or introducing new dependencies.

### Changes

- add the read-only `calculate_cost_scenario` MCP tool
- classify each baseline component as fixed or independently linear-scaling
- return monthly category/component breakdowns plus baseline, average, forecast-total, and ending run-rate summaries
- use Decimal arithmetic with explicit validation and bounded response sizes
- document the capability and add full unit/tool-wrapper coverage

### User experience

Before this change, users could retrieve current prices and generate point-in-time reports, but independently scaling a mixed architecture required external arithmetic and encouraged applying one multiplier to the entire bill.

After this change, an assistant can hold control planes, proxy capacity, gateways, keys, and subscriptions flat while applying distinct ramps to compute, database consumption, requests, storage, data transfer, logs, or AI tokens.

The tool performs arithmetic only. Retrieving account costs, querying current prices, mapping workload usage to priced components, and creating public AWS Pricing Calculator links remain out of scope.

## Validation

- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing` — 263 passed; new module 100% covered
- `uv run --frozen pyright` — 0 errors
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- scoped repository pre-commit hooks, including credential, secret, and license checks

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: N/A — existing-server feature request #4473

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).