### PR TITLE
fix(ecs-mcp-server): add path validation for user-supplied paths

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/infrastructure.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/infrastructure.py
@@ -27,11 +27,11 @@ from awslabs.ecs_mcp_server.utils.aws import (
     get_aws_client_with_role,
     get_default_vpc_and_subnets,
 )
+from awslabs.ecs_mcp_server.utils.path_validation import validate_path
 from awslabs.ecs_mcp_server.utils.security import (
     ValidationError,
     validate_app_name,
     validate_cloudformation_template,
-    validate_file_path,
 )
 from awslabs.ecs_mcp_server.utils.templates import get_templates_dir
 
@@ -46,7 +46,7 @@ def prepare_template_files(app_name: str, app_path: str) -> Dict[str, str]:
 
     Args:
         app_name: Name of the application
-        app_path: Path to the application directory
+        app_path: Path to the application directory. Created if it doesn't exist.
 
     Returns:
         Dict containing paths to the template files
@@ -57,16 +57,12 @@ def prepare_template_files(app_name: str, app_path: str) -> Dict[str, str]:
     # Validate app_name
     validate_app_name(app_name)
 
-    # For app_path, we'll validate it but handle the case where it doesn't exist
+    # Resolve and validate app_path before writing anything to disk. The directory
+    # is created below when missing, so existence is not required here.
     try:
-        validate_file_path(app_path)
-    except ValidationError as e:
-        # If the path doesn't exist, we'll create it
-        if "does not exist" not in str(e):
-            # Some other validation error occurred
-            raise ValidationError(str(e)) from e
-        # Otherwise, we'll continue and create the directory later
-        logger.debug(f"Path {app_path} does not exist, will create it")
+        app_path = validate_path(app_path)
+    except ValueError as e:
+        raise ValidationError(str(e)) from e
 
     # Create templates directory (this will create app_path if it doesn't exist)
     templates_dir = os.path.join(app_path, "cloudformation-templates")

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/docker.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/docker.py
@@ -24,6 +24,7 @@ import time
 from typing import Optional
 
 from awslabs.ecs_mcp_server.utils.aws import get_aws_account_id, get_aws_client
+from awslabs.ecs_mcp_server.utils.path_validation import validate_path
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +85,15 @@ async def build_and_push_image(
         Image tag
 
     Raises:
-        ValueError: If role_arn is not provided
+        ValueError: If role_arn is not provided, or if app_path is invalid
     """
     if not role_arn:
         raise ValueError("role_arn is required for ECR authentication")
+
+    # The whole directory is handed to the Docker daemon as the build context, so
+    # resolve it and reject anything that would pull in a sensitive directory.
+    app_path = validate_path(app_path)
+
     # Generate a timestamp-based tag if none provided
     if tag is None:
         tag = str(int(time.time()))

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/path_validation.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/path_validation.py
@@ -1,0 +1,174 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Path validation for user-supplied filesystem paths.
+
+User-supplied paths reach directory creation, file writes, and Docker build
+contexts in this server. A path such as ``~/.aws`` contains no traversal
+sequences, so pattern matching on the raw string does not stop it; the path has
+to be resolved and then compared against the locations it must never touch.
+
+Every path is therefore resolved with ``os.path.realpath`` -- which expands
+``..`` components and follows symlinks -- and rejected when the result either
+sits inside a sensitive directory or contains one. This mirrors the equivalent
+protection in the EKS MCP Server.
+"""
+
+import os
+import sys
+from typing import Optional, Tuple
+
+# Directories inside a user's home that hold credentials or client configuration.
+_SENSITIVE_HOME_DIRS: Tuple[str, ...] = (".aws", ".ssh", ".kube", ".gnupg", ".docker")
+
+# System directories that hold host configuration and service state.
+_SENSITIVE_SYSTEM_DIRS: Tuple[str, ...] = ("/etc", "/root", "/var/lib")
+
+
+def _home_dirs() -> Tuple[str, ...]:
+    """
+    Collects every directory that may be the current user's home.
+
+    ``os.path.expanduser`` trusts ``$HOME``, so a process started with ``$HOME``
+    unset or pointing elsewhere would otherwise build the blocklist around the
+    wrong directory. The account's home directory from the password database is
+    consulted as a second, environment-independent source.
+
+    Returns:
+        Tuple[str, ...]: The candidate home directories, without duplicates.
+    """
+    homes = [os.path.expanduser("~")]
+
+    try:
+        import pwd
+
+        homes.append(pwd.getpwuid(os.getuid()).pw_dir)
+    except (ImportError, AttributeError, KeyError, OSError):
+        # pwd and os.getuid are POSIX-only, and the account may not be listed in
+        # the password database. $HOME remains the source in that case.
+        pass
+
+    return tuple(dict.fromkeys(home for home in homes if home))
+
+
+def _resolve_blocked_dirs() -> Tuple[str, ...]:
+    """
+    Builds the list of directories that user-supplied paths may never touch.
+
+    Each entry is resolved with ``os.path.realpath`` so that platforms which
+    expose these locations through symlinks (for example macOS, where ``/var``
+    links to ``/private/var``) are compared on their real paths.
+
+    Returns:
+        Tuple[str, ...]: The resolved sensitive directories, without duplicates.
+    """
+    candidates = [
+        os.path.join(home, sensitive_dir)
+        for home in _home_dirs()
+        for sensitive_dir in _SENSITIVE_HOME_DIRS
+    ]
+    candidates.extend(_SENSITIVE_SYSTEM_DIRS)
+    return tuple(dict.fromkeys(os.path.realpath(candidate) for candidate in candidates))
+
+
+BLOCKED_DIRS: Tuple[str, ...] = _resolve_blocked_dirs()
+
+# macOS and Windows filesystems are case-insensitive by default, so "~/.AWS" and
+# "~/.aws" name the same directory there. os.path.normcase only folds case on
+# Windows, so fold explicitly on macOS as well to close that bypass.
+_CASE_INSENSITIVE_FS: bool = sys.platform in ("darwin", "win32")
+
+
+def _normalize(path: str) -> str:
+    """
+    Normalizes a path for comparison against the blocklist.
+
+    Args:
+        path: The path to normalize
+
+    Returns:
+        str: The path in a form that can be compared on this platform
+    """
+    normalized = os.path.normcase(path)
+    return normalized.casefold() if _CASE_INSENSITIVE_FS else normalized
+
+
+def _find_blocked_dir(resolved_path: str) -> Optional[str]:
+    """
+    Finds the sensitive directory that makes a resolved path unusable.
+
+    A path is unusable when it is inside a sensitive directory (``~/.aws`` and
+    ``~/.aws/credentials`` both expose credentials) or when it contains one
+    (``/`` and ``$HOME`` both pull ``~/.aws`` into a Docker build context).
+
+    Args:
+        resolved_path: An already resolved absolute path
+
+    Returns:
+        Optional[str]: The offending sensitive directory, or None if the path is
+        unrelated to every sensitive directory
+    """
+    candidate = _normalize(resolved_path)
+    for blocked in BLOCKED_DIRS:
+        normalized_blocked = _normalize(blocked)
+        if candidate == normalized_blocked:
+            return blocked
+        # Inside a sensitive directory.
+        if candidate.startswith(normalized_blocked + os.sep):
+            return blocked
+        # An ancestor of a sensitive directory, which would pull it along.
+        if normalized_blocked.startswith(candidate.rstrip(os.sep) + os.sep):
+            return blocked
+    return None
+
+
+def validate_path(path: str, must_exist: bool = False) -> str:
+    """
+    Validates a user-supplied filesystem path.
+
+    Relative paths are accepted and resolved against the current working
+    directory, and a leading ``~`` is expanded. Resolution runs through
+    ``os.path.realpath``, so neither ``..`` components nor symlinks can be used
+    to reach a sensitive directory.
+
+    Args:
+        path: The path to validate. May be absolute or relative.
+        must_exist: Whether the resolved path is required to exist already.
+
+    Returns:
+        str: The resolved absolute path.
+
+    Raises:
+        ValueError: If the path is not a non-empty string, is related to a
+            sensitive directory, or does not exist while ``must_exist`` is set.
+    """
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError("Path must be a non-empty string")
+
+    resolved_path = os.path.realpath(os.path.expanduser(path))
+
+    # Checked before existence so that a sensitive path which does not exist yet
+    # is reported as sensitive rather than as merely missing.
+    blocked_dir = _find_blocked_dir(resolved_path)
+    if blocked_dir is not None:
+        raise ValueError(
+            f"Path '{path}' resolves to '{resolved_path}', which is not usable "
+            f"because it would expose the sensitive directory '{blocked_dir}'"
+        )
+
+    if must_exist and not os.path.exists(resolved_path):
+        raise ValueError(f"Path '{path}' does not exist")
+
+    return resolved_path

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/security.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/security.py
@@ -19,9 +19,10 @@ Security utilities for the ECS MCP Server.
 import functools
 import json
 import logging
-import os.path
 import re
 from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Set
+
+from awslabs.ecs_mcp_server.utils.path_validation import validate_path
 
 logger = logging.getLogger(__name__)
 
@@ -97,41 +98,6 @@ def validate_app_name(app_name: str) -> bool:
     return True
 
 
-def validate_file_path(path: str) -> str:
-    """
-    Validates file path to prevent directory traversal attacks.
-
-    Args:
-        path: The file path to validate
-
-    Returns:
-        str: The normalized absolute path
-
-    Raises:
-        ValidationError: If the path is invalid or doesn't exist
-    """
-    # Convert to absolute path and normalize
-    abs_path = os.path.abspath(os.path.normpath(path))
-
-    # Check if the path exists
-    if not os.path.exists(abs_path):
-        raise ValidationError(f"Path '{path}' does not exist")
-
-    # Check for suspicious path components that might indicate traversal attempts
-    suspicious_patterns = [
-        r"/\.\./",  # /../
-        r"\\\.\.\\",  # \..\ (Windows)
-        r"^\.\./",  # ../
-        r"^\.\.\\",  # ..\ (Windows)
-    ]
-
-    for pattern in suspicious_patterns:
-        if re.search(pattern, path):
-            raise ValidationError(f"Path '{path}' contains suspicious traversal patterns")
-
-    return abs_path
-
-
 def validate_cloudformation_template(template_path: str) -> bool:
     """
     Validates a CloudFormation template against basic schema requirements.
@@ -143,10 +109,13 @@ def validate_cloudformation_template(template_path: str) -> bool:
         bool: Whether the template is valid
 
     Raises:
-        ValidationError: If the template is invalid
+        ValidationError: If the path or the template is invalid
     """
     # First validate the file path
-    validated_path = validate_file_path(template_path)
+    try:
+        validated_path = validate_path(template_path, must_exist=True)
+    except ValueError as e:
+        raise ValidationError(str(e)) from e
 
     # Read template file
     try:

--- a/src/ecs-mcp-server/tests/unit/test_infrastructure.py
+++ b/src/ecs-mcp-server/tests/unit/test_infrastructure.py
@@ -2,6 +2,7 @@
 Unit tests for infrastructure module.
 """
 
+import os
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -22,7 +23,7 @@ from awslabs.ecs_mcp_server.utils.security import ValidationError
 
 @pytest.mark.anyio
 @patch("awslabs.ecs_mcp_server.api.infrastructure.validate_app_name")
-@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_file_path")
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_path")
 @patch("awslabs.ecs_mcp_server.api.infrastructure.os.makedirs")
 @patch("awslabs.ecs_mcp_server.api.infrastructure.os.path.join")
 @patch("awslabs.ecs_mcp_server.api.infrastructure.get_templates_dir")
@@ -36,15 +37,15 @@ async def test_prepare_template_files(
     mock_get_templates_dir,
     mock_join,
     mock_makedirs,
-    mock_validate_file_path,
+    mock_validate_path,
     mock_validate_app_name,
 ):
     """Test prepare_template_files."""
     # Mock validate_app_name
     mock_validate_app_name.return_value = True
 
-    # Mock validate_file_path
-    mock_validate_file_path.return_value = "/path/to/app"
+    # Mock validate_path
+    mock_validate_path.return_value = "/path/to/app"
 
     # Mock get_templates_dir
     mock_get_templates_dir.return_value = "/path/to/templates"
@@ -58,8 +59,8 @@ async def test_prepare_template_files(
     # Verify validate_app_name was called
     mock_validate_app_name.assert_called_once_with("test-app")
 
-    # Verify validate_file_path was called
-    mock_validate_file_path.assert_called_once_with("/path/to/app")
+    # Verify validate_path was called
+    mock_validate_path.assert_called_once_with("/path/to/app")
 
     # Verify os.makedirs was called
     mock_makedirs.assert_called_once_with("/path/to/app/cloudformation-templates", exist_ok=True)
@@ -76,16 +77,41 @@ async def test_prepare_template_files(
 
 @pytest.mark.anyio
 @patch("awslabs.ecs_mcp_server.api.infrastructure.validate_app_name")
-@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_file_path")
-async def test_prepare_template_files_path_not_exists(
-    mock_validate_file_path, mock_validate_app_name
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_path")
+async def test_prepare_template_files_uses_resolved_path(
+    mock_validate_path, mock_validate_app_name
 ):
-    """Test prepare_template_files when app_path doesn't exist."""
+    """Test that prepare_template_files writes to the resolved path, not the raw input."""
+    mock_validate_app_name.return_value = True
+    mock_validate_path.return_value = "/resolved/app"
+
+    with (
+        patch("awslabs.ecs_mcp_server.api.infrastructure.os.makedirs") as mock_makedirs,
+        patch(
+            "awslabs.ecs_mcp_server.api.infrastructure.get_templates_dir"
+        ) as mock_get_templates_dir,
+        patch("builtins.open", new_callable=mock_open, read_data="template content"),
+    ):
+        mock_get_templates_dir.return_value = "/path/to/templates"
+
+        result = prepare_template_files(app_name="test-app", app_path="./app")
+
+        mock_makedirs.assert_called_once_with(
+            os.path.join("/resolved/app", "cloudformation-templates"), exist_ok=True
+        )
+        assert result["ecr_template_path"].startswith("/resolved/app")
+
+
+@pytest.mark.anyio
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_app_name")
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_path")
+async def test_prepare_template_files_path_not_exists(mock_validate_path, mock_validate_app_name):
+    """Test prepare_template_files when app_path doesn't exist yet."""
     # Mock validate_app_name
     mock_validate_app_name.return_value = True
 
-    # Mock validate_file_path to raise ValidationError
-    mock_validate_file_path.side_effect = ValidationError("Path /non/existent/path does not exist")
+    # A missing path is valid; the directory is created below
+    mock_validate_path.return_value = "/non/existent/path"
 
     # Use patch to mock os.makedirs and other file operations
     with (
@@ -118,12 +144,43 @@ async def test_prepare_template_files_path_not_exists(
 
 @pytest.mark.anyio
 @patch("awslabs.ecs_mcp_server.api.infrastructure.validate_app_name")
-@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_file_path")
-async def test_prepare_template_files_io_error(mock_validate_file_path, mock_validate_app_name):
-    """Test prepare_template_files handling IO errors."""
-    # Mock validate_app_name and validate_file_path
+async def test_prepare_template_files_rejects_sensitive_path(mock_validate_app_name):
+    """Test that a sensitive app_path is rejected before anything is written to disk."""
     mock_validate_app_name.return_value = True
-    mock_validate_file_path.return_value = True
+    sensitive_path = os.path.join(os.path.expanduser("~"), ".aws")
+
+    with patch("awslabs.ecs_mcp_server.api.infrastructure.os.makedirs") as mock_makedirs:
+        with pytest.raises(ValidationError) as excinfo:
+            prepare_template_files(app_name="test-app", app_path=sensitive_path)
+
+    assert "sensitive directory" in str(excinfo.value)
+    mock_makedirs.assert_not_called()
+
+
+@pytest.mark.anyio
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_app_name")
+async def test_prepare_template_files_rejects_sensitive_path_that_does_not_exist(
+    mock_validate_app_name,
+):
+    """Test that a missing sensitive path is rejected rather than created."""
+    mock_validate_app_name.return_value = True
+    sensitive_path = os.path.join(os.path.expanduser("~"), ".aws", "not-created-by-this-test")
+
+    with patch("awslabs.ecs_mcp_server.api.infrastructure.os.makedirs") as mock_makedirs:
+        with pytest.raises(ValidationError):
+            prepare_template_files(app_name="test-app", app_path=sensitive_path)
+
+    mock_makedirs.assert_not_called()
+
+
+@pytest.mark.anyio
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_app_name")
+@patch("awslabs.ecs_mcp_server.api.infrastructure.validate_path")
+async def test_prepare_template_files_io_error(mock_validate_path, mock_validate_app_name):
+    """Test prepare_template_files handling IO errors."""
+    # Mock validate_app_name and validate_path
+    mock_validate_app_name.return_value = True
+    mock_validate_path.return_value = "/path/to/app"
 
     # Use patch to mock file operations with an IO error
     with (

--- a/src/ecs-mcp-server/tests/unit/utils/test_docker.py
+++ b/src/ecs-mcp-server/tests/unit/utils/test_docker.py
@@ -2,6 +2,7 @@
 Unit tests for docker utility module.
 """
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -74,6 +75,70 @@ async def test_build_and_push_image_missing_role_arn():
 
     # Verify error message
     assert "role_arn is required for ECR authentication" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+@patch("awslabs.ecs_mcp_server.utils.docker.subprocess.run")
+@patch("awslabs.ecs_mcp_server.utils.docker.get_aws_account_id")
+async def test_build_and_push_image_rejects_sensitive_build_context(
+    mock_get_aws_account_id, mock_subprocess_run
+):
+    """A sensitive directory must never be handed to Docker as the build context."""
+    sensitive_path = os.path.join(os.path.expanduser("~"), ".aws")
+
+    with pytest.raises(ValueError) as excinfo:
+        await build_and_push_image(
+            app_path=sensitive_path,
+            repository_uri="test-repository",
+            tag="latest",
+            role_arn="test-role-arn",
+        )
+
+    assert "sensitive directory" in str(excinfo.value)
+    # Nothing may run before the build context is validated.
+    mock_get_aws_account_id.assert_not_called()
+    mock_subprocess_run.assert_not_called()
+
+
+@pytest.mark.anyio
+@patch("awslabs.ecs_mcp_server.utils.docker.subprocess.run")
+@patch("awslabs.ecs_mcp_server.utils.docker.get_aws_account_id")
+async def test_build_and_push_image_rejects_home_directory_build_context(
+    mock_get_aws_account_id, mock_subprocess_run
+):
+    """The home directory must be rejected because it contains sensitive directories."""
+    with pytest.raises(ValueError):
+        await build_and_push_image(
+            app_path=os.path.expanduser("~"),
+            repository_uri="test-repository",
+            tag="latest",
+            role_arn="test-role-arn",
+        )
+
+    mock_get_aws_account_id.assert_not_called()
+    mock_subprocess_run.assert_not_called()
+
+
+@pytest.mark.anyio
+@patch("awslabs.ecs_mcp_server.utils.docker.subprocess.run")
+@patch("awslabs.ecs_mcp_server.utils.docker.get_aws_account_id")
+async def test_build_and_push_image_rejects_symlinked_sensitive_build_context(
+    mock_get_aws_account_id, mock_subprocess_run, tmp_path
+):
+    """A symlink into a sensitive directory must be resolved and rejected."""
+    link = tmp_path / "my-app"
+    os.symlink(os.path.join(os.path.expanduser("~"), ".aws"), str(link))
+
+    with pytest.raises(ValueError):
+        await build_and_push_image(
+            app_path=str(link),
+            repository_uri="test-repository",
+            tag="latest",
+            role_arn="test-role-arn",
+        )
+
+    mock_get_aws_account_id.assert_not_called()
+    mock_subprocess_run.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/src/ecs-mcp-server/tests/unit/utils/test_path_validation.py
+++ b/src/ecs-mcp-server/tests/unit/utils/test_path_validation.py
@@ -1,0 +1,300 @@
+"""
+Unit tests for path validation utilities.
+"""
+
+import os
+
+import pytest
+
+from awslabs.ecs_mcp_server.utils import path_validation
+from awslabs.ecs_mcp_server.utils.path_validation import BLOCKED_DIRS, validate_path
+
+HOME = os.path.realpath(os.path.expanduser("~"))
+
+
+class TestBlockedDirs:
+    """Tests for the sensitive directory blocklist."""
+
+    @pytest.mark.parametrize(
+        "expected",
+        [
+            os.path.join(HOME, ".aws"),
+            os.path.join(HOME, ".ssh"),
+            os.path.join(HOME, ".kube"),
+            os.path.join(HOME, ".gnupg"),
+            os.path.join(HOME, ".docker"),
+            "/etc",
+            "/root",
+            "/var/lib",
+        ],
+    )
+    def test_blocklist_covers_expected_location(self, expected):
+        """Every location reported by AWS Security is on the blocklist."""
+        assert os.path.realpath(expected) in BLOCKED_DIRS
+
+    def test_blocklist_entries_are_fully_resolved(self):
+        """Entries are stored resolved so symlinked system paths still match."""
+        for blocked in BLOCKED_DIRS:
+            assert blocked == os.path.realpath(blocked)
+
+    def test_blocklist_has_no_duplicates(self):
+        """The two home sources normally agree, so entries must be deduplicated."""
+        assert len(BLOCKED_DIRS) == len(set(BLOCKED_DIRS))
+
+    def test_home_dirs_includes_expanded_home(self):
+        """The blocklist is anchored on the home directory $HOME points at."""
+        assert os.path.expanduser("~") in path_validation._home_dirs()
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="requires a POSIX password database")
+    def test_home_dirs_survives_redirected_home(self, tmp_path, monkeypatch):
+        """
+        A redirected $HOME cannot hide the account's real home directory.
+
+        The password database is consulted as a second source so that a server
+        started with $HOME pointing elsewhere still protects the real ~/.aws.
+        """
+        import pwd
+
+        real_home = pwd.getpwuid(os.getuid()).pw_dir
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        homes = path_validation._home_dirs()
+
+        assert str(tmp_path) in homes
+        assert real_home in homes
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="requires a POSIX password database")
+    def test_home_dirs_falls_back_to_env_home_when_password_db_fails(self, monkeypatch):
+        """An account missing from the password database leaves $HOME as the source."""
+        import pwd
+
+        def raise_key_error(*_args, **_kwargs):
+            raise KeyError("uid not found in password database")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        assert path_validation._home_dirs() == (os.path.expanduser("~"),)
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="requires a POSIX password database")
+    def test_blocklist_covers_both_home_sources(self, tmp_path, monkeypatch):
+        """Sensitive directories are blocked under every candidate home."""
+        import pwd
+
+        real_home = pwd.getpwuid(os.getuid()).pw_dir
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        blocked = path_validation._resolve_blocked_dirs()
+
+        assert os.path.realpath(os.path.join(str(tmp_path), ".aws")) in blocked
+        assert os.path.realpath(os.path.join(real_home, ".aws")) in blocked
+
+
+class TestValidatePathRejectsSensitivePaths:
+    """Tests that paths related to sensitive directories are rejected."""
+
+    @pytest.mark.parametrize("blocked", BLOCKED_DIRS)
+    def test_rejects_blocked_directory_itself(self, blocked):
+        """The sensitive directory itself is rejected."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_path(blocked)
+        assert blocked in str(excinfo.value)
+
+    @pytest.mark.parametrize("blocked", BLOCKED_DIRS)
+    def test_rejects_path_inside_blocked_directory(self, blocked):
+        """A file inside a sensitive directory is rejected."""
+        with pytest.raises(ValueError):
+            validate_path(os.path.join(blocked, "credentials"))
+
+    def test_rejects_tilde_form_of_blocked_directory(self):
+        """A tilde path is expanded before the blocklist check."""
+        with pytest.raises(ValueError):
+            validate_path("~/.aws")
+
+    def test_rejects_file_inside_tilde_form_of_blocked_directory(self):
+        """A tilde path to a file inside a sensitive directory is rejected."""
+        with pytest.raises(ValueError):
+            validate_path("~/.aws/credentials")
+
+    def test_rejects_relative_path_resolving_into_blocked_directory(self, monkeypatch):
+        """A relative path is resolved before the blocklist check."""
+        monkeypatch.chdir(HOME)
+        with pytest.raises(ValueError):
+            validate_path(".aws")
+
+    def test_rejects_upward_traversal_into_blocked_directory(self):
+        """Traversal components cannot be used to reach a sensitive directory."""
+        with pytest.raises(ValueError):
+            validate_path(os.path.join(HOME, "some-app", "..", ".aws"))
+
+    def test_rejects_symlink_pointing_into_blocked_directory(self, tmp_path):
+        """Symlinks are resolved, so they cannot be used to reach a sensitive directory."""
+        link = tmp_path / "innocent-looking-app"
+        os.symlink(os.path.join(HOME, ".aws"), str(link))
+
+        with pytest.raises(ValueError):
+            validate_path(str(link))
+
+    def test_rejects_filesystem_root(self):
+        """The filesystem root is rejected because it contains sensitive directories."""
+        with pytest.raises(ValueError):
+            validate_path("/")
+
+    def test_rejects_home_directory(self):
+        """The home directory is rejected because it contains sensitive directories."""
+        with pytest.raises(ValueError):
+            validate_path(HOME)
+
+    def test_rejects_ancestor_of_blocked_directory(self):
+        """An ancestor of a sensitive directory is rejected."""
+        with pytest.raises(ValueError):
+            validate_path(os.path.dirname(os.path.realpath("/var/lib")))
+
+    def test_error_message_names_the_offending_directory(self):
+        """The error explains which sensitive directory caused the rejection."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_path("~/.ssh/id_rsa")
+        assert os.path.realpath(os.path.join(HOME, ".ssh")) in str(excinfo.value)
+
+
+class TestValidatePathAcceptsSafePaths:
+    """Tests that ordinary application paths remain usable."""
+
+    def test_accepts_existing_absolute_path(self, tmp_path):
+        """An ordinary absolute path is returned resolved."""
+        assert validate_path(str(tmp_path)) == os.path.realpath(str(tmp_path))
+
+    def test_accepts_relative_path_and_returns_absolute(self, tmp_path, monkeypatch):
+        """Relative paths stay supported and are resolved to absolute paths."""
+        app_dir = tmp_path / "my-app"
+        app_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        assert validate_path("my-app") == os.path.realpath(str(app_dir))
+
+    def test_accepts_dot_relative_path(self, tmp_path, monkeypatch):
+        """A './' prefixed path is supported."""
+        app_dir = tmp_path / "my-app"
+        app_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        assert validate_path("./my-app") == os.path.realpath(str(app_dir))
+
+    def test_accepts_nonexistent_path_by_default(self, tmp_path):
+        """Existence is not required unless the caller asks for it."""
+        target = tmp_path / "not-created-yet"
+
+        assert validate_path(str(target)) == os.path.realpath(str(target))
+
+    def test_accepts_sibling_of_blocked_directory(self):
+        """A directory whose name merely starts like a blocked one is allowed."""
+        sibling = os.path.join(HOME, ".awsome-app")
+
+        assert validate_path(sibling) == os.path.realpath(sibling)
+
+    def test_accepts_path_with_blocked_prefix_but_different_directory(self):
+        """'/etcetera' is not '/etc' and must not be blocked by prefix matching."""
+        assert validate_path("/etcetera") == os.path.realpath("/etcetera")
+
+    def test_accepts_subdirectory_of_home(self):
+        """An application directory under the home directory is allowed."""
+        app_dir = os.path.join(HOME, "projects", "my-app")
+
+        assert validate_path(app_dir) == os.path.realpath(app_dir)
+
+    def test_resolves_symlink_to_safe_directory(self, tmp_path):
+        """A symlink to a safe directory resolves to its target."""
+        target = tmp_path / "real-app"
+        target.mkdir()
+        link = tmp_path / "link-to-app"
+        os.symlink(str(target), str(link))
+
+        assert validate_path(str(link)) == os.path.realpath(str(target))
+
+
+class TestValidatePathExistence:
+    """Tests for the must_exist behaviour."""
+
+    def test_must_exist_accepts_existing_path(self, tmp_path):
+        """An existing path passes when existence is required."""
+        assert validate_path(str(tmp_path), must_exist=True) == os.path.realpath(str(tmp_path))
+
+    def test_must_exist_rejects_missing_path(self, tmp_path):
+        """A missing path is rejected when existence is required."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_path(str(tmp_path / "missing"), must_exist=True)
+        assert "does not exist" in str(excinfo.value)
+
+    def test_blocklist_is_checked_before_existence(self):
+        """
+        A sensitive path that does not exist is reported as sensitive.
+
+        Callers have historically special-cased "does not exist" errors in order to
+        create missing directories, so a sensitive path must never be reported that
+        way or the rejection could be swallowed.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            validate_path(os.path.join(HOME, ".aws", "definitely-not-created"), must_exist=True)
+        assert "does not exist" not in str(excinfo.value)
+
+
+class TestValidatePathInputHandling:
+    """Tests for malformed input."""
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t\n"])
+    def test_rejects_blank_path(self, value):
+        """Blank paths are rejected rather than resolving to the working directory."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_path(value)
+        assert "non-empty string" in str(excinfo.value)
+
+    @pytest.mark.parametrize("value", [None, 123, [], {}])
+    def test_rejects_non_string_path(self, value):
+        """Non-string input is rejected with a clear error."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_path(value)
+        assert "non-empty string" in str(excinfo.value)
+
+
+class TestCaseInsensitiveFilesystems:
+    """
+    Tests for case handling, which differs by platform.
+
+    macOS and Windows filesystems are case-insensitive by default, so a case
+    variant of a blocked directory names the same directory there and has to be
+    rejected. Linux filesystems are case-sensitive, where the same variant is a
+    genuinely different directory.
+    """
+
+    def test_normalize_folds_case_on_case_insensitive_filesystems(self, monkeypatch):
+        """Comparison keys are case-folded where the filesystem ignores case."""
+        monkeypatch.setattr(path_validation, "_CASE_INSENSITIVE_FS", True)
+
+        assert (
+            path_validation._normalize("/Home/User/.AWS")
+            == os.path.normcase("/Home/User/.AWS").casefold()
+        )
+
+    def test_normalize_preserves_case_on_case_sensitive_filesystems(self, monkeypatch):
+        """Comparison keys preserve case where the filesystem distinguishes it."""
+        monkeypatch.setattr(path_validation, "_CASE_INSENSITIVE_FS", False)
+
+        assert path_validation._normalize("/Home/User/.AWS") == os.path.normcase("/Home/User/.AWS")
+
+    def test_case_variant_of_blocked_dir_rejected_when_case_insensitive(
+        self, tmp_path, monkeypatch
+    ):
+        """A differently cased path cannot be used to reach a blocked directory."""
+        blocked = tmp_path / "secrets"
+        blocked.mkdir()
+        monkeypatch.setattr(path_validation, "BLOCKED_DIRS", (os.path.realpath(str(blocked)),))
+        monkeypatch.setattr(path_validation, "_CASE_INSENSITIVE_FS", True)
+
+        with pytest.raises(ValueError):
+            validate_path(str(tmp_path / "SECRETS"))
+
+    def test_documented_casing_rejected_on_every_platform(self, monkeypatch):
+        """The blocklist casing itself is rejected regardless of platform."""
+        for case_insensitive in (True, False):
+            monkeypatch.setattr(path_validation, "_CASE_INSENSITIVE_FS", case_insensitive)
+            with pytest.raises(ValueError):
+                validate_path(os.path.join(HOME, ".aws"))

--- a/src/ecs-mcp-server/tests/unit/utils/test_security.py
+++ b/src/ecs-mcp-server/tests/unit/utils/test_security.py
@@ -12,7 +12,6 @@ from awslabs.ecs_mcp_server.utils.security import (
     ValidationError,
     validate_app_name,
     validate_cloudformation_template,
-    validate_file_path,
 )
 
 
@@ -156,49 +155,6 @@ class TestValidateAppName:
         assert validate_app_name("web123-api456") is True
 
 
-class TestValidateFilePath:
-    """Tests for validate_file_path function."""
-
-    def test_valid_file_path(self, tmp_path):
-        """Test that valid file paths pass validation."""
-        # Create a temporary file
-        test_file = tmp_path / "test_file.txt"
-        test_file.write_text("test content")
-
-        # Validate the file path
-        result = validate_file_path(str(test_file))
-
-        # Check that the result is the absolute path to the file
-        assert result == os.path.abspath(str(test_file))
-
-    def test_nonexistent_file_path(self):
-        """Test that nonexistent file paths fail validation."""
-        with pytest.raises(ValidationError) as excinfo:
-            validate_file_path("/path/to/nonexistent/file.txt")
-        assert "does not exist" in str(excinfo.value)
-
-    def test_directory_traversal_attempts(self, tmp_path):
-        """Test that directory traversal attempts fail validation."""
-        # Create a temporary file
-        test_file = tmp_path / "test_file.txt"
-        test_file.write_text("test content")
-
-        # Test various directory traversal attempts
-        traversal_attempts = [
-            f"{test_file}/../../../etc/passwd",
-            f"{test_file}/../../..",
-            "../../../etc/passwd",
-            "..\\..\\..\\Windows\\System32\\config\\SAM",  # Windows example
-        ]
-
-        for path in traversal_attempts:
-            with pytest.raises(ValidationError) as excinfo:
-                validate_file_path(path)
-            assert "suspicious traversal patterns" in str(excinfo.value) or "does not exist" in str(
-                excinfo.value
-            )
-
-
 class TestValidateCloudFormationTemplate:
     """Tests for validate_cloudformation_template function."""
 
@@ -314,3 +270,11 @@ class TestValidateCloudFormationTemplate:
         with pytest.raises(ValidationError) as excinfo:
             validate_cloudformation_template(str(valid_template_file))
         assert "Failed to read template file" in str(excinfo.value)
+
+    def test_template_file_in_sensitive_directory(self):
+        """Test that a template path inside a sensitive directory fails validation."""
+        sensitive_template = os.path.join(os.path.expanduser("~"), ".aws", "template.json")
+
+        with pytest.raises(ValidationError) as excinfo:
+            validate_cloudformation_template(sensitive_template)
+        assert "sensitive directory" in str(excinfo.value)


### PR DESCRIPTION
Fixes N/A

## Summary

### Changes

Add a shared `path_validation` module to `ecs-mcp-server`, mirroring the one in
`eks-mcp-server`.

`validate_file_path()` in `utils/security.py` only pattern-matched the raw string for
`../` sequences, so an absolute path, a `~` prefix, or a symlink pointing at a user
configuration directory was accepted. `prepare_template_files()` also swallowed validation
errors whose message contained `does not exist`, so a rejected path could still be created.

The new `validate_path()`:

* Expands `~` and resolves paths with `os.path.realpath`, collapsing `..` and following
  symlinks before any check
* Rejects paths resolving inside a sensitive directory (`~/.aws`, `~/.ssh`, `~/.kube`,
  `~/.gnupg`, `~/.docker`, `/etc`, `/root`, `/var/lib`), and paths containing one, since a
  parent such as `$HOME` would pull it into a Docker build context
* Derives the home directory entries from both `$HOME` and the password database
* Accepts relative paths and returns the resolved absolute path

Applied in `prepare_template_files` (before `os.makedirs` and the template writes),
`build_and_push_image` (before the directory becomes the `docker buildx build` context), and
`validate_cloudformation_template`. `validate_file_path` is removed; every caller now uses the
new module.

Two differences from the EKS module: relative paths are accepted rather than rejected, and one
`validate_path(path, must_exist=False)` replaces two functions with identical bodies.

### User experience

Before, `app_path` was used as written, so `~/.aws` — or a symlink resolving to it — became
the template output directory and the Docker build context. Now such a path is rejected
before anything is written or built:

```
Path '~/.aws' resolves to '/home/user/.aws', which is not usable because it would
expose the sensitive directory '/home/user/.aws'
```

Project directories, absolute or relative, are unaffected.

### Testing

787 tests pass, up from 722 on `main`. `path_validation.py` is at 100% line and branch
coverage, covering symlink, `~`, relative, traversal, ancestor, prefix-collision and
case-insensitive-filesystem inputs. `ruff check`, `ruff format`, `pyright`, `bandit` and
`uv build` are clean.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

Paths resolving inside or containing one of the listed directories are now rejected where they
were previously accepted. No other input is affected.

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
