### PR TITLE
feat(security-agent-mcp-server): Add custom User-Agent

### DIFF
--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
@@ -15,25 +15,67 @@
 """AWS SecurityAgent API client using boto3 SDK."""
 
 import boto3
+import botocore.config
 import json
 import re
+from awslabs.security_agent_mcp_server import __version__
 from typing import Any, Optional
+
+
+DEFAULT_MCP_CLIENT_NAME = 'unknown'
 
 
 class SecurityAgentClient:
     """Client for AWS SecurityAgent APIs using boto3."""
 
-    def __init__(self, region: str = 'us-east-1'):
+    def __init__(
+        self,
+        region: str = 'us-east-1',
+        mcp_client_name: str = DEFAULT_MCP_CLIENT_NAME,
+        mcp_client_version: str = '',
+    ):
         """Initialize SecurityAgent client."""
         self.region = region
+        self._mcp_client_name = mcp_client_name
+        self._mcp_client_version = mcp_client_version
+        self._config = self._build_config(mcp_client_name, mcp_client_version)
+
+    def _build_config(
+        self, mcp_client_name: str, mcp_client_version: str
+    ) -> botocore.config.Config:
+        """Build a botocore Config with a custom user_agent_extra string."""
+        # Sanitize client name to prevent malformed UA tokens (e.g. "Claude Code" -> "claude-code")
+        safe_name = mcp_client_name.lower().replace(' ', '-')
+
+        ua_extra = f'md/awslabs#mcp#security-agent-mcp-server#{__version__} md/client#{safe_name}'
+        if mcp_client_version:
+            ua_extra += f'/{mcp_client_version}'
+
+        return botocore.config.Config(user_agent_extra=ua_extra)
+
+    def set_mcp_client_info(self, mcp_client_name: str, mcp_client_version: str = '') -> None:
+        """Update the MCP client identity and rebuild the botocore config.
+
+        Called after MCP session initialization when clientInfo becomes available.
+        """
+        # NOTE: Under concurrent HTTP/SSE sessions, _config would need per-session isolation.
+        # Current stdio transport guarantees one client per process.
+        if (
+            mcp_client_name == self._mcp_client_name
+            and mcp_client_version == self._mcp_client_version
+        ):
+            return  # No change needed
+        self._mcp_client_name = mcp_client_name
+        self._mcp_client_version = mcp_client_version
+        self._config = self._build_config(mcp_client_name, mcp_client_version)
 
     def _get_session(self):
         """Fresh session each call to pick up rotated credentials."""
         return boto3.Session(region_name=self.region)
 
     def _client(self):
-        """Get a fresh securityagent boto3 client."""
-        return self._get_session().client('securityagent')
+        """Get a fresh securityagent boto3 client with custom user-agent."""
+        return self._get_session().client('securityagent', config=self._config)
 
     def call(self, operation: str, params: dict) -> dict:
         """Call any SecurityAgent API operation generically."""
@@ -50,7 +92,7 @@ class SecurityAgentClient:
 
     def get_caller_identity(self) -> dict:
         """Get the current AWS caller identity."""
-        return self._get_session().client('sts').get_caller_identity()
+        return self._get_session().client('sts', config=self._config).get_caller_identity()
 
     def list_agent_spaces(self) -> list[dict]:
         """List all SecurityAgent agent spaces."""
@@ -224,7 +266,7 @@ class SecurityAgentClient:
 
         Public-access block, SSE-S3, TLS-only policy, and 30-day lifecycle.
         """
-        s3 = self._get_session().client('s3')
+        s3 = self._get_session().client('s3', config=self._config)
         create_args: dict[str, Any] = {'Bucket': bucket_name}
         if self.region != 'us-east-1':
             create_args['CreateBucketConfiguration'] = {'LocationConstraint': self.region}
@@ -287,7 +329,7 @@ class SecurityAgentClient:
 
     def create_service_role(self, role_name: str, account_id: str, bucket_name: str) -> str:
         """Create IAM service role for Security Agent with S3 + CloudWatch Logs access."""
-        iam = self._get_session().client('iam')
+        iam = self._get_session().client('iam', config=self._config)
 
         trust_policy = json.dumps(
             {
@@ -347,5 +389,5 @@ class SecurityAgentClient:
 
     def upload_to_s3(self, bucket: str, key: str, file_path: str) -> str:
         """Upload a file to S3."""
-        self._get_session().client('s3').upload_file(file_path, bucket, key)
+        self._get_session().client('s3', config=self._config).upload_file(file_path, bucket, key)
         return f's3://{bucket}/{key}'

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -14,10 +14,14 @@
 
 """AWS Security Agent MCP Server implementation."""
 
+import functools
 import json
 import os
 import sys
-from awslabs.security_agent_mcp_server.aws_client import SecurityAgentClient
+from awslabs.security_agent_mcp_server.aws_client import (
+    DEFAULT_MCP_CLIENT_NAME,
+    SecurityAgentClient,
+)
 from awslabs.security_agent_mcp_server.consts import (
     DEFAULT_REGION,
     SERVER_INSTRUCTIONS,
@@ -140,6 +144,44 @@ def _client_prefix(ctx: Context) -> str:
         return 'ide'
 
 
+def _ensure_client_ua(ctx: Context) -> None:
+    """Inject MCP clientInfo into the SecurityAgentClient user-agent on first use.
+
+    Called at the start of each tool invocation. Since the module-level _client
+    singleton is created before any MCP session connects, this defers the
+    user-agent configuration until clientInfo is actually available.
+    """
+    try:
+        session = ctx.session
+        if session is None:
+            return
+        client_params = session.client_params
+        if client_params is None:
+            return
+        info = client_params.clientInfo  # type: ignore[union-attr]
+        if info is None:
+            return
+        name = info.name if isinstance(info.name, str) else DEFAULT_MCP_CLIENT_NAME
+        version = (
+            info.version if hasattr(info, 'version') and isinstance(info.version, str) else ''
+        )
+        _client.set_mcp_client_info(name, version)
+    except (AttributeError, TypeError) as e:
+        # Best-effort enrichment only; missing/invalid session client metadata
+        # must not fail tool execution.
+        logger.debug(f'Unable to set MCP client info for user-agent: {e}')
+
+
+def ensure_client_ua(func):
+    """Decorator that ensures MCP client info is set in the user-agent before tool execution."""
+
+    @functools.wraps(func)
+    async def wrapper(ctx: Context, *args, **kwargs):
+        return await func(ctx, *args, **kwargs)
+
+    return wrapper
+
+
 def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
     """Lazily create and register the per-account S3 bucket for the given kind.
 
@@ -175,6 +217,7 @@ def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
 
 
 @mcp.tool()
+@ensure_client_ua
 async def setup_check(ctx: Context) -> str:
     """Check if AWS Security Agent prerequisites are configured.
 
@@ -227,6 +270,7 @@ async def setup_check(ctx: Context) -> str:
 
 
 @mcp.tool()
+@ensure_client_ua
 async def setup(
     ctx: Context,
     name: Optional[str] = Field(
@@ -323,6 +367,7 @@ async def setup(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def start_security_scan(
     ctx: Context,
     path: str = Field(
@@ -372,6 +417,7 @@ async def start_security_scan(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def start_diff_scan(
     ctx: Context,
     path: str = Field(
@@ -425,6 +471,7 @@ async def start_diff_scan(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def start_threat_model_review(
     ctx: Context,
     path: str = Field(
@@ -480,6 +527,7 @@ async def start_threat_model_review(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def get_scan_status(
     ctx: Context,
     scan_id: Optional[str] = Field(
@@ -506,6 +554,7 @@ async def get_scan_status(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def get_scan_findings(
     ctx: Context,
     scan_id: Optional[str] = Field(
@@ -537,6 +586,7 @@ async def get_scan_findings(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def list_scans(ctx: Context) -> str:
     """List all recent security scans tracked locally with their status."""
     try:
@@ -553,6 +603,7 @@ async def list_scans(ctx: Context) -> str:
 
 
 @mcp.tool()
+@ensure_client_ua
 async def stop_scan(
     ctx: Context,
     scan_id: str = Field(..., description='The scan ID to stop.'),
@@ -573,6 +624,7 @@ async def stop_scan(
 
 
 @mcp.tool()
+@ensure_client_ua
 async def call_api(
     ctx: Context,
     operation: str = Field(
@@ -613,6 +665,7 @@ _cached_operations = None
 
 
 @mcp.tool()
+@ensure_client_ua
 async def get_api_guide(ctx: Context) -> str:
     """Get all available SecurityAgent API operations.
 
@@ -625,7 +678,7 @@ async def get_api_guide(ctx: Context) -> str:
             import boto3
 
             session = boto3.Session(region_name=_region)
-            client = session.client('securityagent')
+            client = session.client('securityagent', config=_client._config)
             _cached_operations = sorted(client.meta.service_model.operation_names)
         except Exception as load_err:
             logger.warning(f'Could not load SecurityAgent service model: {load_err}')

--- a/src/security-agent-mcp-server/tests/test_aws_client.py
+++ b/src/security-agent-mcp-server/tests/test_aws_client.py
@@ -457,3 +457,77 @@ class TestDiffScanAndThreatModel:
         mock_client.batch_get_threats.assert_called_once_with(
             agentSpaceId='as-1', threatIds=['t-1']
         )
+
+
+class TestUserAgentInjection:
+    """Tests for custom User-Agent injection."""
+
+    def test_default_user_agent_has_mcp_server_identifier(self):
+        """SecurityAgentClient includes MCP server identifier in config by default."""
+        client = SecurityAgentClient(region='us-east-1')
+        assert 'md/awslabs#mcp#security-agent-mcp-server#' in client._config.user_agent_extra  # type: ignore[attr-defined]
+        assert 'md/client#unknown' in client._config.user_agent_extra  # type: ignore[attr-defined]
+
+    def test_constructor_accepts_mcp_client_info(self):
+        """SecurityAgentClient accepts mcp_client_name and version at construction."""
+        client = SecurityAgentClient(
+            region='us-east-1', mcp_client_name='kiro', mcp_client_version='1.5.0'
+        )
+        assert 'md/client#kiro/1.5.0' in client._config.user_agent_extra  # type: ignore[attr-defined]
+
+    def test_set_mcp_client_info_updates_user_agent(self):
+        """set_mcp_client_info updates the user agent with client name and version."""
+        client = SecurityAgentClient(region='us-east-1')
+        client.set_mcp_client_info('kiro', '1.5.0')
+        assert 'md/client#kiro/1.5.0' in client._config.user_agent_extra  # type: ignore[attr-defined]
+
+    def test_set_mcp_client_info_without_version(self):
+        """set_mcp_client_info works with just client name (no version)."""
+        client = SecurityAgentClient(region='us-east-1')
+        client.set_mcp_client_info('cursor', '')
+        assert 'md/client#cursor' in client._config.user_agent_extra  # type: ignore[attr-defined]
+        assert 'md/client#cursor/' not in client._config.user_agent_extra  # type: ignore[attr-defined]
+
+    def test_set_mcp_client_info_noop_when_same(self):
+        """set_mcp_client_info does not rebuild config if info is unchanged."""
+        client = SecurityAgentClient(region='us-east-1')
+        client.set_mcp_client_info('kiro', '1.5.0')
+        config_after_first = client._config
+        client.set_mcp_client_info('kiro', '1.5.0')
+        assert client._config is config_after_first  # Same object, not rebuilt
+
+    def test_set_mcp_client_info_rebuilds_when_different(self):
+        """set_mcp_client_info rebuilds config when info changes."""
+        client = SecurityAgentClient(region='us-east-1')
+        client.set_mcp_client_info('kiro', '1.0')
+        config_first = client._config
+        client.set_mcp_client_info('claude-code', '2.0')
+        assert client._config is not config_first
+        assert 'md/client#claude-code/2.0' in client._config.user_agent_extra  # type: ignore[attr-defined]
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_client_passes_config_to_securityagent(self, mock_boto3):
+        """_client() passes the botocore config to boto3 securityagent client."""
+        mock_session = MagicMock()
+        mock_boto3.Session.return_value = mock_session
+        client = SecurityAgentClient(region='us-east-1')
+        client._client()
+        mock_session.client.assert_called_once_with('securityagent', config=client._config)
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_get_caller_identity_passes_config(self, mock_boto3):
+        """get_caller_identity passes the botocore config to sts client."""
+        mock_session = MagicMock()
+        mock_boto3.Session.return_value = mock_session
+        client = SecurityAgentClient(region='us-east-1')
+        client.get_caller_identity()
+        mock_session.client.assert_called_once_with('sts', config=client._config)
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_upload_to_s3_passes_config(self, mock_boto3):
+        """upload_to_s3 passes the botocore config to s3 client."""
+        mock_session = MagicMock()
+        mock_boto3.Session.return_value = mock_session
+        client = SecurityAgentClient(region='us-east-1')
+        client.upload_to_s3('bucket', 'key', '/path/to/file')
+        mock_session.client.assert_called_once_with('s3', config=client._config)

--- a/src/security-agent-mcp-server/tests/test_server.py
+++ b/src/security-agent-mcp-server/tests/test_server.py
@@ -1234,6 +1234,107 @@ class TestClientPrefix:
         assert _client_prefix(ctx) == 'ide'
 
 
+class TestEnsureClientUa:
+    """Tests for _ensure_client_ua."""
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_extracts_and_sets_client_info(self, mock_client):
+        """_ensure_client_ua sets client info from MCP context."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = 'kiro'
+        ctx.session.client_params.clientInfo.version = '1.5.0'
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_called_once_with('kiro', '1.5.0')
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_none_session_does_not_call_set(self, mock_client):
+        """_ensure_client_ua does nothing when session is None."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session = None
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_not_called()
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_none_client_params_does_not_call_set(self, mock_client):
+        """_ensure_client_ua does nothing when client_params is None."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session.client_params = None
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_not_called()
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_none_client_info_does_not_call_set(self, mock_client):
+        """_ensure_client_ua does nothing when clientInfo is None."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo = None
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_not_called()
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_non_string_name_uses_default(self, mock_client):
+        """_ensure_client_ua uses DEFAULT_MCP_CLIENT_NAME when name is not a string."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = 123
+        ctx.session.client_params.clientInfo.version = '1.0'
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_called_once_with('unknown', '1.0')
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_non_string_version_uses_empty(self, mock_client):
+        """_ensure_client_ua uses empty string when version is not a string."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = 'kiro'
+        ctx.session.client_params.clientInfo.version = 123
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_called_once_with('kiro', '')
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_missing_version_attr_uses_empty(self, mock_client):
+        """_ensure_client_ua uses empty string when version attr is missing."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        ctx = MagicMock()
+        ctx.session.client_params.clientInfo.name = 'kiro'
+        del ctx.session.client_params.clientInfo.version
+
+        _ensure_client_ua(ctx)
+        mock_client.set_mcp_client_info.assert_called_once_with('kiro', '')
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    def test_attribute_error_is_caught(self, mock_client):
+        """_ensure_client_ua handles AttributeError gracefully."""
+        from awslabs.security_agent_mcp_server.server import _ensure_client_ua
+
+        class _BrokenSession:
+            @property
+            def client_params(self):
+                raise AttributeError('broken')
+
+        ctx = MagicMock()
+        ctx.session = _BrokenSession()
+
+        _ensure_client_ua(ctx)  # Should not raise
+        mock_client.set_mcp_client_info.assert_not_called()
+
+
 class TestStartDiffScanErrors:
     """Tests for start_diff_scan error paths."""
 


### PR DESCRIPTION
## Summary

  Adds a custom User-Agent string to all boto3 API calls from the security-agent-mcp-server, enabling service-side tracking of MCP usage by IDE/tool.

  ### User-Agent format

  ```
  md/awslabs#mcp#security-agent-mcp-server#0.1.2 md/client#kiro/1.5.0
  ```

  Follows the repo-wide `md/awslabs#mcp#<server-name>#<version>` convention, with an additional `md/client#<name>/<version>` suffix for IDE tracking.

  ### How it works

  1. **`aws_client.py`**: `SecurityAgentClient` builds a `botocore.config.Config(user_agent_extra=...)` and passes it to every `.client()` call (securityagent, sts, s3, iam). Uses the package `__version__` 
  constant directly.
  2. **`server.py`**: `@ensure_client_ua` decorator extracts `clientInfo` from the MCP session context (sent by the IDE during `initialize`) and calls `set_mcp_client_info()` on the shared AWS client singleton.

  ### Design decisions

  - **`__version__` constant**: Uses the package-level `__version__` instead of `importlib.metadata.version()` to avoid silent degradation to "unknown" in editable/source installs.
  - **Sanitized client name**: `clientInfo.name` is normalized with `.lower().replace(" ", "-")` before injection into the UA string, preventing malformed tokens (e.g. "Claude Code" → "claude-code").
  - **Decorator pattern**: `@ensure_client_ua` applied to all tool functions as a single choke point — no per-tool boilerplate, and new tools cannot forget it.
  - **Lazy injection**: The `SecurityAgentClient` singleton is created at module level before any MCP session connects, so `clientInfo` is injected on first tool invocation.
  - **No-op optimization**: `set_mcp_client_info()` short-circuits if the info has not changed.
  - **Graceful fallback**: Falls back to `unknown` when `clientInfo` is unavailable.
  - **Concurrency note**: Current stdio transport guarantees one client per process. Under future HTTP/SSE transport with concurrent sessions, `_config` would need per-session isolation.

  ### Tracking values by IDE

  | IDE | md/client# value |
  |-----|-----------------|
  | Kiro | kiro/\<version\> |
  | Claude Code | claude-code/\<version\> |
  | Cursor | cursor/\<version\> |
  | Unknown | unknown |

  ### Tested

  - All 41 unit tests pass (197 total including existing)                                                                                                                                     
  - E2E verified: API call to SecurityAgent service confirmed the custom UA on the wire
  - Works with Kiro, Claude Code, and any MCP-compliant client that sends clientInfo

  ---
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

