### PR TITLE
feat(billing-cost-management): add budget-actions and budget-notifications operations

### DIFF
--- a/src/billing-cost-management-mcp-server/CHANGELOG.md
+++ b/src/billing-cost-management-mcp-server/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added AWS Billing Conductor tools to analize billing groups, account associations, billing group cost reports, pricing rules/plans, and custom line items
 - Added AWS Billing tools for managing and querying billing views
 - Added optional `billing_view_arn` parameter to 7 Cost Explorer operations to scope queries to specific billing views (PRIMARY, BILLING_GROUP, CUSTOM, BILLING_TRANSFER, BILLING_TRANSFER_SHOWBACK)
-- Added read-only budget actions and notifications support to the `budget` tool: `budget-actions` (`DescribeBudgetActionsForAccount`, optionally filtered client-side by budget name) and `budget-notifications` (`DescribeNotificationsForBudget`)
+- Added read-only budget actions and notifications support to the `budget` tool: `budget-actions` and `budget-notifications`. Each routes by `budget_name` — a single-budget read (`DescribeBudgetActionsForBudget` / `DescribeNotificationsForBudget`) when a name is given, or an account-wide audit (`DescribeBudgetActionsForAccount` / `DescribeBudgetNotificationsForAccount`) when omitted. Both support pagination (`max_results`, `next_token`, `max_pages`) and offload large responses to session SQL
 
 ### Fixed
 - Corrected AWS Compute Optimizer recommendation response field names so EC2, Auto Scaling group, Lambda, and RDS tools return actual values instead of null. Fixed the shared savings-opportunity parser (`savingsOpportunityPercentage`), projected utilization metrics, EC2/RDS idle flags, nested ASG instance types, and the RDS instance/storage recommendation schema.

--- a/src/billing-cost-management-mcp-server/CHANGELOG.md
+++ b/src/billing-cost-management-mcp-server/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added AWS Billing Conductor tools to analize billing groups, account associations, billing group cost reports, pricing rules/plans, and custom line items
 - Added AWS Billing tools for managing and querying billing views
 - Added optional `billing_view_arn` parameter to 7 Cost Explorer operations to scope queries to specific billing views (PRIMARY, BILLING_GROUP, CUSTOM, BILLING_TRANSFER, BILLING_TRANSFER_SHOWBACK)
+- Added read-only budget actions and notifications support to the `budget` tool: `budget-actions` (`DescribeBudgetActionsForAccount`, optionally filtered client-side by budget name) and `budget-notifications` (`DescribeNotificationsForBudget`)
 
 ### Fixed
 - Corrected AWS Compute Optimizer recommendation response field names so EC2, Auto Scaling group, Lambda, and RDS tools return actual values instead of null. Fixed the shared savings-opportunity parser (`savingsOpportunityPercentage`), projected utilization metrics, EC2/RDS idle flags, nested ASG instance types, and the RDS instance/storage recommendation schema.

--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -14,7 +14,7 @@ MCP server for accessing AWS Billing and Cost Management capabilities.
 
 - **Cost Explorer insights**: Analyze historical and forecasted AWS costs with flexible grouping and filtering
 - **Usage metrics analysis**: Track resource usage trends across your AWS environment
-- **Budget monitoring**: Check existing budgets and their status against actual spending
+- **Budget monitoring**: Check existing budgets and their status against actual spending, plus their configured enforcement actions and alert notifications (per-budget or account-wide)
 - **Cost anomaly detection**: Identify unusual spending patterns and their root causes
 
 ### Cost Optimization Recommendations
@@ -262,7 +262,9 @@ Compute Optimizer Automation:
 - ec2:DescribeVolumes (required by ListRecommendedActions and ListAutomationRulePreview)
 
 AWS Budgets:
-- budgets:ViewBudget
+- budgets:ViewBudget (also covers budget notifications, per-budget and account-wide)
+- budgets:DescribeBudgetActionsForBudget (required for budget actions by budget name)
+- budgets:DescribeBudgetActionsForAccount (required for account-wide budget actions)
 
 AWS Pricing:
 - pricing:DescribeServices
@@ -365,6 +367,8 @@ The server currently supports the following AWS services
 
 2. **AWS Budgets**
    - describe_budgets
+   - describe_budget_actions (DescribeBudgetActionsForBudget / DescribeBudgetActionsForAccount)
+   - describe_budget_notifications (DescribeNotificationsForBudget / DescribeBudgetNotificationsForAccount)
 
 3. **AWS Free Tier**
    - get_free_tier_usage

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/budget_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/budget_tools.py
@@ -14,7 +14,12 @@
 
 """AWS Budgets tools for the AWS Billing and Cost Management MCP server.
 
-Updated to use shared utility functions.
+File layout:
+- Tool entrypoints: the @budget_server.tool functions the MCP client sees
+  (`budgets`, `budget-actions`, `budget-notifications`).
+- Account helper: `get_aws_account_id`.
+- Operation handlers: the read calls each tool delegates to.
+- Formatters: pure reshapers from raw AWS API dicts to the response shape.
 """
 
 from ..utilities.aws_service_base import create_aws_client, format_response, handle_aws_error
@@ -24,6 +29,11 @@ from typing import Any, Dict, List, Optional
 
 
 budget_server = FastMCP(name='budget-tools', instructions='Tools for working with AWS Budgets API')
+
+
+# =============================================================================
+# Tool entrypoints
+# =============================================================================
 
 
 @budget_server.tool(
@@ -79,6 +89,105 @@ async def budgets(
         return await handle_aws_error(ctx, e, 'budgets', 'AWS Budgets')
 
 
+@budget_server.tool(
+    name='budget-actions',
+    description="""Reads the enforcement action(s) attached to AWS Budgets.
+
+A budget action is what AWS Budgets automatically does when a threshold is crossed — apply an
+IAM or SCP policy, or run an SSM document. Read-only; uses the account-scoped
+DescribeBudgetActionsForAccount API.
+
+- Omit `budget_name` to list every budget's actions in one call — the efficient way to audit
+  which budgets have no enforcement configured.
+- Pass `budget_name` to filter that same result to a single budget (there is no per-budget
+  fan-out; filtering is client-side).
+
+An empty `actions` list is a real answer (a budget with no actions), distinct from an error
+such as AccessDenied. For a budget's spend-vs-limit status use the `budgets` tool; for its alert
+thresholds use `budget-notifications`. The account ID is retrieved automatically or you may pass
+`account_id`.""",
+)
+async def budget_actions(
+    ctx: Context,
+    budget_name: Optional[str] = None,
+    max_results: int = 100,
+    account_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Reads AWS Budgets enforcement actions (DescribeBudgetActionsForAccount).
+
+    Args:
+        ctx: The MCP context object.
+        budget_name: Optional. If provided, the account-wide result is filtered to this budget.
+        max_results: Maximum number of results to return. Defaults to 100.
+        account_id: Optional AWS account ID; retrieved automatically if not provided.
+
+    Returns:
+        Dict containing the formatted action configuration.
+    """
+    try:
+        await ctx.info(f'budget-actions (budget_name={budget_name}, max_results={max_results})')
+
+        if not account_id:
+            account_id = await get_aws_account_id(ctx)
+        await ctx.info(f'Using AWS Account ID: {account_id}')
+
+        return await describe_budget_actions(ctx, account_id, budget_name, max_results)
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'budget-actions', 'AWS Budgets')
+
+
+@budget_server.tool(
+    name='budget-notifications',
+    description="""Reads the alert thresholds (notifications) configured on an AWS Budget.
+
+A notification is an alert that fires when a budget crosses a threshold (e.g. 80% of the limit).
+Read-only; uses the DescribeNotificationsForBudget API, which is per-budget — `budget_name` is
+required (the AWS Budgets API has no account-scoped notifications read).
+
+For a budget's spend-vs-limit status use the `budgets` tool; for its enforcement actions use
+`budget-actions`. The account ID is retrieved automatically or you may pass `account_id`.""",
+)
+async def budget_notifications(
+    ctx: Context,
+    budget_name: str,
+    max_results: int = 100,
+    account_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Reads the notifications configured on a budget (DescribeNotificationsForBudget).
+
+    Args:
+        ctx: The MCP context object.
+        budget_name: The budget whose notifications to read. Required.
+        max_results: Maximum number of results to return. Defaults to 100.
+        account_id: Optional AWS account ID; retrieved automatically if not provided.
+
+    Returns:
+        Dict containing the formatted notification configuration.
+    """
+    try:
+        await ctx.info(
+            f'budget-notifications (budget_name={budget_name}, max_results={max_results})'
+        )
+
+        if not budget_name:
+            raise ValueError('budget_name is required')
+
+        if not account_id:
+            account_id = await get_aws_account_id(ctx)
+        await ctx.info(f'Using AWS Account ID: {account_id}')
+
+        return await describe_notifications_for_budget(ctx, account_id, budget_name, max_results)
+
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'budget-notifications', 'AWS Budgets')
+
+
+# =============================================================================
+# Account helper
+# =============================================================================
+
+
 async def get_aws_account_id(ctx: Context) -> str:
     """Retrieves the AWS account ID of the calling identity.
 
@@ -104,10 +213,15 @@ async def get_aws_account_id(ctx: Context) -> str:
         raise Exception(f'Failed to retrieve AWS account ID: {str(e)}')
 
 
+# =============================================================================
+# Operation handlers (AWS API calls)
+# =============================================================================
+
+
 async def describe_budgets(
     ctx: Context, account_id: str, budget_name: Optional[str], max_results: int
 ) -> Dict[str, Any]:
-    """Retrieves budgets using the AWS Budgets API.
+    """Retrieves budgets using the AWS Budgets API (DescribeBudgets).
 
     Args:
         ctx: The MCP context object.
@@ -176,6 +290,114 @@ async def describe_budgets(
     except Exception as e:
         # Use shared error handler for consistent error reporting
         return await handle_aws_error(ctx, e, 'describe_budgets', 'AWS Budgets')
+
+
+async def describe_budget_actions(
+    ctx: Context, account_id: str, budget_name: Optional[str], max_results: int
+) -> Dict[str, Any]:
+    """Retrieves budget enforcement actions via DescribeBudgetActionsForAccount.
+
+    Always calls the account-scoped API (one permission,
+    `budgets:DescribeBudgetActionsForAccount`, covers both the account-wide audit and a
+    single-budget lookup). If `budget_name` is provided, the account-wide result is filtered to
+    that budget client-side — the AWS API has no `BudgetName` parameter for the account call.
+
+    An empty `actions` list is a real answer (no actions configured), distinct from an error.
+    """
+    try:
+        budgets_client = create_aws_client('budgets', region_name='us-east-1')
+
+        request_params: Dict[str, Any] = {'AccountId': account_id}
+        all_actions: List[Dict[str, Any]] = []
+        next_token = None
+        page_count = 0
+
+        while True:
+            page_count += 1
+            if next_token:
+                request_params['NextToken'] = next_token
+            # When filtering to one budget we cannot bound MaxResults by the filtered
+            # count, so page fully; otherwise stop once we have max_results.
+            if not budget_name:
+                remaining = max_results - len(all_actions)
+                if remaining <= 0:
+                    break
+                request_params['MaxResults'] = min(100, remaining)
+            else:
+                request_params['MaxResults'] = 100
+
+            await ctx.info(f'Fetching account budget actions page {page_count}')
+            response = budgets_client.describe_budget_actions_for_account(**request_params)
+            all_actions.extend(response.get('Actions', []))
+            next_token = response.get('NextToken')
+            if not next_token:
+                break
+
+        if budget_name:
+            all_actions = [a for a in all_actions if a.get('BudgetName') == budget_name]
+            all_actions = all_actions[:max_results]
+
+        data: Dict[str, Any] = {
+            'actions': [format_action(a) for a in all_actions],
+            'total_count': len(all_actions),
+            'account_id': account_id,
+        }
+        if budget_name:
+            data['budget_name'] = budget_name
+
+        return format_response('success', data)
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'describe_budget_actions', 'AWS Budgets')
+
+
+async def describe_notifications_for_budget(
+    ctx: Context, account_id: str, budget_name: str, max_results: int
+) -> Dict[str, Any]:
+    """Retrieves the notifications configured on a budget (DescribeNotificationsForBudget).
+
+    Per-budget only — the AWS Budgets API has no account-scoped notifications read, so this
+    requires `budget_name`. Authorized by `budgets:ViewBudget`.
+    """
+    try:
+        budgets_client = create_aws_client('budgets', region_name='us-east-1')
+
+        request_params: Dict[str, Any] = {'AccountId': account_id, 'BudgetName': budget_name}
+        all_notifications: List[Dict[str, Any]] = []
+        next_token = None
+        page_count = 0
+
+        while True:
+            page_count += 1
+            if next_token:
+                request_params['NextToken'] = next_token
+            remaining = max_results - len(all_notifications)
+            if remaining <= 0:
+                break
+            request_params['MaxResults'] = min(100, remaining)
+
+            await ctx.info(f'Fetching notifications page {page_count}')
+            response = budgets_client.describe_notifications_for_budget(**request_params)
+            all_notifications.extend(response.get('Notifications', []))
+            next_token = response.get('NextToken')
+            if not next_token:
+                break
+
+        return format_response(
+            'success',
+            {
+                'notifications': [format_notification(n) for n in all_notifications],
+                'total_count': len(all_notifications),
+                'budget_name': budget_name,
+                'account_id': account_id,
+            },
+        )
+    except Exception as e:
+        return await handle_aws_error(ctx, e, 'describe_notifications_for_budget', 'AWS Budgets')
+
+
+# =============================================================================
+# Formatters (raw AWS API dict -> response shape)
+# =============================================================================
 
 
 def format_budgets(budgets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -292,3 +514,81 @@ def format_budgets(budgets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         formatted_budgets.append(formatted_budget)
 
     return formatted_budgets
+
+
+def format_action(action: Dict[str, Any]) -> Dict[str, Any]:
+    """Formats a budget Action object from the AWS API response."""
+    formatted: Dict[str, Any] = {
+        'action_id': action.get('ActionId'),
+        'budget_name': action.get('BudgetName'),
+        'notification_type': action.get('NotificationType'),
+        'action_type': action.get('ActionType'),
+        'approval_model': action.get('ApprovalModel'),
+        'execution_role_arn': action.get('ExecutionRoleArn'),
+        'status': action.get('Status'),
+    }
+
+    if 'ActionThreshold' in action:
+        threshold = action['ActionThreshold']
+        formatted['action_threshold'] = {
+            'action_threshold_value': threshold.get('ActionThresholdValue'),
+            'action_threshold_type': threshold.get('ActionThresholdType'),
+        }
+
+    if 'Definition' in action:
+        formatted['definition'] = format_action_definition(action['Definition'])
+
+    if 'Subscribers' in action:
+        formatted['subscribers'] = [
+            {
+                'subscription_type': s.get('SubscriptionType'),
+                'address': s.get('Address'),
+            }
+            for s in action['Subscribers']
+        ]
+
+    return formatted
+
+
+def format_action_definition(definition: Dict[str, Any]) -> Dict[str, Any]:
+    """Formats an action Definition — one of IAM / SCP / SSM sub-definitions."""
+    result: Dict[str, Any] = {}
+
+    if 'IamActionDefinition' in definition:
+        iam = definition['IamActionDefinition']
+        entry: Dict[str, Any] = {'policy_arn': iam.get('PolicyArn')}
+        if iam.get('Roles'):
+            entry['roles'] = iam['Roles']
+        if iam.get('Groups'):
+            entry['groups'] = iam['Groups']
+        if iam.get('Users'):
+            entry['users'] = iam['Users']
+        result['iam_action_definition'] = entry
+
+    if 'ScpActionDefinition' in definition:
+        scp = definition['ScpActionDefinition']
+        result['scp_action_definition'] = {
+            'policy_id': scp.get('PolicyId'),
+            'target_ids': scp.get('TargetIds', []),
+        }
+
+    if 'SsmActionDefinition' in definition:
+        ssm = definition['SsmActionDefinition']
+        result['ssm_action_definition'] = {
+            'action_sub_type': ssm.get('ActionSubType'),
+            'instance_ids': ssm.get('InstanceIds', []),
+            'region': ssm.get('Region'),
+        }
+
+    return result
+
+
+def format_notification(notification: Dict[str, Any]) -> Dict[str, Any]:
+    """Formats a budget Notification object from the AWS API response."""
+    return {
+        'notification_type': notification.get('NotificationType'),
+        'comparison_operator': notification.get('ComparisonOperator'),
+        'threshold': notification.get('Threshold'),
+        'threshold_type': notification.get('ThresholdType'),
+        'notification_state': notification.get('NotificationState'),
+    }

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/budget_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/budget_tools.py
@@ -22,7 +22,13 @@ File layout:
 - Formatters: pure reshapers from raw AWS API dicts to the response shape.
 """
 
-from ..utilities.aws_service_base import create_aws_client, format_response, handle_aws_error
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from ..utilities.sql_utils import convert_response_if_needed
 from datetime import datetime
 from fastmcp import Context, FastMCP
 from typing import Any, Dict, List, Optional
@@ -94,13 +100,18 @@ async def budgets(
     description="""Reads the enforcement action(s) attached to AWS Budgets.
 
 A budget action is what AWS Budgets automatically does when a threshold is crossed — apply an
-IAM or SCP policy, or run an SSM document. Read-only; uses the account-scoped
-DescribeBudgetActionsForAccount API.
+IAM or SCP policy, or run an SSM document. Read-only.
 
-- Omit `budget_name` to list every budget's actions in one call — the efficient way to audit
-  which budgets have no enforcement configured.
-- Pass `budget_name` to filter that same result to a single budget (there is no per-budget
-  fan-out; filtering is client-side).
+- Omit `budget_name` to audit every budget's actions across the account
+  (DescribeBudgetActionsForAccount). This is the efficient way to find budgets with no
+  enforcement configured.
+- Pass `budget_name` to read one budget's actions directly (DescribeBudgetActionsForBudget) —
+  no account-wide scan.
+
+Pagination: a management account can have thousands of budgets, so results are paginated. Use
+`max_results` to bound page size and `max_pages` to bound how many pages are fetched; a
+`next_token` in the response can be passed back to continue. Large responses are automatically
+offloaded to session SQL to save tokens.
 
 An empty `actions` list is a real answer (a budget with no actions), distinct from an error
 such as AccessDenied. For a budget's spend-vs-limit status use the `budgets` tool; for its alert
@@ -112,14 +123,21 @@ async def budget_actions(
     budget_name: Optional[str] = None,
     max_results: int = 100,
     account_id: Optional[str] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Reads AWS Budgets enforcement actions (DescribeBudgetActionsForAccount).
+    """Reads AWS Budgets enforcement actions.
+
+    Routes by ``budget_name``: DescribeBudgetActionsForBudget when a name is given, otherwise
+    the account-wide DescribeBudgetActionsForAccount.
 
     Args:
         ctx: The MCP context object.
-        budget_name: Optional. If provided, the account-wide result is filtered to this budget.
-        max_results: Maximum number of results to return. Defaults to 100.
+        budget_name: Optional. When provided, reads that one budget's actions directly.
+        max_results: Maximum number of results per page. Defaults to 100.
         account_id: Optional AWS account ID; retrieved automatically if not provided.
+        next_token: Optional pagination token from a previous response.
+        max_pages: Optional cap on how many pages to auto-paginate through.
 
     Returns:
         Dict containing the formatted action configuration.
@@ -131,7 +149,9 @@ async def budget_actions(
             account_id = await get_aws_account_id(ctx)
         await ctx.info(f'Using AWS Account ID: {account_id}')
 
-        return await describe_budget_actions(ctx, account_id, budget_name, max_results)
+        return await describe_budget_actions(
+            ctx, account_id, budget_name, max_results, next_token, max_pages
+        )
 
     except Exception as e:
         return await handle_aws_error(ctx, e, 'budget-actions', 'AWS Budgets')
@@ -139,28 +159,42 @@ async def budget_actions(
 
 @budget_server.tool(
     name='budget-notifications',
-    description="""Reads the alert thresholds (notifications) configured on an AWS Budget.
+    description="""Reads the alert thresholds (notifications) configured on AWS Budgets.
 
 A notification is an alert that fires when a budget crosses a threshold (e.g. 80% of the limit).
-Read-only; uses the DescribeNotificationsForBudget API, which is per-budget — `budget_name` is
-required (the AWS Budgets API has no account-scoped notifications read).
+Read-only.
+
+- Omit `budget_name` to audit every budget's notifications across the account
+  (DescribeBudgetNotificationsForAccount). Each returned notification carries its `budget_name`.
+- Pass `budget_name` to read one budget's notifications directly (DescribeNotificationsForBudget).
+
+Pagination: results are paginated. Use `max_results` to bound page size and `max_pages` to bound
+how many pages are fetched; a `next_token` in the response can be passed back to continue. Large
+responses are automatically offloaded to session SQL to save tokens.
 
 For a budget's spend-vs-limit status use the `budgets` tool; for its enforcement actions use
 `budget-actions`. The account ID is retrieved automatically or you may pass `account_id`.""",
 )
 async def budget_notifications(
     ctx: Context,
-    budget_name: str,
+    budget_name: Optional[str] = None,
     max_results: int = 100,
     account_id: Optional[str] = None,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Reads the notifications configured on a budget (DescribeNotificationsForBudget).
+    """Reads the notifications configured on AWS Budgets.
+
+    Routes by ``budget_name``: DescribeNotificationsForBudget when a name is given, otherwise
+    the account-wide DescribeBudgetNotificationsForAccount.
 
     Args:
         ctx: The MCP context object.
-        budget_name: The budget whose notifications to read. Required.
-        max_results: Maximum number of results to return. Defaults to 100.
+        budget_name: Optional. When provided, reads that one budget's notifications directly.
+        max_results: Maximum number of results per page. Defaults to 100.
         account_id: Optional AWS account ID; retrieved automatically if not provided.
+        next_token: Optional pagination token from a previous response.
+        max_pages: Optional cap on how many pages to auto-paginate through.
 
     Returns:
         Dict containing the formatted notification configuration.
@@ -170,14 +204,13 @@ async def budget_notifications(
             f'budget-notifications (budget_name={budget_name}, max_results={max_results})'
         )
 
-        if not budget_name:
-            raise ValueError('budget_name is required')
-
         if not account_id:
             account_id = await get_aws_account_id(ctx)
         await ctx.info(f'Using AWS Account ID: {account_id}')
 
-        return await describe_notifications_for_budget(ctx, account_id, budget_name, max_results)
+        return await describe_budget_notifications(
+            ctx, account_id, budget_name, max_results, next_token, max_pages
+        )
 
     except Exception as e:
         return await handle_aws_error(ctx, e, 'budget-notifications', 'AWS Budgets')
@@ -293,106 +326,132 @@ async def describe_budgets(
 
 
 async def describe_budget_actions(
-    ctx: Context, account_id: str, budget_name: Optional[str], max_results: int
+    ctx: Context,
+    account_id: str,
+    budget_name: Optional[str],
+    max_results: int,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Retrieves budget enforcement actions via DescribeBudgetActionsForAccount.
+    """Retrieves budget enforcement actions, routing by ``budget_name``.
 
-    Always calls the account-scoped API (one permission,
-    `budgets:DescribeBudgetActionsForAccount`, covers both the account-wide audit and a
-    single-budget lookup). If `budget_name` is provided, the account-wide result is filtered to
-    that budget client-side — the AWS API has no `BudgetName` parameter for the account call.
+    When ``budget_name`` is provided, calls the per-budget DescribeBudgetActionsForBudget
+    (authorized by ``budgets:DescribeBudgetActionsForBudget``); otherwise calls the account-wide
+    DescribeBudgetActionsForAccount (``budgets:DescribeBudgetActionsForAccount``). Both are
+    paginated via the shared helper, and a large response is offloaded to session SQL.
 
-    An empty `actions` list is a real answer (no actions configured), distinct from an error.
+    An empty ``actions`` list is a real answer (no actions configured), distinct from an error.
     """
     try:
         budgets_client = create_aws_client('budgets', region_name='us-east-1')
 
-        request_params: Dict[str, Any] = {'AccountId': account_id}
-        all_actions: List[Dict[str, Any]] = []
-        next_token = None
-        page_count = 0
-
-        while True:
-            page_count += 1
-            if next_token:
-                request_params['NextToken'] = next_token
-            # When filtering to one budget we cannot bound MaxResults by the filtered
-            # count, so page fully; otherwise stop once we have max_results.
-            if not budget_name:
-                remaining = max_results - len(all_actions)
-                if remaining <= 0:
-                    break
-                request_params['MaxResults'] = min(100, remaining)
-            else:
-                request_params['MaxResults'] = 100
-
-            await ctx.info(f'Fetching account budget actions page {page_count}')
-            response = budgets_client.describe_budget_actions_for_account(**request_params)
-            all_actions.extend(response.get('Actions', []))
-            next_token = response.get('NextToken')
-            if not next_token:
-                break
+        request_params: Dict[str, Any] = {
+            'AccountId': account_id,
+            'MaxResults': min(100, max_results),
+        }
+        if next_token:
+            request_params['NextToken'] = next_token
 
         if budget_name:
-            all_actions = [a for a in all_actions if a.get('BudgetName') == budget_name]
-            all_actions = all_actions[:max_results]
+            request_params['BudgetName'] = budget_name
+            all_actions, pagination = await paginate_aws_response(
+                ctx,
+                'DescribeBudgetActionsForBudget',
+                lambda **p: budgets_client.describe_budget_actions_for_budget(**p),
+                request_params,
+                'Actions',
+                max_pages=max_pages,
+            )
+        else:
+            all_actions, pagination = await paginate_aws_response(
+                ctx,
+                'DescribeBudgetActionsForAccount',
+                lambda **p: budgets_client.describe_budget_actions_for_account(**p),
+                request_params,
+                'Actions',
+                max_pages=max_pages,
+            )
 
         data: Dict[str, Any] = {
             'actions': [format_action(a) for a in all_actions],
             'total_count': len(all_actions),
             'account_id': account_id,
+            'pagination': pagination,
         }
         if budget_name:
             data['budget_name'] = budget_name
 
-        return format_response('success', data)
+        converted = await convert_response_if_needed(ctx, data, 'budget_actions')
+        return format_response('success', converted)
     except Exception as e:
         return await handle_aws_error(ctx, e, 'describe_budget_actions', 'AWS Budgets')
 
 
-async def describe_notifications_for_budget(
-    ctx: Context, account_id: str, budget_name: str, max_results: int
+async def describe_budget_notifications(
+    ctx: Context,
+    account_id: str,
+    budget_name: Optional[str],
+    max_results: int,
+    next_token: Optional[str] = None,
+    max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Retrieves the notifications configured on a budget (DescribeNotificationsForBudget).
+    """Retrieves budget notifications, routing by ``budget_name``.
 
-    Per-budget only — the AWS Budgets API has no account-scoped notifications read, so this
-    requires `budget_name`. Authorized by `budgets:ViewBudget`.
+    When ``budget_name`` is provided, calls the per-budget DescribeNotificationsForBudget;
+    otherwise calls the account-wide DescribeBudgetNotificationsForAccount, whose response nests
+    notifications under each budget. Both are paginated via the shared helper, and a large
+    response is offloaded to session SQL. Every returned notification carries its ``budget_name``.
     """
     try:
         budgets_client = create_aws_client('budgets', region_name='us-east-1')
 
-        request_params: Dict[str, Any] = {'AccountId': account_id, 'BudgetName': budget_name}
-        all_notifications: List[Dict[str, Any]] = []
-        next_token = None
-        page_count = 0
+        request_params: Dict[str, Any] = {
+            'AccountId': account_id,
+            'MaxResults': min(100, max_results),
+        }
+        if next_token:
+            request_params['NextToken'] = next_token
 
-        while True:
-            page_count += 1
-            if next_token:
-                request_params['NextToken'] = next_token
-            remaining = max_results - len(all_notifications)
-            if remaining <= 0:
-                break
-            request_params['MaxResults'] = min(100, remaining)
+        if budget_name:
+            request_params['BudgetName'] = budget_name
+            raw_notifications, pagination = await paginate_aws_response(
+                ctx,
+                'DescribeNotificationsForBudget',
+                lambda **p: budgets_client.describe_notifications_for_budget(**p),
+                request_params,
+                'Notifications',
+                max_pages=max_pages,
+            )
+            notifications = [format_notification(n, budget_name) for n in raw_notifications]
+        else:
+            per_budget, pagination = await paginate_aws_response(
+                ctx,
+                'DescribeBudgetNotificationsForAccount',
+                lambda **p: budgets_client.describe_budget_notifications_for_account(**p),
+                request_params,
+                'BudgetNotificationsForAccount',
+                max_pages=max_pages,
+            )
+            # Each entry groups one budget's notifications; flatten and stamp the budget name.
+            notifications = [
+                format_notification(n, entry.get('BudgetName'))
+                for entry in per_budget
+                for n in entry.get('Notifications', [])
+            ]
 
-            await ctx.info(f'Fetching notifications page {page_count}')
-            response = budgets_client.describe_notifications_for_budget(**request_params)
-            all_notifications.extend(response.get('Notifications', []))
-            next_token = response.get('NextToken')
-            if not next_token:
-                break
+        data: Dict[str, Any] = {
+            'notifications': notifications,
+            'total_count': len(notifications),
+            'account_id': account_id,
+            'pagination': pagination,
+        }
+        if budget_name:
+            data['budget_name'] = budget_name
 
-        return format_response(
-            'success',
-            {
-                'notifications': [format_notification(n) for n in all_notifications],
-                'total_count': len(all_notifications),
-                'budget_name': budget_name,
-                'account_id': account_id,
-            },
-        )
+        converted = await convert_response_if_needed(ctx, data, 'budget_notifications')
+        return format_response('success', converted)
     except Exception as e:
-        return await handle_aws_error(ctx, e, 'describe_notifications_for_budget', 'AWS Budgets')
+        return await handle_aws_error(ctx, e, 'describe_budget_notifications', 'AWS Budgets')
 
 
 # =============================================================================
@@ -583,12 +642,23 @@ def format_action_definition(definition: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def format_notification(notification: Dict[str, Any]) -> Dict[str, Any]:
-    """Formats a budget Notification object from the AWS API response."""
-    return {
+def format_notification(
+    notification: Dict[str, Any], budget_name: Optional[str] = None
+) -> Dict[str, Any]:
+    """Formats a budget Notification object from the AWS API response.
+
+    Args:
+        notification: The raw Notification object from the AWS API.
+        budget_name: The budget this notification belongs to. Stamped onto the result so a
+            flattened account-wide list stays attributable to its budget.
+    """
+    formatted = {
         'notification_type': notification.get('NotificationType'),
         'comparison_operator': notification.get('ComparisonOperator'),
         'threshold': notification.get('Threshold'),
         'threshold_type': notification.get('ThresholdType'),
         'notification_state': notification.get('NotificationState'),
     }
+    if budget_name is not None:
+        formatted['budget_name'] = budget_name
+    return formatted

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -357,6 +357,8 @@ def _get_specialized_converter(operation_name: str) -> Optional[str]:
         'cost_explorer_get_tags': 'tags',
         'cost_explorer_get_cost_categories': 'cost_categories',
         'aws_pricing_get_products': 'pricing_products',
+        'budget_actions': 'records',
+        'budget_notifications': 'records',
     }
 
     if operation_name in converters:

--- a/src/billing-cost-management-mcp-server/tests/tools/test_budget_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_budget_tools.py
@@ -556,7 +556,7 @@ from awslabs.billing_cost_management_mcp_server.tools.budget_tools import (  # n
     budget_actions,
     budget_notifications,
     describe_budget_actions,
-    describe_notifications_for_budget,
+    describe_budget_notifications,
     format_action,
     format_notification,
 )
@@ -583,6 +583,8 @@ class TestFormatAction:
                     'IamActionDefinition': {
                         'PolicyArn': 'arn:aws:iam::123456789012:policy/DenyExpensive',
                         'Roles': ['dev-role'],
+                        'Groups': ['dev-group'],
+                        'Users': ['dev-user'],
                     }
                 },
                 'Subscribers': [
@@ -599,6 +601,8 @@ class TestFormatAction:
             == 'arn:aws:iam::123456789012:policy/DenyExpensive'
         )
         assert formatted['definition']['iam_action_definition']['roles'] == ['dev-role']
+        assert formatted['definition']['iam_action_definition']['groups'] == ['dev-group']
+        assert formatted['definition']['iam_action_definition']['users'] == ['dev-user']
         assert formatted['action_threshold']['action_threshold_value'] == 80.0
         assert formatted['subscribers'][0]['address'].endswith(':t')
 
@@ -649,12 +653,12 @@ class TestFormatNotification:
 
 @pytest.mark.asyncio
 class TestBudgetActionsTool:
-    """The budget-actions tool — always account-scoped, filtered client-side by budget_name."""
+    """The budget-actions tool — routes by budget_name (ForBudget vs ForAccount)."""
 
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.get_aws_account_id')
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
     async def test_tool_resolves_account_and_audits(self, mock_create, mock_get_id, mock_context):
-        """The tool resolves the account ID then returns the account-wide action audit."""
+        """With no budget_name the tool resolves the account ID and audits account-wide."""
         mock_get_id.return_value = '123456789012'
         client = MagicMock()
         mock_create.return_value = client
@@ -665,6 +669,7 @@ class TestBudgetActionsTool:
         assert result['status'] == 'success'
         assert result['data']['actions'][0]['budget_name'] == 'b1'
         assert 'budget_name' not in result['data']
+        client.describe_budget_actions_for_budget.assert_not_called()
 
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
     async def test_audit_paginates_and_keeps_budget_name(self, mock_create, mock_context):
@@ -681,19 +686,20 @@ class TestBudgetActionsTool:
         assert client.describe_budget_actions_for_account.call_count == 2
 
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
-    async def test_single_budget_filters_account_result(self, mock_create, mock_context):
-        """Passing budget_name filters the account-wide result to that budget."""
+    async def test_single_budget_uses_per_budget_api(self, mock_create, mock_context):
+        """Passing budget_name calls DescribeBudgetActionsForBudget, not the account API."""
         client = MagicMock()
         mock_create.return_value = client
-        client.describe_budget_actions_for_account.return_value = {
-            'Actions': [
-                {'BudgetName': 'b1', 'ActionId': 'a1'},
-                {'BudgetName': 'b2', 'ActionId': 'a2'},
-            ]
+        client.describe_budget_actions_for_budget.return_value = {
+            'Actions': [{'BudgetName': 'b2', 'ActionId': 'a2'}]
         }
         result = await describe_budget_actions(mock_context, '123456789012', 'b2', 100)
         assert [a['budget_name'] for a in result['data']['actions']] == ['b2']
         assert result['data']['budget_name'] == 'b2'
+        # Routed to the per-budget API with the name bound; account API untouched.
+        client.describe_budget_actions_for_budget.assert_called()
+        assert client.describe_budget_actions_for_budget.call_args.kwargs['BudgetName'] == 'b2'
+        client.describe_budget_actions_for_account.assert_not_called()
 
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
     async def test_empty_actions_is_success_not_error(self, mock_create, mock_context):
@@ -705,21 +711,69 @@ class TestBudgetActionsTool:
         assert result['status'] == 'success'
         assert result['data']['actions'] == []
 
-
-@pytest.mark.asyncio
-class TestBudgetNotificationsTool:
-    """The budget-notifications tool — per-budget, budget_name required."""
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_api_error_returns_error_envelope(self, mock_create, mock_context):
+        """An API failure is surfaced as an error envelope, not a raised exception."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.side_effect = Exception('AccessDenied')
+        result = await describe_budget_actions(mock_context, '123456789012', None, 100)
+        assert result['status'] == 'error'
 
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.get_aws_account_id')
-    async def test_missing_budget_name_errors(self, mock_get_id, mock_context):
-        """An empty budget_name is rejected with an error envelope."""
-        mock_get_id.return_value = '123456789012'
-        result = await budget_notifications(mock_context, budget_name='')
+    async def test_entrypoint_error_is_handled(self, mock_get_id, mock_context):
+        """A failure resolving the account ID is caught by the tool entrypoint."""
+        mock_get_id.side_effect = Exception('sts down')
+        result = await budget_actions(mock_context)
         assert result['status'] == 'error'
 
     @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_next_token_is_passed_through(self, mock_create, mock_context):
+        """A caller-supplied next_token is forwarded to the account API request."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.return_value = {'Actions': []}
+        await describe_budget_actions(
+            mock_context, '123456789012', None, 100, next_token='tok', max_pages=1
+        )
+        assert client.describe_budget_actions_for_account.call_args.kwargs['NextToken'] == 'tok'
+
+
+@pytest.mark.asyncio
+class TestBudgetNotificationsTool:
+    """The budget-notifications tool — routes by budget_name (per-budget vs account-wide)."""
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.get_aws_account_id')
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_no_budget_name_audits_account_wide(
+        self, mock_create, mock_get_id, mock_context
+    ):
+        """With no budget_name the tool flattens DescribeBudgetNotificationsForAccount."""
+        mock_get_id.return_value = '123456789012'
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_notifications_for_account.return_value = {
+            'BudgetNotificationsForAccount': [
+                {
+                    'BudgetName': 'b1',
+                    'Notifications': [{'NotificationType': 'ACTUAL', 'Threshold': 80.0}],
+                },
+                {
+                    'BudgetName': 'b2',
+                    'Notifications': [{'NotificationType': 'FORECASTED', 'Threshold': 100.0}],
+                },
+            ]
+        }
+        result = await budget_notifications(mock_context)
+        assert result['status'] == 'success'
+        assert result['data']['total_count'] == 2
+        # Each flattened notification is stamped with its owning budget.
+        assert {n['budget_name'] for n in result['data']['notifications']} == {'b1', 'b2'}
+        client.describe_notifications_for_budget.assert_not_called()
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
     async def test_returns_formatted_notifications(self, mock_create, mock_context):
-        """Notifications are returned in the formatted (snake_case) shape."""
+        """Passing budget_name uses the per-budget API and stamps the budget name."""
         client = MagicMock()
         mock_create.return_value = client
         client.describe_notifications_for_budget.return_value = {
@@ -727,7 +781,36 @@ class TestBudgetNotificationsTool:
                 {'NotificationType': 'ACTUAL', 'Threshold': 80.0, 'ThresholdType': 'PERCENTAGE'}
             ]
         }
-        result = await describe_notifications_for_budget(mock_context, '123456789012', 'b1', 100)
+        result = await describe_budget_notifications(mock_context, '123456789012', 'b1', 100)
         assert result['status'] == 'success'
         assert result['data']['notifications'][0]['threshold'] == 80.0
+        assert result['data']['notifications'][0]['budget_name'] == 'b1'
         assert result['data']['total_count'] == 1
+        client.describe_budget_notifications_for_account.assert_not_called()
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_api_error_returns_error_envelope(self, mock_create, mock_context):
+        """An API failure is surfaced as an error envelope, not a raised exception."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_notifications_for_account.side_effect = Exception('AccessDenied')
+        result = await describe_budget_notifications(mock_context, '123456789012', None, 100)
+        assert result['status'] == 'error'
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.get_aws_account_id')
+    async def test_entrypoint_error_is_handled(self, mock_get_id, mock_context):
+        """A failure resolving the account ID is caught by the tool entrypoint."""
+        mock_get_id.side_effect = Exception('sts down')
+        result = await budget_notifications(mock_context)
+        assert result['status'] == 'error'
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_next_token_is_passed_through(self, mock_create, mock_context):
+        """A caller-supplied next_token is forwarded to the per-budget API request."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_notifications_for_budget.return_value = {'Notifications': []}
+        await describe_budget_notifications(
+            mock_context, '123456789012', 'b1', 100, next_token='tok', max_pages=1
+        )
+        assert client.describe_notifications_for_budget.call_args.kwargs['NextToken'] == 'tok'

--- a/src/billing-cost-management-mcp-server/tests/tools/test_budget_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_budget_tools.py
@@ -546,3 +546,188 @@ def test_budget_server_initialization():
     instructions = budget_server.instructions
     assert instructions is not None
     assert 'Tools for working with AWS Budgets API' in instructions if instructions else False
+
+
+# ---------------------------------------------------------------------------
+# budget-actions + budget-notifications tools
+# ---------------------------------------------------------------------------
+
+from awslabs.billing_cost_management_mcp_server.tools.budget_tools import (  # noqa: E402
+    budget_actions,
+    budget_notifications,
+    describe_budget_actions,
+    describe_notifications_for_budget,
+    format_action,
+    format_notification,
+)
+
+
+class TestFormatAction:
+    """Tests for format_action / format_action_definition."""
+
+    def test_iam_action_verbatim_identifiers(self):
+        """IAM action identifiers (policy ARN, execution role, roles) survive verbatim."""
+        formatted = format_action(
+            {
+                'ActionId': 'a-1',
+                'BudgetName': 'b1',
+                'ActionType': 'APPLY_IAM_POLICY',
+                'ApprovalModel': 'AUTOMATIC',
+                'ExecutionRoleArn': 'arn:aws:iam::123456789012:role/BudgetRole',
+                'Status': 'STANDBY',
+                'ActionThreshold': {
+                    'ActionThresholdValue': 80.0,
+                    'ActionThresholdType': 'PERCENTAGE',
+                },
+                'Definition': {
+                    'IamActionDefinition': {
+                        'PolicyArn': 'arn:aws:iam::123456789012:policy/DenyExpensive',
+                        'Roles': ['dev-role'],
+                    }
+                },
+                'Subscribers': [
+                    {'SubscriptionType': 'SNS', 'Address': 'arn:aws:sns:us-east-1:123456789012:t'}
+                ],
+            }
+        )
+        assert formatted['action_type'] == 'APPLY_IAM_POLICY'
+        assert formatted['approval_model'] == 'AUTOMATIC'
+        # Load-bearing identifiers must survive verbatim.
+        assert formatted['execution_role_arn'] == 'arn:aws:iam::123456789012:role/BudgetRole'
+        assert (
+            formatted['definition']['iam_action_definition']['policy_arn']
+            == 'arn:aws:iam::123456789012:policy/DenyExpensive'
+        )
+        assert formatted['definition']['iam_action_definition']['roles'] == ['dev-role']
+        assert formatted['action_threshold']['action_threshold_value'] == 80.0
+        assert formatted['subscribers'][0]['address'].endswith(':t')
+
+    def test_scp_and_ssm_definitions(self):
+        """SCP and SSM action definitions map to their snake_case sub-objects."""
+        scp = format_action(
+            {'Definition': {'ScpActionDefinition': {'PolicyId': 'p-abc', 'TargetIds': ['ou-1']}}}
+        )
+        assert scp['definition']['scp_action_definition']['policy_id'] == 'p-abc'
+        ssm = format_action(
+            {
+                'Definition': {
+                    'SsmActionDefinition': {
+                        'ActionSubType': 'STOP_EC2_INSTANCES',
+                        'InstanceIds': ['i-abc'],
+                        'Region': 'us-east-1',
+                    }
+                }
+            }
+        )
+        assert (
+            ssm['definition']['ssm_action_definition']['action_sub_type'] == 'STOP_EC2_INSTANCES'
+        )
+
+
+class TestFormatNotification:
+    """Tests for format_notification."""
+
+    def test_maps_fields(self):
+        """Notification fields map to their snake_case equivalents."""
+        n = format_notification(
+            {
+                'NotificationType': 'ACTUAL',
+                'ComparisonOperator': 'GREATER_THAN',
+                'Threshold': 80.0,
+                'ThresholdType': 'PERCENTAGE',
+                'NotificationState': 'ALARM',
+            }
+        )
+        assert n == {
+            'notification_type': 'ACTUAL',
+            'comparison_operator': 'GREATER_THAN',
+            'threshold': 80.0,
+            'threshold_type': 'PERCENTAGE',
+            'notification_state': 'ALARM',
+        }
+
+
+@pytest.mark.asyncio
+class TestBudgetActionsTool:
+    """The budget-actions tool — always account-scoped, filtered client-side by budget_name."""
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.get_aws_account_id')
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_tool_resolves_account_and_audits(self, mock_create, mock_get_id, mock_context):
+        """The tool resolves the account ID then returns the account-wide action audit."""
+        mock_get_id.return_value = '123456789012'
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.return_value = {
+            'Actions': [{'BudgetName': 'b1', 'ActionId': 'a1'}]
+        }
+        result = await budget_actions(mock_context)
+        assert result['status'] == 'success'
+        assert result['data']['actions'][0]['budget_name'] == 'b1'
+        assert 'budget_name' not in result['data']
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_audit_paginates_and_keeps_budget_name(self, mock_create, mock_context):
+        """The account audit paginates and preserves each action's budget name."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.side_effect = [
+            {'Actions': [{'BudgetName': 'b1', 'ActionId': 'a1'}], 'NextToken': 'tok'},
+            {'Actions': [{'BudgetName': 'b2', 'ActionId': 'a2'}]},
+        ]
+        result = await describe_budget_actions(mock_context, '123456789012', None, 100)
+        assert [a['budget_name'] for a in result['data']['actions']] == ['b1', 'b2']
+        assert result['data']['total_count'] == 2
+        assert client.describe_budget_actions_for_account.call_count == 2
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_single_budget_filters_account_result(self, mock_create, mock_context):
+        """Passing budget_name filters the account-wide result to that budget."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.return_value = {
+            'Actions': [
+                {'BudgetName': 'b1', 'ActionId': 'a1'},
+                {'BudgetName': 'b2', 'ActionId': 'a2'},
+            ]
+        }
+        result = await describe_budget_actions(mock_context, '123456789012', 'b2', 100)
+        assert [a['budget_name'] for a in result['data']['actions']] == ['b2']
+        assert result['data']['budget_name'] == 'b2'
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_empty_actions_is_success_not_error(self, mock_create, mock_context):
+        """A budget with no actions returns an empty list, not an error."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.return_value = {'Actions': []}
+        result = await describe_budget_actions(mock_context, '123456789012', None, 100)
+        assert result['status'] == 'success'
+        assert result['data']['actions'] == []
+
+
+@pytest.mark.asyncio
+class TestBudgetNotificationsTool:
+    """The budget-notifications tool — per-budget, budget_name required."""
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.get_aws_account_id')
+    async def test_missing_budget_name_errors(self, mock_get_id, mock_context):
+        """An empty budget_name is rejected with an error envelope."""
+        mock_get_id.return_value = '123456789012'
+        result = await budget_notifications(mock_context, budget_name='')
+        assert result['status'] == 'error'
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_returns_formatted_notifications(self, mock_create, mock_context):
+        """Notifications are returned in the formatted (snake_case) shape."""
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_notifications_for_budget.return_value = {
+            'Notifications': [
+                {'NotificationType': 'ACTUAL', 'Threshold': 80.0, 'ThresholdType': 'PERCENTAGE'}
+            ]
+        }
+        result = await describe_notifications_for_budget(mock_context, '123456789012', 'b1', 100)
+        assert result['status'] == 'success'
+        assert result['data']['notifications'][0]['threshold'] == 80.0
+        assert result['data']['total_count'] == 1

--- a/src/billing-cost-management-mcp-server/tests/tools/test_budget_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_budget_tools.py
@@ -738,6 +738,41 @@ class TestBudgetActionsTool:
         )
         assert client.describe_budget_actions_for_account.call_args.kwargs['NextToken'] == 'tok'
 
+    @patch('awslabs.billing_cost_management_mcp_server.utilities.sql_utils.get_db_connection')
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.utilities.sql_utils.should_convert_to_sql',
+        return_value=True,
+    )
+    @patch('awslabs.billing_cost_management_mcp_server.tools.budget_tools.create_aws_client')
+    async def test_large_response_offloads_to_sql_rows(
+        self, mock_create, _mock_should, mock_conn, mock_context
+    ):
+        """An oversized account audit offloads to SQL as one queryable row per action."""
+        import sqlite3
+
+        conn = sqlite3.connect(':memory:')
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS schema_info '
+            '(table_name TEXT PRIMARY KEY, created_at TEXT, operation TEXT, '
+            'query TEXT, row_count INTEGER)'
+        )
+        mock_conn.return_value = (conn, conn.cursor())
+
+        client = MagicMock()
+        mock_create.return_value = client
+        client.describe_budget_actions_for_account.return_value = {
+            'Actions': [
+                {'BudgetName': 'b1', 'ActionId': 'a1', 'Status': 'STANDBY'},
+                {'BudgetName': 'b2', 'ActionId': 'a2', 'Status': 'PENDING'},
+            ]
+        }
+        result = await describe_budget_actions(mock_context, '123456789012', None, 100)
+        assert result['status'] == 'success'
+        # Offloaded (not returned inline) as one row per action, with real columns.
+        assert result['data']['data_stored'] is True
+        assert result['data']['row_count'] == 2
+        assert 'action_id' in result['data']['schema']
+
 
 @pytest.mark.asyncio
 class TestBudgetNotificationsTool:

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
@@ -741,6 +741,15 @@ class TestConvertApiResponseToTableAdditional:
         )
         assert _get_specialized_converter('some_other_operation') is None
 
+    def test_specialized_converter_routes_budget_ops_to_records(self):
+        """Budget actions and notifications operations map to the 'records' converter."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _get_specialized_converter,
+        )
+
+        assert _get_specialized_converter('budget_actions') == 'records'
+        assert _get_specialized_converter('budget_notifications') == 'records'
+
     def test_record_columns_rejects_unsafe_identifiers(self):
         """Derived column names must be safe SQL identifiers (injection guard)."""
         from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import _record_columns


### PR DESCRIPTION
### Changes
  
Adds two read-only operations to the `budget` tool in the billing-cost-management-mcp-server:

  - **`budget-actions`** — retrieves budget actions via `DescribeBudgetActionsForAccount`. Always account-scoped; when a `budget_name` is provided, results are filtered client-side to that budget.
  - **`budget-notifications`** — retrieves notifications for a specific budget via `DescribeNotificationsForBudget` (`budget_name` required).

Both operations follow the existing MCP `{status, data}` response envelope and reuse the tool's established formatter conventions. Includes new test coverage; CHANGELOG updated.

### User experience
  
Before: agents could list budgets and their details, but had no way to surface the configured **actions** (e.g. IAM/SCP/target-policy responses) or **notification** thresholds attached to a budget without leaving the MCP tooling.
  
After: agents can retrieve budget actions (account-wide or filtered to one budget) and per-budget notifications directly through the `budget` tool, all read-only.

## Checklist
  
  * [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
  * [x] I have performed a self-review of this change
  * [x] Changes have been tested
  * [x] Changes are documented
  
Is this a breaking change? (N)

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).