### PR TITLE
fix(security-agent-mcp-server): enforce S3 bucket ownership to prevent bucket-squatting code leak

### DIFF
--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
@@ -19,6 +19,8 @@ import botocore.config
 import json
 import re
 from awslabs.security_agent_mcp_server import __version__
+from boto3.exceptions import S3UploadFailedError
+from botocore.exceptions import ClientError
 from typing import Any, Optional
 
 
@@ -36,6 +38,7 @@ class SecurityAgentClient:
     ):
         """Initialize SecurityAgent client."""
         self.region = region
+        self._cached_account_id: Optional[str] = None
         self._mcp_client_name = mcp_client_name
         self._mcp_client_version = mcp_client_version
         self._config = self._build_config(mcp_client_name, mcp_client_version)
@@ -72,6 +75,12 @@ class SecurityAgentClient:
     def _get_session(self):
         """Fresh session each call to pick up rotated credentials."""
         return boto3.Session(region_name=self.region)
+
+    def _account_id(self) -> str:
+        """Cache and return the caller's account ID for bucket-ownership guards."""
+        if self._cached_account_id is None:
+            self._cached_account_id = str(self.get_caller_identity()['Account'])
+        return self._cached_account_id
 
     def _client(self):
         """Get a fresh securityagent boto3 client with custom user-agent."""
@@ -327,6 +336,12 @@ class SecurityAgentClient:
         )
         return bucket_name
 
+    def verify_bucket_owner(self, bucket_name: str) -> None:
+        """Raise if the caller's account does not own the bucket (403 = squatted)."""
+        self._get_session().client('s3', config=self._config).head_bucket(
+            Bucket=bucket_name, ExpectedBucketOwner=self._account_id()
+        )
+
     def create_service_role(self, role_name: str, account_id: str, bucket_name: str) -> str:
         """Create IAM service role for Security Agent with S3 + CloudWatch Logs access."""
         iam = self._get_session().client('iam', config=self._config)
@@ -388,6 +403,18 @@ class SecurityAgentClient:
         return f'arn:aws:iam::{account_id}:role/{role_name}'
 
     def upload_to_s3(self, bucket: str, key: str, file_path: str) -> str:
-        """Upload a file to S3."""
-        self._get_session().client('s3', config=self._config).upload_file(file_path, bucket, key)
+        """Upload a file to S3, rejecting the write if the bucket is owned by another account."""
+        try:
+            self._get_session().client('s3', config=self._config).upload_file(
+                file_path,
+                bucket,
+                key,
+                ExtraArgs={'ExpectedBucketOwner': self._account_id()},
+            )
+        except S3UploadFailedError as e:
+            # Re-raise the underlying ClientError (e.g. 403) so callers can handle it.
+            cause = e.__cause__ or e.__context__
+            if isinstance(cause, ClientError):
+                raise cause
+            raise
         return f's3://{bucket}/{key}'

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/aws_client.py
@@ -39,6 +39,7 @@ class SecurityAgentClient:
         """Initialize SecurityAgent client."""
         self.region = region
         self._cached_account_id: Optional[str] = None
+        self._cached_account_key: Optional[str] = None
         self._mcp_client_name = mcp_client_name
         self._mcp_client_version = mcp_client_version
         self._config = self._build_config(mcp_client_name, mcp_client_version)
@@ -77,9 +78,15 @@ class SecurityAgentClient:
         return boto3.Session(region_name=self.region)
 
     def _account_id(self) -> str:
-        """Cache and return the caller's account ID for bucket-ownership guards."""
-        if self._cached_account_id is None:
-            self._cached_account_id = str(self.get_caller_identity()['Account'])
+        """Return the caller's account ID, cached per credential set."""
+        session = self._get_session()
+        creds = session.get_credentials()
+        key = creds.get_frozen_credentials().access_key if creds else None
+        if self._cached_account_id is None or self._cached_account_key != key:
+            self._cached_account_id = str(
+                session.client('sts', config=self._config).get_caller_identity()['Account']
+            )
+            self._cached_account_key = key
         return self._cached_account_id
 
     def _client(self):
@@ -413,8 +420,8 @@ class SecurityAgentClient:
             )
         except S3UploadFailedError as e:
             # Re-raise the underlying ClientError (e.g. 403) so callers can handle it.
-            cause = e.__cause__ or e.__context__
-            if isinstance(cause, ClientError):
-                raise cause
+            for cand in (e.__cause__, e.__context__):
+                if isinstance(cand, ClientError):
+                    raise cand
             raise
         return f's3://{bucket}/{key}'

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -52,7 +52,7 @@ _REMEDIATION = {
     'EntityAlreadyExistsException': 'The resource already exists; reuse it or pick a different name.',
     'ResourceNotFoundException': 'The resource does not exist or was deleted; run setup again.',
     'NoSuchEntity': 'The IAM resource does not exist; run setup again.',
-    'BucketAlreadyExists': 'The S3 bucket name is taken globally; pick a different name.',
+    'BucketAlreadyExists': 'SECURITY ALERT: this bucket name is owned by a different AWS account — possible squatting; investigate before retrying.',
     'BucketAlreadyOwnedByYou': 'You already own this bucket; reuse it.',
     'ValidationException': 'Request parameters were invalid; check the operation inputs.',
     'ThrottlingException': 'Request was throttled; retry with backoff.',
@@ -191,7 +191,7 @@ def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
     config_key = 's3_bucket' if kind == 'scans' else 'threat_model_s3_bucket'
     if config.get(config_key):
         return
-    account_id = _client.get_caller_identity()['Account']
+    account_id = _client._account_id()
     bucket = f'security-agent-{kind}-{account_id}-{_region}'
     try:
         _client.create_s3_bucket(bucket)
@@ -200,8 +200,19 @@ def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
         if e.response.get('Error', {}).get('Code') != 'BucketAlreadyOwnedByYou':
             raise
 
-    # Confirm ownership before trusting the bucket — 403 means it's squatted.
-    _client.verify_bucket_owner(bucket)
+    # Only 403 means squat; upload_to_s3 re-checks ownership so transient errors are safe to swallow.
+    try:
+        _client.verify_bucket_owner(bucket)
+    except ClientError as e:
+        err = e.response.get('Error', {}) if hasattr(e, 'response') else {}
+        code = err.get('Code')
+        status = (
+            e.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
+            if hasattr(e, 'response')
+            else None
+        )
+        if code in ('403', 'AccessDenied', 'Forbidden') or status == 403:
+            raise
 
     # Register bucket on agent space so the service can access it
     agent_space_id = config['agent_space_id']

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/server.py
@@ -196,8 +196,12 @@ def _ensure_s3_bucket(config: dict, kind: str = 'scans') -> None:
     try:
         _client.create_s3_bucket(bucket)
     except ClientError as e:
+        # Reuse only if we already own it; BucketAlreadyExists (squatted) stays fatal.
         if e.response.get('Error', {}).get('Code') != 'BucketAlreadyOwnedByYou':
             raise
+
+    # Confirm ownership before trusting the bucket — 403 means it's squatted.
+    _client.verify_bucket_owner(bucket)
 
     # Register bucket on agent space so the service can access it
     agent_space_id = config['agent_space_id']

--- a/src/security-agent-mcp-server/tests/test_aws_client.py
+++ b/src/security-agent-mcp-server/tests/test_aws_client.py
@@ -5,6 +5,8 @@
 
 import pytest
 from awslabs.security_agent_mcp_server.aws_client import SecurityAgentClient
+from boto3.exceptions import S3UploadFailedError
+from botocore.exceptions import ClientError
 from unittest.mock import MagicMock, patch
 
 
@@ -340,15 +342,94 @@ class TestSecurityAgentClient:
 
     @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
     def test_upload_to_s3(self, mock_boto3):
-        """upload_to_s3 returns the s3:// URL and calls boto3.upload_file."""
+        """upload_to_s3 returns the s3:// URL and passes ExpectedBucketOwner."""
         mock_s3 = MagicMock()
+        mock_s3.get_caller_identity.return_value = {'Account': '123456789012'}
         mock_boto3.Session.return_value.client.return_value = mock_s3
 
         client = SecurityAgentClient()
         url = client.upload_to_s3('bkt', 'k.zip', '/tmp/source.zip')
 
         assert url == 's3://bkt/k.zip'
-        mock_s3.upload_file.assert_called_once_with('/tmp/source.zip', 'bkt', 'k.zip')
+        mock_s3.upload_file.assert_called_once_with(
+            '/tmp/source.zip',
+            'bkt',
+            'k.zip',
+            ExtraArgs={'ExpectedBucketOwner': '123456789012'},
+        )
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_upload_to_s3_caches_account_id(self, mock_boto3):
+        """The account ID is resolved once and reused across uploads."""
+        mock_s3 = MagicMock()
+        mock_s3.get_caller_identity.return_value = {'Account': '123456789012'}
+        mock_boto3.Session.return_value.client.return_value = mock_s3
+
+        client = SecurityAgentClient()
+        client.upload_to_s3('bkt', 'a.zip', '/tmp/a.zip')
+        client.upload_to_s3('bkt', 'b.zip', '/tmp/b.zip')
+
+        # STS is only called once even though there were two uploads.
+        assert mock_s3.get_caller_identity.call_count == 1
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_verify_bucket_owner_passes_expected_owner(self, mock_boto3):
+        """verify_bucket_owner calls head_bucket with the caller's account ID."""
+        mock_s3 = MagicMock()
+        mock_s3.get_caller_identity.return_value = {'Account': '123456789012'}
+        mock_boto3.Session.return_value.client.return_value = mock_s3
+
+        client = SecurityAgentClient()
+        client.verify_bucket_owner('my-bucket')
+
+        mock_s3.head_bucket.assert_called_once_with(
+            Bucket='my-bucket', ExpectedBucketOwner='123456789012'
+        )
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_verify_bucket_owner_raises_on_403(self, mock_boto3):
+        """A squatted bucket (403 from head_bucket) propagates as a fatal error."""
+        mock_s3 = MagicMock()
+        mock_s3.get_caller_identity.return_value = {'Account': '123456789012'}
+        mock_s3.head_bucket.side_effect = ClientError(
+            {'Error': {'Code': '403', 'Message': 'Forbidden'}}, 'HeadBucket'
+        )
+        mock_boto3.Session.return_value.client.return_value = mock_s3
+
+        client = SecurityAgentClient()
+        with pytest.raises(ClientError):
+            client.verify_bucket_owner('squatted-bucket')
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_upload_to_s3_unwraps_client_error(self, mock_boto3):
+        """A 403 wrapped in S3UploadFailedError is re-raised as the underlying ClientError."""
+        mock_s3 = MagicMock()
+        mock_s3.get_caller_identity.return_value = {'Account': '123456789012'}
+        cause = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Forbidden'}}, 'PutObject'
+        )
+        # boto3's transfer manager chains via __context__ (implicit), not __cause__.
+        wrapper = S3UploadFailedError('failed: 403')
+        wrapper.__context__ = cause
+        mock_s3.upload_file.side_effect = wrapper
+        mock_boto3.Session.return_value.client.return_value = mock_s3
+
+        client = SecurityAgentClient()
+        with pytest.raises(ClientError) as exc_info:
+            client.upload_to_s3('squatted-bucket', 'k.zip', '/tmp/source.zip')
+        assert exc_info.value is cause
+
+    @patch('awslabs.security_agent_mcp_server.aws_client.boto3')
+    def test_upload_to_s3_reraises_unwrapped_wrapper(self, mock_boto3):
+        """A wrapper without a ClientError cause propagates unchanged, not silently swallowed."""
+        mock_s3 = MagicMock()
+        mock_s3.get_caller_identity.return_value = {'Account': '123456789012'}
+        mock_s3.upload_file.side_effect = S3UploadFailedError('disk full')
+        mock_boto3.Session.return_value.client.return_value = mock_s3
+
+        client = SecurityAgentClient()
+        with pytest.raises(S3UploadFailedError):
+            client.upload_to_s3('bkt', 'k.zip', '/tmp/source.zip')
 
 
 class TestDiffScanAndThreatModel:
@@ -529,5 +610,6 @@ class TestUserAgentInjection:
         mock_session = MagicMock()
         mock_boto3.Session.return_value = mock_session
         client = SecurityAgentClient(region='us-east-1')
+        client._cached_account_id = '123456789012'
         client.upload_to_s3('bucket', 'key', '/path/to/file')
         mock_session.client.assert_called_once_with('s3', config=client._config)

--- a/src/security-agent-mcp-server/tests/test_aws_client.py
+++ b/src/security-agent-mcp-server/tests/test_aws_client.py
@@ -611,5 +611,8 @@ class TestUserAgentInjection:
         mock_boto3.Session.return_value = mock_session
         client = SecurityAgentClient(region='us-east-1')
         client._cached_account_id = '123456789012'
+        client._cached_account_key = (
+            mock_session.get_credentials().get_frozen_credentials().access_key
+        )
         client.upload_to_s3('bucket', 'key', '/path/to/file')
         mock_session.client.assert_called_once_with('s3', config=client._config)

--- a/src/security-agent-mcp-server/tests/test_server.py
+++ b/src/security-agent-mcp-server/tests/test_server.py
@@ -1116,6 +1116,42 @@ class TestEnsureS3BucketHelper:
         with pytest.raises(ClientError):
             _ensure_s3_bucket(config, 'scans')
 
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    def test_squatted_bucket_aborts_before_caching(self, mock_state, mock_client):
+        """A 403 from the ownership assertion aborts without registering or caching the bucket."""
+        from awslabs.security_agent_mcp_server.server import _ensure_s3_bucket
+        from botocore.exceptions import ClientError
+
+        config = {'agent_space_id': 'as-1'}
+        mock_client.get_caller_identity.return_value = {'Account': '123'}
+        mock_client.create_s3_bucket.side_effect = ClientError(
+            {'Error': {'Code': 'BucketAlreadyExists', 'Message': 'taken'}}, 'CreateBucket'
+        )
+        with pytest.raises(ClientError):
+            _ensure_s3_bucket(config, 'scans')
+        mock_client.verify_bucket_owner.assert_not_called()
+        mock_client.update_agent_space.assert_not_called()
+        mock_state.update_config.assert_not_called()
+
+    @patch('awslabs.security_agent_mcp_server.server._client')
+    @patch('awslabs.security_agent_mcp_server.server._state')
+    def test_ownership_assertion_403_aborts(self, mock_state, mock_client):
+        """If create succeeds but ownership can't be confirmed, abort without caching."""
+        from awslabs.security_agent_mcp_server.server import _ensure_s3_bucket
+        from botocore.exceptions import ClientError
+
+        config = {'agent_space_id': 'as-1'}
+        mock_client.get_caller_identity.return_value = {'Account': '123'}
+        mock_client.create_s3_bucket.return_value = 'security-agent-scans-123-us-east-1'
+        mock_client.verify_bucket_owner.side_effect = ClientError(
+            {'Error': {'Code': '403', 'Message': 'Forbidden'}}, 'HeadBucket'
+        )
+        with pytest.raises(ClientError):
+            _ensure_s3_bucket(config, 'scans')
+        mock_client.update_agent_space.assert_not_called()
+        mock_state.update_config.assert_not_called()
+
 
 class TestValidatePath:
     """Tests for _validate_path workspace boundary enforcement."""


### PR DESCRIPTION
## Summary

  The Security Agent MCP server creates per-account S3 buckets with **deterministic
  names** (`security-agent-<kind>-<account>-<region>`) to hold uploaded source before
  a scan. Because S3's namespace is global, any account can pre-register that
  predictable name. Creation only guarded against `BucketAlreadyOwnedByYou`, so a
  bucket pre-created by *another* account (`BucketAlreadyExists`) was silently reused,
  and `upload_to_s3` wrote the caller's source code into it — **leaking code to an
  attacker-controlled bucket**.

  ## Changes
  
  - **`verify_bucket_owner()`** — `head_bucket` with `ExpectedBucketOwner`; a 403 on a
    foreign-owned bucket is fatal.
  - **`_ensure_s3_bucket`** — `BucketAlreadyExists` now propagates (only
    `BucketAlreadyOwnedByYou` is reused), and ownership is confirmed **before** the
    bucket is registered on the agent space or cached in config.
  - **`upload_to_s3`** — passes `ExpectedBucketOwner` so every write is rejected if the
    bucket isn't owned by the caller. Also unwraps boto3's `S3UploadFailedError` to
    re-raise the underlying `ClientError`, so the existing `ClientError` handlers in the
    scanner/server surface the structured error contract instead of a raw traceback.
  - Caller account ID is resolved once via STS and cached.
  
  ## User experience
  
  - **Before:** if an attacker pre-created the predictable bucket name, the victim's scan
    silently uploaded source into the attacker's bucket — no error, no signal.
  - **After:** the scan aborts with a clear ownership error (403) and uploads nothing.
    Legitimate users who already own the bucket are unaffected — it's reused as before.

  ## Testing
  
  Verified end-to-end against **real S3** with a two-account squat PoC:
  
  | Path | Result |
  |---|---|
  | Attacker squats `security-agent-scans-<victim>-<region>` | attacker owns it |
  | **Before fix** — raw `upload_file`, no owner check | ⚠️  upload succeeds → victim source lands in attacker bucket |
  | **After fix** — `upload_to_s3` (`ExpectedBucketOwner`) | ✅ 403, nothing written |
  | **After fix** — `create_s3_bucket` guard | ✅ `BucketAlreadyExists` → abort |
  | **After fix** — `verify_bucket_owner` guard | ✅ 403 → ownership check fails |

  Unit tests cover the pass path, the 403 squat path at the upload and ensure-bucket
  layers, the `S3UploadFailedError` unwrap, and that a squatted bucket is never
  registered or cached.

  ## Checklist

  - [x] I have performed a self-review of this change
  - [x] Changes have been tested (unit + real-S3 two-account PoC)
  - [x] Changes are documented (docstrings/comments on the new guards)
  
  **Is this a breaking change?** N

  ## Acknowledgment

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

