### PR TITLE
fix(scripts): narrow package-name false-positive filter (#2656)

### DIFF
--- a/scripts/test_verify_package_name.py
+++ b/scripts/test_verify_package_name.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for verify_package_name.py's README reference filtering.
+
+Regression coverage for https://github.com/awslabs/mcp/issues/2656: the script
+used to hardcode a list of "safe" prefixes (asset/model/property/hierarchy) to
+skip when filtering `word@something` false positives, which would have hidden
+a real package reference such as ``asset-manager@latest`` had one ever been
+added. The replacement filters on whether the text after ``@`` looks like a
+version identifier instead of matching a fixed word list.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from verify_package_name import find_package_references_in_readme
+
+
+class TestFindPackageReferencesInReadme(unittest.TestCase):
+    """Tests for find_package_references_in_readme."""
+
+    def _refs(self, content: str):
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.md', delete=False, encoding='utf-8'
+        ) as f:
+            f.write(content)
+            path = Path(f.name)
+        try:
+            return [ref for ref, _ in find_package_references_in_readme(path)]
+        finally:
+            path.unlink()
+
+    def test_code_example_with_invalid_placeholder_is_filtered(self):
+        """Doc code examples like create_asset("asset@invalid", ...) are not package refs."""
+        content = 'create_asset("asset@invalid", "model-id")  # Fails: invalid characters\n'
+        self.assertNotIn('asset@invalid', self._refs(content))
+
+    def test_previously_hardcoded_prefixes_no_longer_hide_real_packages(self):
+        """A real package starting with a formerly-hardcoded prefix must be detected."""
+        content = '"mcpServers": {"x": {"command": "uvx", "args": ["asset-manager@latest"]}}\n'
+        self.assertIn('asset-manager@latest', self._refs(content))
+
+    def test_bare_numeric_version_is_kept(self):
+        """A short numeric version tag (no dot) is still recognized as a package ref."""
+        content = '"model-toolkit@2" is referenced here\n'
+        self.assertIn('model-toolkit@2', self._refs(content))
+
+    def test_non_version_suffix_is_filtered_regardless_of_prefix(self):
+        """Any word@non-version token is filtered, not just the old hardcoded words."""
+        content = 'create_model("model@bad-input")\n'
+        self.assertNotIn('model@bad-input', self._refs(content))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test_verify_package_name.py
+++ b/scripts/test_verify_package_name.py
@@ -14,12 +14,21 @@
 # limitations under the License.
 """Tests for verify_package_name.py's README reference filtering.
 
-Regression coverage for https://github.com/awslabs/mcp/issues/2656: the script
-used to hardcode a list of "safe" prefixes (asset/model/property/hierarchy) to
-skip when filtering `word@something` false positives, which would have hidden
-a real package reference such as ``asset-manager@latest`` had one ever been
-added. The replacement filters on whether the text after ``@`` looks like a
-version identifier instead of matching a fixed word list.
+Regression coverage for https://github.com/awslabs/mcp/issues/2656.
+
+The old filter matched on `ref.split('@')[0].lower() in ['asset', 'model',
+'property', 'hierarchy']` (an exact-equality check on the whole prefix, not a
+`startswith` check). That meant a compound name like `asset-manager@latest`
+was never affected by the old exclusion (its prefix is `"asset-manager"`,
+which is not in the list) -- the old code already detected it correctly. The
+only real gap was a package literally named `asset`, `model`, `property`, or
+`hierarchy` (exact match) that had a valid version, e.g. `asset@latest`,
+which the old code silently hid.
+
+The replacement drops the word list and instead matches the single known
+code-sample false positive (`asset@invalid`, from the SiteWise README's
+``create_asset("asset@invalid", "model-id")`` input-validation example) by
+its exact literal value.
 """
 
 import tempfile
@@ -42,25 +51,35 @@ class TestFindPackageReferencesInReadme(unittest.TestCase):
         finally:
             path.unlink()
 
-    def test_code_example_with_invalid_placeholder_is_filtered(self):
-        """Doc code examples like create_asset("asset@invalid", ...) are not package refs."""
+    def test_known_sitewise_false_positive_is_filtered(self):
+        """The documented create_asset("asset@invalid", ...) sample is not a package ref."""
         content = 'create_asset("asset@invalid", "model-id")  # Fails: invalid characters\n'
         self.assertNotIn('asset@invalid', self._refs(content))
 
-    def test_previously_hardcoded_prefixes_no_longer_hide_real_packages(self):
-        """A real package starting with a formerly-hardcoded prefix must be detected."""
+    def test_exact_word_package_with_valid_version_is_now_detected(self):
+        """A package literally named one of the old hardcoded words must be detected.
+
+        Discriminates old vs. new behavior: the old code excluded ANY
+        `asset@<version>` reference by exact-prefix match, even with a
+        legitimate version. This is the actual bug the old code had.
+        """
+        content = '"mcpServers": {"x": {"command": "uvx", "args": ["asset@latest"]}}\n'
+        self.assertIn('asset@latest', self._refs(content))
+
+    def test_exact_word_package_property_with_numeric_version_is_now_detected(self):
+        """Same discrimination as above for another formerly-hardcoded word."""
+        content = '"property@2" is referenced here\n'
+        self.assertIn('property@2', self._refs(content))
+
+    def test_compound_name_starting_with_hardcoded_word_was_always_detected(self):
+        """Sanity check: compound names were never broken by the old exact-match list.
+
+        This does NOT discriminate old vs. new (both detect it), but guards
+        against a future regression that reintroduces prefix/startswith
+        matching instead of exact matching.
+        """
         content = '"mcpServers": {"x": {"command": "uvx", "args": ["asset-manager@latest"]}}\n'
         self.assertIn('asset-manager@latest', self._refs(content))
-
-    def test_bare_numeric_version_is_kept(self):
-        """A short numeric version tag (no dot) is still recognized as a package ref."""
-        content = '"model-toolkit@2" is referenced here\n'
-        self.assertIn('model-toolkit@2', self._refs(content))
-
-    def test_non_version_suffix_is_filtered_regardless_of_prefix(self):
-        """Any word@non-version token is filtered, not just the old hardcoded words."""
-        content = 'create_model("model@bad-input")\n'
-        self.assertNotIn('model@bad-input', self._refs(content))
 
 
 if __name__ == '__main__':

--- a/scripts/verify_package_name.py
+++ b/scripts/verify_package_name.py
@@ -215,16 +215,14 @@ def find_package_references_in_readme(
         # But allow package names that look like they could be valid (contain hyphens)
         if '.' not in ref and '@' not in ref and '-' not in ref:
             continue
-        # Skip common false positives in code examples (word@something where the
-        # part after '@' doesn't look like a real package version, e.g. Python
-        # snippets such as create_asset("asset@invalid", ...) that demonstrate
-        # input validation rather than an installation instruction).
-        # A real package reference's version is either the literal "latest" or
-        # a numeric tag such as "1", "2.0", or "v1.2".
-        if '@' in ref and '.' not in ref:
-            version_part = ref.split('@', 1)[1]
-            if not re.fullmatch(r'latest|v?\d+(\.\d+)*', version_part, re.IGNORECASE):
-                continue
+        # Skip the one known code-sample false positive in the SiteWise README:
+        # create_asset("asset@invalid", "model-id") demonstrates input
+        # validation, not an install instruction. Matched by exact literal
+        # value (not a word-prefix list) so we don't silently hide real
+        # "word@version" package references that happen to start with the
+        # same word (e.g. a hypothetical "asset-manager@latest").
+        if ref.lower() == 'asset@invalid':
+            continue
         filtered_references.append((ref, line_num))
 
     return filtered_references

--- a/scripts/verify_package_name.py
+++ b/scripts/verify_package_name.py
@@ -215,12 +215,15 @@ def find_package_references_in_readme(
         # But allow package names that look like they could be valid (contain hyphens)
         if '.' not in ref and '@' not in ref and '-' not in ref:
             continue
-        # Skip common false positives in code examples (word@something where word is not a package name)
+        # Skip common false positives in code examples (word@something where the
+        # part after '@' doesn't look like a real package version, e.g. Python
+        # snippets such as create_asset("asset@invalid", ...) that demonstrate
+        # input validation rather than an installation instruction).
+        # A real package reference's version is either the literal "latest" or
+        # a numeric tag such as "1", "2.0", or "v1.2".
         if '@' in ref and '.' not in ref:
-            # Extract the part before @
-            prefix = ref.split('@')[0].lower()
-            # Different scenarios where the prefix is not a package name
-            if prefix in ['asset', 'model', 'property', 'hierarchy']:
+            version_part = ref.split('@', 1)[1]
+            if not re.fullmatch(r'latest|v?\d+(\.\d+)*', version_part, re.IGNORECASE):
                 continue
         filtered_references.append((ref, line_num))
 


### PR DESCRIPTION
Fixes #2656

## Summary

### Corrected root cause

The original version of this PR claimed the old exclusion list (`asset`, `model`, `property`, `hierarchy`) was a prefix match that would hide real packages like a hypothetical `asset-manager`. That claim was wrong, and I want to be upfront about it rather than leave a misleading description in place.

The old code in `scripts/verify_package_name.py` did this:

```python
prefix = ref.split('@')[0].lower()
if prefix in ['asset', 'model', 'property', 'hierarchy']:
    continue
```

`prefix` is the *whole* string before `@`, and the check is exact **equality**, not `startswith`. So for `asset-manager@latest`, `prefix == "asset-manager"`, which was never in the list — the old code already detected that reference correctly. I verified this by running the old code (from the commit before this PR) against a synthetic `asset-manager@latest` reference and confirmed it was kept, not filtered.

The actual (much narrower) gap: a package literally named exactly `asset`, `model`, `property`, or `hierarchy` with a valid version (e.g. `asset@latest`) was incorrectly hidden, because the exact-match list didn't distinguish "the real SiteWise doc false positive" from "a real package that happens to share one of those exact names." I confirmed this is the only gap by scanning all 59 existing package READMEs for anything matching the old exclusion condition — the *only* hit anywhere in the repo is the one documented case: `create_asset("asset@invalid", "model-id")` in `src/aws-iot-sitewise-mcp-server/README.md` (and its docusaurus translation).

### What changed (this revision)

Instead of a version-format regex (which was in an earlier version of this PR and has its own problem — see below), the fix now replaces the four-word exact-match exclusion with an exact match on the one real documented false positive:

```python
if ref.lower() == 'asset@invalid':
    continue
```

This is deliberately narrow: it fixes the real gap (a literally-named `asset`/`model`/`property`/`hierarchy` package with a real version is no longer silently hidden) without inventing a new failure mode.

**Why not a version-format regex?** An earlier version of this fix filtered any `word@version` where `version` didn't match `latest|v?\d+(\.\d+)*`. That would have introduced a *new* false-exclusion class: legitimate npm/package dist-tags like `pkg@beta`, `pkg@next`, `pkg@stable`, `pkg@dev`, or `pkg@rc1` don't match that pattern and would have been silently filtered — the same "hides a valid package reference" failure mode issue #2656 was about, just via a different mechanism. I verified the current (exact-match) version does **not** exhibit this: all of `pkg@beta`, `pkg@next`, `pkg@stable`, `pkg@dev`, `pkg@rc1` are correctly kept.

### Verification

- Ran `scripts/verify_package_name.py` against all 59 existing `src/*` packages with both the old (pre-PR) and new logic — identical pass/fail results, no regression.
- The 4 tests in `scripts/test_verify_package_name.py` all pass against the new code. Two of them (`asset@latest`, `property@2`) **fail against the old code** — confirmed by running the same test file against a copy of the pre-PR `verify_package_name.py` — so they actually discriminate old vs. new behavior, unlike the previous test set (which passed unchanged against the old code and proved nothing).

### Known test-coverage gap (disclosed, not hidden)

`scripts/test_verify_package_name.py` is **not currently run by CI**. `.github/workflows/python.yml` only runs `scripts/verify_package_name.py` itself (the CLI, against each package's README) as part of the per-package build matrix — it does not run any `scripts/test_*.py` unit tests, there's no root `pyproject.toml`/`pytest.ini`/`tox.ini` that would auto-discover it, and there is no existing precedent in this repo for testing files under `scripts/`. I did not invent a new CI job for this, since that's a broader change than this fix needs and there's no established pattern to follow. Flagging it here rather than claiming coverage CI doesn't actually enforce — happy to wire it in if a maintainer points at the preferred convention.

### User experience

No behavior change for any of the 59 existing packages (verified before/after — all pass, see above). The only behavior change is for a hypothetical future package literally named `asset`, `model`, `property`, or `hierarchy` with a real version — it will now be checked instead of silently skipped.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): N

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
