### PR TITLE
fix(elasticache-mcp-server): guard against IndexError when a cluster has no cache nodes yet

### DIFF
--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/cc/connect.py
@@ -61,6 +61,8 @@ async def _configure_security_groups(
         raise ValueError(f'No security groups found for cache cluster {cache_cluster_id}')
 
     # Get cache cluster port
+    if not cache_cluster.get('CacheNodes'):
+        raise ValueError(f'No cache nodes found for cluster {cache_cluster_id}')
     cache_port = cache_cluster['CacheNodes'][0]['Endpoint']['Port']
 
     # Get EC2 instance details

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/connect.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/tools/rg/connect.py
@@ -92,6 +92,8 @@ async def _configure_security_groups(
         )
 
     # Get cache cluster port from first node
+    if not first_cluster.get('CacheNodes'):
+        raise ValueError(f'No cache nodes found for cluster {first_cluster_id}')
     cache_port = first_cluster['CacheNodes'][0]['Endpoint']['Port']
 
     # Get cache cluster security groups from all member clusters

--- a/src/elasticache-mcp-server/tests/tools/cc/test_connect.py
+++ b/src/elasticache-mcp-server/tests/tools/cc/test_connect.py
@@ -200,7 +200,9 @@ async def test_configure_security_groups_no_cache_nodes():
             }
         ]
     }
-
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-1234'}]
+    }
     with pytest.raises(ValueError) as exc_info:
         await _configure_security_groups('cluster-1', 'i-1234', mock_ec2, mock_elasticache)
 

--- a/src/elasticache-mcp-server/tests/tools/cc/test_connect.py
+++ b/src/elasticache-mcp-server/tests/tools/cc/test_connect.py
@@ -186,6 +186,28 @@ async def test_configure_security_groups_vpc_mismatch():
 
 
 @pytest.mark.asyncio
+async def test_configure_security_groups_no_cache_nodes():
+    """Test that a cluster with no cache nodes yet (still provisioning) raises ValueError, not IndexError."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+                'SecurityGroups': [{'SecurityGroupId': 'sg-cache'}],
+                'CacheNodes': [],
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        await _configure_security_groups('cluster-1', 'i-1234', mock_ec2, mock_elasticache)
+
+    assert 'No cache nodes found for cluster cluster-1' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_connect_jump_host_cc_success():
     """Test successful jump host connection."""
     with patch(

--- a/src/elasticache-mcp-server/tests/tools/rg/test_connect.py
+++ b/src/elasticache-mcp-server/tests/tools/rg/test_connect.py
@@ -137,6 +137,42 @@ async def test_configure_security_groups_vpc_mismatch():
 
 
 @pytest.mark.asyncio
+async def test_configure_security_groups_no_cache_nodes():
+    """Test that a replication group whose first cluster has no cache nodes yet (still provisioning) raises ValueError, not IndexError."""
+    mock_ec2 = MagicMock()
+    mock_elasticache = MagicMock()
+
+    mock_elasticache.describe_replication_groups.return_value = {
+        'ReplicationGroups': [{'MemberClusters': ['cluster-1']}]
+    }
+    mock_elasticache.describe_cache_clusters.return_value = {
+        'CacheClusters': [
+            {
+                'CacheSubnetGroupName': 'subnet-group-1',
+                'CacheNodes': [],
+            }
+        ]
+    }
+    mock_elasticache.describe_cache_subnet_groups.return_value = {
+        'CacheSubnetGroups': [{'VpcId': 'vpc-123'}]
+    }
+    mock_ec2.describe_instances.return_value = {
+        'Reservations': [
+            {'Instances': [{'VpcId': 'vpc-123', 'SecurityGroups': [{'GroupId': 'sg-instance'}]}]}
+        ]
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        await _configure_security_groups(
+            'rg-test',
+            'i-123',
+            ec2_client=mock_ec2,
+            elasticache_client=mock_elasticache,
+        )
+    assert 'No cache nodes found for cluster cluster-1' in str(excinfo.value)
+
+
+@pytest.mark.asyncio
 async def test_connect_jump_host_rg_success():
     """Test successful jump host connection."""
     mock_ec2 = MagicMock()


### PR DESCRIPTION
`_configure_security_groups()` in both `cc/connect.py` and `rg/connect.py` indexes `CacheNodes[0]` unconditionally to get the cache port. A cluster that's still provisioning has an empty `CacheNodes` list, so this raises a bare `IndexError` instead of a clear error.

Both files already guard this exact case elsewhere — `cc/connect.py`'s own `get_ssh_tunnel_command_cc()` checks `if not cache_cluster.get("CacheNodes")` a few functions away — this just applies the same guard consistently to `_configure_security_groups()` in both files.

Added a regression test to each of the existing `test_connect.py` files, following the same mock setup already used by the neighboring VPC-mismatch tests. Confirmed both fail with the original `IndexError` on unpatched code and pass after the fix. `ruff check`/`ruff format`/`pyright` all clean on the changed files.