### PR TITLE
fix(billing-cost-management-mcp-server): block ATTACH DATABASE in session-sql

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py
@@ -118,6 +118,25 @@ def cleanup_session_db() -> None:
             logger.warning(f'Failed to remove session database: {str(e)}')
 
 
+def _session_authorizer(action, arg1, arg2, db_name, trigger_name):
+    """SQLite authorizer callback: deny cross-DB attach/detach.
+
+    Belt-and-suspenders with the regex blacklist in
+    :func:`validate_sql_query`. The regex catches the query text
+    before SQLite parses it; this authorizer catches every SQL parser
+    action the connection actually attempts, including anything the
+    regex filter might miss (comment tricks, whitespace variants,
+    dynamic SQL from triggers, etc.).
+
+    Any ATTACH/DETACH DATABASE attempt returns ``SQLITE_DENY``; every
+    other action returns ``SQLITE_OK`` so the session tool retains
+    full read/write access to its own database.
+    """
+    if action == sqlite3.SQLITE_ATTACH or action == sqlite3.SQLITE_DETACH:
+        return sqlite3.SQLITE_DENY
+    return sqlite3.SQLITE_OK
+
+
 def get_db_connection() -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
     """Get a connection to the session database.
 
@@ -133,6 +152,12 @@ def get_db_connection() -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
     conn = sqlite3.connect(db_path)
     conn.execute('PRAGMA journal_mode=WAL')
     conn.execute(f'PRAGMA busy_timeout={BUSY_TIMEOUT_MS}')
+    # Install the engine-level authorizer AFTER PRAGMA setup — the
+    # authorizer denies ATTACH/DETACH but SQLITE_PRAGMA is separately
+    # gated, so setup pragmas above still run. Every subsequent call
+    # through this connection (including anything from the
+    # session-sql tool) is guarded. See _session_authorizer.
+    conn.set_authorizer(_session_authorizer)
     cursor = conn.cursor()
 
     # Create schema_info table to track created tables if it doesn't exist
@@ -294,6 +319,17 @@ def validate_sql_query(query: str) -> bool:
         r'\bDELETE\b.*\bFROM\b',
         r'\bTRUNCATE\b.*\bTABLE\b',
         r'\bALTER\b.*\bTABLE\b',
+        # ATTACH / DETACH must NOT be allowed on the session
+        # connection. ATTACH DATABASE lets a caller mount any SQLite
+        # file readable by the process (browser cookie stores,
+        # credential DBs, other files under the same user) as an
+        # alias inside the session, and then read its contents back
+        # via SELECT. The engine-level `set_authorizer` on the
+        # session connection is the primary defense; this regex is
+        # the first-line filter that gives callers a clear error
+        # message.
+        r'\bATTACH\b',
+        r'\bDETACH\b',
         r'\bEXEC\b',
         r'\bSYSTEM\b',
         r';.*\b',

--- a/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
+++ b/src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py
@@ -1066,6 +1066,128 @@ class TestValidateSqlQuery:
         with pytest.raises(ValueError, match='Query contains potentially harmful operations'):
             validate_sql_query('SELECT * FROM users; DROP TABLE users')
 
+    def test_validate_sql_query_dangerous_attach_database(self):
+        """ATTACH DATABASE must be rejected.
+
+        Without this rejection, an attacker (or a prompt-injected
+        agent) can attach any SQLite file readable by the process
+        and read it back via subsequent SELECTs — a filter bypass
+        that the blacklist previously missed.
+        """
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            validate_sql_query,
+        )
+
+        with pytest.raises(ValueError, match='Query contains potentially harmful operations'):
+            validate_sql_query("ATTACH DATABASE '/tmp/victim.db' AS victim_db")
+
+    def test_validate_sql_query_dangerous_attach_lowercase(self):
+        """Case-insensitive: ATTACH must be rejected regardless of case."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            validate_sql_query,
+        )
+
+        with pytest.raises(ValueError, match='Query contains potentially harmful operations'):
+            validate_sql_query("attach database '/tmp/victim.db' as victim_db")
+
+    def test_validate_sql_query_dangerous_detach(self):
+        """Symmetric case: DETACH is rejected too."""
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            validate_sql_query,
+        )
+
+        with pytest.raises(ValueError, match='Query contains potentially harmful operations'):
+            validate_sql_query('DETACH DATABASE victim_db')
+
+
+class TestSessionAuthorizer:
+    """Engine-level defense against ATTACH DATABASE.
+
+    The authorizer is the second line of defense behind the regex
+    blacklist in ``validate_sql_query``. Even if the query text were
+    to slip past the blacklist (comment tricks, whitespace variants,
+    dynamic SQL from a trigger), the SQLite parser calls the
+    authorizer for every operation the query would perform. ATTACH
+    returns SQLITE_DENY here, so the connection refuses to mount any
+    external database file.
+    """
+
+    def test_authorizer_denies_attach(self, tmp_path):
+        """A connection with the authorizer refuses ATTACH DATABASE."""
+        import sqlite3
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _session_authorizer,
+        )
+
+        conn = sqlite3.connect(':memory:')
+        conn.set_authorizer(_session_authorizer)
+
+        victim = tmp_path / 'victim.db'
+        # Populate the victim DB with something that would be visible
+        # if ATTACH succeeded — the assertion is that ATTACH raises,
+        # not that this data is or isn't readable.
+        sqlite3.connect(str(victim)).execute(
+            'CREATE TABLE secrets (v TEXT)',
+        )
+
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute(f"ATTACH DATABASE '{victim}' AS victim")
+
+    def test_authorizer_denies_detach(self):
+        """The authorizer refuses DETACH as well (symmetric coverage)."""
+        import sqlite3
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _session_authorizer,
+        )
+
+        conn = sqlite3.connect(':memory:')
+        conn.set_authorizer(_session_authorizer)
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute('DETACH DATABASE anything')
+
+    def test_authorizer_allows_normal_select(self):
+        """Normal SELECT/INSERT/CREATE operations still work.
+
+        The authorizer only denies ATTACH/DETACH; everything else
+        returns SQLITE_OK, so the session tool retains full
+        read/write access to its own database.
+        """
+        import sqlite3
+        from awslabs.billing_cost_management_mcp_server.utilities.sql_utils import (
+            _session_authorizer,
+        )
+
+        conn = sqlite3.connect(':memory:')
+        conn.set_authorizer(_session_authorizer)
+        conn.execute('CREATE TABLE t (a INTEGER, b TEXT)')
+        conn.execute("INSERT INTO t VALUES (1, 'hello'), (2, 'world')")
+        rows = list(conn.execute('SELECT a, b FROM t ORDER BY a'))
+        assert rows == [(1, 'hello'), (2, 'world')]
+
+    def test_get_db_connection_installs_authorizer(self, tmp_path, monkeypatch):
+        """The session connection factory installs the authorizer.
+
+        Guarantees the tool-facing code path is guarded end-to-end
+        rather than relying on callers to remember to attach the
+        authorizer themselves.
+        """
+        import sqlite3
+        from awslabs.billing_cost_management_mcp_server.utilities import sql_utils
+
+        # Isolate the session DB in a tmpdir so this test doesn't
+        # pollute the shared session location.
+        session_db = tmp_path / 'session.db'
+        monkeypatch.setattr(sql_utils, 'get_session_db_path', lambda: str(session_db))
+
+        conn, cursor = sql_utils.get_db_connection()
+        try:
+            victim = tmp_path / 'victim.db'
+            sqlite3.connect(str(victim)).execute('CREATE TABLE secrets (v TEXT)')
+            with pytest.raises(sqlite3.DatabaseError):
+                cursor.execute(f"ATTACH DATABASE '{victim}' AS victim")
+        finally:
+            conn.close()
+
 
 class TestGetSpecializedConverter:
     """Test _get_specialized_converter function."""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes: reported via AWS security disclosure. `session-sql` blacklist bypass via SQLite `ATTACH DATABASE`.

## Summary

### Changes

The `session-sql` tool's query filter (`validate_sql_query` in `src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/sql_utils.py`) uses a regex blacklist that omits SQLite's `ATTACH DATABASE` statement. A caller — including a prompt-injected agent — can therefore mount any SQLite file readable by the MCP server process (browser cookie stores, credential databases, other files under the same user account, etc.) as an alias inside the session, and then read its contents back through subsequent `SELECT`s in the tool's JSON response.

This PR closes the bypass with two complementary defenses in `sql_utils.py`:

1. **Blacklist update.** Add `\bATTACH\b` and `\bDETACH\b` to `dangerous_patterns` in `validate_sql_query`. First-line filter; rejects the query text with a clear error message before it ever reaches SQLite.

2. **Engine-level authorizer.** Install `sqlite3.Connection.set_authorizer()` on every session connection returned by `get_db_connection()`. The authorizer returns `SQLITE_DENY` for `SQLITE_ATTACH` / `SQLITE_DETACH` and `SQLITE_OK` for every other action. Catches anything a text filter might miss (comment tricks, whitespace variants, dynamic SQL from triggers).

The two are deliberately complementary — even if a caller crafts a query that slips past the regex, SQLite's parser calls the authorizer for every operation the query would perform, and ATTACH is refused there too.

### User experience

**Before:** `session-sql` accepts `ATTACH DATABASE '<path>' AS victim_db` and subsequent `SELECT * FROM victim_db.<table>` returns the attached database's contents in the tool's JSON response.

```python
# Reproduction (before this change):
await session_sql(ctx, "ATTACH DATABASE '/home/user/.mozilla/firefox/.../cookies.sqlite' AS victim")
await session_sql(ctx, "SELECT * FROM victim.moz_cookies")
# → { "status": "success", "columns": [...], "rows": [<all cookie rows>] }
```

**After:** the tool refuses the ATTACH statement at both the filter and the SQLite engine level.

```python
await session_sql(ctx, "ATTACH DATABASE '/tmp/anything.db' AS victim")
# → ValueError: Query contains potentially harmful operations: ATTACH DATABASE '/tmp/anything.db' AS victim
```

No functional regression: `session-sql`'s legitimate use case is a single per-session database. The full test suite passes (1245 tests, of which 7 are new regression tests introduced by this PR). A grep confirms zero call sites of `ATTACH`/`DETACH` in `src/billing-cost-management-mcp-server/awslabs/` or `src/billing-cost-management-mcp-server/tests/` outside these new tests.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? **No.** The blocked statement (`ATTACH DATABASE`) is not used by any production code path in the package, and the authorizer explicitly allows every other action.

**RFC issue number**: n/a (security fix)

Checklist:

* [ ] Migration process documented — n/a, no migration required
* [ ] Implement warnings (if it can live side by side) — n/a, the behavior being removed is not documented or supported

## Tests

New tests in `src/billing-cost-management-mcp-server/tests/utilities/test_sql_utils.py`:

- `TestValidateSqlQuery`:
  - `test_validate_sql_query_dangerous_attach_database` — regex rejects `ATTACH DATABASE`.
  - `test_validate_sql_query_dangerous_attach_lowercase` — case-insensitive.
  - `test_validate_sql_query_dangerous_detach` — symmetric coverage for `DETACH`.
- `TestSessionAuthorizer`:
  - `test_authorizer_denies_attach` — engine-level deny on ATTACH.
  - `test_authorizer_denies_detach` — engine-level deny on DETACH.
  - `test_authorizer_allows_normal_select` — proves regular `CREATE`/`INSERT`/`SELECT` still work.
  - `test_get_db_connection_installs_authorizer` — end-to-end guard via the factory.

```
$ uv run pytest -q
1245 passed in 21.06s
```

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
