### PR TITLE
feat(billing-cost-management): add Savings Plans management tools

### DIFF
--- a/src/billing-cost-management-mcp-server/README.md
+++ b/src/billing-cost-management-mcp-server/README.md
@@ -25,7 +25,11 @@ MCP server for accessing AWS Billing and Cost Management capabilities.
 ### Savings Plans and Reserved Instanaces
 
 - **Reserved Instance planning**: Analyze RI coverage and receive purchase recommendations
-- **Savings Plans guidance**: Get personalized Savings Plans recommendations based on usage patterns
+- **Savings Plans performance**: Analyze how much eligible spend existing plans cover and how much of their commitment is consumed over a lookback window
+- **Savings Plans inventory**: Describe the plans an account owns with their state, term, payment option, commitment, and expiry, including the queued, returned, and payment-failed plans that Cost Explorer does not report
+- **Savings Plans rates and offerings**: Look up the rates locked in on plans already owned, and the offerings available to purchase with their rates, to compare terms and payment options against real numbers
+- **Savings Plans recommendations**: Get personalized purchase recommendations based on usage patterns, the hourly data-points behind a recommendation, and the history of when recommendations were generated
+- **Savings Plans purchase analysis**: Retrieve the projected cost, coverage, and utilization of a planned purchase from a Purchase Analyzer analysis, and list the analyses an account has run
 
 ### S3 Storage Lens Analysis
 
@@ -210,6 +214,10 @@ Cost Explorer:
 - ce:GetSavingsPlansCoverage
 - ce:GetSavingsPlansUtilizationDetails
 - ce:GetSavingsPlansPurchaseRecommendation
+- ce:GetSavingsPlanPurchaseRecommendationDetails
+- ce:ListSavingsPlansPurchaseRecommendationGeneration
+- ce:GetCommitmentPurchaseAnalysis
+- ce:ListCommitmentPurchaseAnalyses
 - ce:GetCostAndUsageComparisons
 - ce:GetCostComparisonDrivers
 - ce:GetAnomalies
@@ -221,6 +229,12 @@ Cost Explorer:
 - ce:GetUsageForecast
 - ce:GetTags
 - ce:GetCostCategories
+
+Savings Plans:
+- savingsplans:DescribeSavingsPlans
+- savingsplans:DescribeSavingsPlanRates
+- savingsplans:DescribeSavingsPlansOfferings
+- savingsplans:DescribeSavingsPlansOfferingRates
 
 Cost Allocation Tags:
 - ce:ListCostAllocationTags

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/server.py
@@ -77,8 +77,17 @@ from awslabs.billing_cost_management_mcp_server.tools.recommendation_details_too
 from awslabs.billing_cost_management_mcp_server.tools.ri_performance_tools import (
     ri_performance_server,
 )
+from awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools import (
+    sp_explorer_server,
+)
 from awslabs.billing_cost_management_mcp_server.tools.sp_performance_tools import (
     sp_performance_server,
+)
+from awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools import (
+    sp_purchase_analyzer_server,
+)
+from awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools import (
+    sp_recommendation_server,
 )
 from awslabs.billing_cost_management_mcp_server.tools.storage_lens_tools import storage_lens_server
 from awslabs.billing_cost_management_mcp_server.tools.unified_sql_tools import unified_sql_server
@@ -158,6 +167,9 @@ TOOLS:
 - rec-details: Get enhanced cost optimization recommendations
 - ri-performance: Analyze Reserved Instance coverage and utilization
 - sp-performance: Analyze Savings Plans coverage and utilization
+- sp-explorer: Describe the Savings Plans an account owns, including queued, returned, and payment-failed plans that Cost Explorer does not report, plus rates on owned plans and the offerings available to purchase
+- sp-recommendation: Get Savings Plans purchase recommendations, the hourly data-points behind one, and the recommendation generation history
+- sp-purchase-analyzer: Read the projected cost, coverage, and utilization of a planned purchase from a Purchase Analyzer analysis that was already run
 - session-sql: Execute SQL queries on the session database
 - billing-conductor: AWS Billing Conductor tools for AWS Proforma billing (billing groups and associated accounts and cost reports, pricing rules/plans, custom line items)
 - billing-view: AWS Billing View tools for managing and querying billing views (get-billing-view, list-billing-views, list-source-views-for-billing-view, get-resource-policy)
@@ -219,6 +231,9 @@ def setup():
     mcp.mount(recommendation_details_server)
     mcp.mount(ri_performance_server)
     mcp.mount(sp_performance_server)
+    mcp.mount(sp_explorer_server)
+    mcp.mount(sp_recommendation_server)
+    mcp.mount(sp_purchase_analyzer_server)
     mcp.mount(unified_sql_server)
     mcp.mount(billing_conductor_server)
     mcp.mount(bvs_server)
@@ -249,6 +264,9 @@ def setup():
         'rec-details',
         'ri-performance',
         'sp-performance',
+        'sp-explorer',
+        'sp-recommendation',
+        'sp-purchase-analyzer',
         'session-sql',
         'list-billing-groups',
         'list-billing-group-cost-reports',

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_operations.py
@@ -267,6 +267,7 @@ async def get_dimension_values(
     next_token: Optional[str] = None,
     max_pages: Optional[int] = None,
     billing_view_arn: Optional[str] = None,
+    context: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Get available dimension values.
 
@@ -283,6 +284,8 @@ async def get_dimension_values(
         max_pages: Maximum number of pages to fetch
         billing_view_arn: Optional ARN of a billing view to scope the query.
             If not provided, defaults to the account's primary billing view.
+        context: The context for the call, which can be COST_AND_USAGE, RESERVATIONS, or
+            SAVINGS_PLANS. The default is COST_AND_USAGE. The context scopes which values come back.
 
     Returns:
         Dimension values response
@@ -312,6 +315,9 @@ async def get_dimension_values(
 
         if billing_view_arn:
             request_params['BillingViewArn'] = billing_view_arn
+
+        if context:
+            request_params['Context'] = context
 
         # Handle pagination
         if next_token or max_pages:

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/cost_explorer_tools.py
@@ -170,6 +170,7 @@ async def cost_explorer(
     tag_key: Optional[str] = None,
     cost_category_name: Optional[str] = None,
     billing_view_arn: Optional[str] = None,
+    context: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Main entry point for Cost Explorer operations.
 
@@ -195,6 +196,8 @@ async def cost_explorer(
         tag_key: Tag key to get values for
         cost_category_name: Cost category to get values for
         billing_view_arn: Optional ARN of a billing view to scope the query
+        context: The context for (getDimensionValues), which can be COST_AND_USAGE (the default),
+            RESERVATIONS, or SAVINGS_PLANS. SAVINGS_PLANS scopes values to the plans an account owns.
 
     Returns:
         Response from the operation handler
@@ -267,6 +270,7 @@ async def cost_explorer(
                 next_token,
                 max_pages,
                 billing_view_arn,
+                context,
             )
 
         elif operation == 'getCostForecast':

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/sp_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/sp_explorer_tools.py
@@ -1,0 +1,541 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Savings Plans inventory and offering tools for the AWS Billing and Cost Management MCP server."""
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from ..utilities.logging_utils import get_context_logger
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, List, Optional
+
+
+sp_explorer_server = FastMCP(
+    name='sp-explorer-tools',
+    instructions='Tools for working with the AWS Savings Plans inventory and offering APIs',
+)
+
+
+@sp_explorer_server.tool(
+    name='sp-explorer',
+    description="""Tool that describes Savings Plans inventory and purchasable offerings.
+
+This tool provides visibility into what an account already owns and what it can buy through four
+operations:
+
+1. describe_savings_plans: The plans the account owns, with state, term, payment option, and
+   expiry. Pass states to scope the result.
+2. describe_savings_plan_rates: The rates on one Savings Plan the customer already owns.
+3. describe_savings_plans_offerings: The offerings available to purchase.
+4. describe_savings_plans_offering_rates: The rates for offerings available to purchase.
+
+USE THIS TOOL FOR:
+- **What plans an account owns** — including plans in the queued, returned, and payment-failed
+  states, which Cost Explorer does not report on
+- **When a plan expires or can still be returned** — the end and returnableUntil fields
+- **The rates locked in on an existing plan**
+- **What is available to purchase and at what rate** — to compare the rate one plan type, term, and
+  payment option gets against another for the same usage
+
+DO NOT USE THIS TOOL FOR:
+- Coverage or utilization of existing plans, which is sp-performance
+- Recommended savings plans to purchase, which is sp-recommendation
+
+Tags come back on each plan in describe_savings_plans, so there is no separate tag operation.
+
+IMPORTANT: the vocabulary here differs from Cost Explorer's, so values carried over from a Cost
+Explorer response or recommendation will be rejected. See the individual parameter descriptions.""",
+)
+async def sp_explorer(
+    ctx: Context,
+    operation: str,
+    savings_plan_arns: Optional[List[str]] = None,
+    savings_plan_ids: Optional[List[str]] = None,
+    states: Optional[List[str]] = None,
+    savings_plan_id: Optional[str] = None,
+    offering_ids: Optional[List[str]] = None,
+    payment_options: Optional[List[str]] = None,
+    plan_types: Optional[List[str]] = None,
+    product_type: Optional[str] = None,
+    products: Optional[List[str]] = None,
+    durations: Optional[List[int]] = None,
+    currencies: Optional[List[str]] = None,
+    descriptions: Optional[List[str]] = None,
+    service_codes: Optional[List[str]] = None,
+    usage_types: Optional[List[str]] = None,
+    operations: Optional[List[str]] = None,
+    filters: Optional[List[Dict[str, Any]]] = None,
+    next_token: Optional[str] = None,
+    max_results: Optional[int] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Tool that describes Savings Plans inventory and purchasable offerings.
+
+    Args:
+        ctx: The MCP context object
+        operation: The operation to perform: 'describe_savings_plans', 'describe_savings_plan_rates', 'describe_savings_plans_offerings', or 'describe_savings_plans_offering_rates'
+        savings_plan_arns: The Savings Plan ARNs to describe as a list.
+        savings_plan_ids: The Savings Plan IDs to describe as a list.
+        states: The current states of the Savings Plans as a list. One or more of
+            payment-pending, payment-failed, active, retired, queued, queued-deleted,
+            pending-return, and returned. Omitting it returns every state, which for a mature
+            account means mostly retired plans.
+        savings_plan_id: The ID of the Savings Plan to describe rates for. Required for
+            describe_savings_plan_rates.
+        offering_ids: The IDs of the offerings as a list. Used by both offering
+            operations.
+        payment_options: The payment options as a list. One or more of 'No Upfront',
+            'Partial Upfront', and 'All Upfront' — note the spaces. Used by both offering
+            operations.
+        plan_types: The plan types as a list. One or more of Compute, EC2Instance,
+            SageMaker, and Database. Used by both offering operations.
+        product_type: The product type — EC2, Fargate, Lambda, SageMaker, RDS, DSQL, DynamoDB,
+            ElastiCache, DocDB, Neptune, Timestream, Keyspaces, DMS, or OpenSearch. Used by
+            describe_savings_plans_offerings.
+        products: The products as a list, from the same set as product_type. Used by
+            describe_savings_plans_offering_rates.
+        durations: The durations, in seconds as a list. A one-year term is 31536000
+            and a three-year term is 94608000.
+        currencies: The currencies as a list. One or more of CNY, USD, and EUR.
+        descriptions: The descriptions as a list.
+        service_codes: The service codes as a list. For
+            describe_savings_plans_offering_rates these are AmazonEC2, AmazonECS, AmazonEKS,
+            AWSLambda, AmazonSageMaker, AmazonRDS, AuroraDSQL, AmazonDynamoDB, AmazonElastiCache,
+            AmazonDocDB, AmazonNeptune, AmazonTimestream, AmazonMCS, AWSDatabaseMigrationSvc, and
+            AmazonES.
+        usage_types: The usage types as a list.
+        operations: The operations as a list.
+        filters: The filters as a list of {"name": ..., "values": [...]} objects. The
+            accepted names differ per operation: describe_savings_plans takes region,
+            ec2-instance-family, commitment, upfront, term, savings-plan-type, payment-option,
+            start, end, and instance-family; describe_savings_plan_rates takes region, instanceType,
+            productDescription, tenancy, productType, serviceCode, usageType, and operation;
+            describe_savings_plans_offerings takes region and instanceFamily; and
+            describe_savings_plans_offering_rates takes region, instanceFamily, instanceType,
+            productDescription, tenancy, and productId.
+        next_token: The token for the next page of results. Paging is handled for you, so this is
+            only needed to resume from a token a previous call returned.
+        max_results: The maximum number of results to return with a single call.
+        max_pages: The maximum number of pages to fetch. Omitting it fetches every page.
+
+    Returns:
+        Dict containing the Savings Plans inventory, rates, or offerings
+    """
+    try:
+        await ctx.info(f'Savings Plans explorer operation: {operation}')
+
+        # Initialize Savings Plans client using shared utility
+        sp_client = create_aws_client('savingsplans', region_name='us-east-1')
+
+        if operation == 'describe_savings_plans':
+            return await describe_savings_plans(
+                ctx,
+                sp_client,
+                savings_plan_arns,
+                savings_plan_ids,
+                states,
+                filters,
+                next_token,
+                max_results,
+                max_pages,
+            )
+        elif operation == 'describe_savings_plan_rates':
+            return await describe_savings_plan_rates(
+                ctx, sp_client, savings_plan_id, filters, next_token, max_results, max_pages
+            )
+        elif operation == 'describe_savings_plans_offerings':
+            return await describe_savings_plans_offerings(
+                ctx,
+                sp_client,
+                offering_ids,
+                payment_options,
+                product_type,
+                plan_types,
+                durations,
+                currencies,
+                descriptions,
+                service_codes,
+                usage_types,
+                operations,
+                filters,
+                next_token,
+                max_results,
+                max_pages,
+            )
+        elif operation == 'describe_savings_plans_offering_rates':
+            return await describe_savings_plans_offering_rates(
+                ctx,
+                sp_client,
+                offering_ids,
+                payment_options,
+                plan_types,
+                products,
+                service_codes,
+                usage_types,
+                operations,
+                filters,
+                next_token,
+                max_results,
+                max_pages,
+            )
+        else:
+            return format_response(
+                'error',
+                {},
+                f'Unsupported operation: {operation}. Use '
+                "'describe_savings_plans', 'describe_savings_plan_rates', "
+                "'describe_savings_plans_offerings', or "
+                "'describe_savings_plans_offering_rates'.",
+            )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'sp_explorer', 'Savings Plans')
+
+
+async def describe_savings_plans(
+    ctx: Context,
+    sp_client: Any,
+    savings_plan_arns: Optional[List[str]],
+    savings_plan_ids: Optional[List[str]],
+    states: Optional[List[str]],
+    filters: Optional[List[Dict[str, Any]]],
+    next_token: Optional[str],
+    max_results: Optional[int],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Describes the specified Savings Plans.
+
+    Args:
+        ctx: The MCP context
+        sp_client: Savings Plans client
+        savings_plan_arns: The Savings Plan ARNs as a list.
+        savings_plan_ids: The Savings Plan IDs as a list.
+        states: The current states of the Savings Plans as a list.
+        filters: The filters as a list.
+        next_token: The token for the next page of results.
+        max_results: The maximum number of results to return with a single call.
+        max_pages: The maximum number of pages to fetch. None fetches every page.
+
+    Returns:
+        Dict containing the Savings Plans
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info(f'Describing Savings Plans with states {states}')
+
+        # Create request parameters
+        request_params: dict = {}
+
+        # Add optional parameters if provided
+        if savings_plan_arns:
+            request_params['savingsPlanArns'] = savings_plan_arns
+        if savings_plan_ids:
+            request_params['savingsPlanIds'] = savings_plan_ids
+        if states:
+            request_params['states'] = states
+        if filters:
+            request_params['filters'] = filters
+        if next_token:
+            request_params['nextToken'] = next_token
+        if max_results:
+            request_params['maxResults'] = int(max_results)
+
+        all_plans, pagination_metadata = await paginate_aws_response(
+            ctx=ctx,
+            operation_name='DescribeSavingsPlans',
+            api_function=sp_client.describe_savings_plans,
+            request_params=request_params,
+            result_key='savingsPlans',
+            token_param='nextToken',
+            token_key='nextToken',
+            max_pages=max_pages,
+        )
+
+        return format_response(
+            'success',
+            {'savingsPlans': all_plans, 'pagination': pagination_metadata},
+        )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'describe_savings_plans', 'Savings Plans')
+
+
+async def describe_savings_plan_rates(
+    ctx: Context,
+    sp_client: Any,
+    savings_plan_id: Optional[str],
+    filters: Optional[List[Dict[str, Any]]],
+    next_token: Optional[str],
+    max_results: Optional[int],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Describes the rates for a specific, existing Savings Plan.
+
+    Args:
+        ctx: The MCP context
+        sp_client: Savings Plans client
+        savings_plan_id: The ID of the Savings Plan.
+        filters: The filters as a list.
+        next_token: The token for the next page of results.
+        max_results: The maximum number of results to return with a single call.
+        max_pages: The maximum number of pages to fetch. None fetches every page.
+
+    Returns:
+        Dict containing the Savings Plan rates
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info(f'Describing rates for Savings Plan {savings_plan_id}')
+
+        # Create request parameters
+        request_params: dict = {'savingsPlanId': savings_plan_id}
+
+        # Add optional parameters if provided
+        if filters:
+            request_params['filters'] = filters
+        if next_token:
+            request_params['nextToken'] = next_token
+        if max_results:
+            request_params['maxResults'] = int(max_results)
+
+        all_rates, pagination_metadata = await paginate_aws_response(
+            ctx=ctx,
+            operation_name='DescribeSavingsPlanRates',
+            api_function=sp_client.describe_savings_plan_rates,
+            request_params=request_params,
+            result_key='searchResults',
+            token_param='nextToken',
+            token_key='nextToken',
+            max_pages=max_pages,
+        )
+
+        # savingsPlanId is echoed at the top level of each page. Carry it through
+        # so the merged result still says which plan these rates belong to.
+        return format_response(
+            'success',
+            {
+                'savingsPlanId': savings_plan_id,
+                'searchResults': all_rates,
+                'pagination': pagination_metadata,
+            },
+        )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'describe_savings_plan_rates', 'Savings Plans')
+
+
+async def describe_savings_plans_offerings(
+    ctx: Context,
+    sp_client: Any,
+    offering_ids: Optional[List[str]],
+    payment_options: Optional[List[str]],
+    product_type: Optional[str],
+    plan_types: Optional[List[str]],
+    durations: Optional[List[int]],
+    currencies: Optional[List[str]],
+    descriptions: Optional[List[str]],
+    service_codes: Optional[List[str]],
+    usage_types: Optional[List[str]],
+    operations: Optional[List[str]],
+    filters: Optional[List[Dict[str, Any]]],
+    next_token: Optional[str],
+    max_results: Optional[int],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Describes the offerings for the specified Savings Plans.
+
+    Args:
+        ctx: The MCP context
+        sp_client: Savings Plans client
+        offering_ids: The IDs of the offerings as a list.
+        payment_options: The payment options as a list.
+        product_type: The product type.
+        plan_types: The plan types as a list.
+        durations: The durations, in seconds as a list.
+        currencies: The currencies as a list.
+        descriptions: The descriptions as a list.
+        service_codes: The service codes as a list.
+        usage_types: The usage types as a list.
+        operations: The operations as a list.
+        filters: The filters as a list.
+        next_token: The token for the next page of results.
+        max_results: The maximum number of results to return with a single call.
+        max_pages: The maximum number of pages to fetch. None fetches every page.
+
+    Returns:
+        Dict containing the Savings Plans offerings
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info('Describing Savings Plans offerings')
+
+        # Create request parameters
+        request_params: dict = {}
+
+        # Add optional parameters if provided
+        if offering_ids:
+            request_params['offeringIds'] = offering_ids
+        if payment_options:
+            request_params['paymentOptions'] = payment_options
+        if product_type:
+            request_params['productType'] = product_type
+        if plan_types:
+            request_params['planTypes'] = plan_types
+        if durations:
+            request_params['durations'] = durations
+        if currencies:
+            request_params['currencies'] = currencies
+        if descriptions:
+            request_params['descriptions'] = descriptions
+        if service_codes:
+            request_params['serviceCodes'] = service_codes
+        if usage_types:
+            request_params['usageTypes'] = usage_types
+        if operations:
+            request_params['operations'] = operations
+        if filters:
+            request_params['filters'] = filters
+        if next_token:
+            request_params['nextToken'] = next_token
+        if max_results:
+            request_params['maxResults'] = int(max_results)
+
+        # The offering catalog runs to thousands of entries for an unfiltered
+        # query. Page through it here: the token key is lowercase `nextToken` on
+        # this service and `NextToken` or `NextPageToken` on Cost Explorer, and a
+        # caller that threads the wrong one silently re-reads the first page.
+        all_offerings, pagination_metadata = await paginate_aws_response(
+            ctx=ctx,
+            operation_name='DescribeSavingsPlansOfferings',
+            api_function=sp_client.describe_savings_plans_offerings,
+            request_params=request_params,
+            result_key='searchResults',
+            token_param='nextToken',
+            token_key='nextToken',
+            max_pages=max_pages,
+        )
+
+        return format_response(
+            'success',
+            {'searchResults': all_offerings, 'pagination': pagination_metadata},
+        )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'describe_savings_plans_offerings', 'Savings Plans')
+
+
+async def describe_savings_plans_offering_rates(
+    ctx: Context,
+    sp_client: Any,
+    offering_ids: Optional[List[str]],
+    payment_options: Optional[List[str]],
+    plan_types: Optional[List[str]],
+    products: Optional[List[str]],
+    service_codes: Optional[List[str]],
+    usage_types: Optional[List[str]],
+    operations: Optional[List[str]],
+    filters: Optional[List[Dict[str, Any]]],
+    next_token: Optional[str],
+    max_results: Optional[int],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Describes the offering rates for Savings Plans you might want to purchase.
+
+    Args:
+        ctx: The MCP context
+        sp_client: Savings Plans client
+        offering_ids: The IDs of the offerings as a list.
+        payment_options: The payment options as a list.
+        plan_types: The plan types as a list.
+        products: The products as a list.
+        service_codes: The service codes as a list.
+        usage_types: The usage types as a list.
+        operations: The operations as a list.
+        filters: The filters as a list.
+        next_token: The token for the next page of results.
+        max_results: The maximum number of results to return with a single call.
+        max_pages: The maximum number of pages to fetch. None fetches every page.
+
+    Returns:
+        Dict containing the Savings Plans offering rates
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info('Describing Savings Plans offering rates')
+
+        # Create request parameters
+        request_params: dict = {}
+
+        # Add optional parameters if provided
+        # This API prefixes three fields that describe_savings_plans_offerings leaves bare. The
+        # tool exposes one parameter name for each concept and maps it here, so a caller does not
+        # have to know which spelling a given operation wants.
+        if offering_ids:
+            request_params['savingsPlanOfferingIds'] = offering_ids
+        if payment_options:
+            request_params['savingsPlanPaymentOptions'] = payment_options
+        if plan_types:
+            request_params['savingsPlanTypes'] = plan_types
+        if products:
+            request_params['products'] = products
+        if service_codes:
+            request_params['serviceCodes'] = service_codes
+        if usage_types:
+            request_params['usageTypes'] = usage_types
+        if operations:
+            request_params['operations'] = operations
+        if filters:
+            request_params['filters'] = filters
+        if next_token:
+            request_params['nextToken'] = next_token
+        if max_results:
+            request_params['maxResults'] = int(max_results)
+
+        all_rates, pagination_metadata = await paginate_aws_response(
+            ctx=ctx,
+            operation_name='DescribeSavingsPlansOfferingRates',
+            api_function=sp_client.describe_savings_plans_offering_rates,
+            request_params=request_params,
+            result_key='searchResults',
+            token_param='nextToken',
+            token_key='nextToken',
+            max_pages=max_pages,
+        )
+
+        return format_response(
+            'success',
+            {'searchResults': all_rates, 'pagination': pagination_metadata},
+        )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(
+            ctx, e, 'describe_savings_plans_offering_rates', 'Savings Plans'
+        )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/sp_purchase_analyzer_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/sp_purchase_analyzer_tools.py
@@ -1,0 +1,213 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Savings Plans Purchase Analyzer tools for the AWS Billing and Cost Management MCP server."""
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from ..utilities.logging_utils import get_context_logger
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, List, Optional
+
+
+sp_purchase_analyzer_server = FastMCP(
+    name='sp-purchase-analyzer-tools',
+    instructions='Tools for reading AWS Savings Plans Purchase Analyzer results',
+)
+
+
+@sp_purchase_analyzer_server.tool(
+    name='sp-purchase-analyzer',
+    description="""Tool that reads AWS Savings Plans Purchase Analyzer results using the Cost Explorer API.
+
+This tool retrieves the projected cost, coverage, and utilization of a planned commitment purchase
+from an analysis that has already been run, through two operations:
+
+1. get_commitment_purchase_analysis: Retrieves a result by AnalysisId.
+2. list_commitment_purchase_analyses: Lists the analyses for the account, so an existing result can
+   be found without knowing its id.
+
+USE THIS TOOL FOR:
+- **What a planned purchase would do** — the projected coverage, utilization, and cost from a
+  completed analysis
+- **Whether an analysis is finished** — the AnalysisStatus field
+- **What analyses have already been run** — including one still in progress
+
+DO NOT USE THIS TOOL FOR:
+- Starting an analysis. This tool is read-only, and no operation here starts one. An analysis has to
+  be started in the AWS Cost Management console, under Savings Plans, Purchase Analyzer.
+- A precomputed recommendation, which is sp-recommendation and needs no analysis at all
+- What the customer already owns, which is sp-explorer
+- Coverage or utilization of existing plans, which is sp-performance
+
+IMPORTANT: an analysis carries the configuration it was run with. Read AnalysisType from the
+response rather than assuming which scenario it modelled — MAX_SAVINGS, CUSTOM_COMMITMENT, and
+TARGET_AVERAGE_COVERAGE answer different questions, and a result presented as the wrong one is
+misleading.""",
+)
+async def sp_purchase_analyzer(
+    ctx: Context,
+    operation: str,
+    analysis_id: Optional[str] = None,
+    analysis_ids: Optional[List[str]] = None,
+    analysis_status: Optional[str] = None,
+    next_page_token: Optional[str] = None,
+    page_size: Optional[int] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Tool that reads AWS Savings Plans Purchase Analyzer results.
+
+    Args:
+        ctx: The MCP context object
+        operation: The operation to perform: 'get_commitment_purchase_analysis' or 'list_commitment_purchase_analyses'
+        analysis_id: The analysis ID that's associated with the commitment purchase analysis.
+            Required for get_commitment_purchase_analysis.
+        analysis_ids: The analysis IDs associated with the commitment purchase analyses.
+            Filters list_commitment_purchase_analyses.
+        analysis_status: The status of the analysis — SUCCEEDED, PROCESSING, or FAILED. Filters
+            list_commitment_purchase_analyses.
+        next_page_token: The token to retrieve the next set of results. Paging is handled for you, so
+            this is only needed to resume from a token a previous call returned.
+        page_size: The number of analyses that you want returned in a single response object.
+        max_pages: The maximum number of pages to fetch. Omitting it fetches every page.
+
+    Returns:
+        Dict containing the analysis results or history
+    """
+    try:
+        await ctx.info(f'Savings Plans Purchase Analyzer operation: {operation}')
+
+        # Initialize Cost Explorer client using shared utility
+        ce_client = create_aws_client('ce', region_name='us-east-1')
+
+        if operation == 'get_commitment_purchase_analysis':
+            return await get_commitment_purchase_analysis(ctx, ce_client, analysis_id)
+        elif operation == 'list_commitment_purchase_analyses':
+            return await list_commitment_purchase_analyses(
+                ctx,
+                ce_client,
+                analysis_status,
+                analysis_ids,
+                next_page_token,
+                page_size,
+                max_pages,
+            )
+        else:
+            return format_response(
+                'error',
+                {},
+                f'Unsupported operation: {operation}. Use '
+                "'get_commitment_purchase_analysis' or 'list_commitment_purchase_analyses'.",
+            )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'sp_purchase_analyzer', 'Cost Explorer')
+
+
+async def get_commitment_purchase_analysis(
+    ctx: Context,
+    ce_client: Any,
+    analysis_id: Optional[str],
+) -> Dict[str, Any]:
+    """Retrieves a commitment purchase analysis result based on the AnalysisId.
+
+    Args:
+        ctx: The MCP context
+        ce_client: Cost Explorer client
+        analysis_id: The analysis ID that's associated with the commitment purchase analysis.
+
+    Returns:
+        Dict containing the analysis status and, once complete, its results
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info(f'Fetching commitment purchase analysis {analysis_id}')
+
+        response = ce_client.get_commitment_purchase_analysis(AnalysisId=analysis_id)
+
+        return format_response('success', response)
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'get_commitment_purchase_analysis', 'Cost Explorer')
+
+
+async def list_commitment_purchase_analyses(
+    ctx: Context,
+    ce_client: Any,
+    analysis_status: Optional[str],
+    analysis_ids: Optional[List[str]],
+    next_page_token: Optional[str],
+    page_size: Optional[int],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Lists the commitment purchase analyses for your account.
+
+    Args:
+        ctx: The MCP context
+        ce_client: Cost Explorer client
+        analysis_status: The status of the analysis.
+        analysis_ids: The analysis IDs associated with the commitment purchase analyses.
+        next_page_token: The token to retrieve the next set of results.
+        page_size: The number of analyses that you want returned in a single response object.
+        max_pages: The maximum number of pages to fetch. None fetches every page.
+
+    Returns:
+        Dict containing the analysis history
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info('Listing commitment purchase analyses')
+
+        # Create request parameters
+        request_params: dict = {}
+
+        # Add optional parameters if provided
+        if analysis_status:
+            request_params['AnalysisStatus'] = analysis_status
+        if analysis_ids:
+            request_params['AnalysisIds'] = analysis_ids
+        if next_page_token:
+            request_params['NextPageToken'] = next_page_token
+        if page_size:
+            request_params['PageSize'] = int(page_size)
+
+        all_analyses, pagination_metadata = await paginate_aws_response(
+            ctx=ctx,
+            operation_name='ListCommitmentPurchaseAnalyses',
+            api_function=ce_client.list_commitment_purchase_analyses,
+            request_params=request_params,
+            result_key='AnalysisSummaryList',
+            token_param='NextPageToken',
+            token_key='NextPageToken',
+            max_pages=max_pages,
+        )
+
+        return format_response(
+            'success',
+            {'AnalysisSummaryList': all_analyses, 'pagination': pagination_metadata},
+        )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'list_commitment_purchase_analyses', 'Cost Explorer')

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/sp_recommendation_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/sp_recommendation_tools.py
@@ -1,0 +1,328 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Savings Plans purchase recommendation tools for the AWS Billing and Cost Management MCP server."""
+
+from ..utilities.aws_service_base import (
+    create_aws_client,
+    format_response,
+    handle_aws_error,
+    paginate_aws_response,
+)
+from ..utilities.logging_utils import get_context_logger
+from fastmcp import Context, FastMCP
+from typing import Any, Dict, List, Optional
+
+
+sp_recommendation_server = FastMCP(
+    name='sp-recommendation-tools',
+    instructions='Tools for working with AWS Savings Plans purchase recommendations',
+)
+
+
+@sp_recommendation_server.tool(
+    name='sp-recommendation',
+    description="""Tool that retrieves AWS Savings Plans purchase recommendations using the Cost Explorer API.
+
+This tool provides the commitment a customer should consider buying, and the evidence behind it,
+through three operations:
+
+1. get_savings_plans_purchase_recommendation: The recommended commitment for a given plan type,
+   term, and payment option, with estimated savings, coverage, and utilization.
+2. get_savings_plan_purchase_recommendation_details: The hourly data-points behind a single
+   recommendation, keyed by the RecommendationDetailId returned above.
+3. list_savings_plans_purchase_recommendation_generation: Generation history with status and
+   timestamps.
+
+USE THIS TOOL FOR:
+- **What to buy** — the recommended commitment for a given plan type, term, and payment option
+- **Whether that commitment would go unused** — the hourly EstimatedNewCommitmentUtilization behind
+  the recommendation, rather than a figure derived from the raw spend series
+- **How stale the recommendation is** — when it was last generated
+
+DO NOT USE THIS TOOL FOR:
+- What the customer already owns, which is sp-explorer
+- Coverage or utilization of existing plans, which is sp-performance
+- Modeling a commitment the customer specifies rather than a recommended one
+
+This tool is read-only. Refreshing a recommendation is a mutation and is not exposed here.
+
+IMPORTANT: get_savings_plans_purchase_recommendation requires savings_plans_type, term_in_years,
+payment_option, and lookback_period_in_days. None of them has a default — each changes the
+recommended commitment, so the caller must choose. Recommendations are precomputed and may be
+stale; the response carries the generation timestamp.""",
+)
+async def sp_recommendation(
+    ctx: Context,
+    operation: str,
+    savings_plans_type: Optional[str] = None,
+    term_in_years: Optional[str] = None,
+    payment_option: Optional[str] = None,
+    lookback_period_in_days: Optional[str] = None,
+    account_scope: Optional[str] = None,
+    filter: Optional[Dict[str, Any]] = None,
+    recommendation_detail_id: Optional[str] = None,
+    generation_status: Optional[str] = None,
+    recommendation_ids: Optional[List[str]] = None,
+    next_page_token: Optional[str] = None,
+    page_size: Optional[int] = None,
+    max_pages: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Tool that retrieves AWS Savings Plans purchase recommendations.
+
+    Args:
+        ctx: The MCP context object
+        operation: The operation to perform: 'get_savings_plans_purchase_recommendation', 'get_savings_plan_purchase_recommendation_details', or 'list_savings_plans_purchase_recommendation_generation'
+        savings_plans_type: COMPUTE_SP, EC2_INSTANCE_SP, SAGEMAKER_SP, or DATABASE_SP. Required for get_savings_plans_purchase_recommendation.
+        term_in_years: ONE_YEAR or THREE_YEARS. Required for get_savings_plans_purchase_recommendation.
+        payment_option: NO_UPFRONT, PARTIAL_UPFRONT, or ALL_UPFRONT. Required for get_savings_plans_purchase_recommendation. The API shape also accepts three
+            LIGHT/MEDIUM/HEAVY_UTILIZATION values, which are Reserved Instance utilization levels and do not apply to Savings Plans.
+        lookback_period_in_days: SEVEN_DAYS, THIRTY_DAYS, or SIXTY_DAYS. Required for get_savings_plans_purchase_recommendation.
+        account_scope: PAYER or LINKED.
+        filter: Filter recommendations by Account ID. Includes Dimensions only,
+            with Key as LINKED_ACCOUNT and Value one or more Account IDs. AND and OR operators are
+            not supported. Applies to get_savings_plans_purchase_recommendation only.
+        recommendation_detail_id: Required for get_savings_plan_purchase_recommendation_details. Comes from the RecommendationDetailId field of a recommendation.
+        generation_status: SUCCEEDED, PROCESSING, or FAILED. Filters list_savings_plans_purchase_recommendation_generation.
+        recommendation_ids: Recommendation IDs to filter to.
+        next_page_token: Pagination token.
+        page_size: Maximum number of results to return per page.
+        max_pages: The maximum number of pages to fetch when listing generations. Omitting it
+            fetches every page.
+
+    Returns:
+        Dict containing the savings plans purchase recommendation information
+    """
+    try:
+        await ctx.info(f'Savings Plans purchase recommendation operation: {operation}')
+
+        # Initialize Cost Explorer client using shared utility
+        ce_client = create_aws_client('ce', region_name='us-east-1')
+
+        if operation == 'get_savings_plans_purchase_recommendation':
+            return await get_savings_plans_purchase_recommendation(
+                ctx,
+                ce_client,
+                savings_plans_type,
+                term_in_years,
+                payment_option,
+                lookback_period_in_days,
+                account_scope,
+                filter,
+                next_page_token,
+                page_size,
+            )
+        elif operation == 'get_savings_plan_purchase_recommendation_details':
+            return await get_savings_plan_purchase_recommendation_details(
+                ctx, ce_client, recommendation_detail_id
+            )
+        elif operation == 'list_savings_plans_purchase_recommendation_generation':
+            return await list_savings_plans_purchase_recommendation_generation(
+                ctx,
+                ce_client,
+                generation_status,
+                recommendation_ids,
+                next_page_token,
+                page_size,
+                max_pages,
+            )
+        else:
+            return format_response(
+                'error',
+                {},
+                f'Unsupported operation: {operation}. Use '
+                "'get_savings_plans_purchase_recommendation', "
+                "'get_savings_plan_purchase_recommendation_details', or "
+                "'list_savings_plans_purchase_recommendation_generation'.",
+            )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(ctx, e, 'sp_recommendation', 'Cost Explorer')
+
+
+async def get_savings_plans_purchase_recommendation(
+    ctx: Context,
+    ce_client: Any,
+    savings_plans_type: Optional[str],
+    term_in_years: Optional[str],
+    payment_option: Optional[str],
+    lookback_period_in_days: Optional[str],
+    account_scope: Optional[str],
+    filter_expr: Optional[Dict[str, Any]],
+    next_page_token: Optional[str],
+    page_size: Optional[int],
+) -> Dict[str, Any]:
+    """Retrieves the Savings Plans recommendations for your account.
+
+    Args:
+        ctx: The MCP context
+        ce_client: Cost Explorer client
+        savings_plans_type: The Savings Plans recommendation type that's requested.
+        term_in_years: The savings plan recommendation term that's used to generate these
+            recommendations.
+        payment_option: The payment option that's used to generate these recommendations.
+        lookback_period_in_days: The lookback period that's used to generate the recommendation.
+        account_scope: The account scope that you want your recommendations for. AWS calculates
+            recommendations including the management account and member accounts if the value is
+            set to PAYER. If the value is LINKED, recommendations are calculated for individual
+            member accounts only.
+        filter_expr: Filter by Account ID with the LINKED_ACCOUNT dimension.
+        next_page_token: The token to retrieve the next set of results. AWS provides the token when
+            the response from a previous call has more results than the maximum page size.
+        page_size: The number of recommendations that you want returned in a single response
+            object.
+
+    Returns:
+        Dict containing the recommendation
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info(
+            f'Fetching {savings_plans_type} recommendation: {term_in_years}, '
+            f'{payment_option}, {lookback_period_in_days} lookback'
+        )
+
+        # Prepare the request parameters
+        request_params: dict = {
+            'SavingsPlansType': savings_plans_type,
+            'TermInYears': term_in_years,
+            'PaymentOption': payment_option,
+            'LookbackPeriodInDays': lookback_period_in_days,
+        }
+
+        # Add optional parameters if provided
+        if account_scope:
+            request_params['AccountScope'] = account_scope
+        if filter_expr:
+            request_params['Filter'] = filter_expr
+        if next_page_token:
+            request_params['NextPageToken'] = next_page_token
+        if page_size:
+            request_params['PageSize'] = int(page_size)
+
+        response = ce_client.get_savings_plans_purchase_recommendation(**request_params)
+
+        return format_response('success', response)
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(
+            ctx, e, 'get_savings_plans_purchase_recommendation', 'Cost Explorer'
+        )
+
+
+async def get_savings_plan_purchase_recommendation_details(
+    ctx: Context,
+    ce_client: Any,
+    recommendation_detail_id: Optional[str],
+) -> Dict[str, Any]:
+    """Retrieves the details for a Savings Plan recommendation.
+
+    These details include the hourly data-points that construct the cost, coverage, and
+    utilization charts.
+
+    Args:
+        ctx: The MCP context
+        ce_client: Cost Explorer client
+        recommendation_detail_id: The ID that is associated with the Savings Plan recommendation.
+
+    Returns:
+        Dict containing the recommendation detail
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info(f'Fetching recommendation detail {recommendation_detail_id}')
+
+        response = ce_client.get_savings_plan_purchase_recommendation_details(
+            RecommendationDetailId=recommendation_detail_id
+        )
+
+        return format_response('success', response)
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(
+            ctx, e, 'get_savings_plan_purchase_recommendation_details', 'Cost Explorer'
+        )
+
+
+async def list_savings_plans_purchase_recommendation_generation(
+    ctx: Context,
+    ce_client: Any,
+    generation_status: Optional[str],
+    recommendation_ids: Optional[List[str]],
+    next_page_token: Optional[str],
+    page_size: Optional[int],
+    max_pages: Optional[int],
+) -> Dict[str, Any]:
+    """Retrieves a list of your historical recommendation generations within the past 30 days.
+
+    Args:
+        ctx: The MCP context
+        ce_client: Cost Explorer client
+        generation_status: The status of the recommendation generation.
+        recommendation_ids: The IDs for each specific recommendation.
+        next_page_token: The token to retrieve the next set of results.
+        page_size: The number of recommendations that you want returned in a single response
+            object.
+        max_pages: The maximum number of pages to fetch. None fetches every page.
+
+    Returns:
+        Dict containing the generation history
+    """
+    # Get context logger for consistent logging
+    ctx_logger = get_context_logger(ctx, __name__)
+
+    try:
+        await ctx_logger.info('Listing Savings Plans purchase recommendation generations')
+
+        # Create request parameters
+        request_params: dict = {}
+
+        # Add optional parameters if provided
+        if generation_status:
+            request_params['GenerationStatus'] = generation_status
+        if recommendation_ids:
+            request_params['RecommendationIds'] = recommendation_ids
+        if next_page_token:
+            request_params['NextPageToken'] = next_page_token
+        if page_size:
+            request_params['PageSize'] = int(page_size)
+
+        all_generations, pagination_metadata = await paginate_aws_response(
+            ctx=ctx,
+            operation_name='ListSavingsPlansPurchaseRecommendationGeneration',
+            api_function=ce_client.list_savings_plans_purchase_recommendation_generation,
+            request_params=request_params,
+            result_key='GenerationSummaryList',
+            token_param='NextPageToken',
+            token_key='NextPageToken',
+            max_pages=max_pages,
+        )
+
+        return format_response(
+            'success',
+            {'GenerationSummaryList': all_generations, 'pagination': pagination_metadata},
+        )
+
+    except Exception as e:
+        # Use shared error handler for consistent error reporting
+        return await handle_aws_error(
+            ctx, e, 'list_savings_plans_purchase_recommendation_generation', 'Cost Explorer'
+        )

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/aws_service_base.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/utilities/aws_service_base.py
@@ -75,6 +75,7 @@ def create_aws_client(service_name: str, region_name: Optional[str] = None) -> A
         'billingconductor',  # AWS Billing Conductor
         'billing',  # AWS Billing
         'invoicing',  # AWS Invoicing
+        'savingsplans',  # AWS Savings Plans
     ]
 
     # Validate requested service

--- a/src/billing-cost-management-mcp-server/tests/test_server.py
+++ b/src/billing-cost-management-mcp-server/tests/test_server.py
@@ -97,7 +97,7 @@ def test_setup_function(mock_register_prompts, mock_mcp):
 
     setup()
 
-    assert mock_mcp.mount.call_count == 23
+    assert mock_mcp.mount.call_count == 26
     mock_register_prompts.assert_called_once()
 
 

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_operations.py
@@ -174,6 +174,36 @@ class TestBillingViewArnSupport:
         call_kwargs = mock_ce_client.get_dimension_values.call_args[1]
         assert call_kwargs['BillingViewArn'] == sample_billing_view_arn
 
+    async def test_get_dimension_values_with_context(self, mock_context, mock_ce_client):
+        """Test get_dimension_values includes Context."""
+        result = await get_dimension_values(
+            mock_context,
+            mock_ce_client,
+            dimension='SAVINGS_PLANS_TYPE',
+            context='SAVINGS_PLANS',
+        )
+        assert result['status'] == 'success'
+        call_kwargs = mock_ce_client.get_dimension_values.call_args[1]
+        assert call_kwargs['Context'] == 'SAVINGS_PLANS'
+        assert call_kwargs['Dimension'] == 'SAVINGS_PLANS_TYPE'
+
+    async def test_get_dimension_values_without_context_omits_it(
+        self, mock_context, mock_ce_client
+    ):
+        """Test get_dimension_values leaves Context out when not supplied.
+
+        The API defaults to COST_AND_USAGE, so sending it explicitly would change
+        nothing; omitting it keeps the request minimal.
+        """
+        result = await get_dimension_values(
+            mock_context,
+            mock_ce_client,
+            dimension='SERVICE',
+        )
+        assert result['status'] == 'success'
+        call_kwargs = mock_ce_client.get_dimension_values.call_args[1]
+        assert 'Context' not in call_kwargs
+
     async def test_get_cost_forecast_with_billing_view_arn(
         self, mock_context, mock_ce_client, sample_billing_view_arn
     ):

--- a/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_cost_explorer_tools.py
@@ -984,6 +984,7 @@ async def test_ce_real_get_dimension_values_passes_args_reload_identity_decorato
             'abc',
             2,
             None,
+            None,
         )
 
 
@@ -1406,6 +1407,7 @@ async def test_ce_real_get_dimension_values_with_billing_view_arn(
             None,
             None,
             sample_billing_view_arn,
+            None,
         )
 
 

--- a/src/billing-cost-management-mcp-server/tests/tools/test_sp_explorer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_sp_explorer_tools.py
@@ -1,0 +1,601 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Savings Plans explorer tools.
+
+The Savings Plans service does not share Cost Explorer's vocabulary, and these
+tests fix the differences that are easy to get wrong: request parameters are
+camelCase, the pagination token is lowercase `nextToken`, payment options carry
+spaces, plan types are not suffixed with _SP, and terms are durations in seconds.
+They also fix the two offering operations sharing one set of tool parameter names
+while the API spells three of its fields differently for each.
+"""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools import (
+    describe_savings_plan_rates,
+    describe_savings_plans,
+    describe_savings_plans_offering_rates,
+    describe_savings_plans_offerings,
+    sp_explorer,
+    sp_explorer_server,
+)
+from fastmcp import Context
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context."""
+    context = MagicMock(spec=Context)
+    context.info = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def sample_savings_plan():
+    """One active Savings Plan, shaped as the Savings Plans API returns it."""
+    return {
+        'offeringId': '7fb303ac-60fa-44c3-bb28-e847aa8073ac',
+        'savingsPlanId': '577d4a65-34e7-4b2e-92d7-5e845ba5e55d',
+        'savingsPlanArn': 'arn:aws:savingsplans::123456789012:savingsplan/577d4a65',
+        'description': '1 year All Upfront Compute Savings Plan',
+        'start': '2025-12-19T12:12:12.000Z',
+        'end': '2026-12-19T12:12:11.000Z',
+        'state': 'active',
+        'savingsPlanType': 'Compute',
+        'paymentOption': 'All Upfront',
+        'productTypes': ['Fargate', 'EC2', 'Lambda'],
+        'currency': 'USD',
+        'commitment': '0.00100000',
+        'upfrontPaymentAmount': '8.76000000',
+        'recurringPaymentAmount': '0.00000000',
+        'termDurationInSeconds': 31536000,
+        'tags': {},
+        'returnableUntil': '2025-12-26T12:12:12.000Z',
+    }
+
+
+@pytest.fixture
+def mock_sp_client(sample_savings_plan):
+    """Create a mock Savings Plans boto3 client."""
+    client = MagicMock()
+    client.describe_savings_plans.return_value = {
+        'savingsPlans': [sample_savings_plan],
+    }
+    client.describe_savings_plan_rates.return_value = {
+        'savingsPlanId': '577d4a65-34e7-4b2e-92d7-5e845ba5e55d',
+        'searchResults': [
+            {
+                'rate': '0.0464',
+                'currency': 'USD',
+                'unit': 'Hrs',
+                'productType': 'EC2',
+                'serviceCode': 'AmazonEC2',
+                'usageType': 'APN1-DedicatedUsage:c6i.large',
+                'operation': 'RunInstances',
+                'properties': [{'name': 'instanceType', 'value': 'c6i.large'}],
+            }
+        ],
+    }
+    client.describe_savings_plans_offerings.return_value = {
+        'searchResults': [
+            {
+                'offeringId': '005305de-48ea-405e-bae3-8b764b913a8e',
+                'productTypes': ['EC2'],
+                'planType': 'Compute',
+                'description': '1 year No Upfront Compute Savings Plan',
+                'paymentOption': 'No Upfront',
+                'durationSeconds': 31536000,
+                'currency': 'USD',
+                'serviceCode': 'AmazonEC2',
+                'usageType': 'APN1-DedicatedUsage:c6i.large',
+                'operation': 'RunInstances',
+                'properties': [{'name': 'region', 'value': 'ap-northeast-1'}],
+            }
+        ],
+    }
+    client.describe_savings_plans_offering_rates.return_value = {
+        'searchResults': [
+            {
+                'savingsPlanOffering': {
+                    'offeringId': '005305de-48ea-405e-bae3-8b764b913a8e',
+                    'paymentOption': 'No Upfront',
+                    'planType': 'Compute',
+                    'durationSeconds': 31536000,
+                    'currency': 'USD',
+                    'planDescription': '1 year No Upfront Compute Savings Plan',
+                },
+                'rate': '0.0464',
+                'unit': 'Hrs',
+                'productType': 'EC2',
+                'serviceCode': 'AmazonEC2',
+                'usageType': 'APN1-DedicatedUsage:c6i.large',
+                'operation': 'RunInstances',
+                'properties': [{'name': 'instanceType', 'value': 'c6i.large'}],
+            }
+        ],
+    }
+    return client
+
+
+PAGINATION_COMPLETE = {
+    'complete_dataset': True,
+    'pages_fetched': 1,
+    'total_results': 1,
+    'has_more': False,
+    'next_token': None,
+    'duration_ms': 1,
+}
+
+
+@pytest.mark.asyncio
+class TestDescribeSavingsPlans:
+    """Tests for describe_savings_plans."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_basic(self, mock_paginate, mock_context, mock_sp_client, sample_savings_plan):
+        """Inventory comes back under the API's own key, with pagination metadata."""
+        mock_paginate.return_value = ([sample_savings_plan], PAGINATION_COMPLETE)
+
+        result = await describe_savings_plans(
+            mock_context, mock_sp_client, None, None, None, None, None, None, None
+        )
+
+        call_kwargs = mock_paginate.call_args[1]
+        assert call_kwargs['operation_name'] == 'DescribeSavingsPlans'
+        assert call_kwargs['result_key'] == 'savingsPlans'
+        # The Savings Plans service uses a lowercase token; Cost Explorer does not.
+        assert call_kwargs['token_param'] == 'nextToken'
+        assert call_kwargs['token_key'] == 'nextToken'
+        assert call_kwargs['request_params'] == {}
+
+        assert result['status'] == 'success'
+        assert result['data']['savingsPlans'] == [sample_savings_plan]
+        assert result['data']['pagination']['complete_dataset'] is True
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_states_and_filters_are_json_decoded(
+        self, mock_paginate, mock_context, mock_sp_client
+    ):
+        """List parameters are passed through to boto3 unchanged."""
+        mock_paginate.return_value = ([], PAGINATION_COMPLETE)
+
+        await describe_savings_plans(
+            mock_context,
+            mock_sp_client,
+            ['arn:aws:savingsplans::123456789012:savingsplan/abc'],
+            ['577d4a65'],
+            ['active', 'queued', 'payment-failed'],
+            [{'name': 'savings-plan-type', 'values': ['Compute']}],
+            'token-from-caller',
+            50,
+            3,
+        )
+
+        request_params = mock_paginate.call_args[1]['request_params']
+        assert request_params['states'] == ['active', 'queued', 'payment-failed']
+        assert request_params['savingsPlanIds'] == ['577d4a65']
+        assert request_params['savingsPlanArns'] == [
+            'arn:aws:savingsplans::123456789012:savingsplan/abc'
+        ]
+        assert request_params['filters'] == [{'name': 'savings-plan-type', 'values': ['Compute']}]
+        assert request_params['nextToken'] == 'token-from-caller'
+        assert request_params['maxResults'] == 50
+        assert mock_paginate.call_args[1]['max_pages'] == 3
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_error(self, mock_paginate, mock_context, mock_sp_client):
+        """A client failure is reported rather than raised."""
+        mock_paginate.side_effect = Exception('AccessDeniedException')
+
+        result = await describe_savings_plans(
+            mock_context, mock_sp_client, None, None, None, None, None, None, None
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestDescribeSavingsPlanRates:
+    """Tests for describe_savings_plan_rates."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_basic(self, mock_paginate, mock_context, mock_sp_client):
+        """Rates page through searchResults and keep the plan id on the result."""
+        rates = mock_sp_client.describe_savings_plan_rates.return_value['searchResults']
+        mock_paginate.return_value = (rates, PAGINATION_COMPLETE)
+
+        result = await describe_savings_plan_rates(
+            mock_context, mock_sp_client, '577d4a65', None, None, None, None
+        )
+
+        call_kwargs = mock_paginate.call_args[1]
+        assert call_kwargs['operation_name'] == 'DescribeSavingsPlanRates'
+        assert call_kwargs['result_key'] == 'searchResults'
+        assert call_kwargs['token_param'] == 'nextToken'
+        assert call_kwargs['request_params']['savingsPlanId'] == '577d4a65'
+
+        # Each page echoes savingsPlanId at the top level; the merged result has to
+        # carry it too, or the rates lose the plan they belong to.
+        assert result['data']['savingsPlanId'] == '577d4a65'
+        assert result['data']['searchResults'] == rates
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_with_filters(self, mock_paginate, mock_context, mock_sp_client):
+        """This operation's filter names are camelCase, unlike describe_savings_plans."""
+        mock_paginate.return_value = ([], PAGINATION_COMPLETE)
+
+        await describe_savings_plan_rates(
+            mock_context,
+            mock_sp_client,
+            '577d4a65',
+            [{'name': 'instanceType', 'values': ['c6i.large']}],
+            'resume-here',
+            5,
+            None,
+        )
+
+        request_params = mock_paginate.call_args[1]['request_params']
+        assert request_params['filters'] == [{'name': 'instanceType', 'values': ['c6i.large']}]
+        assert request_params['maxResults'] == 5
+        assert request_params['nextToken'] == 'resume-here'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_error(self, mock_paginate, mock_context, mock_sp_client):
+        """A client failure is reported rather than raised."""
+        mock_paginate.side_effect = Exception('ResourceNotFoundException')
+
+        result = await describe_savings_plan_rates(
+            mock_context, mock_sp_client, 'missing', None, None, None, None
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestDescribeSavingsPlansOfferings:
+    """Tests for describe_savings_plans_offerings."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_basic(self, mock_paginate, mock_context, mock_sp_client):
+        """Offerings page through searchResults."""
+        offerings = mock_sp_client.describe_savings_plans_offerings.return_value['searchResults']
+        mock_paginate.return_value = (offerings, PAGINATION_COMPLETE)
+
+        result = await describe_savings_plans_offerings(
+            mock_context,
+            mock_sp_client,
+            offering_ids=None,
+            payment_options=None,
+            product_type=None,
+            plan_types=None,
+            durations=None,
+            currencies=None,
+            descriptions=None,
+            service_codes=None,
+            usage_types=None,
+            operations=None,
+            filters=None,
+            next_token=None,
+            max_results=None,
+            max_pages=None,
+        )
+
+        call_kwargs = mock_paginate.call_args[1]
+        assert call_kwargs['operation_name'] == 'DescribeSavingsPlansOfferings'
+        assert call_kwargs['result_key'] == 'searchResults'
+        assert result['data']['searchResults'] == offerings
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_savings_plans_vocabulary_passes_through_unchanged(
+        self, mock_paginate, mock_context, mock_sp_client
+    ):
+        """Payment options keep their spaces, plan types have no _SP, terms are seconds."""
+        mock_paginate.return_value = ([], PAGINATION_COMPLETE)
+
+        await describe_savings_plans_offerings(
+            mock_context,
+            mock_sp_client,
+            ['005305de'],
+            ['No Upfront', 'All Upfront'],
+            'EC2',
+            ['Compute', 'EC2Instance'],
+            [31536000, 94608000],
+            ['USD'],
+            ['1 year No Upfront Compute Savings Plan'],
+            ['AmazonEC2'],
+            ['APN1-DedicatedUsage:c6i.large'],
+            ['RunInstances'],
+            [{'name': 'instanceFamily', 'values': ['c6i']}],
+            'resume-here',
+            10,
+            None,
+        )
+
+        request_params = mock_paginate.call_args[1]['request_params']
+        assert request_params['nextToken'] == 'resume-here'
+        assert request_params['paymentOptions'] == ['No Upfront', 'All Upfront']
+        assert request_params['planTypes'] == ['Compute', 'EC2Instance']
+        assert request_params['durations'] == [31536000, 94608000]
+        assert request_params['currencies'] == ['USD']
+        assert request_params['serviceCodes'] == ['AmazonEC2']
+        assert request_params['offeringIds'] == ['005305de']
+        assert request_params['usageTypes'] == ['APN1-DedicatedUsage:c6i.large']
+        assert request_params['operations'] == ['RunInstances']
+        assert request_params['filters'] == [{'name': 'instanceFamily', 'values': ['c6i']}]
+        # productType is the one scalar in this operation; the rates operation takes a
+        # list called products instead.
+        assert request_params['productType'] == 'EC2'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_error(self, mock_paginate, mock_context, mock_sp_client):
+        """A client failure is reported rather than raised."""
+        mock_paginate.side_effect = Exception('ValidationException')
+
+        result = await describe_savings_plans_offerings(
+            mock_context,
+            mock_sp_client,
+            offering_ids=None,
+            payment_options=None,
+            product_type=None,
+            plan_types=None,
+            durations=None,
+            currencies=None,
+            descriptions=None,
+            service_codes=None,
+            usage_types=None,
+            operations=None,
+            filters=None,
+            next_token=None,
+            max_results=None,
+            max_pages=None,
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestDescribeSavingsPlansOfferingRates:
+    """Tests for describe_savings_plans_offering_rates."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_basic(self, mock_paginate, mock_context, mock_sp_client):
+        """Offering rates page through searchResults."""
+        rates = mock_sp_client.describe_savings_plans_offering_rates.return_value['searchResults']
+        mock_paginate.return_value = (rates, PAGINATION_COMPLETE)
+
+        result = await describe_savings_plans_offering_rates(
+            mock_context,
+            mock_sp_client,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+        call_kwargs = mock_paginate.call_args[1]
+        assert call_kwargs['operation_name'] == 'DescribeSavingsPlansOfferingRates'
+        assert call_kwargs['result_key'] == 'searchResults'
+        assert result['data']['searchResults'] == rates
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_shared_parameters_map_to_the_prefixed_api_fields(
+        self, mock_paginate, mock_context, mock_sp_client
+    ):
+        """The tool's shared parameter names land on this API's prefixed field names."""
+        mock_paginate.return_value = ([], PAGINATION_COMPLETE)
+
+        await describe_savings_plans_offering_rates(
+            mock_context,
+            mock_sp_client,
+            ['005305de'],
+            ['No Upfront'],
+            ['Compute'],
+            ['EC2', 'Lambda'],
+            ['AmazonEC2'],
+            ['APN1-DedicatedUsage:c6i.large'],
+            ['RunInstances'],
+            [{'name': 'instanceType', 'values': ['c6i.large']}],
+            'resume-here',
+            20,
+            None,
+        )
+
+        request_params = mock_paginate.call_args[1]['request_params']
+        assert request_params['nextToken'] == 'resume-here'
+        assert request_params['savingsPlanOfferingIds'] == ['005305de']
+        assert request_params['savingsPlanPaymentOptions'] == ['No Upfront']
+        assert request_params['savingsPlanTypes'] == ['Compute']
+        assert request_params['products'] == ['EC2', 'Lambda']
+        assert request_params['serviceCodes'] == ['AmazonEC2']
+        assert request_params['maxResults'] == 20
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.paginate_aws_response'
+    )
+    async def test_error(self, mock_paginate, mock_context, mock_sp_client):
+        """A client failure is reported rather than raised."""
+        mock_paginate.side_effect = Exception('ValidationException')
+
+        result = await describe_savings_plans_offering_rates(
+            mock_context,
+            mock_sp_client,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestSpExplorerDispatch:
+    """Tests for the sp_explorer dispatcher."""
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.create_aws_client')
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.describe_savings_plans'
+    )
+    async def test_routes_to_describe_savings_plans(
+        self, mock_impl, mock_create_client, mock_context
+    ):
+        """describe_savings_plans receives the inventory parameters."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        result = await sp_explorer(
+            mock_context,
+            operation='describe_savings_plans',
+            states=['active'],
+            max_pages=2,
+        )
+
+        assert result['status'] == 'success'
+        # The Savings Plans service is a separate client from Cost Explorer, and it
+        # has to be on create_aws_client's allowlist to be built at all.
+        mock_create_client.assert_called_once_with('savingsplans', region_name='us-east-1')
+        args = mock_impl.await_args[0]
+        assert args[4] == ['active']
+        assert args[8] == 2
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.create_aws_client')
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.describe_savings_plan_rates'
+    )
+    async def test_routes_to_describe_savings_plan_rates(
+        self, mock_impl, mock_create_client, mock_context
+    ):
+        """describe_savings_plan_rates receives the plan id."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_explorer(
+            mock_context,
+            operation='describe_savings_plan_rates',
+            savings_plan_id='577d4a65',
+        )
+
+        assert mock_impl.await_args[0][2] == '577d4a65'
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.create_aws_client')
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.describe_savings_plans_offerings'
+    )
+    async def test_routes_to_describe_savings_plans_offerings(
+        self, mock_impl, mock_create_client, mock_context
+    ):
+        """describe_savings_plans_offerings receives the offering filters."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_explorer(
+            mock_context,
+            operation='describe_savings_plans_offerings',
+            product_type='Lambda',
+            payment_options=['No Upfront'],
+            plan_types=['Compute'],
+        )
+
+        args = mock_impl.await_args[0]
+        assert args[3] == ['No Upfront']
+        assert args[4] == 'Lambda'
+        assert args[5] == ['Compute']
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.create_aws_client')
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.describe_savings_plans_offering_rates'
+    )
+    async def test_routes_to_describe_savings_plans_offering_rates(
+        self, mock_impl, mock_create_client, mock_context
+    ):
+        """describe_savings_plans_offering_rates receives the rate filters."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_explorer(
+            mock_context,
+            operation='describe_savings_plans_offering_rates',
+            usage_types=['APN1-DedicatedUsage:c6i.large'],
+            payment_options=['No Upfront'],
+            plan_types=['Compute'],
+        )
+
+        args = mock_impl.await_args[0]
+        assert args[3] == ['No Upfront']
+        assert args[4] == ['Compute']
+        assert args[7] == ['APN1-DedicatedUsage:c6i.large']
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.create_aws_client')
+    async def test_unsupported_operation_lists_the_valid_ones(
+        self, mock_create_client, mock_context
+    ):
+        """An unknown operation names the four that exist."""
+        result = await sp_explorer(mock_context, operation='list_tags_for_resource')
+
+        assert result['status'] == 'error'
+        message = result['message']
+        assert 'describe_savings_plans' in message
+        assert 'describe_savings_plan_rates' in message
+        assert 'describe_savings_plans_offerings' in message
+        assert 'describe_savings_plans_offering_rates' in message
+
+    @patch('awslabs.billing_cost_management_mcp_server.tools.sp_explorer_tools.create_aws_client')
+    async def test_client_creation_failure_is_reported(self, mock_create_client, mock_context):
+        """A service that is not on the allowlist surfaces as an error, not a crash."""
+        mock_create_client.side_effect = ValueError("Service 'savingsplans' is not allowed")
+
+        result = await sp_explorer(mock_context, operation='describe_savings_plans')
+
+        assert result['status'] == 'error'
+
+
+def test_sp_explorer_server_initialization():
+    """The server is named and carries instructions."""
+    assert sp_explorer_server.name == 'sp-explorer-tools'
+    assert sp_explorer_server.instructions is not None

--- a/src/billing-cost-management-mcp-server/tests/tools/test_sp_purchase_analyzer_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_sp_purchase_analyzer_tools.py
@@ -1,0 +1,253 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Savings Plans Purchase Analyzer tools.
+
+This tool is read-only: it retrieves analyses that were started elsewhere. These tests
+fix that boundary, and the pagination token spelling, which is NextPageToken on Cost
+Explorer and lowercase nextToken on the Savings Plans service.
+"""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools import (
+    get_commitment_purchase_analysis,
+    list_commitment_purchase_analyses,
+    sp_purchase_analyzer,
+    sp_purchase_analyzer_server,
+)
+from fastmcp import Context
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context."""
+    context = MagicMock(spec=Context)
+    context.info = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def mock_ce_client():
+    """Create a mock Cost Explorer boto3 client."""
+    client = MagicMock()
+    client.get_commitment_purchase_analysis.return_value = {
+        'AnalysisId': '23a6da4c-c5f8-448b-8e69-31c27d0f2603',
+        'AnalysisStatus': 'SUCCEEDED',
+        'AnalysisStartedTime': '2026-08-11T22:13:33Z',
+        'AnalysisCompletionTime': '2026-08-11T22:13:38Z',
+        'AnalysisDetails': {
+            'SavingsPlansPurchaseAnalysisDetails': {
+                'CurrentAverageCoverage': '5.62',
+                'EstimatedAverageCoverage': '84.37',
+                'EstimatedAverageUtilization': '96.16',
+                'UpfrontCost': '0.0',
+            }
+        },
+    }
+    client.list_commitment_purchase_analyses.return_value = {
+        'AnalysisSummaryList': [
+            {
+                'AnalysisId': '23a6da4c-c5f8-448b-8e69-31c27d0f2603',
+                'AnalysisStatus': 'SUCCEEDED',
+                'AnalysisStartedTime': '2026-08-11T22:13:33Z',
+            }
+        ],
+    }
+    return client
+
+
+PAGINATION_COMPLETE = {
+    'complete_dataset': True,
+    'pages_fetched': 1,
+    'total_results': 1,
+    'has_more': False,
+    'next_token': None,
+    'duration_ms': 1,
+}
+
+
+@pytest.mark.asyncio
+class TestGetCommitmentPurchaseAnalysis:
+    """Tests for get_commitment_purchase_analysis."""
+
+    async def test_basic(self, mock_context, mock_ce_client):
+        """The analysis is fetched by id and returned as the API shapes it."""
+        result = await get_commitment_purchase_analysis(
+            mock_context, mock_ce_client, '23a6da4c-c5f8-448b-8e69-31c27d0f2603'
+        )
+
+        mock_ce_client.get_commitment_purchase_analysis.assert_called_once_with(
+            AnalysisId='23a6da4c-c5f8-448b-8e69-31c27d0f2603'
+        )
+        assert result['status'] == 'success'
+        assert result['data']['AnalysisStatus'] == 'SUCCEEDED'
+        details = result['data']['AnalysisDetails']['SavingsPlansPurchaseAnalysisDetails']
+        assert details['EstimatedAverageCoverage'] == '84.37'
+
+    async def test_error(self, mock_context, mock_ce_client):
+        """An unknown id is reported rather than raised."""
+        mock_ce_client.get_commitment_purchase_analysis.side_effect = Exception(
+            'AnalysisNotFoundException'
+        )
+
+        result = await get_commitment_purchase_analysis(mock_context, mock_ce_client, 'missing-id')
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestListCommitmentPurchaseAnalyses:
+    """Tests for list_commitment_purchase_analyses."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.paginate_aws_response'
+    )
+    async def test_basic(self, mock_paginate, mock_context, mock_ce_client):
+        """Analyses page through AnalysisSummaryList."""
+        analyses = mock_ce_client.list_commitment_purchase_analyses.return_value[
+            'AnalysisSummaryList'
+        ]
+        mock_paginate.return_value = (analyses, PAGINATION_COMPLETE)
+
+        result = await list_commitment_purchase_analyses(
+            mock_context, mock_ce_client, None, None, None, None, None
+        )
+
+        call_kwargs = mock_paginate.call_args[1]
+        assert call_kwargs['operation_name'] == 'ListCommitmentPurchaseAnalyses'
+        assert call_kwargs['result_key'] == 'AnalysisSummaryList'
+        assert call_kwargs['token_param'] == 'NextPageToken'
+        assert call_kwargs['token_key'] == 'NextPageToken'
+
+        assert result['status'] == 'success'
+        assert result['data']['AnalysisSummaryList'] == analyses
+        assert result['data']['pagination']['complete_dataset'] is True
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.paginate_aws_response'
+    )
+    async def test_optional_parameters(self, mock_paginate, mock_context, mock_ce_client):
+        """Listing what has already run is cheaper than starting another analysis."""
+        mock_paginate.return_value = ([], PAGINATION_COMPLETE)
+
+        await list_commitment_purchase_analyses(
+            mock_context,
+            mock_ce_client,
+            'SUCCEEDED',
+            ['23a6da4c-c5f8-448b-8e69-31c27d0f2603'],
+            'token-from-caller',
+            10,
+            2,
+        )
+
+        request_params = mock_paginate.call_args[1]['request_params']
+        assert request_params['AnalysisStatus'] == 'SUCCEEDED'
+        assert request_params['AnalysisIds'] == ['23a6da4c-c5f8-448b-8e69-31c27d0f2603']
+        assert request_params['NextPageToken'] == 'token-from-caller'
+        assert request_params['PageSize'] == 10
+        assert mock_paginate.call_args[1]['max_pages'] == 2
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.paginate_aws_response'
+    )
+    async def test_error(self, mock_paginate, mock_context, mock_ce_client):
+        """A client failure is reported rather than raised."""
+        mock_paginate.side_effect = Exception('AccessDeniedException')
+
+        result = await list_commitment_purchase_analyses(
+            mock_context, mock_ce_client, None, None, None, None, None
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestSpPurchaseAnalyzerDispatch:
+    """Tests for the sp_purchase_analyzer dispatcher."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.create_aws_client'
+    )
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.get_commitment_purchase_analysis'
+    )
+    async def test_routes_to_get_analysis(self, mock_impl, mock_create_client, mock_context):
+        """The analysis id is the only parameter this operation takes."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_purchase_analyzer(
+            mock_context,
+            operation='get_commitment_purchase_analysis',
+            analysis_id='23a6da4c',
+        )
+
+        assert mock_impl.await_args[0][2] == '23a6da4c'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.create_aws_client'
+    )
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.list_commitment_purchase_analyses'
+    )
+    async def test_routes_to_list_analyses(self, mock_impl, mock_create_client, mock_context):
+        """The status filter and max_pages arrive."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_purchase_analyzer(
+            mock_context,
+            operation='list_commitment_purchase_analyses',
+            analysis_status='PROCESSING',
+            max_pages=2,
+        )
+
+        args = mock_impl.await_args[0]
+        assert args[2] == 'PROCESSING'
+        assert args[6] == 2
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.create_aws_client'
+    )
+    async def test_unsupported_operation_lists_the_valid_ones(
+        self, mock_create_client, mock_context
+    ):
+        """Starting an analysis is a mutation, so the dispatcher rejects it."""
+        result = await sp_purchase_analyzer(
+            mock_context, operation='start_commitment_purchase_analysis'
+        )
+
+        assert result['status'] == 'error'
+        message = result['message']
+        assert 'get_commitment_purchase_analysis' in message
+        assert 'list_commitment_purchase_analyses' in message
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_purchase_analyzer_tools.create_aws_client'
+    )
+    async def test_client_creation_failure_is_reported(self, mock_create_client, mock_context):
+        """A client that cannot be built surfaces as an error, not a crash."""
+        mock_create_client.side_effect = ValueError("Service 'ce' is not allowed")
+
+        result = await sp_purchase_analyzer(
+            mock_context, operation='list_commitment_purchase_analyses'
+        )
+
+        assert result['status'] == 'error'
+
+
+def test_sp_purchase_analyzer_server_initialization():
+    """The server is named and carries instructions."""
+    assert sp_purchase_analyzer_server.name == 'sp-purchase-analyzer-tools'
+    assert sp_purchase_analyzer_server.instructions is not None

--- a/src/billing-cost-management-mcp-server/tests/tools/test_sp_recommendation_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_sp_recommendation_tools.py
@@ -1,0 +1,429 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Savings Plans purchase recommendation tools.
+
+Cost Explorer requires four parameters for a recommendation and none of them has a
+default, because each one changes the recommended commitment. These tests fix that
+contract, and the pagination token spelling, which is NextPageToken here and
+lowercase nextToken on the Savings Plans service.
+"""
+
+import pytest
+from awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools import (
+    get_savings_plan_purchase_recommendation_details,
+    get_savings_plans_purchase_recommendation,
+    list_savings_plans_purchase_recommendation_generation,
+    sp_recommendation,
+    sp_recommendation_server,
+)
+from fastmcp import Context
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MCP context."""
+    context = MagicMock(spec=Context)
+    context.info = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def sample_recommendation():
+    """A recommendation response, shaped as Cost Explorer returns it."""
+    return {
+        'Metadata': {
+            'RecommendationId': 'a1b2c3d4-1111-2222-3333-444455556666',
+            'GenerationTimestamp': '2026-08-09T00:00:00Z',
+        },
+        'SavingsPlansPurchaseRecommendation': {
+            'AccountScope': 'PAYER',
+            'SavingsPlansType': 'COMPUTE_SP',
+            'TermInYears': 'ONE_YEAR',
+            'PaymentOption': 'NO_UPFRONT',
+            'LookbackPeriodInDays': 'THIRTY_DAYS',
+            'SavingsPlansPurchaseRecommendationDetails': [
+                {
+                    'RecommendationDetailId': 'd1e2f3a4-5555-6666-7777-888899990000',
+                    'HourlyCommitmentToPurchase': '0.174',
+                    'EstimatedAverageUtilization': '96.16',
+                    'EstimatedAverageCoverage': '84.37',
+                    'EstimatedMonthlySavingsAmount': '11.47',
+                }
+            ],
+            'SavingsPlansPurchaseRecommendationSummary': {
+                'HourlyCommitmentToPurchase': '0.174',
+                'EstimatedSavingsPercentage': '6.91',
+            },
+        },
+    }
+
+
+@pytest.fixture
+def sample_recommendation_details():
+    """A recommendation detail response with a short hourly series."""
+    return {
+        'RecommendationDetailId': 'd1e2f3a4-5555-6666-7777-888899990000',
+        'RecommendationDetailData': {
+            'SavingsPlansType': 'COMPUTE_SP',
+            'TermInYears': 'ONE_YEAR',
+            'PaymentOption': 'NO_UPFRONT',
+            'HourlyCommitmentToPurchase': '0.174',
+            'EstimatedAverageCoverage': '84.37',
+            'MetricsOverLookbackPeriod': [
+                {
+                    'StartTime': '2026-07-15T00:00:00Z',
+                    'EstimatedOnDemandCost': '0.2199',
+                    'CurrentCoverage': '5.62',
+                    'EstimatedCoverage': '84.37',
+                    'EstimatedNewCommitmentUtilization': '100.0',
+                },
+            ],
+        },
+    }
+
+
+@pytest.fixture
+def mock_ce_client(sample_recommendation, sample_recommendation_details):
+    """Create a mock Cost Explorer boto3 client."""
+    client = MagicMock()
+    client.get_savings_plans_purchase_recommendation.return_value = sample_recommendation
+    client.get_savings_plan_purchase_recommendation_details.return_value = (
+        sample_recommendation_details
+    )
+    client.list_savings_plans_purchase_recommendation_generation.return_value = {
+        'GenerationSummaryList': [
+            {
+                'RecommendationId': 'a1b2c3d4-1111-2222-3333-444455556666',
+                'GenerationStatus': 'SUCCEEDED',
+                'GenerationStartedTime': '2026-08-09T00:00:00Z',
+                'GenerationCompletionTime': '2026-08-09T00:04:00Z',
+            }
+        ],
+    }
+    return client
+
+
+PAGINATION_COMPLETE = {
+    'complete_dataset': True,
+    'pages_fetched': 1,
+    'total_results': 1,
+    'has_more': False,
+    'next_token': None,
+    'duration_ms': 1,
+}
+
+
+@pytest.mark.asyncio
+class TestGetSavingsPlansPurchaseRecommendation:
+    """Tests for get_savings_plans_purchase_recommendation."""
+
+    async def test_basic(self, mock_context, mock_ce_client, sample_recommendation):
+        """The four required parameters reach the API and the response is untouched."""
+        result = await get_savings_plans_purchase_recommendation(
+            mock_context,
+            mock_ce_client,
+            'COMPUTE_SP',
+            'ONE_YEAR',
+            'NO_UPFRONT',
+            'THIRTY_DAYS',
+            None,
+            None,
+            None,
+            None,
+        )
+
+        request_params = mock_ce_client.get_savings_plans_purchase_recommendation.call_args[1]
+        assert request_params == {
+            'SavingsPlansType': 'COMPUTE_SP',
+            'TermInYears': 'ONE_YEAR',
+            'PaymentOption': 'NO_UPFRONT',
+            'LookbackPeriodInDays': 'THIRTY_DAYS',
+        }
+
+        assert result['status'] == 'success'
+        # The generation timestamp lives on Metadata, not on the recommendation.
+        assert result['data']['Metadata']['GenerationTimestamp'] == '2026-08-09T00:00:00Z'
+        assert result['data'] == sample_recommendation
+
+    async def test_optional_parameters(self, mock_context, mock_ce_client):
+        """Account scope, filter, and paging are added only when supplied."""
+        await get_savings_plans_purchase_recommendation(
+            mock_context,
+            mock_ce_client,
+            'EC2_INSTANCE_SP',
+            'THREE_YEARS',
+            'ALL_UPFRONT',
+            'SIXTY_DAYS',
+            'PAYER',
+            {'Dimensions': {'Key': 'LINKED_ACCOUNT', 'Values': ['111122223333']}},
+            'token-from-caller',
+            25,
+        )
+
+        request_params = mock_ce_client.get_savings_plans_purchase_recommendation.call_args[1]
+        assert request_params['AccountScope'] == 'PAYER'
+        assert request_params['Filter'] == {
+            'Dimensions': {'Key': 'LINKED_ACCOUNT', 'Values': ['111122223333']}
+        }
+        assert request_params['NextPageToken'] == 'token-from-caller'
+        assert request_params['PageSize'] == 25
+
+    async def test_missing_required_parameters_are_rejected_by_botocore(
+        self, mock_context, mock_ce_client
+    ):
+        """The tool does not guess a scenario when a required parameter is absent.
+
+        botocore validates required members client-side, so the failure costs no API
+        call and names every field that was left out.
+        """
+        mock_ce_client.get_savings_plans_purchase_recommendation.side_effect = Exception(
+            'Parameter validation failed: Missing required parameter in input: "TermInYears"'
+        )
+
+        result = await get_savings_plans_purchase_recommendation(
+            mock_context, mock_ce_client, 'COMPUTE_SP', None, None, None, None, None, None, None
+        )
+
+        assert result['status'] == 'error'
+
+    async def test_error(self, mock_context, mock_ce_client):
+        """A client failure is reported rather than raised."""
+        mock_ce_client.get_savings_plans_purchase_recommendation.side_effect = Exception(
+            'AccessDeniedException'
+        )
+
+        result = await get_savings_plans_purchase_recommendation(
+            mock_context,
+            mock_ce_client,
+            'COMPUTE_SP',
+            'ONE_YEAR',
+            'NO_UPFRONT',
+            'THIRTY_DAYS',
+            None,
+            None,
+            None,
+            None,
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestGetSavingsPlanPurchaseRecommendationDetails:
+    """Tests for get_savings_plan_purchase_recommendation_details."""
+
+    async def test_basic(self, mock_context, mock_ce_client, sample_recommendation_details):
+        """The hourly series is returned as the API shapes it."""
+        result = await get_savings_plan_purchase_recommendation_details(
+            mock_context, mock_ce_client, 'd1e2f3a4-5555-6666-7777-888899990000'
+        )
+
+        mock_ce_client.get_savings_plan_purchase_recommendation_details.assert_called_once_with(
+            RecommendationDetailId='d1e2f3a4-5555-6666-7777-888899990000'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == sample_recommendation_details
+        # MetricsOverLookbackPeriod keeps its API name so callers can match the docs.
+        series = result['data']['RecommendationDetailData']['MetricsOverLookbackPeriod']
+        assert series[0]['EstimatedNewCommitmentUtilization'] == '100.0'
+
+    async def test_error(self, mock_context, mock_ce_client):
+        """A client failure is reported rather than raised."""
+        mock_ce_client.get_savings_plan_purchase_recommendation_details.side_effect = Exception(
+            'DataUnavailableException'
+        )
+
+        result = await get_savings_plan_purchase_recommendation_details(
+            mock_context, mock_ce_client, 'missing-id'
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestListSavingsPlansPurchaseRecommendationGeneration:
+    """Tests for list_savings_plans_purchase_recommendation_generation."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.paginate_aws_response'
+    )
+    async def test_basic(self, mock_paginate, mock_context, mock_ce_client):
+        """Generations page through GenerationSummaryList."""
+        generations = (
+            mock_ce_client.list_savings_plans_purchase_recommendation_generation.return_value[
+                'GenerationSummaryList'
+            ]
+        )
+        mock_paginate.return_value = (generations, PAGINATION_COMPLETE)
+
+        result = await list_savings_plans_purchase_recommendation_generation(
+            mock_context, mock_ce_client, None, None, None, None, None
+        )
+
+        call_kwargs = mock_paginate.call_args[1]
+        assert call_kwargs['operation_name'] == 'ListSavingsPlansPurchaseRecommendationGeneration'
+        assert call_kwargs['result_key'] == 'GenerationSummaryList'
+        # Cost Explorer uses NextPageToken; the Savings Plans service uses nextToken.
+        assert call_kwargs['token_param'] == 'NextPageToken'
+        assert call_kwargs['token_key'] == 'NextPageToken'
+
+        assert result['status'] == 'success'
+        assert result['data']['GenerationSummaryList'] == generations
+        assert result['data']['pagination']['complete_dataset'] is True
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.paginate_aws_response'
+    )
+    async def test_optional_parameters(self, mock_paginate, mock_context, mock_ce_client):
+        """Status and id filters are decoded and forwarded."""
+        mock_paginate.return_value = ([], PAGINATION_COMPLETE)
+
+        await list_savings_plans_purchase_recommendation_generation(
+            mock_context,
+            mock_ce_client,
+            'SUCCEEDED',
+            ['a1b2c3d4-1111-2222-3333-444455556666'],
+            'token-from-caller',
+            10,
+            2,
+        )
+
+        request_params = mock_paginate.call_args[1]['request_params']
+        assert request_params['GenerationStatus'] == 'SUCCEEDED'
+        assert request_params['RecommendationIds'] == ['a1b2c3d4-1111-2222-3333-444455556666']
+        assert request_params['NextPageToken'] == 'token-from-caller'
+        assert request_params['PageSize'] == 10
+        assert mock_paginate.call_args[1]['max_pages'] == 2
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.paginate_aws_response'
+    )
+    async def test_error(self, mock_paginate, mock_context, mock_ce_client):
+        """A client failure is reported rather than raised."""
+        mock_paginate.side_effect = Exception('LimitExceededException')
+
+        result = await list_savings_plans_purchase_recommendation_generation(
+            mock_context, mock_ce_client, None, None, None, None, None
+        )
+
+        assert result['status'] == 'error'
+
+
+@pytest.mark.asyncio
+class TestSpRecommendationDispatch:
+    """Tests for the sp_recommendation dispatcher."""
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.create_aws_client'
+    )
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.get_savings_plans_purchase_recommendation'
+    )
+    async def test_routes_to_get_recommendation(self, mock_impl, mock_create_client, mock_context):
+        """The four required parameters arrive in order."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        result = await sp_recommendation(
+            mock_context,
+            operation='get_savings_plans_purchase_recommendation',
+            savings_plans_type='COMPUTE_SP',
+            term_in_years='ONE_YEAR',
+            payment_option='NO_UPFRONT',
+            lookback_period_in_days='THIRTY_DAYS',
+        )
+
+        assert result['status'] == 'success'
+        mock_create_client.assert_called_once_with('ce', region_name='us-east-1')
+        args = mock_impl.await_args[0]
+        assert args[2:6] == ('COMPUTE_SP', 'ONE_YEAR', 'NO_UPFRONT', 'THIRTY_DAYS')
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.create_aws_client'
+    )
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.get_savings_plan_purchase_recommendation_details'
+    )
+    async def test_routes_to_get_details(self, mock_impl, mock_create_client, mock_context):
+        """The detail id is the only parameter this operation takes."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_recommendation(
+            mock_context,
+            operation='get_savings_plan_purchase_recommendation_details',
+            recommendation_detail_id='d1e2f3a4',
+        )
+
+        assert mock_impl.await_args[0][2] == 'd1e2f3a4'
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.create_aws_client'
+    )
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.list_savings_plans_purchase_recommendation_generation'
+    )
+    async def test_routes_to_list_generations(self, mock_impl, mock_create_client, mock_context):
+        """The generation status filter and max_pages arrive."""
+        mock_impl.return_value = {'status': 'success', 'data': {}}
+
+        await sp_recommendation(
+            mock_context,
+            operation='list_savings_plans_purchase_recommendation_generation',
+            generation_status='FAILED',
+            max_pages=2,
+        )
+
+        args = mock_impl.await_args[0]
+        assert args[2] == 'FAILED'
+        assert args[6] == 2
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.create_aws_client'
+    )
+    async def test_unsupported_operation_lists_the_valid_ones(
+        self, mock_create_client, mock_context
+    ):
+        """Refreshing a recommendation is a mutation and is not exposed by this tool."""
+        result = await sp_recommendation(
+            mock_context,
+            operation='start_savings_plans_purchase_recommendation_generation',
+        )
+
+        assert result['status'] == 'error'
+        message = result['message']
+        assert 'get_savings_plans_purchase_recommendation' in message
+        assert 'get_savings_plan_purchase_recommendation_details' in message
+        assert 'list_savings_plans_purchase_recommendation_generation' in message
+
+    @patch(
+        'awslabs.billing_cost_management_mcp_server.tools.sp_recommendation_tools.create_aws_client'
+    )
+    async def test_client_creation_failure_is_reported(self, mock_create_client, mock_context):
+        """A client that cannot be built surfaces as an error, not a crash."""
+        mock_create_client.side_effect = ValueError("Service 'ce' is not allowed")
+
+        result = await sp_recommendation(
+            mock_context, operation='get_savings_plans_purchase_recommendation'
+        )
+
+        assert result['status'] == 'error'
+
+
+def test_sp_recommendation_server_initialization():
+    """The server is named and carries instructions."""
+    assert sp_recommendation_server.name == 'sp-recommendation-tools'
+    assert sp_recommendation_server.instructions is not None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

### Changes

Three tools covering the Savings Plans Management behaviors the BCM MCP did not reach:

- sp-explorer covers four things: plan inventory, the rates on plans already owned, the offerings available to purchase, and the rates on those offerings. It calls the Savings Plans service, which is the only source for plans in the queued, returned, and payment-failed states — Cost Explorer reports on plans that have utilization records, so those states are absent from it entirely.
- sp-recommendation returns a purchase recommendation, the hourly data-points behind one, and the generation history.
- sp-purchase-analyzer reads Purchase Analyzer results by AnalysisId and lists the analyses an account has run. It is read-only: the operations that start an analysis or refresh a recommendation mutate state and are not exposed.

Also adds the context parameter to cost-explorer's getDimensionValues. The tool description already listed it as optional but the signature did not accept it, so dimension values could only be resolved in the default COST_AND_USAGE context. SAVINGS_PLANS scopes them to the plans an account owns instead, which is what a utilization query needs.

savingsplans joins the create_aws_client allowlist, since it is a separate service from Cost Explorer.

Tests: 
- 46 new cases — 44 across the three new modules plus 2 for the context parameter. 100% statement and branch coverage on all three new modules.
- Checked responses for all APIs on Inspector with a test account

### User experience

Before, an agent could reach Savings Plans coverage and utilization, and recommendations only
through Cost Optimization Hub. Now:

**sp-explorer**
- What plans an account owns, including the queued, returned, and payment-failed ones that were
  invisible
- When a plan can still be returned
- The rate locked in on a plan already owned
- What is purchasable, and the rate for each term and payment option

**sp-recommendation**
- A recommendation for any plan type, term, and payment option the caller picks, from Cost
  Explorer rather than inherited from a Cost Optimization Hub recommendation's configuration
- The hourly detail behind a recommendation

**sp-purchase-analyzer**
- History of analysis runs
- The result of an analysis started in the console

The context parameter closes a smaller gap: resolving a filter value for a utilization query needs
values scoped to the plans an account owns, and only the default COST_AND_USAGE context was
reachable, which scopes them to usage instead.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
