### PR TITLE
fix(security-agent-mcp-server): validate base_ref in start_diff_scan

### DIFF
--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
@@ -251,7 +251,10 @@ class Scanner:
             return {'error': 'No S3 bucket configured. Run setup first.'}
 
         # Validate base_ref before it reaches the git commands below.
-        self._validate_git_ref(base_ref)
+        try:
+            self._validate_git_ref(base_ref)
+        except ValueError as e:
+            return {'error': str(e)}
 
         # Verify agent space still exists
         space = self._client.get_agent_space(agent_space_id)

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/scanner.py
@@ -68,6 +68,22 @@ class Scanner:
         """Stable short identifier for a workspace path, used as the S3 key prefix."""
         return hashlib.md5(abs_path.encode(), usedforsecurity=False).hexdigest()[:12]
 
+    @staticmethod
+    def _validate_git_ref(base_ref: str) -> None:
+        """Validate base_ref before it is used on a git command line.
+
+        ``base_ref`` is placed on git command lines (``git diff <base_ref> --`` and
+        ``git archive ... -- <base_ref>``). A value that is empty or begins with ``-`` is
+        rejected: git would otherwise treat a leading-dash value as an option rather than a
+        revision, which is never intended here. Well-formed refs are left for git to resolve.
+        """
+        if not base_ref or not base_ref.strip():
+            raise ValueError('base_ref must not be empty.')
+        if base_ref.strip().startswith('-'):
+            raise ValueError(
+                f'Invalid base_ref "{base_ref}": must be a git ref, not start with "-".'
+            )
+
     def _zip_and_upload_source(self, path: str, abs_path: str, s3_bucket: str) -> tuple[str, int]:
         """Zip the workspace and upload to a stable per-workspace S3 key, overwriting any prior upload.
 
@@ -233,6 +249,9 @@ class Scanner:
             return {'error': 'Not configured. Run setup_check and setup first.'}
         if not s3_bucket:
             return {'error': 'No S3 bucket configured. Run setup first.'}
+
+        # Validate base_ref before it reaches the git commands below.
+        self._validate_git_ref(base_ref)
 
         # Verify agent space still exists
         space = self._client.get_agent_space(agent_space_id)

--- a/src/security-agent-mcp-server/tests/test_scanner.py
+++ b/src/security-agent-mcp-server/tests/test_scanner.py
@@ -629,6 +629,63 @@ class TestDiffScan:
         assert 'Not configured' in result['error']
 
     @pytest.mark.asyncio
+    async def test_diff_scan_rejects_option_like_base_ref(self, mock_client, mock_state, tmp_path):
+        """A base_ref beginning with '-' is rejected before any git subprocess runs."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            with pytest.raises(ValueError, match='not start with'):
+                await scanner.start_diff_scan(path=str(code_dir), base_ref='--not-a-ref')
+
+        # Bailed before any git call, S3 upload, or the agent-space check — no side effects.
+        mock_run.assert_not_called()
+        mock_client.upload_to_s3.assert_not_called()
+        mock_client.get_agent_space.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_rejects_short_option_base_ref(
+        self, mock_client, mock_state, tmp_path
+    ):
+        """A bare short option (e.g. '-o') is also rejected."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            with pytest.raises(ValueError, match='not start with'):
+                await scanner.start_diff_scan(path=str(code_dir), base_ref='-o')
+
+        mock_run.assert_not_called()
+        mock_client.upload_to_s3.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_diff_scan_rejects_empty_base_ref(self, mock_client, mock_state, tmp_path):
+        """An empty/whitespace base_ref is rejected before any git subprocess runs."""
+        code_dir = tmp_path / 'code'
+        code_dir.mkdir()
+        scanner = Scanner(client=mock_client, state=mock_state)
+
+        with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
+            with pytest.raises(ValueError, match='must not be empty'):
+                await scanner.start_diff_scan(path=str(code_dir), base_ref='   ')
+
+        mock_run.assert_not_called()
+        mock_client.upload_to_s3.assert_not_called()
+
+    def test_validate_git_ref_allows_valid_refs(self):
+        """Legitimate refs pass validation (no exception)."""
+        for ref in ['HEAD', 'main', 'origin/main', 'HEAD~1', 'v1.2.3', 'abc1234']:
+            Scanner._validate_git_ref(ref)  # must not raise
+
+    def test_validate_git_ref_rejects_option_like_refs(self):
+        """Hyphen-prefixed and empty refs raise ValueError."""
+        for ref in ['--not-a-ref', '-o', '  --not-a-ref', '', '   ']:
+            with pytest.raises(ValueError):
+                Scanner._validate_git_ref(ref)
+
+    @pytest.mark.asyncio
     async def test_diff_scan_branch_ref(self, mock_client, mock_state, tmp_path):
         """Uses 'git diff base_ref' and 'git archive base_ref' for branch mode."""
         code_dir = tmp_path / 'code'

--- a/src/security-agent-mcp-server/tests/test_scanner.py
+++ b/src/security-agent-mcp-server/tests/test_scanner.py
@@ -636,9 +636,10 @@ class TestDiffScan:
         scanner = Scanner(client=mock_client, state=mock_state)
 
         with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
-            with pytest.raises(ValueError, match='not start with'):
-                await scanner.start_diff_scan(path=str(code_dir), base_ref='--not-a-ref')
+            result = await scanner.start_diff_scan(path=str(code_dir), base_ref='--not-a-ref')
 
+        assert 'error' in result
+        assert 'not start with' in result['error']
         # Bailed before any git call, S3 upload, or the agent-space check — no side effects.
         mock_run.assert_not_called()
         mock_client.upload_to_s3.assert_not_called()
@@ -654,9 +655,10 @@ class TestDiffScan:
         scanner = Scanner(client=mock_client, state=mock_state)
 
         with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
-            with pytest.raises(ValueError, match='not start with'):
-                await scanner.start_diff_scan(path=str(code_dir), base_ref='-o')
+            result = await scanner.start_diff_scan(path=str(code_dir), base_ref='-o')
 
+        assert 'error' in result
+        assert 'not start with' in result['error']
         mock_run.assert_not_called()
         mock_client.upload_to_s3.assert_not_called()
 
@@ -668,9 +670,10 @@ class TestDiffScan:
         scanner = Scanner(client=mock_client, state=mock_state)
 
         with patch('awslabs.security_agent_mcp_server.scanner.subprocess.run') as mock_run:
-            with pytest.raises(ValueError, match='must not be empty'):
-                await scanner.start_diff_scan(path=str(code_dir), base_ref='   ')
+            result = await scanner.start_diff_scan(path=str(code_dir), base_ref='   ')
 
+        assert 'error' in result
+        assert 'must not be empty' in result['error']
         mock_run.assert_not_called()
         mock_client.upload_to_s3.assert_not_called()
 


### PR DESCRIPTION
## Summary

`start_diff_scan` passed `base_ref` straight onto the `git` command line
(`git diff <base_ref> --`). A `base_ref` that is empty or begins with `-` can be
misread by git as an option rather than a revision, which leads to confusing
behavior and is never intended here. This adds a small `_validate_git_ref` check
that rejects those inputs before any git subprocess runs.

## Changes

- Reject empty/whitespace and leading-dash `base_ref` in `start_diff_scan`
  before invoking git.
- Add regression tests covering the rejected inputs and valid refs.

## Testing

`ruff check`, `ruff format --check`, `pyright`, and `pytest` all pass (138 tests).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
