### PR TITLE
fix(aws-location-mcp-server): fix optimize_waypoints response parsing

### DIFF
--- a/src/aws-location-mcp-server/awslabs/aws_location_server/server.py
+++ b/src/aws-location-mcp-server/awslabs/aws_location_server/server.py
@@ -800,13 +800,12 @@ async def optimize_waypoints(
         response = await asyncio.to_thread(client.optimize_waypoints, **params)
         if mode == 'raw':
             return response
-        routes = response.get('Routes', [])
+        routes = response.get('OptimizedWaypoints', [])
         if not routes:
             return {'error': 'No route found'}
-        route = routes[0]
-        distance_meters = route.get('Distance', None)
-        duration_seconds = route.get('DurationSeconds', None)
-        optimized_order = [wp.get('Position') for wp in route.get('Waypoints', [])]
+        distance_meters = response.get('Distance', None)
+        duration_seconds = response.get('Duration', None)
+        optimized_order = [wp.get('Position') for wp in routes]
         return {
             'distance_meters': distance_meters,
             'duration_seconds': duration_seconds,

--- a/src/aws-location-mcp-server/tests/test_server.py
+++ b/src/aws-location-mcp-server/tests/test_server.py
@@ -828,15 +828,11 @@ async def test_optimize_waypoints(mock_boto3_client, mock_context):
     """Test the optimize_waypoints tool."""
     # Set up mock response
     mock_boto3_client.optimize_waypoints.return_value = {
-        'Routes': [
-            {
-                'Distance': 150.0,
-                'DurationSeconds': 450,
-                'Waypoints': [
-                    {'Position': [-122.200676, 47.610149]},
-                ],
-            }
+        'OptimizedWaypoints': [
+            {'Id': 'Waypoint0', 'Position': [-122.200676, 47.610149]},
         ],
+        'Distance': 150.0,
+        'Duration': 450,
     }
 
     # Patch the geo_routes_client in the server module


### PR DESCRIPTION
Fixes #3494

## Summary

### Changes

The `optimize_waypoints` tool always returned `{"error": "No route found"}` because it read `response.get("Routes", [])`, but the `optimize_waypoints` API returns a different response structure with no `Routes` key.

Fixed three errors in the response parsing:
- `response.get("Routes", [])` → `response.get("OptimizedWaypoints", [])`
- `route.get("DurationSeconds")` → `response.get("Duration")`
- `route.get("Distance")` → `response.get("Distance")`

Also updated the test mock data to match the actual API response structure.

### User experience

**Before:** `optimize_waypoints` always returns `{"error": "No route found"}` regardless of input (100% broken in non-raw mode).

**After:** `optimize_waypoints` correctly returns `distance_meters`, `duration_seconds`, and `optimized_order` from the API response.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).