### PR TITLE
chore: add manaswini1920 as code owner for mysql-mcp-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,7 @@ NOTICE                                                         @awslabs/mcp-admi
 /src/mcp-lambda-handler                                        @awslabs/mcp-admins @awslabs/mcp-maintainers  @mikegc-aws @Lukas-Xue
 /src/memcached-mcp-server                                      @awslabs/mcp-admins @awslabs/mcp-maintainers  @swarnaprakash @madolson @allenss-amazon @kevinmcgehee
 /src/mssql-mcp-server                                          @awslabs/mcp-admins @awslabs/mcp-maintainers  @RobinGolden @shreyaskshekhar
-/src/mysql-mcp-server                                          @awslabs/mcp-admins @awslabs/mcp-maintainers  @kennthhz @happycupofjava
+/src/mysql-mcp-server                                          @awslabs/mcp-admins @awslabs/mcp-maintainers  @kennthhz @happycupofjava @manaswini1920
 /src/openapi-mcp-server                                        @awslabs/mcp-admins @awslabs/mcp-maintainers  @prajwalendra
 /src/oracle-mcp-server                                         @awslabs/mcp-admins @awslabs/mcp-maintainers  @RobinGolden
 /src/postgres-mcp-server                                       @awslabs/mcp-admins @awslabs/mcp-maintainers  @kennthhz @thephantomthief


### PR DESCRIPTION
PR title: chore: add manaswini1920 as code owner for mysql-mcp-server
  
  PR description:
  
  ## Summary
  
  ### Changes
  
  Add @manaswini1920 as a code owner for mysql-mcp-server.
  
  ### User experience
  
  No user-facing changes.
  
  ## Checklist
  
  * [x] I have reviewed the contributing guidelines
  * [x] I have performed a self-review of this change
  
  Is this a breaking change? N
  
  ## Acknowledgment
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
