### PR TITLE
fix(postgres-mcp-server): validate create_cluster bootstrap connection on reconnect

### DIFF
--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -451,6 +451,29 @@ async def run_query(
         )
         return [{'error': query_injection_risk_key}]
 
+    # Bootstrap hardening: a connection seeded by create_cluster enters the
+    # cache WITHOUT going through the validating connect/startup path, so it
+    # carries no privilege posture (effective_is_over_privileged is None). A
+    # direct run_query -- with no intervening connect_to_database to trip the
+    # cache-hit guardrail -- would otherwise execute against that unvalidated
+    # (possibly rds_superuser) connection. Validate it lazily on first use.
+    # 'off' means the operator opted out of privilege checks entirely, so skip
+    # (also avoids a per-query probe); gating on `is None` makes the probe fire
+    # at most once -- enforce/warn record the posture, so later queries on the
+    # same connection short-circuit. Under enforce validate_or_evict evicts and
+    # closes the connection before raising, so it is unreachable thereafter.
+    if (
+        privilege_check_policy != PRIVILEGE_CHECK_OFF
+        and db_connection.effective_is_over_privileged is None
+    ):
+        try:
+            await validate_or_evict(db_connection)
+        except Exception as e:
+            msg = f'Connection rejected by privilege guardrail: {type(e).__name__}: {e}'
+            logger.error(msg)
+            await ctx.error(msg)
+            return [{'error': msg}]
+
     try:
         logger.debug(
             (

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/server.py
@@ -337,6 +337,38 @@ def attach_privilege_advisory(llm_response: str, db_connection: AbstractDBConnec
     return json.dumps(payload, indent=2, default=str)
 
 
+async def validate_or_evict(db_connection: AbstractDBConnection) -> None:
+    """Run the post-connect guardrail; on failure evict AND close the connection.
+
+    Shared by connect_to_database's newly-created and bootstrap cache-hit paths.
+    Eagerly initializes a psycopg pool (so the privilege probe can run and
+    created_time is set at connect time), then validates under the active
+    policy. On ANY failure:
+
+      - evict so a rejected/broken connection can't be reached later via
+        run_query (fail-closed: a connection we could not validate must not
+        remain cached);
+      - close so we don't orphan an already-opened AsyncConnectionPool with
+        live backend sessions.
+
+    Eviction is by object identity because the map key uses the AWS-resolved
+    endpoint/port, which may differ from the caller-supplied args (empty
+    db_endpoint, non-5432 port, host casing); a key-based remove() rebuilt from
+    caller args could miss and leave the connection cached.
+    """
+    try:
+        if isinstance(db_connection, PsycopgPoolConnection):
+            await db_connection.initialize_pool()
+        await validate_connection(db_connection, privilege_check_policy)
+    except Exception:
+        db_connection_map.remove_connection(db_connection)
+        try:
+            await db_connection.close()
+        except Exception as close_err:
+            logger.warning(f'Error closing rejected/failed connection during cleanup: {close_err}')
+        raise
+
+
 mcp = FastMCP(
     'pg-mcp MCP server. This is the starting point for all solutions created',
     dependencies=[
@@ -587,36 +619,31 @@ async def connect_to_database(
         was_cached = any(existing is db_connection for existing in existing_connections)
 
         if was_cached:
-            # A previously-validated over-privileged connection keeps its
-            # diagnostic flag, so re-surface the advisory on reconnect too.
+            # Most cached connections were validated when first established
+            # (connect_to_database or the startup path), so skip re-probing:
+            # it is a redundant round-trip and a transient failure would evict a
+            # healthy, in-use shared connection.
+            #
+            # The exception is a connection seeded by create_cluster /
+            # create_cluster_worker: it enters the cache WITHOUT validation (the
+            # bootstrap exemption -- a freshly created cluster has only its
+            # rds_superuser master and no least-privilege role yet), so it still
+            # has effective_is_over_privileged is None. Validate that one now --
+            # the deferred half of "validate-on-create with a bootstrap
+            # exemption" -- so 'enforce' cannot surface an unvalidated,
+            # over-privileged bootstrap connection as a usable success. On
+            # rejection validate_or_evict evicts AND closes it, so it can no
+            # longer be reached via run_query.
+            if db_connection.effective_is_over_privileged is None:
+                await validate_or_evict(db_connection)
+            # A previously- or now-validated over-privileged connection keeps
+            # its diagnostic flag, so surface the advisory on reconnect too.
             return attach_privilege_advisory(str(llm_response), db_connection)
 
-        # Newly-created connection: eagerly initialize the pool (so it's ready
-        # for queries and created_time is set at connect time) and run the
-        # least-privilege guardrail. On ANY failure, evict AND close the fresh
-        # connection:
-        #   - evict so a rejected/broken connection can't be reached later via
-        #     run_query (fail-closed: a fresh connection we could not validate
-        #     must not remain cached);
-        #   - close so we don't orphan an already-opened AsyncConnectionPool
-        #     with live backend sessions.
-        # Evict by object identity because the map key uses the AWS-resolved
-        # endpoint/port, which may differ from the caller-supplied args here
-        # (empty db_endpoint, non-5432 port, host casing); a key-based remove()
-        # rebuilt from caller args could miss and leave the connection cached.
-        try:
-            if isinstance(db_connection, PsycopgPoolConnection):
-                await db_connection.initialize_pool()
-            await validate_connection(db_connection, privilege_check_policy)
-        except Exception:
-            db_connection_map.remove_connection(db_connection)
-            try:
-                await db_connection.close()
-            except Exception as close_err:
-                logger.warning(
-                    f'Error closing rejected/failed connection during cleanup: {close_err}'
-                )
-            raise
+        # Newly-created connection: eagerly initialize the pool and run the
+        # least-privilege guardrail, evicting+closing on any failure. See
+        # validate_or_evict for the fail-closed rationale.
+        await validate_or_evict(db_connection)
 
         return attach_privilege_advisory(str(llm_response), db_connection)
 

--- a/src/postgres-mcp-server/tests/conftest.py
+++ b/src/postgres-mcp-server/tests/conftest.py
@@ -174,6 +174,9 @@ class Mock_DBConnection:
         self.readonly = readonly
         self.error = error
         self._data_client = Mock_boto3_client(error)
+        # Mirror AbstractDBConnection's contract: a freshly created connection
+        # has no privilege posture until validate_connection has run.
+        self.effective_is_over_privileged = None
 
     @property
     def data_client(self):
@@ -512,6 +515,9 @@ class Mock_PsycopgPoolConnection:
         self.min_size = min_size
         self.max_size = max_size
         self.is_test = is_test
+        # Mirror AbstractDBConnection's contract: no privilege posture until
+        # validate_connection has run.
+        self.effective_is_over_privileged = None
         self.pool = MockConnectionPool(
             conninfo=f'host={host} port={port} dbname={database} user=test_user password=test_password',
             min_size=min_size,

--- a/src/postgres-mcp-server/tests/test_privilege_guardrail.py
+++ b/src/postgres-mcp-server/tests/test_privilege_guardrail.py
@@ -22,17 +22,26 @@ exercises the same contract that both PsycopgPoolConnection and
 RDSDataAPIConnection satisfy.
 """
 
+import json
 import pytest
 from awslabs.postgres_mcp_server.connection.abstract_db_connection import AbstractDBConnection
+from awslabs.postgres_mcp_server.connection.db_connection_map import (
+    ConnectionMethod,
+    DatabaseType,
+)
 from awslabs.postgres_mcp_server.server import (
     POSTGRES_PRIVILEGE_QUERY,
     PRIVILEGE_CHECK_ENFORCE,
     PRIVILEGE_CHECK_OFF,
     PRIVILEGE_CHECK_WARN,
     ConnectionValidationError,
+    connect_to_database,
+    db_connection_map,
     privilege_check_policy,
+    run_query,
     validate_connection,
 )
+from tests.conftest import DummyCtx
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
@@ -408,3 +417,163 @@ class TestEffectiveIsOverPrivilegedDiagnostic:
         conn = FakeConnection(response={'columnMetadata': [], 'records': []})
         await validate_connection(conn, PRIVILEGE_CHECK_WARN)
         assert conn.effective_is_over_privileged is None
+
+
+# Coordinates for the create_cluster bootstrap scenario. run_query looks the
+# connection up WITHOUT a port, so everything uses the 5432 default to keep one
+# consistent map key across the seed -> connect -> query flow.
+_REGION = 'us-east-1'
+_METHOD = ConnectionMethod.RDS_API
+_CLUSTER = 'victim-cluster'
+_ENDPOINT = 'victim.cluster-abc.us-east-1.rds.amazonaws.com'
+_DATABASE = 'appdb'
+_PORT = 5432
+
+
+def _seed_bootstrap_connection(conn: AbstractDBConnection) -> None:
+    """Reproduce the post-create_cluster map state.
+
+    create_cluster / create_cluster_worker seed the freshly created cluster's
+    rds_superuser master connection via internal_create_connection WITHOUT ever
+    calling validate_connection, so the connection lands in the map with
+    effective_is_over_privileged still None. Seeding directly yields the
+    identical map state without the AWS API calls create_cluster would make.
+    """
+    db_connection_map.map.clear()
+    db_connection_map.set(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, conn, _PORT)
+
+
+class TestBootstrapReconnectGuardrail:
+    """Reconnecting to a create_cluster-seeded connection must honor the policy.
+
+    A connection seeded by create_cluster enters the cache WITHOUT going through
+    the validating connect/startup path, so it carries no privilege posture
+    (effective_is_over_privileged is None). connect_to_database's cache-hit
+    fast-return must not surface such an unvalidated over-privileged connection
+    as a usable success under 'enforce'.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reconnect_validates_and_rejects_bootstrap_superuser_under_enforce(self):
+        """enforce: reconnecting to an unvalidated rds_superuser conn is rejected+evicted."""
+        conn = FakeConnection(response=privilege_response(False, True))  # rds_superuser
+        _seed_bootstrap_connection(conn)
+        assert conn.effective_is_over_privileged is None  # never validated (bootstrap)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_ENFORCE
+        ):
+            result = await connect_to_database(
+                region=_REGION,
+                database_type=DatabaseType.APG,
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                port=_PORT,
+                database=_DATABASE,
+            )
+
+        parsed = json.loads(result)
+        # The over-privileged bootstrap connection must be rejected, not surfaced.
+        assert parsed.get('status') == 'Failed', f'expected rejection, got {parsed}'
+        # ...and evicted, so it cannot be reached later via run_query (fail-closed).
+        assert db_connection_map.get(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, _PORT) is None, (
+            'over-privileged bootstrap connection must be evicted on rejection'
+        )
+        # The privilege probe actually ran on the cache-hit path.
+        assert POSTGRES_PRIVILEGE_QUERY in conn.queries
+        db_connection_map.map.clear()
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_connection_not_queryable_after_rejected_reconnect(self):
+        """enforce: the PoC consequence is cured -- run_query can't reach the conn."""
+        conn = FakeConnection(response=privilege_response(False, True))  # rds_superuser
+        _seed_bootstrap_connection(conn)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_ENFORCE
+        ):
+            await connect_to_database(
+                region=_REGION,
+                database_type=DatabaseType.APG,
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                port=_PORT,
+                database=_DATABASE,
+            )
+            rows = await run_query(
+                sql='SELECT rolname, rolpassword FROM pg_authid',  # superuser-only read
+                ctx=DummyCtx(),
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                database=_DATABASE,
+            )
+
+        # run_query returns an error payload (no connection), never data rows.
+        assert len(rows) == 1 and 'error' in rows[0], f'expected no-connection error, got {rows}'
+        db_connection_map.map.clear()
+
+    @pytest.mark.asyncio
+    async def test_already_validated_cached_connection_not_revalidated(self):
+        """A previously-validated cached connection short-circuits with no re-probe.
+
+        Guards the caching contract: reconnecting to a healthy, already-validated
+        connection must not issue a fresh (billable / evict-risking) privilege
+        probe.
+        """
+        conn = FakeConnection(response=privilege_response(False, False))  # clean role
+        conn.effective_is_over_privileged = False  # simulate a prior successful validation
+        _seed_bootstrap_connection(conn)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_ENFORCE
+        ):
+            result = await connect_to_database(
+                region=_REGION,
+                database_type=DatabaseType.APG,
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                port=_PORT,
+                database=_DATABASE,
+            )
+
+        parsed = json.loads(result)
+        assert parsed.get('status') != 'Failed', f'expected success, got {parsed}'
+        # No privilege probe was issued on the already-validated cache hit.
+        assert conn.queries == [], f'expected no re-validation probe, got {conn.queries}'
+        assert db_connection_map.get(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, _PORT) is conn
+        db_connection_map.map.clear()
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_over_privileged_allowed_with_advisory_under_warn(self):
+        """warn: an unvalidated over-privileged bootstrap conn is allowed, with advisory."""
+        conn = FakeConnection(response=privilege_response(False, True))  # rds_superuser
+        _seed_bootstrap_connection(conn)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_WARN
+        ):
+            result = await connect_to_database(
+                region=_REGION,
+                database_type=DatabaseType.APG,
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                port=_PORT,
+                database=_DATABASE,
+            )
+
+        parsed = json.loads(result)
+        assert parsed.get('status') != 'Failed', f'expected allow under warn, got {parsed}'
+        # The posture is now determined and surfaced to the caller.
+        assert conn.effective_is_over_privileged is True
+        advisories = parsed.get('advisories', [])
+        assert any(a.get('code') == 'over_privileged_role' for a in advisories), (
+            f'expected over_privileged advisory, got {parsed}'
+        )
+        # Under warn the connection remains cached (allowed).
+        assert db_connection_map.get(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, _PORT) is conn
+        db_connection_map.map.clear()

--- a/src/postgres-mcp-server/tests/test_privilege_guardrail.py
+++ b/src/postgres-mcp-server/tests/test_privilege_guardrail.py
@@ -577,3 +577,130 @@ class TestBootstrapReconnectGuardrail:
         # Under warn the connection remains cached (allowed).
         assert db_connection_map.get(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, _PORT) is conn
         db_connection_map.map.clear()
+
+
+# A superuser-only read used as the "attacker payload" in the direct-run_query
+# scenario. Read-only (passes run_query's readonly gate) and free of mutating /
+# injection patterns, so the ONLY thing that can stop it is the privilege gate.
+_SENSITIVE_SQL = 'SELECT rolname FROM pg_authid'
+
+
+class TestRunQueryBootstrapGuardrail:
+    """Direct run_query must not trust a never-validated (bootstrap) connection.
+
+    Closes the residual path left open by the connect_to_database fix: an
+    attacker who calls run_query directly -- with NO intervening
+    connect_to_database -- would otherwise execute against a create_cluster-
+    seeded rds_superuser connection whose privilege posture was never checked
+    (effective_is_over_privileged is None). run_query now validates such a
+    connection lazily on first use, honoring the active policy.
+    """
+
+    @pytest.mark.asyncio
+    async def test_direct_run_query_rejects_unvalidated_over_privileged_under_enforce(self):
+        """enforce: a direct run_query on an unvalidated rds_superuser conn is refused."""
+        conn = FakeConnection(response=privilege_response(False, True))  # rds_superuser
+        _seed_bootstrap_connection(conn)
+        assert conn.effective_is_over_privileged is None  # never validated (bootstrap)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_ENFORCE
+        ):
+            rows = await run_query(
+                sql=_SENSITIVE_SQL,
+                ctx=DummyCtx(),
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                database=_DATABASE,
+            )
+
+        # The query is refused with an error payload, never data rows.
+        assert len(rows) == 1 and 'error' in rows[0], f'expected rejection, got {rows}'
+        # The privilege probe ran, but the sensitive read never executed.
+        assert POSTGRES_PRIVILEGE_QUERY in conn.queries
+        assert _SENSITIVE_SQL not in conn.queries, 'sensitive query must not execute'
+        # And the rejected connection is evicted (fail-closed).
+        assert db_connection_map.get(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, _PORT) is None
+        db_connection_map.map.clear()
+
+    @pytest.mark.asyncio
+    async def test_direct_run_query_allows_unvalidated_over_privileged_under_warn(self):
+        """warn: the query runs, the posture is recorded, the connection stays cached."""
+        conn = FakeConnection(response=privilege_response(False, True))  # rds_superuser
+        _seed_bootstrap_connection(conn)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_WARN
+        ):
+            rows = await run_query(
+                sql=_SENSITIVE_SQL,
+                ctx=DummyCtx(),
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                database=_DATABASE,
+            )
+
+        # Allowed: real rows, not an error payload.
+        assert not (len(rows) == 1 and 'error' in rows[0]), (
+            f'expected allow under warn, got {rows}'
+        )
+        # The posture was probed and recorded, and the sensitive read executed.
+        assert conn.effective_is_over_privileged is True
+        assert POSTGRES_PRIVILEGE_QUERY in conn.queries
+        assert _SENSITIVE_SQL in conn.queries
+        assert db_connection_map.get(_METHOD, _CLUSTER, _ENDPOINT, _DATABASE, _PORT) is conn
+        db_connection_map.map.clear()
+
+    @pytest.mark.asyncio
+    async def test_direct_run_query_does_not_revalidate_already_validated_connection(self):
+        """A previously-validated connection is not re-probed on every run_query."""
+        conn = FakeConnection(response=privilege_response(False, False))  # clean role
+        conn.effective_is_over_privileged = False  # simulate a prior successful validation
+        _seed_bootstrap_connection(conn)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_ENFORCE
+        ):
+            rows = await run_query(
+                sql=_SENSITIVE_SQL,
+                ctx=DummyCtx(),
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                database=_DATABASE,
+            )
+
+        assert not (len(rows) == 1 and 'error' in rows[0]), f'expected success, got {rows}'
+        # No re-validation probe; only the actual query ran.
+        assert POSTGRES_PRIVILEGE_QUERY not in conn.queries
+        assert conn.queries == [_SENSITIVE_SQL]
+        db_connection_map.map.clear()
+
+    @pytest.mark.asyncio
+    async def test_direct_run_query_skips_validation_when_policy_off(self):
+        """off: the operator opted out -- no lazy probe, no per-query overhead."""
+        conn = FakeConnection(response=privilege_response(False, True))  # rds_superuser
+        _seed_bootstrap_connection(conn)
+
+        with patch(
+            'awslabs.postgres_mcp_server.server.privilege_check_policy', PRIVILEGE_CHECK_OFF
+        ):
+            rows = await run_query(
+                sql=_SENSITIVE_SQL,
+                ctx=DummyCtx(),
+                connection_method=_METHOD,
+                cluster_identifier=_CLUSTER,
+                db_endpoint=_ENDPOINT,
+                database=_DATABASE,
+            )
+
+        assert not (len(rows) == 1 and 'error' in rows[0]), (
+            f'expected success under off, got {rows}'
+        )
+        # No privilege probe was issued; posture stays undetermined.
+        assert POSTGRES_PRIVILEGE_QUERY not in conn.queries
+        assert conn.effective_is_over_privileged is None
+        assert conn.queries == [_SENSITIVE_SQL]
+        db_connection_map.map.clear()

--- a/src/postgres-mcp-server/tests/test_server.py
+++ b/src/postgres-mcp-server/tests/test_server.py
@@ -489,6 +489,12 @@ def validate_normal_query_response(column_records):
 
 def setup_mock_connection(mock_db_connection, connection_method=ConnectionMethod.RDS_API):
     """Helper function to set up a mock connection in the global db_connection_map."""
+    # A connection cached and ready to serve run_query has, in production, been
+    # validated by connect_to_database (or startup). Mark it validated (clean)
+    # so run_query's lazy bootstrap guardrail short-circuits, matching that
+    # realistic post-connect state. Tests that specifically exercise the
+    # never-validated bootstrap path seed connections directly instead.
+    mock_db_connection.effective_is_over_privileged = False
     db_connection_map.set(
         connection_method, 'test-cluster', 'test-endpoint', 'test-db', mock_db_connection
     )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes the `create_cluster` bootstrap privilege-check bypass reported as a follow-up on #4299 (the least-privilege guardrail PR).

## Summary

Under `--privilege_check=enforce` (the mode the guardrail PR calls "recommended for production"), an over-privileged bootstrap connection could stay reachable and queryable, defeating the guardrail.

`create_cluster` / `create_cluster_worker` connect to the freshly created cluster as its `rds_superuser` master and seed `db_connection_map` via `internal_create_connection` **without ever calling `validate_connection`**, leaving `effective_is_over_privileged=None`. Two paths could then reach that unvalidated connection:

1. A later `connect_to_database` for that same target hit the `was_cached` fast-return and reported success **before (and instead of)** running the guardrail.
2. A direct `run_query` (with no intervening `connect_to_database`) fetched the cached connection and executed **without any privilege validation at all**.

Either way, every subsequent query ran as `rds_superuser`. This PR closes **both** paths with a single validation/eviction primitive.

### Changes

- **`server.py`**
  - Add `validate_or_evict(db_connection)`: runs the post-connect guardrail (`initialize_pool` for pooled connections, then `validate_connection`) and, on rejection, **evicts and closes** the connection before re-raising. Eviction is what cures the downstream "trust the cache" consequence.
  - In `connect_to_database`, the `was_cached` branch now **lazily validates** a cached connection that was never validated (`effective_is_over_privileged is None`) — the "validate-on-create with a bootstrap exemption" approach documented as the maintainers' intended follow-up. Already-validated connections are **not** re-validated.
  - In `run_query`, add the same lazy guardrail for a never-validated cached connection so a **direct `run_query` cannot trust an unvalidated (possibly `rds_superuser`) bootstrap connection**. Honors the active policy: `enforce` rejects the query and evicts+closes the connection (fail-closed); `warn` allows and records the posture; `off` skips (operator opted out — no per-query probe). Gating on `effective_is_over_privileged is None` means the probe fires **at most once** per connection.
  - Refactor the newly-created-connection branch to call the same `validate_or_evict` helper (single validation/eviction path shared by all three call sites).
- **`tests/test_privilege_guardrail.py`**
  - `TestBootstrapReconnectGuardrail` (connect path): reconnect validates and **rejects** a bootstrap `rds_superuser` under `enforce`; the rejected/evicted connection is **not queryable**; an already-validated connection is **not re-validated**; under `warn` it is allowed **with an advisory**.
  - `TestRunQueryBootstrapGuardrail` (direct-`run_query` path): a direct `run_query` on an unvalidated `rds_superuser` connection is **refused and evicted** under `enforce` (the sensitive query never executes); **allowed with the posture recorded** under `warn`; an **already-validated connection is not re-probed**; and validation is **skipped under `off`**.
- **`tests/conftest.py`, `tests/test_server.py`** — the test doubles (`Mock_DBConnection`, `Mock_PsycopgPoolConnection`) now mirror `AbstractDBConnection`'s `effective_is_over_privileged` contract, and `setup_mock_connection` marks cached connections validated to reflect the realistic post-connect state (a connection reaching `run_query` in production has already been validated by `connect_to_database`).

### User experience

- **Before:** `create_cluster` → the over-privileged connection is reachable both via `connect_to_database` (cache fast-return, no guardrail) **and** via a direct `run_query` (no validation), so `run_query` runs as `rds_superuser` under `enforce`.
- **After:** the first use of a never-validated bootstrap connection — whether through `connect_to_database` **or** directly through `run_query` — runs the guardrail. Under `enforce` an over-privileged connection is rejected, evicted, and closed (not queryable); under `warn` it is allowed with the posture surfaced (advisory on connect, warning logged on query); under `off` nothing changes. Already-validated connections are unaffected (no redundant probe).

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) N — behavior change only for previously-unvalidated over-privileged bootstrap connections under `enforce`, which the guardrail was already intended to reject.

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
