### PR TITLE
fix(aws-network-mcp-server): find_ip_address now locates ENIs by secondary IP

### DIFF
--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/general/find_ip_address.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/general/find_ip_address.py
@@ -76,7 +76,7 @@ async def find_ip_address(
     if not all_regions:
         try:
             response = ec2_client.describe_network_interfaces(
-                Filters=[{'Name': 'private-ip-address', 'Values': [ip_address]}]
+                Filters=[{'Name': 'addresses.private-ip-address', 'Values': [ip_address]}]
             )
 
             if response['NetworkInterfaces']:
@@ -107,7 +107,7 @@ async def find_ip_address(
             ec2_client = get_aws_client('ec2', region, profile_name)
             try:
                 response = ec2_client.describe_network_interfaces(
-                    Filters=[{'Name': 'private-ip-address', 'Values': [ip_address]}]
+                    Filters=[{'Name': 'addresses.private-ip-address', 'Values': [ip_address]}]
                 )
 
                 if response['NetworkInterfaces']:

--- a/src/aws-network-mcp-server/tests/tools/general/test_find_ip_address.py
+++ b/src/aws-network-mcp-server/tests/tools/general/test_find_ip_address.py
@@ -64,7 +64,7 @@ class TestFindIpAddress:
         assert result == sample_eni_response
         mock_get_client.assert_called_once_with('ec2', 'us-east-1', None)
         mock_ec2_client.describe_network_interfaces.assert_called_once_with(
-            Filters=[{'Name': 'private-ip-address', 'Values': ['10.0.1.100']}]
+            Filters=[{'Name': 'addresses.private-ip-address', 'Values': ['10.0.1.100']}]
         )
 
     @patch.object(find_ip_module, 'get_aws_client')


### PR DESCRIPTION
Fixes #3495

## Summary

### Changes

Changed the EC2 `describe_network_interfaces` filter from `private-ip-address` to `addresses.private-ip-address` in `find_ip_address.py` (2 places). The `addresses.private-ip-address` filter matches both primary and secondary private IPs on an ENI.

### User experience

**Before:** `find_ip_address` fails with "IP address not found" when the IP is configured as a secondary IP on an ENI.

**After:** `find_ip_address` correctly locates the ENI regardless of whether the IP is primary or secondary.

### Verification

- Reproduced the actual EC2 API behavior in a sandbox account: `private-ip-address` filter fails to find an ENI by its secondary IP, while `addresses.private-ip-address` finds it correctly. Both filters find the ENI by its primary IP as a control.
- Updated the existing unit test's filter assertion to match; all 7 tests in `test_find_ip_address.py` pass.
- `ruff check` / `ruff format --check` pass on the changed files.

## Checklist
- [x] I have reviewed the contributing guidelines
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).