### PR TITLE
fix(aws-documentation-mcp-server): stop returning Highly Rated recommendations

### DIFF
--- a/src/aws-documentation-mcp-server/CHANGELOG.md
+++ b/src/aws-documentation-mcp-server/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add environment variable `AWS_DOCUMENTATION_PARTITION` to select AWS documentation partition.
 - Add `get_available_services` and `read_documentation` when `AWS_DOCUMENTATION_PARTITION` is set to `aws-cn`.
 
+### Removed
+
+- The `recommend` tool no longer returns Highly Rated recommendations. The upstream recommendation type has been retired, so the tool now returns New, Similar, and Journey results only.
+
 ## [1.0.0] - 2025-05-26
 
 ### Removed

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_aws.py
@@ -659,19 +659,17 @@ async def recommend(
 
     ## Recommendation Types
 
-    The recommendations include four categories:
+    The recommendations include three categories:
 
-    1. **Highly Rated**: Popular pages within the same AWS service
-    2. **New**: Recently added pages within the same AWS service - useful for finding newly released features
-    3. **Similar**: Pages covering similar topics to the current page
-    4. **Journey**: Pages commonly viewed next by other users
+    1. **New**: Recently added pages within the same AWS service - useful for finding newly released features
+    2. **Similar**: Pages covering similar topics to the current page
+    3. **Journey**: Pages commonly viewed next by other users
 
     ## When to Use
 
     - After reading a documentation page to find related content
     - When exploring a new AWS service to discover important pages
     - To find alternative explanations of complex concepts
-    - To discover the most popular pages for a service
     - To find newly released information by using a service's welcome page URL and checking the **New** recommendations
 
     ## Finding New Features

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
@@ -376,17 +376,6 @@ def parse_recommendation_results(data: Dict[str, Any]) -> List[RecommendationRes
     """
     results = []
 
-    # Process highly rated recommendations
-    if 'highlyRated' in data and 'items' in data['highlyRated']:
-        for item in data['highlyRated']['items']:
-            context = item.get('abstract') if 'abstract' in item else None
-
-            results.append(
-                RecommendationResult(
-                    url=item.get('url', ''), title=item.get('assetTitle', ''), context=context
-                )
-            )
-
     # Process journey recommendations (organized by intent)
     if 'journey' in data and 'items' in data['journey']:
         for intent_group in data['journey']['items']:

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -1090,12 +1090,12 @@ class TestRecommend:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            'highlyRated': {
+            'new': {
                 'items': [
                     {
                         'url': 'https://docs.aws.amazon.com/rec1',
                         'assetTitle': 'Recommendation 1',
-                        'abstract': 'This is recommendation 1.',
+                        'dateCreated': '2026-01-01',
                     }
                 ]
             },
@@ -1118,7 +1118,7 @@ class TestRecommend:
             assert len(results) == 2
             assert results[0].url == 'https://docs.aws.amazon.com/rec1'
             assert results[0].title == 'Recommendation 1'
-            assert results[0].context == 'This is recommendation 1.'
+            assert results[0].context == 'New content added on 2026-01-01'
             assert results[1].url == 'https://docs.aws.amazon.com/rec2'
             assert results[1].title == 'Recommendation 2'
             assert results[1].context == 'This is recommendation 2.'

--- a/src/aws-documentation-mcp-server/tests/test_util.py
+++ b/src/aws-documentation-mcp-server/tests/test_util.py
@@ -363,29 +363,6 @@ class TestParseRecommendationResults:
         results = parse_recommendation_results(data)
         assert results == []
 
-    def test_highly_rated_recommendations(self):
-        """Test parsing highly rated recommendations."""
-        data = {
-            'highlyRated': {
-                'items': [
-                    {
-                        'url': 'https://docs.aws.amazon.com/test1',
-                        'assetTitle': 'Test 1',
-                        'abstract': 'Abstract 1',
-                    },
-                    {'url': 'https://docs.aws.amazon.com/test2', 'assetTitle': 'Test 2'},
-                ]
-            }
-        }
-        results = parse_recommendation_results(data)
-        assert len(results) == 2
-        assert results[0].url == 'https://docs.aws.amazon.com/test1'
-        assert results[0].title == 'Test 1'
-        assert results[0].context == 'Abstract 1'
-        assert results[1].url == 'https://docs.aws.amazon.com/test2'
-        assert results[1].title == 'Test 2'
-        assert results[1].context is None
-
     def test_journey_recommendations(self):
         """Test parsing journey recommendations."""
         data = {
@@ -464,9 +441,6 @@ class TestParseRecommendationResults:
     def test_all_recommendation_types(self):
         """Test parsing all recommendation types together."""
         data = {
-            'highlyRated': {
-                'items': [{'url': 'https://docs.aws.amazon.com/hr', 'assetTitle': 'HR'}]
-            },
             'journey': {
                 'items': [
                     {
@@ -483,10 +457,9 @@ class TestParseRecommendationResults:
             },
         }
         results = parse_recommendation_results(data)
-        assert len(results) == 4
+        assert len(results) == 3
         # Check that we have one of each type (order doesn't matter for this test)
         urls = [r.url for r in results]
-        assert 'https://docs.aws.amazon.com/hr' in urls
         assert 'https://docs.aws.amazon.com/journey' in urls
         assert 'https://docs.aws.amazon.com/new' in urls
         assert 'https://docs.aws.amazon.com/similar' in urls


### PR DESCRIPTION
## Summary

### Changes

The Highly Rated recommendation type is being retired upstream, so the `highlyRated` block in the recommendations API response will stop being populated.

- Dropped the `highlyRated` branch from `parse_recommendation_results`.
- Updated the `recommend` tool description to three categories (New, Similar, Journey), and removed the "most popular pages for a service" guidance, which was Highly Rated only.
- Dropped the `highlyRated` cases from the parser tests, and switched one block  in the `test_recommend` mock response from `highlyRated` to `new` so that test still covers two recommendation categories.

Only `recommend` is affected, and it is global-only, so the China-partition server is untouched.

### User experience

`recommend` now returns New, Similar, and Journey items only.

Result counts drop by roughly half to two-thirds, because Highly Rated is a fixed 12-item block and the largest part of the response today, but that data is being retired and will stop being refreshed.

New, Similar, and Journey are unchanged item for item, and there is no schema change: still `List[RecommendationResult]`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
