### PR TITLE
fix(well-architected-security): fix Inspector severity filter parameter name

### DIFF
--- a/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/server.py
+++ b/src/well-architected-security-mcp-server/awslabs/well_architected_security_mcp_server/server.py
@@ -438,7 +438,7 @@ async def get_security_findings(
                 }
             elif service_name == "inspector":
                 filter_criteria = {
-                    "severities": [{"comparison": "EQUALS", "value": severity_filter.upper()}]
+                    "severity": [{"comparison": "EQUALS", "value": severity_filter.upper()}]
                 }
             elif service_name == "trustedadvisor":
                 # For Trusted Advisor, severity maps to status (error, warning, ok)


### PR DESCRIPTION
The Inspector filterCriteria uses "severity" (singular) but the code sends "severities" (plural), causing all Inspector finding queries to fail with a parameter validation error.

This was reported in #2237 and a fix was attempted in #2243 but closed without merging. The bug persists in the latest release (0.1.10).

Changed "severities" → "severity" to match the Inspector2 API spec.