### PR TITLE
fix(deps): repair uv.lock parse failure from pyjwt 2.13.0 bump (11 servers)

### DIFF
--- a/src/cloudwatch-mcp-server/uv.lock
+++ b/src/cloudwatch-mcp-server/uv.lock
@@ -1323,7 +1323,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/documentdb-mcp-server/uv.lock
+++ b/src/documentdb-mcp-server/uv.lock
@@ -1005,7 +1005,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/elasticache-mcp-server/uv.lock
+++ b/src/elasticache-mcp-server/uv.lock
@@ -1030,7 +1030,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/finch-mcp-server/uv.lock
+++ b/src/finch-mcp-server/uv.lock
@@ -1097,7 +1097,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/iam-mcp-server/uv.lock
+++ b/src/iam-mcp-server/uv.lock
@@ -1055,7 +1055,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/memcached-mcp-server/uv.lock
+++ b/src/memcached-mcp-server/uv.lock
@@ -998,7 +998,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/prometheus-mcp-server/uv.lock
+++ b/src/prometheus-mcp-server/uv.lock
@@ -1084,7 +1084,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/redshift-mcp-server/uv.lock
+++ b/src/redshift-mcp-server/uv.lock
@@ -1057,7 +1057,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/timestream-for-influxdb-mcp-server/uv.lock
+++ b/src/timestream-for-influxdb-mcp-server/uv.lock
@@ -1067,7 +1067,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/valkey-mcp-server/uv.lock
+++ b/src/valkey-mcp-server/uv.lock
@@ -1249,7 +1249,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [

--- a/src/well-architected-security-mcp-server/uv.lock
+++ b/src/well-architected-security-mcp-server/uv.lock
@@ -810,7 +810,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes the `Install dependencies` build failure introduced by #4503 (merged as a7b32633).

## Summary

### Changes

Dependabot #4503 bumped `pyjwt` 2.10.1 → 2.13.0 across 30 directories. pyjwt 2.13.0 introduced a **new conditional dependency** on `typing-extensions` for `python_full_version < '3.11'`.

Dependabot edits `uv.lock` surgically rather than re-resolving, and in **11 of the 30** locks it wrote that new edge with an explicit version pin:

```toml
{ name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
```

In `uv.lock`, a dependency edge carries `version`/`source` **only** when the lock holds multiple forked versions of that package. Each of these 11 locks contains a **single** `typing-extensions` entry (`4.16.0`), so the pinned edge (`4.13.2` or `4.14.0`) pointed at a package with no `[[package]]` stanza. uv rejects the file at parse time:

```
error: Failed to parse `uv.lock`
  Caused by: For package `pyjwt==2.13.0 @ registry+https://pypi.org/simple`,
             found dependency `typing-extensions==4.14.0` with no locked package
```

The remaining 19 locks received a *bare* edge and were unaffected — the failing set is exactly the pinned set.

**Fix:** drop the bogus `version`/`source` pin so each edge binds to the single locked `typing-extensions`. This is the canonical form uv itself emits, and is exactly what the 19 healthy locks contain. One line per lockfile, 11 files.

> [!NOTE]
> `uv lock` cannot regenerate these files — it hits the same parse error before it can re-resolve, so the repair has to be textual. **No resolved versions change**: `typing-extensions 4.16.0` was already the only locked version, so this only restores the lock to a parseable state.

Affected servers: `cloudwatch`, `documentdb`, `elasticache`, `finch`, `iam`, `memcached`, `prometheus`, `redshift`, `timestream-for-influxdb`, `valkey`, `well-architected-security`.

### User experience

**Before** — `uv sync --frozen --all-extras --dev` fails for all 11 servers, so `Build <pkg>` is red on `main` and these servers cannot be installed from the committed lock:

```
$ cd src/iam-mcp-server && uv sync --frozen --all-extras --dev
error: Failed to parse `uv.lock`
  Caused by: For package `pyjwt==2.13.0 ...`, found dependency
             `typing-extensions==4.14.0` with no locked package
```

**After** — installs cleanly and CI goes green:

```
$ cd src/iam-mcp-server && uv sync --frozen --all-extras --dev
$ uv run --frozen pytest -q
174 passed in 2.18s
```

## Verification

Reproduced the failure across all 30 touched directories, confirming exactly 11 fail and that they correspond 1:1 with the pinned-edge locks. After the fix, for **all 11** servers on **Python 3.10** (the version where the marker is active, and what CI pins via `.python-version`):

| Check | Result |
|---|---|
| `uv sync --frozen --all-extras --dev` (the failing CI step) | 11/11 pass |
| `pyjwt` 2.13.0 imports against `typing-extensions` 4.16.0 and signs a token | 11/11 pass |
| `uv run --frozen pytest` | 11/11 pass |

<details>
<summary>Note on <code>uv lock --check</code> and two locally-flaky suites</summary>

- `uv lock --check` reports "needs to be updated" for these locks — but it does so for **untouched** packages too (`aurora-dsql`, `postgres`, `aws-location`), so that drift is pre-existing and repo-wide, not introduced here. The CI gate is `uv sync --frozen`, which passes.
- `elasticache` and `timestream-for-influxdb` each showed 1 failure locally purely because a local `AWS_PROFILE` leaked into `Session(...)` assertions. With `AWS_PROFILE` unset (as in CI): 414 passed and 154 passed respectively.

</details>

## Follow-up (not in this PR)

This can recur on any Dependabot bump that introduces a *new* transitive dependency, since Dependabot may emit a pinned edge the host lock cannot satisfy. Worth considering a CI check that runs `uv sync --frozen` on changed lock directories in the Dependabot PR itself, so the breakage is caught before merge rather than on `main`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
