### PR TITLE
fix(aws-transform): increase artifact transfer timeouts

### DIFF
--- a/src/aws-transform-mcp-server/CHANGELOG.md
+++ b/src/aws-transform-mcp-server/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Artifact uploads and downloads now use transfer-specific HTTP timeouts instead
+  of HTTPX's five-second default, preventing large pre-signed S3 transfers from
+  failing while data is still being sent or received.
 - `load_instructions` now discovers instruction documents stored inside
   artifact-store folders. Customer uploads (the `upload_artifact` tool and the
   AWS Transform web console) are stored under the store's `User Uploads/`

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/consts.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/consts.py
@@ -14,6 +14,7 @@
 
 """Constants for aws-transform-mcp-server."""
 
+import httpx
 from typing import List, Set
 
 
@@ -38,6 +39,22 @@ STARTUP_TIMEOUT_SECONDS: float = 5.0
 STARTUP_MAX_RETRIES: int = 0
 MAX_RETRIES: int = 3
 RETRYABLE_STATUSES: Set[int] = {429, 500, 502, 503, 504}
+
+# ── Artifact transfer timeout ────────────────────────────────────────────
+# Uploads are buffered and sent as a single byte stream, so large files need
+# a longer write timeout than ordinary API requests.
+ARTIFACT_UPLOAD_TIMEOUT = httpx.Timeout(
+    connect=10.0,
+    read=60.0,
+    write=900.0,
+    pool=10.0,
+)
+ARTIFACT_DOWNLOAD_TIMEOUT = httpx.Timeout(
+    connect=10.0,
+    read=60.0,
+    write=60.0,
+    pool=10.0,
+)
 
 # ── Token refresh ────────────────────────────────────────────────────────
 TOKEN_REFRESH_BUFFER_SECS: int = 300  # refresh if < 5 min left

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tool_utils.py
@@ -17,6 +17,7 @@
 import httpx
 import json
 import os
+from awslabs.aws_transform_mcp_server.consts import ARTIFACT_DOWNLOAD_TIMEOUT
 from typing import Any, Dict, Optional
 
 
@@ -257,7 +258,7 @@ async def download_s3_content(
     """
     from awslabs.aws_transform_mcp_server.file_validation import validate_write_path
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=ARTIFACT_DOWNLOAD_TIMEOUT) as client:
         response = await client.get(s3_url, follow_redirects=True)
         response.raise_for_status()
 

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/artifact.py
@@ -24,6 +24,7 @@ import httpx
 import os
 from awslabs.aws_transform_mcp_server.audit import audited_tool
 from awslabs.aws_transform_mcp_server.config_store import is_fes_available
+from awslabs.aws_transform_mcp_server.consts import ARTIFACT_UPLOAD_TIMEOUT
 from awslabs.aws_transform_mcp_server.file_validation import validate_read_path
 from awslabs.aws_transform_mcp_server.guidance_nudge import (
     matches_instruction_label,
@@ -171,7 +172,7 @@ class ArtifactHandler:
                     if values:
                         put_headers[key] = ', '.join(values)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=ARTIFACT_UPLOAD_TIMEOUT) as client:
                 s3_response = await client.put(
                     init_result['s3PreSignedUrl'],
                     content=content_bytes,

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/hitl.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/tools/hitl.py
@@ -19,6 +19,7 @@ import os
 import uuid
 from awslabs.aws_transform_mcp_server.audit import audited_tool
 from awslabs.aws_transform_mcp_server.config_store import is_fes_available
+from awslabs.aws_transform_mcp_server.consts import ARTIFACT_DOWNLOAD_TIMEOUT
 from awslabs.aws_transform_mcp_server.file_validation import validate_read_path
 from awslabs.aws_transform_mcp_server.guidance_nudge import job_needs_check
 from awslabs.aws_transform_mcp_server.hitl_schemas import format_and_validate
@@ -96,7 +97,7 @@ async def download_agent_artifact(
         )
         s3_url = url_result['s3PreSignedUrl']
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=ARTIFACT_DOWNLOAD_TIMEOUT) as client:
             # Stream GET to check Content-Length before reading body
             async with client.stream('GET', s3_url, follow_redirects=True) as resp:
                 if resp.status_code >= 400:

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/upload_helper.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/upload_helper.py
@@ -24,6 +24,7 @@ import base64
 import hashlib
 import httpx
 import os
+from awslabs.aws_transform_mcp_server.consts import ARTIFACT_UPLOAD_TIMEOUT
 from awslabs.aws_transform_mcp_server.file_validation import validate_read_path
 from awslabs.aws_transform_mcp_server.transform_api_client import call_transform_api
 from awslabs.aws_transform_mcp_server.transform_api_models import (
@@ -97,7 +98,7 @@ async def upload_json_artifact(
 
     put_headers = _flatten_request_headers(init_result.get('requestHeaders'))
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=ARTIFACT_UPLOAD_TIMEOUT) as client:
         s3_response = await client.put(
             init_result['s3PreSignedUrl'],
             content=content_bytes,
@@ -178,7 +179,7 @@ async def upload_file_artifact(
 
     put_headers = _flatten_request_headers(init_result.get('requestHeaders'))
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=ARTIFACT_UPLOAD_TIMEOUT) as client:
         s3_response = await client.put(
             init_result['s3PreSignedUrl'],
             content=content_bytes,

--- a/src/aws-transform-mcp-server/tests/test_artifact.py
+++ b/src/aws-transform-mcp-server/tests/test_artifact.py
@@ -96,6 +96,11 @@ class TestUploadArtifactFromFile:
 
             assert parsed['success'] is True
             assert parsed['data']['artifactId'] == 'art-file-1'
+            timeout = mock_httpx_cls.call_args.kwargs['timeout']
+            assert timeout.connect == 10.0
+            assert timeout.read == 60.0
+            assert timeout.write == 900.0
+            assert timeout.pool == 10.0
 
             # Verify fileMetadata was sent
             create_call = mock_fes.call_args_list[0]

--- a/src/aws-transform-mcp-server/tests/test_hitl.py
+++ b/src/aws-transform-mcp-server/tests/test_hitl.py
@@ -475,6 +475,7 @@ class TestDownloadAgentArtifact:
 
             result = await download_agent_artifact('ws-1', 'job-1', 'art-1')
 
+        assert mock_client.call_args.kwargs['timeout'].read == 60.0
         assert result['content'] == {'key': 'value'}
         assert result['rawText'] == '{"key": "value"}'
         assert 'warning' not in result

--- a/src/aws-transform-mcp-server/tests/test_tool_utils.py
+++ b/src/aws-transform-mcp-server/tests/test_tool_utils.py
@@ -220,6 +220,11 @@ class TestDownloadS3Content:
 
             result = await download_s3_content('https://s3.example.com/file.txt')
             assert result == {'content': 'file contents here'}
+            timeout = MockClient.call_args.kwargs['timeout']
+            assert timeout.connect == 10.0
+            assert timeout.read == 60.0
+            assert timeout.write == 60.0
+            assert timeout.pool == 10.0
 
     @pytest.mark.asyncio
     async def test_saves_to_disk(self, tmp_path):

--- a/src/aws-transform-mcp-server/tests/test_upload_helper.py
+++ b/src/aws-transform-mcp-server/tests/test_upload_helper.py
@@ -61,6 +61,7 @@ class TestUploadJsonArtifact:
         result = await upload_json_artifact('ws-1', 'job-1', content)
 
         assert result == 'art-123'
+        assert mock_httpx_cls.call_args.kwargs['timeout'].write == 900.0
 
         # Verify CreateArtifactUploadUrl was called with correct params
         create_call = mock_fes.call_args_list[0]
@@ -212,6 +213,7 @@ class TestUploadFileArtifact:
         result = await upload_file_artifact('ws-1', 'job-1', str(test_file))
 
         assert result == 'art-file-1'
+        assert mock_httpx_cls.call_args.kwargs['timeout'].write == 900.0
 
         # Verify CreateArtifactUploadUrl was called with fileMetadata
         create_call = mock_fes.call_args_list[0]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Increasing timeouts while downloading and uploading artifacts.

### User experience

> Please share what the user experience looks like before and after this change

Users will be able to upload and download artifacts >100 MB in size from MCP

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
