### PR TITLE
fix(mysql-mcp-server): enforce TLS on the Secrets Manager credential path

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -615,7 +615,7 @@
         "filename": "src/mysql-mcp-server/tests/test_asyncmy_connector.py",
         "hashed_secret": "c68ff3acf9f357b3963b1a7720162b573536689c",
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 188,
         "is_secret": false
       },
       {
@@ -623,7 +623,7 @@
         "filename": "src/mysql-mcp-server/tests/test_asyncmy_connector.py",
         "hashed_secret": "fef341f85d87439e7d91a2d465b9871ef66b5e98",
         "is_verified": false,
-        "line_number": 687,
+        "line_number": 689,
         "is_secret": false
       }
     ],
@@ -633,7 +633,7 @@
         "filename": "src/mysql-mcp-server/tests/test_ca_bundle.py",
         "hashed_secret": "43b5a7ccc96b402d0fc814b5e03f8e23c2d9d1d8",
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 246,
         "is_secret": false
       }
     ],
@@ -1266,5 +1266,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-27T03:39:50Z"
+  "generated_at": "2026-08-28T17:21:25Z"
 }

--- a/src/mysql-mcp-server/CHANGELOG.md
+++ b/src/mysql-mcp-server/CHANGELOG.md
@@ -43,6 +43,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- **BREAKING (CWE-319):** TLS is now enforced on the Secrets Manager credential
+  path (`mysqlwire` with a managed secret), not just IAM auth. Previously these
+  connections were plaintext-capable; the server now upgrades them to verified
+  TLS against the bundled Amazon RDS CA bundle. Installations that relied on
+  plaintext or a server-certificate-managed TLS setup must supply `--ca_bundle
+  <path>` (or reinstall to restore the bundled CA bundle), otherwise the
+  connection fails with `CERTIFICATE_VERIFY_FAILED`. The `--ca_bundle` override
+  is now correctly honoured on the `mysqlwire` path as well.
+
 ### Added
 
 - `database_type` parameter on `connect_to_database` accepts `aurora-mysql`,

--- a/src/mysql-mcp-server/README.md
+++ b/src/mysql-mcp-server/README.md
@@ -127,6 +127,17 @@ directly via `mysqlwire` with the endpoint, port, and credentials.
 - VPC security group must allow inbound connections from your MCP server to the database
 - For `mysqlwire_iam`: IAM authentication must be enabled on the Aurora MySQL cluster
 - The AWS identity needs `rds:DescribeDBClusters` and `rds:DescribeDBInstances`. A caller-supplied `db_endpoint` is validated against the cluster's AWS-resolved endpoints before connecting; resolving those endpoints requires both permissions. Without them, endpoint validation cannot enumerate the cluster's real endpoints and the connection is refused.
+- **TLS is required whenever real credentials are on the wire** — both IAM auth
+  (`mysqlwire_iam`) and Secrets Manager passwords (`mysqlwire` with a managed
+  secret). The server verifies the server certificate against the bundled Amazon
+  RDS global CA bundle. If your server certificate does not chain to that bundle,
+  supply your own trust store with `--ca_bundle <path>`; otherwise the connection
+  fails with `CERTIFICATE_VERIFY_FAILED`.
+
+  > **Breaking change:** earlier versions left `mysqlwire` (non-IAM) connections
+  > plaintext-capable. They are now upgraded to verified TLS. Installations that
+  > relied on plaintext or a server-certificate-managed TLS setup must pass
+  > `--ca_bundle <path>` (or reinstall to restore the bundled CA bundle).
 
 #### rdsapi
 - RDS Data API must be enabled on the Aurora MySQL cluster

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/connection/asyncmy_pool_connection.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/connection/asyncmy_pool_connection.py
@@ -35,9 +35,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 # Path to the bundled Amazon RDS global CA bundle. The bundle is fetched
-# at build time by hatch_build.py and shipped inside the wheel so that IAM
-# authenticated connections can perform strict TLS verification out of the
-# box. The PEM is gitignored; rebuilding the package fetches a fresh copy.
+# at build time by hatch_build.py and shipped inside the wheel so that
+# credentialed connections (IAM auth and Secrets Manager) can perform strict
+# TLS verification out of the box. The PEM is gitignored; rebuilding the
+# package fetches a fresh copy.
 #
 # Users who maintain their own trust store can override the bundled file
 # by passing --ca_bundle <path> on the server command line.
@@ -114,8 +115,9 @@ class AsyncmyPoolConnection(AbstractDBConnection):
             max_size: Maximum number of connections in the pool
             is_test: Whether this is a test connection
             ca_bundle_path: Optional path to an alternate CA bundle to trust
-                for IAM-auth SSL verification. When set, the bundled Amazon
-                RDS CA bundle is ignored.
+                for SSL verification on credentialed connections (IAM auth or
+                Secrets Manager). When set, the bundled Amazon RDS CA bundle is
+                ignored.
         """
         super().__init__(readonly)
         self.host = host
@@ -168,25 +170,33 @@ class AsyncmyPoolConnection(AbstractDBConnection):
 
         self.created_time = datetime.now()
 
-        # Build SSL context for IAM auth (required for RDS IAM tokens).
+        # Build SSL context whenever real credentials go on the wire:
+        #   - IAM auth tokens (is_iam_auth)
+        #   - Secrets Manager passwords (secret_arn)
+        # Without TLS a MITM or attacker-controlled endpoint can capture the
+        # credential in cleartext. The two paths share identical trust logic;
+        # the auth flavour only affects the log message.
+        #
         # Trust decisions, in order of preference:
         #   1. --ca_bundle override supplied by the operator (explicit trust)
         #   2. Bundled Amazon RDS CA bundle verified against a pinned SHA-256
         #      (protects against silent tampering of the PEM on disk)
         #   3. System trust store (may not include RDS regional CAs — warned)
         ssl_ctx = None
-        if self.is_iam_auth:
+        if self.is_iam_auth or self.secret_arn:
+            auth_flavour = 'IAM auth' if self.is_iam_auth else 'Secrets Manager auth'
             cafile = self.ca_bundle_path or _bundled_ca_file()
             if cafile:
                 ssl_ctx = ssl_module.create_default_context(cafile=cafile)
-                logger.debug('Using CA bundle for IAM auth: {}', cafile)
+                logger.debug('Using CA bundle for {}: {}', auth_flavour, cafile)
             else:
                 ssl_ctx = ssl_module.create_default_context()
                 logger.warning(
-                    'No verified RDS CA bundle available; falling back to '
-                    'the system trust store. IAM auth may fail with '
+                    'No verified RDS CA bundle available for {}; falling back '
+                    'to the system trust store. The connection may fail with '
                     'CERTIFICATE_VERIFY_FAILED. Supply --ca_bundle <path> '
-                    'or reinstall the package to restore the bundled bundle.'
+                    'or reinstall the package to restore the bundled bundle.',
+                    auth_flavour,
                 )
 
         self.pool = await asyncmy.create_pool(

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
@@ -57,8 +57,9 @@ write_query_prohibited_key = 'Your MCP tool only allows readonly query. If you w
 query_comment_prohibited_key = 'The comment in query is prohibited because of injection risk'
 query_injection_risk_key = 'Your query contains risky injection patterns'
 readonly_query = True
-# Optional path to a CA bundle trusted for IAM-auth SSL verification. Set by
-# the CLI flag --ca_bundle on server start. When None, the package's bundled
+# Optional path to a CA bundle trusted for SSL verification on credentialed
+# connections (IAM auth or Secrets Manager). Set by the CLI flag --ca_bundle
+# on server start. When None, the package's bundled
 # Amazon RDS global bundle (verified against a pinned hash) is used.
 ca_bundle_path: Optional[str] = None
 
@@ -840,6 +841,9 @@ def internal_connect_to_database(
             db_user='',
             region=region,
             is_iam_auth=False,
+            # Wire the operator's --ca_bundle override into the Secrets Manager
+            # TLS path too; without this the override is unreachable here.
+            ca_bundle_path=ca_bundle_path,
         )
 
     # Every supported connection_method assigns db_connection above (the
@@ -898,7 +902,8 @@ def main():
         '--ca_bundle',
         default=None,
         help=(
-            'Path to an alternate CA bundle (PEM) for IAM-auth SSL verification. '
+            'Path to an alternate CA bundle (PEM) for SSL verification on '
+            'credentialed connections (IAM auth or Secrets Manager). '
             'Overrides the bundled Amazon RDS global bundle shipped with the '
             'package. Use this if you maintain your own trust store or if AWS '
             'rotates CAs faster than the package release cadence.'

--- a/src/mysql-mcp-server/tests/test_asyncmy_connector.py
+++ b/src/mysql-mcp-server/tests/test_asyncmy_connector.py
@@ -150,7 +150,9 @@ class TestAsyncmyPoolConnectionInitializePool:
         assert call_kwargs['db'] == 'testdb'
         assert call_kwargs['user'] == 'test_user'
         assert call_kwargs['password'] == 'test_password'
-        assert call_kwargs['ssl'] is None
+        assert (
+            call_kwargs['ssl'] is not None
+        )  # TLS required when a Secrets Manager password is on the wire
         assert conn.pool is mock_pool
 
     @patch(

--- a/src/mysql-mcp-server/tests/test_ca_bundle.py
+++ b/src/mysql-mcp-server/tests/test_ca_bundle.py
@@ -7,9 +7,10 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 """Tests for CA bundle loading and --ca_bundle override.
 
-These tests guard the IAM-auth trust resolution path: which CA file ends
-up trusted by the SSL context depending on whether the bundled PEM is
-present and whether the operator passed --ca_bundle <path>.
+These tests guard the trust resolution path for credentialed connections
+(IAM auth and Secrets Manager): which CA file ends up trusted by the SSL
+context depending on whether the bundled PEM is present and whether the
+operator passed --ca_bundle <path>.
 """
 
 import os
@@ -220,12 +221,12 @@ class TestCaBundleSslContextWiring:
             'called with no cafile so the system trust store is used (warned).'
         )
 
-    async def test_no_ssl_context_for_non_iam(self, monkeypatch):
-        """Non-IAM connections must not configure an SSL context.
+    async def test_ssl_context_for_secret_arn_path(self, monkeypatch):
+        """The Secrets Manager credential path must configure an SSL context.
 
-        Setting an SSL context on `mysqlwire` (no IAM) connections would
-        force-upgrade them to TLS, which can break installations relying on
-        plaintext or server-certificate-managed TLS.
+        When secret_arn is set, a password is transmitted on the wire, so TLS
+        is required to prevent credential interception by an attacker-controlled
+        endpoint or a network observer (CWE-319).
         """
         from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -250,8 +251,79 @@ class TestCaBundleSslContextWiring:
             )
             await conn.initialize_pool()
 
-        assert captured['ssl_calls'] == 0, (
-            'create_default_context was called for a non-IAM connection. '
-            'mysqlwire must remain plaintext-capable.'
+        assert captured['ssl_calls'] == 1, (
+            'create_default_context must be called for the Secrets Manager path. '
+            'TLS is required when a password is on the wire.'
         )
+        assert mock_pool.call_args.kwargs['ssl'] is not None
+
+    async def test_no_ssl_when_no_secret_arn_and_no_iam(self, monkeypatch):
+        """With neither a secret nor IAM auth, no SSL context is configured.
+
+        Covers the false branch of the credentials-on-the-wire gate: when the
+        connection carries no secret_arn and is not IAM auth, no SSL context is
+        built (ssl stays None).
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        captured = {'ssl_calls': 0}
+
+        def fake_create_default_context(cafile=None):
+            captured['ssl_calls'] += 1
+            return MagicMock()
+
+        monkeypatch.setattr(mod.ssl_module, 'create_default_context', fake_create_default_context)
+        with patch.object(mod.asyncmy, 'create_pool', new_callable=AsyncMock) as mock_pool:
+            conn = AsyncmyPoolConnection(
+                host='localhost',
+                port=3306,
+                database='testdb',
+                readonly=True,
+                secret_arn='',  # no secret
+                db_user='testuser',
+                region='us-east-1',
+                is_iam_auth=False,  # no IAM auth
+                is_test=True,
+            )
+            await conn.initialize_pool()
+
+        assert captured['ssl_calls'] == 0
         assert mock_pool.call_args.kwargs['ssl'] is None
+
+    async def test_secret_path_uses_ca_bundle_override_when_set(self, monkeypatch):
+        """The Secrets Manager SSL path uses ca_bundle_path when the connection has one.
+
+        Unit-level check of the connection class: given a ca_bundle_path, the
+        Secrets Manager path builds its SSL context from that file rather than
+        the bundled fallback. (The server.py wiring that supplies this value
+        through the real entry point is guarded separately in test_server.py's
+        test_mysql_wire_protocol_builds_secret_pool.)
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        captured: dict = {'cafile': 'UNSET'}
+
+        def fake_create_default_context(cafile=None):
+            captured['cafile'] = cafile
+            return MagicMock()
+
+        monkeypatch.setattr(mod.ssl_module, 'create_default_context', fake_create_default_context)
+        with patch.object(mod.asyncmy, 'create_pool', new_callable=AsyncMock):
+            conn = AsyncmyPoolConnection(
+                host='localhost',
+                port=3306,
+                database='testdb',
+                readonly=True,
+                secret_arn='arn:secret',
+                db_user='',
+                region='us-east-1',
+                is_iam_auth=False,
+                ca_bundle_path='/tmp/operator-supplied.pem',
+                is_test=True,
+            )
+            await conn.initialize_pool()
+
+        assert captured['cafile'] == '/tmp/operator-supplied.pem', (
+            'The operator-supplied --ca_bundle must be used for the Secrets '
+            'Manager TLS path, not the bundled fallback.'
+        )

--- a/src/mysql-mcp-server/tests/test_server.py
+++ b/src/mysql-mcp-server/tests/test_server.py
@@ -309,11 +309,18 @@ class TestInternalConnectToDatabaseRouting:
         assert kwargs['db_user'] == 'admin'
         assert kwargs['secret_arn'] == ''
 
+    @patch('awslabs.mysql_mcp_server.server.ca_bundle_path', '/tmp/operator-supplied.pem')
     @patch('awslabs.mysql_mcp_server.server.db_connection_map')
     @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
     @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
     def test_mysql_wire_protocol_builds_secret_pool(self, mock_pool_cls, mock_get_props, mock_map):
-        """MYSQL_WIRE_PROTOCOL routes to AsyncmyPoolConnection with is_iam_auth=False."""
+        """MYSQL_WIRE_PROTOCOL routes to AsyncmyPoolConnection with is_iam_auth=False.
+
+        Also asserts that the operator's --ca_bundle override (the module-level
+        ca_bundle_path) is threaded into the constructor through the real entry
+        point. This is the regression guard for the server.py wiring: reverting
+        that one-line change makes this assertion fail.
+        """
         from awslabs.mysql_mcp_server.server import internal_connect_to_database
 
         mock_map.get.return_value = None
@@ -339,6 +346,8 @@ class TestInternalConnectToDatabaseRouting:
         kwargs = mock_pool_cls.call_args.kwargs
         assert kwargs['is_iam_auth'] is False
         assert kwargs['secret_arn'] == 'arn:secret'
+        # The --ca_bundle override must reach the constructor via the real path.
+        assert kwargs['ca_bundle_path'] == '/tmp/operator-supplied.pem'
 
     @patch('awslabs.mysql_mcp_server.server.db_connection_map')
     @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties')


### PR DESCRIPTION
### Fixes
Fixes a cleartext-credential exposure on the mysqlwire (Secrets Manager) connection path (CWE-319): only IAM-auth connections built an SSL context, so a mysqlwire connection backed by a managed secret transmitted the database password with ssl=None — interceptable by a MITM or an attacker-controlled endpoint.

### Summary
### Changes
Enforce verified TLS whenever real credentials are on the wire — both IAM auth tokens and Secrets Manager passwords — not just IAM auth.

Build the SSL context for is_iam_auth or secret_arn, collapsing the two identical trust-decision branches into one (the auth flavour only affects the log message).
Thread the operator's --ca_bundle override into the MYSQL_WIRE_PROTOCOL connection construction so it is honoured on the Secrets Manager path (previously it was silently ignored there).
Trust order is unchanged: operator --ca_bundle → bundled Amazon RDS CA bundle → system trust store (warned).
Document the behaviour change (breaking) and the CERTIFICATE_VERIFY_FAILED escape hatch in the README and CHANGELOG.

Tests: the Secrets Manager path now configures TLS; add a test asserting the --ca_bundle override reaches that path.
Split out of #4515 (endpoint validation) per review so it can be reviewed and rolled back independently.

### User experience
Before: A mysqlwire connection using a Secrets Manager secret sent the database password over an unencrypted connection (ssl=None), and an operator-supplied --ca_bundle was ignored on that path.

After: The Secrets Manager path is upgraded to verified TLS against the bundled Amazon RDS CA bundle, and --ca_bundle <path> is honoured. Operators whose server certificate does not chain to the bundled bundle supply --ca_bundle; otherwise the connection fails fast with CERTIFICATE_VERIFY_FAILED rather than sending credentials in cleartext.

### Checklist
If your change doesn't seem to apply, please leave them unchecked.

[x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
[x] I have performed a self-review of this change
[x] Changes have been tested
[x] Changes are documented
Is this a breaking change? Y

RFC issue number:

### Checklist:

[x] Migration process documented
[ ] Implement warnings (if it can live side by side)
Migration: installations that relied on plaintext or server-certificate-managed TLS on the mysqlwire path must pass --ca_bundle <path> (or reinstall to restore the bundled Amazon RDS CA bundle). Documented in the README ("Prerequisites by Connection Method") and CHANGELOG. TLS enforcement cannot meaningfully live side by side with plaintext, so it is not gated behind a warning-only phase; the fallback-to-system-trust-store case is logged as a warning.

### Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).