### PR TITLE
fix: add missing api calls for s3 to static customizations map

### DIFF
--- a/src/aws-api-mcp-server/CHANGELOG.md
+++ b/src/aws-api-mcp-server/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Missing api calls for s3 customizations in static map (#4548)
+
+## [1.5.1] - 2026-08-11
+
+### Fixed
+
+- Operation name matching in security policy (#4432)
+
+## [1.5.0] - 2026-08-05
+
+### Changed
+
+- Upgrade AWS CLI to v1.46.0 (#4444)
+
+## [1.4.0] - 2026-07-23
+
 ### Added
 
 - Deprecation warning and feature flag to suppress (#4313)

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
@@ -330,7 +330,8 @@
         "aws s3api upload-part",
         "aws s3api head-object",
         "aws s3api get-object",
-        "aws s3api delete-object"
+        "aws s3api delete-object",
+        "aws s3api list-objects-v2"
       ]
     },
     "s3 presign": {
@@ -356,7 +357,8 @@
         "aws s3api upload-part",
         "aws s3api head-object",
         "aws s3api get-object",
-        "aws s3api delete-object"
+        "aws s3api delete-object",
+        "aws s3api list-objects-v2"
       ]
     },
     "s3 website": {

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
@@ -326,6 +326,10 @@
       "api_calls": [
         "aws s3api copy-object",
         "aws s3api upload-part-copy",
+        "aws s3api put-object",
+        "aws s3api upload-part",
+        "aws s3api head-object",
+        "aws s3api get-object",
         "aws s3api delete-object"
       ]
     },
@@ -351,7 +355,8 @@
         "aws s3api put-object",
         "aws s3api upload-part",
         "aws s3api head-object",
-        "aws s3api get-object"
+        "aws s3api get-object",
+        "aws s3api delete-object"
       ]
     },
     "s3 website": {

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/security/aws_api_customization.json
@@ -306,15 +306,21 @@
         "aws s3api copy-object",
         "aws s3api upload-part-copy",
         "aws s3api put-object",
+        "aws s3api create-multipart-upload",
         "aws s3api upload-part",
+        "aws s3api complete-multipart-upload",
+        "aws s3api abort-multipart-upload",
         "aws s3api head-object",
-        "aws s3api get-object"
+        "aws s3api get-object",
+        "aws s3api list-objects-v2",
+        "aws s3api create-session"
       ]
     },
     "s3 ls": {
       "api_calls": [
         "aws s3api list-buckets",
-        "aws s3api list-objects-v2"
+        "aws s3api list-objects-v2",
+        "aws s3api create-session"
       ]
     },
     "s3 mb": {
@@ -327,11 +333,15 @@
         "aws s3api copy-object",
         "aws s3api upload-part-copy",
         "aws s3api put-object",
+        "aws s3api create-multipart-upload",
         "aws s3api upload-part",
+        "aws s3api complete-multipart-upload",
+        "aws s3api abort-multipart-upload",
         "aws s3api head-object",
         "aws s3api get-object",
         "aws s3api delete-object",
-        "aws s3api list-objects-v2"
+        "aws s3api list-objects-v2",
+        "aws s3api create-session"
       ]
     },
     "s3 presign": {
@@ -341,12 +351,17 @@
     },
     "s3 rb": {
       "api_calls": [
-        "aws s3api delete-bucket"
+        "aws s3api delete-bucket",
+        "aws s3api list-objects-v2",
+        "aws s3api delete-object",
+        "aws s3api create-session"
       ]
     },
     "s3 rm": {
       "api_calls": [
-        "aws s3api delete-object"
+        "aws s3api delete-object",
+        "aws s3api list-objects-v2",
+        "aws s3api create-session"
       ]
     },
     "s3 sync": {
@@ -354,11 +369,15 @@
         "aws s3api copy-object",
         "aws s3api upload-part-copy",
         "aws s3api put-object",
+        "aws s3api create-multipart-upload",
         "aws s3api upload-part",
+        "aws s3api complete-multipart-upload",
+        "aws s3api abort-multipart-upload",
         "aws s3api head-object",
         "aws s3api get-object",
         "aws s3api delete-object",
-        "aws s3api list-objects-v2"
+        "aws s3api list-objects-v2",
+        "aws s3api create-session"
       ]
     },
     "s3 website": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

`s3 sync` and `s3 mv` didn't list all the api calls, this PR remedies that

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
