### PR TITLE
feat(redshift-mcp-server): paginate and shape discovery responses

### DIFF
--- a/src/redshift-mcp-server/README.md
+++ b/src/redshift-mcp-server/README.md
@@ -110,6 +110,11 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 - `AWS_PROFILE`: AWS profile to use (optional, uses default if not specified)
 - `FASTMCP_LOG_LEVEL`: Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
 - `LOG_FILE`: Path to log file (optional, logs to stdout if not specified)
+- `REDSHIFT_MAX_RESULT_ROWS`: Maximum rows any one statement may return (default: `1000`). Only a
+  whole number above zero is accepted; anything else, including `0`, is logged as unusable and the
+  default of `1000` applies instead, so the cap cannot be switched off. Read once at startup, so a
+  change takes a server restart. A statement returning more rows than this fails rather than
+  returning a short answer — see [Result size](#result-size).
 
 ## Prompt Examples
 
@@ -117,7 +122,7 @@ or docker after a successful `docker build -t awslabs/redshift-mcp-server:latest
 
 1. **Discover Clusters and Workgroups**: Call `list_clusters` to find all provisioned clusters and serverless workgroups, noting their identifiers, types, and status
 2. **Select Target Environment**: Choose a specific cluster or workgroup based on your query needs
-3. **List Databases**: Use `list_databases` to explore databases in the selected cluster/workgroup, returning database names, owners, types (local/shared), and access control info
+3. **List Databases**: Use `list_databases` to explore databases in the selected cluster/workgroup, returning database names, owners, types (such as local, shared, or auto mounted catalog), and access control info
 4. **Explore Schemas**: For a given database, call `list_schemas` to find available schemas and their owners
 5. **Inspect Tables**: Use `list_tables` to browse tables, views, and external tables within a schema, including table types and owners
 6. **Examine Columns**: Call `list_columns` to get column metadata — names, data types, nullability, default values, and constraints
@@ -330,18 +335,23 @@ list_clusters() -> list[RedshiftCluster]
 Lists all databases in a specified Redshift cluster.
 
 ```python
-list_databases(cluster_identifier: str, database_name: str = "dev") -> list[RedshiftDatabase]
+list_databases(
+    cluster_identifier: str,
+    database_name: str = "dev",
+    verbosity_level: Literal["low", "standard"] | None = "standard",
+) -> list[RedshiftDatabase]
 ```
 
 **Parameters**:
 
 - `cluster_identifier`: The cluster identifier from `list_clusters`
 - `database_name`: Database to connect to for querying (default: "dev")
+- `verbosity_level`: How much detail to return per database, `"low"` or `"standard"` (see [Response shaping](#response-shaping))
 
-**Returns**: List of database information including:
+**Returns**: A list of databases, each including:
 
 - Database name and owner
-- Database type (local/shared)
+- Database type (such as local, shared, or auto mounted catalog)
 - Access control information
 - Isolation level
 
@@ -350,15 +360,20 @@ list_databases(cluster_identifier: str, database_name: str = "dev") -> list[Reds
 Lists all schemas in a specified database.
 
 ```python
-list_schemas(cluster_identifier: str, schema_database_name: str) -> list[RedshiftSchema]
+list_schemas(
+    cluster_identifier: str,
+    schema_database_name: str,
+    verbosity_level: Literal["low", "standard"] | None = "standard",
+) -> list[RedshiftSchema]
 ```
 
 **Parameters**:
 
 - `cluster_identifier`: The cluster identifier from `list_clusters`
 - `schema_database_name`: Database name to list schemas for
+- `verbosity_level`: How much detail to return per schema, `"low"` or `"standard"` (see [Response shaping](#response-shaping))
 
-**Returns**: List of schema information including:
+**Returns**: A list of schemas, each including:
 
 - Schema name and owner
 - Schema type (local/external/shared)
@@ -370,7 +385,12 @@ list_schemas(cluster_identifier: str, schema_database_name: str) -> list[Redshif
 Lists all tables in a specified schema.
 
 ```python
-list_tables(cluster_identifier: str, table_database_name: str, table_schema_name: str) -> list[RedshiftTable]
+list_tables(
+    cluster_identifier: str,
+    table_database_name: str,
+    table_schema_name: str,
+    verbosity_level: Literal["low", "standard"] | None = "standard",
+) -> list[RedshiftTable]
 ```
 
 **Parameters**:
@@ -378,8 +398,9 @@ list_tables(cluster_identifier: str, table_database_name: str, table_schema_name
 - `cluster_identifier`: The cluster identifier from `list_clusters`
 - `table_database_name`: Database name containing the schema
 - `table_schema_name`: Schema name to list tables for
+- `verbosity_level`: How much detail to return per table, `"low"` or `"standard"` (see [Response shaping](#response-shaping))
 
-**Returns**: List of table information including:
+**Returns**: A list of tables, each including:
 
 - Table name and type (TABLE/VIEW/EXTERNAL TABLE)
 - Access permissions
@@ -394,7 +415,8 @@ list_columns(
     cluster_identifier: str,
     column_database_name: str,
     column_schema_name: str,
-    column_table_name: str
+    column_table_name: str,
+    verbosity_level: Literal["low", "standard"] | None = "standard",
 ) -> list[RedshiftColumn]
 ```
 
@@ -404,14 +426,98 @@ list_columns(
 - `column_database_name`: Database name containing the table
 - `column_schema_name`: Schema name containing the table
 - `column_table_name`: Table name to list columns for
+- `verbosity_level`: How much detail to return per column, `"low"` or `"standard"` (see [Response shaping](#response-shaping))
 
-**Returns**: List of column information including:
+**Returns**: A list of columns, each including:
 
 - Column name and data type
 - Nullable status and default values
 - Numeric precision and scale
 - Character length limits
 - Ordinal position and remarks
+
+### Response shaping
+
+The four discovery tools above (`list_databases`, `list_schemas`, `list_tables`, `list_columns`)
+each return a plain list and share one `verbosity_level` parameter. What bounds a response is the
+row cap described under [Result size](#result-size).
+
+**Verbosity levels.** `verbosity_level` selects the fields returned on each item.
+
+| Level | Returns | Use it when |
+|---|---|---|
+| `low` | The names identifying an object, plus its own type | Navigating to an object, or writing a query against one. No ownership, permissions or physical design, so responses stay small |
+| `standard` (default) | Every field the tool has always returned | You need sizing detail, ownership or permissions |
+
+The rule is the same for all four tools, so `low` returns:
+
+| Tool | `low` fields |
+|---|---|
+| `list_databases` | `database_name`, `database_type` |
+| `list_schemas` | `database_name`, `schema_name`, `schema_type` |
+| `list_tables` | `database_name`, `schema_name`, `table_name`, `table_type` |
+| `list_columns` | `database_name`, `schema_name`, `table_name`, `column_name`, `data_type` |
+
+The type is included because a name alone is not enough to act on: an agent needs `data_type` to
+write a well-typed predicate, and `table_type` to know whether it is querying a table or a view.
+Sizing detail such as `character_maximum_length`, `numeric_precision` and `numeric_scale` stays in
+`standard`, so `low` is enough to write a correct query, not to reproduce a column definition.
+
+`low` is always a subset of `standard`, so asking for more detail never drops a field.
+
+### Result size
+
+Every tool returns a whole result set in one response. Retrieval follows every page of the
+Redshift Data API internally, so a large result set is never silently cut short at the first page.
+
+What bounds a response instead is `REDSHIFT_MAX_RESULT_ROWS`, a cap on the rows any one statement
+may return, shipping as `1000`. **A statement returning more rows than the cap fails rather than
+returning a short answer**, so a caller can never mistake a partial result for a complete one.
+Retrieval stops as soon as the cap is known to be exceeded, so an oversized statement is refused
+without reading its whole result set into memory.
+
+The cap cannot be turned off. Only a whole number above zero is accepted, and anything else is
+logged as unusable with the default applied in its place, so a misconfiguration lowers the cap to a
+safe value rather than removing it. An operator who needs more rows raises the number.
+
+The cap applies to every tool that reaches the Data API, including `execute_query`. How to stay
+under it differs by tool, because only `execute_query` runs SQL that a caller wrote.
+
+With `execute_query`, shape the statement:
+
+- Prefer aggregation, a selective `WHERE` predicate, or a `LIMIT` clause over retrieving many rows
+  and reducing them afterwards.
+- Page through a large table yourself with `LIMIT` and `OFFSET`, or by filtering on a sort key.
+
+The discovery tools take no query of their own, so there is no clause to add and no ordering to
+exploit. Narrowing means choosing a smaller target:
+
+- List one database or schema at a time, and use `low` verbosity while navigating.
+- A column listing has no target narrower than its table, so a table wider than the cap needs an
+  operator to raise it.
+
+Whether the cap is reachable at all differs by object type, because of the
+[Amazon Redshift quotas](https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html)
+on each:
+
+| Tool | Redshift quota | Effect at the default cap of 1000 |
+|---|---|---|
+| `list_databases` | 60 per provisioned cluster, 100 per serverless namespace, excluding datashare databases | Never reached |
+| `list_schemas` | 9,900 per database | Reachable on a large database |
+| `list_tables` | up to 200,000 per cluster on the larger node types | Reachable on a large schema |
+| `list_columns` | 1,600 per table | Reachable on a very wide table |
+
+**Compatibility note.** The discovery tools still return a list of the same models, and at the
+default `standard` verbosity each item still carries the same *values* as before. Three behaviours
+change:
+
+- A field with no value is now absent from a response rather than present as `null`. Verbosity is
+  applied by blanking the fields above the level asked for, and serialization drops every `None`,
+  so a field that is genuinely NULL in Redshift disappears alongside them. Read a missing key as
+  "no value", exactly as `null` read before.
+- A result set larger than one Data API page is retrieved in full instead of being silently
+  truncated.
+- A result set larger than the cap fails instead of returning part of the data.
 
 ### execute_query
 

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/consts.py
@@ -14,12 +14,27 @@
 
 """Redshift MCP Server constants."""
 
+from typing import Literal
+
+
 # System
+
+# Verbosity levels for the discovery tools, least to most detail. A field marked with a
+# level is returned at that level and at every level after it.
+VERBOSITY_LEVEL_LOW = 'low'
+VERBOSITY_LEVEL_STANDARD = 'standard'
+VERBOSITY_LEVELS = (VERBOSITY_LEVEL_LOW, VERBOSITY_LEVEL_STANDARD)
+VERBOSITY_LEVEL_DEFAULT = VERBOSITY_LEVEL_STANDARD
+# The tools' parameter type. Literal takes only literals, so a new level goes both in
+# VERBOSITY_LEVELS and here; a test holds the two to the same values in the same order.
+VerbosityLevel = Literal['low', 'standard']
+
 CLIENT_CONNECT_TIMEOUT = 60
 CLIENT_READ_TIMEOUT = 600
 CLIENT_RETRIES = {'max_attempts': 5, 'mode': 'adaptive'}
 CLIENT_USER_AGENT_NAME = 'awslabs/mcp/redshift-mcp-server'
 DEFAULT_LOG_LEVEL = 'WARNING'
+MAX_RESULT_ROWS_DEFAULT = 1000
 QUERY_TIMEOUT = 3600
 QUERY_POLL_INTERVAL = 1
 QUERY_LONG_POLL = 30

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/models.py
@@ -14,9 +14,14 @@
 
 """Redshift MCP Server Pydantic models."""
 
+from awslabs.redshift_mcp_server.consts import (
+    VERBOSITY_LEVEL_LOW,
+    VERBOSITY_LEVEL_STANDARD,
+    VERBOSITY_LEVELS,
+)
 from datetime import datetime
-from pydantic import BaseModel, Field
-from typing import Any, Dict, Optional, TypeVar
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+from typing import Annotated, Any, Dict, Optional, TypeVar
 
 
 RedshiftDataModelT = TypeVar('RedshiftDataModelT', bound='RedshiftDataModel')
@@ -28,7 +33,53 @@ class RedshiftDataModel(BaseModel):
     Subclasses declare their fields named to match the SHOW result columns.
     `from_redshift_response` maps result columns to those fields by name, so
     parsing is independent of column order; unknown columns are ignored.
+
+    Each field also carries the verbosity level it first appears at, as
+    `Annotated` metadata on the field itself rather than in a list kept
+    elsewhere, so the two cannot drift apart. A field marked `low` is one an
+    agent needs to find an object and write a well-typed predicate against it:
+    the identifying names and the object's own type. An unmarked field counts
+    as `standard`, so nothing reaches `low` by accident.
+
+    `at_verbosity_level` blanks the fields above the level asked for, and
+    serialization drops every None, so a response carries that level's fields
+    and no others while the tools keep returning these models.
     """
+
+    @model_serializer(mode='wrap')
+    def _drop_none(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        """Serialize as usual, then drop the keys that came out None.
+
+        This turns the fields `at_verbosity_level` blanked into absent keys, and drops
+        genuinely NULL fields too, since both arrive here as None.
+
+        `handler` is Pydantic's own serializer, so `mode`, `by_alias` and `exclude`
+        still apply.
+        """
+        return {name: value for name, value in handler(self).items() if value is not None}
+
+    @classmethod
+    def field_verbosity_level(cls, name: str) -> str:
+        """The level a field first appears at, defaulting to standard when unmarked."""
+        for marker in cls.model_fields[name].metadata:
+            if isinstance(marker, str) and marker in VERBOSITY_LEVELS:
+                return marker
+        return VERBOSITY_LEVEL_STANDARD
+
+    @classmethod
+    def fields_at_verbosity_level(cls, level: str) -> tuple[str, ...]:
+        """The fields the given level returns, in the order they were declared."""
+        ceiling = VERBOSITY_LEVELS.index(level)
+        return tuple(
+            name
+            for name in cls.model_fields
+            if VERBOSITY_LEVELS.index(cls.field_verbosity_level(name)) <= ceiling
+        )
+
+    def at_verbosity_level(self: RedshiftDataModelT, level: str) -> RedshiftDataModelT:
+        """A copy of this item with every field above the given level set to None."""
+        above = set(self.model_fields) - set(self.fields_at_verbosity_level(level))
+        return self.model_copy(update=dict.fromkeys(above))
 
     @staticmethod
     def cell_value(cell: dict) -> Any:
@@ -76,10 +127,12 @@ class RedshiftCluster(BaseModel):
 class RedshiftDatabase(RedshiftDataModel):
     """Information about a database in a Redshift cluster."""
 
-    database_name: str = Field(..., description='The name of the database')
+    database_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the database'
+    )
     database_owner: Optional[int] = Field(None, description='The database owner user ID')
-    database_type: Optional[str] = Field(
-        None, description='The type of database (local or shared)'
+    database_type: Annotated[Optional[str], VERBOSITY_LEVEL_LOW] = Field(
+        None, description='The type of database, such as local, shared, or auto mounted catalog'
     )
     database_acl: Optional[str] = Field(
         None, description='Access control information (for internal use)'
@@ -94,10 +147,14 @@ class RedshiftDatabase(RedshiftDataModel):
 class RedshiftSchema(RedshiftDataModel):
     """Information about a schema in a Redshift database."""
 
-    database_name: str = Field(..., description='The name of the database where the schema exists')
-    schema_name: str = Field(..., description='The name of the schema')
+    database_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the database where the schema exists'
+    )
+    schema_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the schema'
+    )
     schema_owner: Optional[int] = Field(None, description='The user ID of the schema owner')
-    schema_type: Optional[str] = Field(
+    schema_type: Annotated[Optional[str], VERBOSITY_LEVEL_LOW] = Field(
         None, description='The type of the schema (external, local, or shared)'
     )
     schema_acl: Optional[str] = Field(
@@ -114,13 +171,19 @@ class RedshiftSchema(RedshiftDataModel):
 class RedshiftTable(RedshiftDataModel):
     """Information about a table in a Redshift database."""
 
-    database_name: str = Field(..., description='The name of the database where the table exists')
-    schema_name: str = Field(..., description='The schema name for the table')
-    table_name: str = Field(..., description='The name of the table')
+    database_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the database where the table exists'
+    )
+    schema_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The schema name for the table'
+    )
+    table_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the table'
+    )
     table_acl: Optional[str] = Field(
         None, description='The permissions for the specified user or user group for the table'
     )
-    table_type: Optional[str] = Field(
+    table_type: Annotated[Optional[str], VERBOSITY_LEVEL_LOW] = Field(
         None,
         description='The type of the table (views, base tables, external tables, shared tables)',
     )
@@ -130,10 +193,18 @@ class RedshiftTable(RedshiftDataModel):
 class RedshiftColumn(RedshiftDataModel):
     """Information about a column in a Redshift table."""
 
-    database_name: str = Field(..., description='The name of the database')
-    schema_name: str = Field(..., description='The name of the schema')
-    table_name: str = Field(..., description='The name of the table')
-    column_name: str = Field(..., description='The name of the column')
+    database_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the database'
+    )
+    schema_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the schema'
+    )
+    table_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the table'
+    )
+    column_name: Annotated[str, VERBOSITY_LEVEL_LOW] = Field(
+        ..., description='The name of the column'
+    )
     ordinal_position: Optional[int] = Field(
         None, description='The position of the column in the table'
     )
@@ -141,7 +212,9 @@ class RedshiftColumn(RedshiftDataModel):
     is_nullable: Optional[str] = Field(
         None, description='Whether the column is nullable (yes or no)'
     )
-    data_type: Optional[str] = Field(None, description='The data type of the column')
+    data_type: Annotated[Optional[str], VERBOSITY_LEVEL_LOW] = Field(
+        None, description='The data type of the column'
+    )
     character_maximum_length: Optional[int] = Field(
         None, description='The maximum number of characters in the column'
     )

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/redshift.py
@@ -26,6 +26,7 @@ from awslabs.redshift_mcp_server.consts import (
     CLIENT_USER_AGENT_NAME,
     COLUMNS_SQL,
     DATABASES_SQL,
+    MAX_RESULT_ROWS_DEFAULT,
     QUERY_LONG_POLL,
     QUERY_POLL_INTERVAL,
     QUERY_TIMEOUT,
@@ -232,6 +233,133 @@ class RedshiftSessionManager:
         return (time.time() - session_info['created_at']) > self._session_keepalive
 
 
+def _resolve_max_result_rows() -> int:
+    """Resolve the row cap from the environment, failing closed to the shipped default.
+
+    A whole number above zero is the cap. Anything else, whether zero, negative or not a
+    number at all, falls back to `MAX_RESULT_ROWS_DEFAULT`, so a misconfiguration lowers
+    the cap rather than removing it or stopping the server.
+
+    Returns:
+        The most rows any one statement may return, always one or more.
+    """
+    configured = os.environ.get('REDSHIFT_MAX_RESULT_ROWS', str(MAX_RESULT_ROWS_DEFAULT)).strip()
+
+    try:
+        rows = int(configured)
+    except ValueError:
+        logger.warning(
+            f'REDSHIFT_MAX_RESULT_ROWS={configured!r} is not a whole number; '
+            f'falling back to {MAX_RESULT_ROWS_DEFAULT}.'
+        )
+        return MAX_RESULT_ROWS_DEFAULT
+
+    if rows <= 0:
+        logger.warning(
+            f'REDSHIFT_MAX_RESULT_ROWS={configured!r} is not above zero; '
+            f'falling back to {MAX_RESULT_ROWS_DEFAULT}.'
+        )
+        return MAX_RESULT_ROWS_DEFAULT
+
+    return rows
+
+
+# Resolved once at import: the cap cannot change while the server runs.
+MAX_RESULT_ROWS = _resolve_max_result_rows()
+
+
+async def _fetch_result_set(data_client, query_id: str, row_cap: int) -> dict:
+    """Retrieve a completed statement's result set in full, or raise if it exceeds the row cap.
+
+    GetStatementResult returns one page at a time, so this keeps asking, passing back each
+    response's token until one comes back without one. Rows are returned only after every page
+    has arrived, so a caller never receives a partial set.
+
+    Retrieval stops and raises as soon as the row count is known to exceed row_cap, so an
+    oversized statement is refused without its whole result set being read into memory.
+
+    The caller reads HasResultSet from the statement response it already holds, so this is
+    never called for a statement that produced none.
+
+    Args:
+        data_client: The Redshift Data API client.
+        query_id: The identifier of the completed statement to retrieve the result set for.
+        row_cap: The most rows this result set may hold, one or more. Passed in rather than
+            read here, so the bound is explicit at each call site.
+
+    Returns:
+        {'Records': [...], 'ColumnMetadata': [...]} -- every page's rows and the metadata
+        describing them, the only two keys a caller reads. NextToken and TotalNumRows drive
+        the loop here and are not passed on.
+
+    Raises:
+        RuntimeError: If the statement returns more rows than row_cap allows, if a page request
+            fails, if the Redshift Data API repeats a continuation token, or if the rows
+            retrieved do not add up to the total it reported.
+    """
+    records: list = []
+    column_metadata: list = []
+    total_num_rows: int | None = None
+    used_tokens: set[str] = set()
+    next_token: str | None = None
+
+    while True:
+        try:
+            page_params = {} if next_token is None else {'NextToken': next_token}
+            page_response = await asyncio.to_thread(
+                data_client.get_statement_result, Id=query_id, **page_params
+            )
+        # Broad: a page can fail for reasons beyond ClientError, and the statement id is
+        # worth attaching to any of them. The cause is chained, not swallowed.
+        except Exception as e:
+            raise RuntimeError(
+                f'Result set of statement {query_id} was retrieved incompletely: {e}'
+            ) from e
+
+        records.extend(page_response.get('Records', []))
+
+        # Column metadata describes the whole result set; keep the first page that reports it.
+        if not column_metadata:
+            column_metadata = page_response.get('ColumnMetadata') or []
+
+        reported_total = page_response.get('TotalNumRows')
+        if total_num_rows is None and isinstance(reported_total, int) and reported_total >= 0:
+            total_num_rows = reported_total
+
+        # A reported total refuses an oversized statement after a single page, keeping its
+        # result set out of memory. The rows in hand are the fallback for a response that
+        # carries no total, where they are the only thing enforcing the cap at all.
+        known_rows = total_num_rows if total_num_rows is not None else len(records)
+        if known_rows > row_cap:
+            raise RuntimeError(
+                f'Statement {query_id} returned {known_rows} rows, more than the '
+                f'{row_cap}-row maximum this server returns. Narrow the request: for a '
+                'query add a LIMIT clause, a more selective WHERE predicate, or an '
+                'aggregation; for a listing, choose a smaller schema or table. An operator '
+                'can raise the maximum with REDSHIFT_MAX_RESULT_ROWS.'
+            )
+
+        next_token = page_response.get('NextToken')
+        if not next_token:
+            break
+
+        # A repeated token would otherwise loop forever collecting the same page.
+        if next_token in used_tokens:
+            raise RuntimeError(
+                f'Result set pagination of statement {query_id} did not advance: '
+                'the same continuation token was returned twice.'
+            )
+        used_tokens.add(next_token)
+
+    if total_num_rows is not None and total_num_rows != len(records):
+        raise RuntimeError(
+            f'Result set of statement {query_id} was retrieved incompletely: '
+            f'{len(records)} rows were retrieved but {total_num_rows} rows were reported.'
+        )
+
+    return {'Records': records, 'ColumnMetadata': column_metadata}
+
+
 async def _execute_protected_statement(
     cluster_identifier: str,
     database_name: str,
@@ -363,7 +491,7 @@ async def _execute_protected_statement(
     # Only fetch results when the statement produced a result set (e.g. SET does not).
     if user_statement.get('HasResultSet'):
         data_client = client_manager.redshift_data_client()
-        results_response = data_client.get_statement_result(Id=user_query_id)
+        results_response = await _fetch_result_set(data_client, user_query_id, MAX_RESULT_ROWS)
     else:
         results_response = {'Records': [], 'ColumnMetadata': []}
     return results_response, user_query_id

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/server.py
@@ -18,6 +18,8 @@ import os
 import sys
 from awslabs.redshift_mcp_server.consts import (
     DEFAULT_LOG_LEVEL,
+    VERBOSITY_LEVEL_DEFAULT,
+    VerbosityLevel,
 )
 from awslabs.redshift_mcp_server.models import (
     QueryResult,
@@ -41,6 +43,7 @@ from loguru import logger
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
 from pydantic import Field
+from typing import Annotated
 
 
 # Remove default handler and add custom configuration
@@ -95,6 +98,43 @@ Requires the connected database user to hold the sys:monitor role (or be a super
 2. Use the list_clusters tool to discover available Redshift instances.
 3. Note the cluster identifiers for use with other tools (coming in future milestones).
 
+## Verbosity
+
+The four discovery tools (list_databases, list_schemas, list_tables, list_columns) each take a
+`verbosity_level` that selects how much detail comes back per item. The rule is the same for
+all four:
+
+- `low` returns what identifies an object plus its own type. That is the database, schema,
+  table and column names that apply, with `database_type`, `schema_type`, `table_type` or
+  `data_type` respectively. Enough to navigate to an object and write a well-typed predicate
+  against it.
+- `standard`, the default, returns every field the tool lists in its own description.
+
+`low` is a subset of `standard`, so asking for more detail never drops a field. Prefer `low`
+while navigating, and `standard` once you need ownership, permissions, or the sizing of a
+table's columns.
+
+## Result Size
+
+Every tool returns a whole result set in one response, following every page of the Redshift
+Data API internally, so a large result set is never cut short at the first page.
+
+What bounds a response is `REDSHIFT_MAX_RESULT_ROWS`, a cap on the rows any one statement may
+return, shipping as 1000. Only a whole number above zero is accepted: anything else is logged
+as unusable and the shipped default applies instead, so the cap cannot be switched off.
+Changing it takes a server restart.
+
+A statement returning more rows than the cap fails rather than returning a short answer, so
+plan for small result sets:
+
+- With `execute_query`, prefer an aggregation, a selective WHERE predicate, or a LIMIT clause
+  over retrieving many rows and reducing them afterwards. Retrieve a large table in parts
+  using LIMIT and OFFSET, or by filtering on a sort key.
+- The discovery tools take no query of their own, so there is no clause to add. Narrow them by
+  listing one database or schema at a time, and use `low` verbosity while navigating.
+- A column listing is the exception: it reads one table and there is no narrower target to
+  choose, so a table with more columns than the cap needs an operator to raise it.
+
 ## Session Management and Concurrency
 
 The server reuses one Redshift Data API session per `cluster:database`:
@@ -147,6 +187,11 @@ def _read_only_annotations(title: str) -> ToolAnnotations:
         idempotent_hint=True,
         open_world_hint=True,
     )
+
+
+def _requested_level(verbosity_level: str | None) -> str:
+    """The level to apply, treating an omitted or null parameter as the default."""
+    return verbosity_level or VERBOSITY_LEVEL_DEFAULT
 
 
 @mcp.tool(
@@ -225,6 +270,14 @@ async def list_databases_tool(
         'dev',
         description='The database to connect to for metadata discovery. Defaults to "dev".',
     ),
+    verbosity_level: Annotated[
+        VerbosityLevel | None,
+        Field(
+            description='How much detail to return per database. "low" returns the name '
+            'identifying a database plus its type; "standard" returns every field this tool '
+            'reports. Defaults to "standard".'
+        ),
+    ] = VERBOSITY_LEVEL_DEFAULT,
 ) -> list[RedshiftDatabase]:
     """List all databases in a specified Amazon Redshift cluster.
 
@@ -244,14 +297,17 @@ async def list_databases_tool(
     - cluster_identifier: The unique identifier of the Redshift cluster to query.
                          IMPORTANT: Use a valid cluster identifier from the list_clusters tool.
     - database_name: The database to connect to for metadata discovery (defaults to 'dev').
+    - verbosity_level: How much detail to return per database, 'low' or 'standard'
+                      (defaults to 'standard').
 
     ## Response Structure
 
-    Returns a list of RedshiftDatabase objects with the following structure:
+    Returns a list of database objects, each carrying the fields the requested verbosity level
+    includes:
 
     - database_name: The name of the database.
     - database_owner: The database owner user ID.
-    - database_type: The type of database (local or shared).
+    - database_type: The type of database, such as local, shared, or auto mounted catalog.
     - database_acl: Access control information (for internal use).
     - parameters: The properties of the database.
     - database_isolation_level: The isolation level (Snapshot Isolation or Serializable).
@@ -261,7 +317,8 @@ async def list_databases_tool(
     1. First use list_clusters to get valid cluster identifiers.
     2. Ensure the cluster status is 'available' before querying databases.
     3. Use the default database name unless you know a specific database exists.
-    4. Note database types to understand if they are local or shared from datashares.
+    4. Note database types to tell a cluster-native database from one reached through a
+       datashare or an external catalog.
     5. Shared (datashare) databases appear only if the connecting principal has been granted access to the consumer database (e.g. GRANT USAGE ON DATABASE <db> TO <principal>); otherwise they are omitted even though the datashare exists.
 
     ## Interpretation Best Practices
@@ -277,10 +334,12 @@ async def list_databases_tool(
             cluster_identifier=cluster_identifier, database_name=database_name
         )
 
+        level = _requested_level(verbosity_level)
+
         logger.info(
             f'Successfully retrieved {len(databases)} databases from cluster {cluster_identifier}'
         )
-        return databases
+        return [database.at_verbosity_level(level) for database in databases]
 
     except Exception as e:
         logger.error(f'Error in list_databases_tool: {str(e)}')
@@ -302,6 +361,14 @@ async def list_schemas_tool(
         ...,
         description='The database name to list schemas for. Also used to connect to. Must be a valid database name from the list_databases tool.',
     ),
+    verbosity_level: Annotated[
+        VerbosityLevel | None,
+        Field(
+            description='How much detail to return per schema. "low" returns the names '
+            'identifying a schema plus its type; "standard" returns every field this tool '
+            'reports. Defaults to "standard".'
+        ),
+    ] = VERBOSITY_LEVEL_DEFAULT,
 ) -> list[RedshiftSchema]:
     """List all schemas in a specified database within a Redshift cluster.
 
@@ -322,10 +389,13 @@ async def list_schemas_tool(
                          IMPORTANT: Use a valid cluster identifier from the list_clusters tool.
     - schema_database_name: The database name to list schemas for. Also used to connect to.
                            IMPORTANT: Use a valid database name from the list_databases tool.
+    - verbosity_level: How much detail to return per schema, 'low' or 'standard'
+                      (defaults to 'standard').
 
     ## Response Structure
 
-    Returns a list of RedshiftSchema objects with the following structure:
+    Returns a list of schema objects, each carrying the fields the requested verbosity level
+    includes:
 
     - database_name: The name of the database where the schema exists.
     - schema_name: The name of the schema.
@@ -360,10 +430,12 @@ async def list_schemas_tool(
             cluster_identifier=cluster_identifier, schema_database_name=schema_database_name
         )
 
+        level = _requested_level(verbosity_level)
+
         logger.info(
             f'Successfully retrieved {len(schemas)} schemas from database {schema_database_name} on cluster {cluster_identifier}'
         )
-        return schemas
+        return [schema.at_verbosity_level(level) for schema in schemas]
 
     except Exception as e:
         logger.error(f'Error in list_schemas_tool: {str(e)}')
@@ -391,6 +463,14 @@ async def list_tables_tool(
         ...,
         description='The schema name to list tables for. Also used to connect to. Must be a valid schema name from the list_schemas tool.',
     ),
+    verbosity_level: Annotated[
+        VerbosityLevel | None,
+        Field(
+            description='How much detail to return per table. "low" returns the names '
+            'identifying a table plus its type; "standard" returns every field this tool '
+            'reports. Defaults to "standard".'
+        ),
+    ] = VERBOSITY_LEVEL_DEFAULT,
 ) -> list[RedshiftTable]:
     """List all tables in a specified schema within a Redshift database.
 
@@ -413,10 +493,13 @@ async def list_tables_tool(
                           IMPORTANT: Use a valid database name from the list_databases tool.
     - table_schema_name: The schema name to list tables for.
                         IMPORTANT: Use a valid schema name from the list_schemas tool.
+    - verbosity_level: How much detail to return per table, 'low' or 'standard'
+                      (defaults to 'standard').
 
     ## Response Structure
 
-    Returns a list of RedshiftTable objects with the following structure:
+    Returns a list of table objects, each carrying the fields the requested verbosity level
+    includes:
 
     - database_name: The name of the database where the table exists.
     - schema_name: The schema name for the table.
@@ -452,10 +535,12 @@ async def list_tables_tool(
             table_schema_name=table_schema_name,
         )
 
+        level = _requested_level(verbosity_level)
+
         logger.info(
             f'Successfully retrieved {len(tables)} tables from schema {table_schema_name} in database {table_database_name} on cluster {cluster_identifier}'
         )
-        return tables
+        return [table.at_verbosity_level(level) for table in tables]
 
     except Exception as e:
         logger.error(f'Error in list_tables_tool: {str(e)}')
@@ -487,6 +572,14 @@ async def list_columns_tool(
         ...,
         description='The table name to list columns for. Must be a valid table name from the list_tables tool.',
     ),
+    verbosity_level: Annotated[
+        VerbosityLevel | None,
+        Field(
+            description='How much detail to return per column. "low" returns the names '
+            'identifying a column plus its data type; "standard" returns every field this '
+            'tool reports. Defaults to "standard".'
+        ),
+    ] = VERBOSITY_LEVEL_DEFAULT,
 ) -> list[RedshiftColumn]:
     """List all columns in a specified table within a Redshift schema.
 
@@ -511,10 +604,13 @@ async def list_columns_tool(
                          IMPORTANT: Use a valid schema name from the list_schemas tool.
     - column_table_name: The table name to list columns for.
                         IMPORTANT: Use a valid table name from the list_tables tool.
+    - verbosity_level: How much detail to return per column, 'low' or 'standard'
+                      (defaults to 'standard').
 
     ## Response Structure
 
-    Returns a list of RedshiftColumn objects with the following structure:
+    Returns a list of column objects, each carrying the fields the requested verbosity level
+    includes:
 
     - database_name: The name of the database.
     - schema_name: The name of the schema.
@@ -528,6 +624,12 @@ async def list_columns_tool(
     - numeric_precision: The numeric precision.
     - numeric_scale: The numeric scale.
     - remarks: Remarks about the column.
+
+    An empty list does not confirm that the table exists and has no columns. SHOW COLUMNS
+    returns nothing both for a table that is absent and for one the caller lacks the privileges
+    to see, without distinguishing the two. Confirm the name with list_tables before concluding
+    the table is absent; seeing a table's columns needs ownership of it, or USAGE on the schema
+    together with SELECT on the table or column.
 
     ## Usage Tips
 
@@ -558,10 +660,12 @@ async def list_columns_tool(
             column_table_name=column_table_name,
         )
 
+        level = _requested_level(verbosity_level)
+
         logger.info(
             f'Successfully retrieved {len(columns)} columns from table {column_table_name} in schema {column_schema_name} in database {column_database_name} on cluster {cluster_identifier}'
         )
-        return columns
+        return [column.at_verbosity_level(level) for column in columns]
 
     except Exception as e:
         logger.error(f'Error in list_columns_tool: {str(e)}')

--- a/src/redshift-mcp-server/tests/test_models.py
+++ b/src/redshift-mcp-server/tests/test_models.py
@@ -1,0 +1,175 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the discovery models: the verbosity level each field carries, and serialization."""
+
+import pytest
+from awslabs.redshift_mcp_server.consts import (
+    VERBOSITY_LEVEL_LOW,
+    VERBOSITY_LEVEL_STANDARD,
+    VERBOSITY_LEVELS,
+)
+from awslabs.redshift_mcp_server.models import (
+    RedshiftColumn,
+    RedshiftDatabase,
+    RedshiftSchema,
+    RedshiftTable,
+)
+from typing import Optional
+
+
+DISCOVERY_MODELS = [RedshiftDatabase, RedshiftSchema, RedshiftTable, RedshiftColumn]
+
+# The smallest set of values that satisfies each model's required fields.
+REQUIRED_VALUES = {
+    RedshiftDatabase: {'database_name': 'dev'},
+    RedshiftSchema: {'database_name': 'dev', 'schema_name': 'public'},
+    RedshiftTable: {'database_name': 'dev', 'schema_name': 'public', 'table_name': 'orders'},
+    RedshiftColumn: {
+        'database_name': 'dev',
+        'schema_name': 'public',
+        'table_name': 'orders',
+        'column_name': 'id',
+    },
+}
+
+
+def _response(values: dict) -> dict:
+    """Build a single-row Data API result set from column name to value."""
+    return {
+        'ColumnMetadata': [{'name': name} for name in values],
+        'Records': [[{'stringValue': value} for value in values.values()]],
+    }
+
+
+def _item(model_class):
+    """Build one model instance carrying only its required fields."""
+    return model_class.model_validate(REQUIRED_VALUES[model_class])
+
+
+def _full_item(model_class):
+    """Build one model instance with every field populated.
+
+    Serialization drops None, so only an item with no null of its own can show that a
+    missing key came from the requested level rather than from an absent value.
+    """
+    values = {
+        name: 1 if field.annotation in (int, Optional[int]) else f'{name}-value'
+        for name, field in model_class.model_fields.items()
+    }
+    return model_class.model_validate(values)
+
+
+class TestVerbosityLevels:
+    """Tests for the level each field is marked with, and for serializing onto a level."""
+
+    def test_low_fields_are_pinned(self):
+        """Low returns these fields and no others, so nothing can join it unnoticed.
+
+        Low is the identifying names plus the object's type: enough to navigate to an object
+        and write a well-typed predicate against it, with no permissions, ownership or
+        physical design. Widening it would enlarge every low-verbosity response, so a field
+        added to low fails this test until it is added here too.
+        """
+        assert RedshiftDatabase.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW) == (
+            'database_name',
+            'database_type',
+        )
+        assert RedshiftSchema.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW) == (
+            'database_name',
+            'schema_name',
+            'schema_type',
+        )
+        assert RedshiftTable.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW) == (
+            'database_name',
+            'schema_name',
+            'table_name',
+            'table_type',
+        )
+        assert RedshiftColumn.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW) == (
+            'database_name',
+            'schema_name',
+            'table_name',
+            'column_name',
+            'data_type',
+        )
+
+    @pytest.mark.parametrize('model_class', DISCOVERY_MODELS)
+    def test_standard_returns_every_declared_field(self, model_class):
+        """Standard is what the tool returned before levels existed: every declared field."""
+        assert model_class.fields_at_verbosity_level(VERBOSITY_LEVEL_STANDARD) == tuple(
+            model_class.model_fields
+        )
+
+    @pytest.mark.parametrize('model_class', DISCOVERY_MODELS)
+    def test_low_is_contained_in_standard(self, model_class):
+        """The levels are nested, so asking for more detail never drops a field."""
+        low = set(model_class.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW))
+        assert low < set(model_class.fields_at_verbosity_level(VERBOSITY_LEVEL_STANDARD))
+
+    @pytest.mark.parametrize('model_class', DISCOVERY_MODELS)
+    def test_unmarked_fields_default_to_standard(self, model_class):
+        """Only the low fields carry a marker; everything else falls back to standard.
+
+        The fallback is what keeps a field added later out of `low` without the author having
+        to think about it. Marking every standard field instead would put the same word on two
+        dozen declarations to say what the fallback already says.
+        """
+        standard_only = set(model_class.fields_at_verbosity_level(VERBOSITY_LEVEL_STANDARD)) - set(
+            model_class.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW)
+        )
+        assert standard_only, 'expected at least one standard-only field to assert on'
+        assert all(
+            model_class.field_verbosity_level(name) == VERBOSITY_LEVEL_STANDARD
+            for name in standard_only
+        )
+
+    @pytest.mark.parametrize('level', list(VERBOSITY_LEVELS))
+    @pytest.mark.parametrize('model_class', DISCOVERY_MODELS)
+    def test_serialization_follows_declaration_order(self, model_class, level):
+        """A serialized item carries the level's fields, in the order they were declared.
+
+        Asserting the order also asserts the set, so this covers both: no field above the
+        level survives, and none at or below it goes missing.
+
+        The order is the models' own, not the order a level happens to list, which is why a
+        type field declared after the detail fields still reads last rather than jumping
+        forward to sit with the names it shares a level with.
+        """
+        serialized = _full_item(model_class).at_verbosity_level(level).model_dump()
+
+        assert list(serialized) == list(model_class.fields_at_verbosity_level(level))
+
+    @pytest.mark.parametrize('model_class', DISCOVERY_MODELS)
+    def test_the_level_keeps_its_own_values(self, model_class):
+        """Blanking the levels above leaves the ones at or below it untouched."""
+        full = _full_item(model_class)
+        low = full.at_verbosity_level(VERBOSITY_LEVEL_LOW)
+
+        for name in model_class.fields_at_verbosity_level(VERBOSITY_LEVEL_LOW):
+            assert getattr(low, name) == getattr(full, name)
+
+    def test_a_null_field_is_dropped_at_its_own_level(self):
+        """A field that is NULL in Redshift is absent rather than null in the response.
+
+        None is the only signal serialization has, so a genuinely null value reads the same
+        as one the level blanked. Standard callers see the key disappear, not carry null.
+        """
+        values = dict(REQUIRED_VALUES[RedshiftTable], table_type='TABLE')
+        item = RedshiftTable.from_redshift_response(_response(values))[0]
+
+        serialized = item.at_verbosity_level(VERBOSITY_LEVEL_STANDARD).model_dump()
+
+        assert item.remarks is None
+        assert 'remarks' not in serialized

--- a/src/redshift-mcp-server/tests/test_redshift.py
+++ b/src/redshift-mcp-server/tests/test_redshift.py
@@ -19,6 +19,7 @@ import pytest
 import sqlglot
 import time
 from awslabs.redshift_mcp_server.consts import (
+    MAX_RESULT_ROWS_DEFAULT,
     QUERY_LONG_POLL,
     QUERY_POLL_INTERVAL,
 )
@@ -28,6 +29,8 @@ from awslabs.redshift_mcp_server.redshift import (
     RedshiftSessionManager,
     _execute_protected_statement,
     _execute_statement,
+    _fetch_result_set,
+    _resolve_max_result_rows,
     _sql_identifier,
     discover_clusters,
     discover_columns,
@@ -462,6 +465,167 @@ class TestExecuteProtectedStatement:
         mock_data_client.get_statement_result.assert_called_once_with(Id='user-stmt-id')
         assert query_id == 'user-stmt-id'
         assert results_response == expected_result
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_follows_every_page(self, mocker):
+        """Every page is retrieved in order, each request after the first carrying its token."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.side_effect = [
+            {
+                'Records': [[{'longValue': 1}]],
+                'ColumnMetadata': [{'name': 'n'}],
+                'TotalNumRows': 3,
+                'NextToken': 'page-2',
+            },
+            {'Records': [[{'longValue': 2}]], 'NextToken': 'page-3'},
+            {'Records': [[{'longValue': 3}]]},
+        ]
+
+        results_response = await _fetch_result_set(mock_data_client, 'user-stmt-id', 10)
+
+        # Rows arrive concatenated in page order, none omitted and none repeated.
+        assert results_response['Records'] == [
+            [{'longValue': 1}],
+            [{'longValue': 2}],
+            [{'longValue': 3}],
+        ]
+        # Column metadata is taken from the first page that reported it.
+        assert results_response['ColumnMetadata'] == [{'name': 'n'}]
+        assert mock_data_client.get_statement_result.call_args_list == [
+            mocker.call(Id='user-stmt-id'),
+            mocker.call(Id='user-stmt-id', NextToken='page-2'),
+            mocker.call(Id='user-stmt-id', NextToken='page-3'),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_page_failure_returns_no_rows(self, mocker):
+        """A page failure discards what was retrieved and names the statement."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.side_effect = [
+            {'Records': [[{'longValue': 1}]], 'NextToken': 'page-2'},
+            Exception('Data API unavailable'),
+        ]
+
+        with pytest.raises(RuntimeError, match='user-stmt-id.*retrieved incompletely'):
+            await _fetch_result_set(mock_data_client, 'user-stmt-id', 10)
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_row_count_mismatch_returns_no_rows(self, mocker):
+        """Retrieving fewer rows than were reported is an error, not a short result set."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'longValue': 1}]],
+            'ColumnMetadata': [{'name': 'n'}],
+            'TotalNumRows': 2,
+        }
+
+        with pytest.raises(RuntimeError, match='1 rows were retrieved but 2 rows were reported'):
+            await _fetch_result_set(mock_data_client, 'user-stmt-id', 10)
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_repeated_token_stops(self, mocker):
+        """A token the Data API repeats stops paging instead of looping on one page."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'longValue': 1}]],
+            'ColumnMetadata': [{'name': 'n'}],
+            'NextToken': 'stuck',
+        }
+
+        with pytest.raises(RuntimeError, match='user-stmt-id did not advance'):
+            await _fetch_result_set(mock_data_client, 'user-stmt-id', 10)
+
+    @pytest.mark.parametrize(
+        'configured, expected',
+        [
+            (None, MAX_RESULT_ROWS_DEFAULT),
+            ('250', 250),
+            ('', MAX_RESULT_ROWS_DEFAULT),
+            ('   ', MAX_RESULT_ROWS_DEFAULT),
+            ('lots', MAX_RESULT_ROWS_DEFAULT),
+            ('12.5', MAX_RESULT_ROWS_DEFAULT),
+            ('0', MAX_RESULT_ROWS_DEFAULT),
+            ('-1', MAX_RESULT_ROWS_DEFAULT),
+        ],
+        ids=[
+            'unset',
+            'positive',
+            'empty',
+            'whitespace',
+            'not_a_number',
+            'not_an_integer',
+            'zero',
+            'negative',
+        ],
+    )
+    def test_resolve_max_result_rows(self, monkeypatch, configured, expected):
+        """Only a whole number above zero is a usable cap; anything else takes the default.
+
+        Zero and negatives are rejected rather than treated as "no cap", so a misconfiguration
+        cannot silently remove the bound.
+        """
+        if configured is None:
+            monkeypatch.delenv('REDSHIFT_MAX_RESULT_ROWS', raising=False)
+        else:
+            monkeypatch.setenv('REDSHIFT_MAX_RESULT_ROWS', configured)
+
+        assert _resolve_max_result_rows() == expected
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_over_the_cap_fails_closed(self, mocker):
+        """A statement over the cap raises with advice rather than returning a short answer."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'longValue': n}] for n in range(3)],
+            'ColumnMetadata': [{'name': 'n'}],
+        }
+
+        with pytest.raises(RuntimeError, match='returned 3 rows, more than the 2'):
+            await _fetch_result_set(mock_data_client, 'user-stmt-id', 2)
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_stops_fetching_once_over_the_cap(self, mocker):
+        """The cap is enforced during retrieval, so later pages are never requested."""
+        mock_data_client = mocker.Mock()
+        # The reported total already exceeds the cap on the first page.
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'longValue': 1}], [{'longValue': 2}]],
+            'ColumnMetadata': [{'name': 'n'}],
+            'TotalNumRows': 500,
+            'NextToken': 'page-2',
+        }
+
+        with pytest.raises(RuntimeError, match='returned 500 rows, more than the 1'):
+            await _fetch_result_set(mock_data_client, 'user-stmt-id', 1)
+
+        # One page requested, then refused; the rest of the result set was never read.
+        assert mock_data_client.get_statement_result.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_at_the_cap_is_returned(self, mocker):
+        """A statement exactly at the cap is within it, so the rows come back."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'longValue': 1}], [{'longValue': 2}]],
+            'ColumnMetadata': [{'name': 'n'}],
+        }
+
+        results_response = await _fetch_result_set(mock_data_client, 'user-stmt-id', 2)
+
+        assert len(results_response['Records']) == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_set_without_reported_total_is_accepted(self, mocker):
+        """With no total reported there is nothing to reconcile, so the rows stand."""
+        mock_data_client = mocker.Mock()
+        mock_data_client.get_statement_result.return_value = {
+            'Records': [[{'longValue': 1}]],
+            'ColumnMetadata': [{'name': 'n'}],
+        }
+
+        results_response = await _fetch_result_set(mock_data_client, 'user-stmt-id', 10)
+
+        assert results_response['Records'] == [[{'longValue': 1}]]
 
     @pytest.mark.asyncio
     async def test_execute_protected_statement_denylisted_statements_rejected(self, mocker):

--- a/src/redshift-mcp-server/tests/test_server.py
+++ b/src/redshift-mcp-server/tests/test_server.py
@@ -15,6 +15,9 @@
 """Tests for the Redshift MCP Server tools."""
 
 import pytest
+from awslabs.redshift_mcp_server.consts import (
+    VERBOSITY_LEVEL_STANDARD,
+)
 from awslabs.redshift_mcp_server.models import (
     QueryResult,
     RedshiftCluster,
@@ -66,6 +69,149 @@ async def test_tool_annotations():
         assert annotations.destructive_hint is False
         assert annotations.idempotent_hint is True
         assert annotations.open_world_hint is True
+
+
+# Each discovery tool with the parameters it publishes and what it takes to call it.
+DISCOVERY_TOOLS = {
+    'list_databases': {
+        'parameters': {'cluster_identifier', 'database_name', 'verbosity_level'},
+        'tool': list_databases_tool,
+        'patch': 'awslabs.redshift_mcp_server.server.discover_databases',
+        'args': ('test-cluster', 'dev'),
+        'model': RedshiftDatabase,
+        'values': lambda index: {
+            'database_name': f'db{index}',
+            'database_owner': 100,
+            'database_type': 'local',
+            'database_acl': 'rw',
+            'parameters': 'none',
+            'database_isolation_level': 'Serializable',
+        },
+    },
+    'list_schemas': {
+        'parameters': {'cluster_identifier', 'schema_database_name', 'verbosity_level'},
+        'tool': list_schemas_tool,
+        'patch': 'awslabs.redshift_mcp_server.server.discover_schemas',
+        'args': ('test-cluster', 'dev'),
+        'model': RedshiftSchema,
+        'values': lambda index: {
+            'database_name': 'dev',
+            'schema_name': f'sc{index}',
+            'schema_owner': 100,
+            'schema_type': 'local',
+            'schema_acl': 'rw',
+            'source_database': 'src',
+            'schema_option': 'opt',
+        },
+    },
+    'list_tables': {
+        'parameters': {
+            'cluster_identifier',
+            'table_database_name',
+            'table_schema_name',
+            'verbosity_level',
+        },
+        'tool': list_tables_tool,
+        'patch': 'awslabs.redshift_mcp_server.server.discover_tables',
+        'args': ('test-cluster', 'dev', 'public'),
+        'model': RedshiftTable,
+        'values': lambda index: {
+            'database_name': 'dev',
+            'schema_name': 'public',
+            'table_name': f'tb{index}',
+            'table_acl': 'rw',
+            'table_type': 'TABLE',
+            'remarks': 'note',
+        },
+    },
+    'list_columns': {
+        'parameters': {
+            'cluster_identifier',
+            'column_database_name',
+            'column_schema_name',
+            'column_table_name',
+            'verbosity_level',
+        },
+        'tool': list_columns_tool,
+        'patch': 'awslabs.redshift_mcp_server.server.discover_columns',
+        'args': ('test-cluster', 'dev', 'public', 'orders'),
+        'model': RedshiftColumn,
+        'values': lambda index: {
+            'database_name': 'dev',
+            'schema_name': 'public',
+            'table_name': 'orders',
+            'column_name': f'col{index}',
+            'ordinal_position': index,
+            'column_default': '0',
+            'is_nullable': 'NO',
+            'data_type': 'integer',
+            'character_maximum_length': 255,
+            'numeric_precision': 10,
+            'numeric_scale': 0,
+            'remarks': 'note',
+        },
+    },
+}
+
+
+def _discovery_items(spec, count):
+    """Build a discover_* return value of count items."""
+    return [spec['model'].model_validate(spec['values'](i)) for i in range(1, count + 1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('tool_name', list(DISCOVERY_TOOLS))
+async def test_discovery_tool_input_schema(tool_name):
+    """Each discovery tool publishes exactly the parameters it accepts.
+
+    The full parameter set is written out here rather than checking a few names, so a parameter
+    added later fails this test until it is added here too. That makes any change to what a
+    caller can pass a deliberate one.
+    """
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    properties = tools[tool_name].input_schema['properties']
+
+    assert set(properties) == DISCOVERY_TOOLS[tool_name]['parameters']
+
+    verbosity = properties['verbosity_level']
+    assert verbosity['default'] == 'standard'
+    assert {'low', 'standard'} == {
+        value for option in verbosity['anyOf'] for value in option.get('enum', [])
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('tool_name', list(DISCOVERY_TOOLS))
+async def test_discovery_tool_returns_a_plain_list_of_models(mocker, tool_name):
+    """A discovery tool returns every item it found as a plain list of its own model.
+
+    A list rather than an envelope, and typed items rather than dictionaries, so the
+    published output schema keeps describing the fields.
+    """
+    spec = DISCOVERY_TOOLS[tool_name]
+    mocker.patch(spec['patch'], return_value=_discovery_items(spec, 3))
+
+    result = await spec['tool'](Context(), *spec['args'])
+
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(item, spec['model']) for item in result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('level', [None, 'low', 'standard'])
+@pytest.mark.parametrize('tool_name', list(DISCOVERY_TOOLS))
+async def test_discovery_tool_applies_the_requested_level(mocker, tool_name, level):
+    """Each item carries exactly the level's fields; omitting the level means standard."""
+    spec = DISCOVERY_TOOLS[tool_name]
+    mocker.patch(spec['patch'], return_value=_discovery_items(spec, 1))
+    expected_level = level or VERBOSITY_LEVEL_STANDARD
+
+    result = await spec['tool'](Context(), *spec['args'], verbosity_level=level)
+
+    assert set(result[0].model_dump()) == set(
+        spec['model'].fields_at_verbosity_level(expected_level)
+    )
 
 
 class TestListClustersTool:
@@ -217,7 +363,7 @@ class TestListDatabasesTool:
 
         # Verify return type
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_list_databases_tool_error(self, mocker):
@@ -292,7 +438,7 @@ class TestListSchemasTool:
 
         # Verify return type
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_list_schemas_tool_error(self, mocker):
@@ -365,7 +511,7 @@ class TestListTablesTool:
 
         # Verify return type
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_list_tables_tool_error(self, mocker):
@@ -452,7 +598,7 @@ class TestListColumnsTool:
 
         # Verify return type
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_list_columns_tool_error(self, mocker):


### PR DESCRIPTION
### Changes

**1. Complete result-set retrieval (bug fix).** `GetStatementResult` returns one page at a time, but
the server read only the first page and discarded the token, so a result set larger than one page was
silently truncated. Retrieval now follows every page, stops if the API repeats a page token, and
reconciles the rows retrieved against the total the API reports. Because
`_execute_protected_statement` is the single funnel to the Data API, `execute_query` and
`review_cluster` inherit this with no change of their own.

**2. A cap on result rows.** `REDSHIFT_MAX_RESULT_ROWS` caps the rows any one statement may return,
shipping as `1000`. Only a whole number above zero is accepted: anything else is logged as unusable
and the shipped default applies instead, so the cap cannot be switched off and a misconfiguration
lowers it to a safe value rather than removing it. It is read once at startup, so changing it takes
a server restart. Enforcement lives in the retrieval layer, so it covers `execute_query` as well as
the four discovery tools, and it is stated in the server instructions so an agent can plan for it.

A statement over the cap fails, and the error names what to do about it:

```
Statement <id> returned 1500 rows, more than the 1000-row maximum this server returns.
Narrow the request: for a query add a LIMIT clause, a more selective WHERE predicate, or
an aggregation; for a listing, choose a smaller schema or table. An operator can raise
the maximum with REDSHIFT_MAX_RESULT_ROWS.
```

Retrieval stops as soon as the cap is known to be exceeded, so an oversized statement is refused
without its whole result set being read into memory. When the API reports the row total on the first
page, that happens after one page.

**3. Discovery verbosity levels.** Each of the four discovery tools accepts `verbosity_level`:

- `low` returns what identifies an object plus its own type: the database, schema, table and column
  names that apply, with `database_type`, `schema_type`, `table_type` or `data_type` respectively.
  Enough to navigate to an object and write a well-typed predicate against it, without ownership,
  permissions or column sizing.
- `standard` is the default and returns the fields each tool returned before, so an existing caller
  sees no change.

| Tool | `low` fields |
|---|---|
| `list_databases` | `database_name`, `database_type` |
| `list_schemas` | `database_name`, `schema_name`, `schema_type` |
| `list_tables` | `database_name`, `schema_name`, `table_name`, `table_type` |
| `list_columns` | `database_name`, `schema_name`, `table_name`, `column_name`, `data_type` |

`low` is always a subset of `standard`. Each field carries the level it first appears at as
`Annotated` metadata on the field, so the two cannot drift apart; an unmarked field counts as
`standard`. The levels themselves are constants in `consts.py`, ordered least to most detail, with a
single `Literal` alias the four tools annotate with, so the values are written once.

### User experience

A discovery tool returns a list, as before. At the default `standard` level each item carries the
same fields, except that a field with no value is now absent rather than `null`:

```jsonc
[ { "database_name": "dev", "database_owner": 100, "database_type": "local", ... } ]
```

`low` returns the name and the type, which is useful while navigating:

```jsonc
[ { "database_name": "dev", "database_type": "local" },
  { "database_name": "sample_data_dev", "database_type": "shared" } ]
```

Three behaviours change. A result set spanning several Data API pages now comes back whole, where it
was previously cut off at the first page without any indication. A result set larger than the cap now
fails, where a caller would previously have received part of the data believing it complete. And a
field with no value is omitted rather than sent as `null`.

Whether the cap is reachable at all differs by object type, because of the [Amazon Redshift quotas](https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html) on each. This is documented in the server instructions and in the README:

| Tool | Redshift quota | At the default cap of 1000 |
|---|---|---|
| `list_databases` | 60 per provisioned cluster, 100 per serverless namespace, excluding datashare databases | Never reached |
| `list_schemas` | 9,900 per database | Reachable on a large database |
| `list_tables` | up to 200,000 per cluster on the larger node types | Reachable on a large schema |
| `list_columns` | 1,600 per table | Reachable on a very wide table |



## Testing

266 unit tests passing, 100% line coverage of `awslabs`, with `ruff format`, `ruff check` and
`pyright` clean.

End-to-end against a provisioned cluster and a serverless workgroup. Nothing was written to either;
only `SHOW`, `SELECT` and `SET` ran.

<details>
<summary>Verbosity and row-cap scenarios</summary>

```
% kiro-cli chat \
    --model claude-opus-5 \
    --no-interactive \
    --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
'Use Redshift MCP Server to run end-to-end (integration) tests covering the scenarios for the changes introduced in the current branch only. Get the test scenario ideas from the unit tests under the project directory. Provide a short testing summary, one line per scenario.'

...

All scenarios executed end-to-end against live cluster `redshift-cluster-1` (us-east-1). Testing summary, one line per scenario:

**Discovery verbosity levels** (list_databases/schemas/tables/columns)
1. ✅ `list_databases` with verbosity omitted → returned full/standard fields (owner, acl, isolation level) — default is `standard`.
2. ✅ `list_databases verbosity_level=low` → returned only `database_name` + `database_type`.
3. ✅ `list_schemas` low → only `{database_name, schema_name, schema_type}`; standard added `schema_owner`/`schema_acl` (low ⊂ standard).
4. ✅ `list_tables` low → only `{database_name, schema_name, table_name, table_type}`; standard added `table_acl` (low ⊂ standard).
5. ✅ `list_columns` (tickit.sales) low → only `{database_name, schema_name, table_name, column_name, data_type}`; standard added `ordinal_position`/`is_nullable`/`numeric_precision`/`numeric_scale` (low ⊂ standard).
6. ✅ NULL fields dropped (absent, not `null`) at standard — e.g. `database_acl`/`parameters` on most DBs, `remarks`/`character_maximum_length`, and `numeric_precision` on the `timestamp` column all omitted.

**Result-row cap** (`REDSHIFT_MAX_RESULT_ROWS`, default 1000) + full pagination
7. ✅ `execute_query` returning 999 rows → full result set returned (`row_count=999`), within cap.
8. ✅ `execute_query` returning exactly 1000 rows → returned (`row_count=1000`), boundary is inclusive.
9. ✅ `execute_query` returning 1001 rows → failed closed with advice: *"returned 1001 rows, more than the 1000-row maximum… Narrow the request… An operator can raise the maximum with REDSHIFT_MAX_RESULT_ROWS."*
10. ✅ Narrowing works: `COUNT(*)` over a 100,000-row `generate_series` → 1 row, well under cap.

All 10 scenarios (derived from the branch's unit tests in `test_models.py`, `test_redshift.py`, `test_server.py`) passed. Scope was limited to the branch-only commit `289ed8ab` (result-row cap + discovery verbosity); read-only queries only, using synthetic `generate_series` data. One unit-test idea I could not force end-to-end is a discovery listing exceeding the cap (would require 1000+ schemas/columns) — the cap on that path is inherited from the same retrieval layer already exercised by scenarios 8–9.



```

</details>

<details>
<summary>All seven tools, and the existing protections</summary>

```
% kiro-cli chat \
    --model claude-opus-5 \
    --no-interactive \
    --trust-tools "@{awslabsredshift-mcp-server}/*,execute_bash,fs_read" \
'Use Redshift MCP Server to run a complete set of end-to-end (integration) tests covering all its tools. Check both provisioned and serverless clusters, including the database schema exploration in both. Check the SQL read-only protection, transaction breaker protection, failed user SQL behavior. Get the test scenario ideas from the unit tests under the project directory. Provide a short testing summary, one line per tool.'

...


All tests passed. Here is the testing summary.

## Redshift MCP Server — Integration Test Summary

**Environment:** provisioned `redshift-cluster-1` + serverless `redshift-cluster-serverless` (us-east-1), sample data in `sample_data_dev.tickit`.

**One line per tool:**
- **list_clusters** — ✅ Discovered 3 provisioned clusters + 1 serverless workgroup with correct type/status/config fields.
- **list_databases** — ✅ Listed databases on both cluster types; `low` verbosity correctly returned only `database_name`+`database_type`.
- **list_schemas** — ✅ Returned local/catalog schemas on both; `low` verbosity trimmed to name+type as designed.
- **list_tables** — ✅ Listed 7 `tickit` tables on both; `low` gave 4 identifying fields, `standard` added `table_acl`.
- **list_columns** — ✅ Returned typed column metadata on both; `character_maximum_length`/`numeric_precision` shown per type and NULL fields correctly omitted (e.g. `saletime`).
- **execute_query** — ✅ Valid read queries succeeded on both (provisioned sales aggregate = 344,912 rows; serverless venue ranking, with NULL values preserved).
- **review_cluster** — ✅ Ran on both; serverless = 8 signals/0 findings, provisioned = 11 signals/10 effort-ordered findings; provisioned-only diagnostics auto-skipped for serverless.

**One line per protection:**
- **SQL read-only (deny-list)** — ✅ `TRUNCATE` (provisioned) and `GRANT` (serverless) rejected pre-execution with `Statement type not allowed in read-only mode: <KW>`; multi-statement `SELECT 1; SELECT 2` rejected with `Only a single SQL statement is allowed`.
- **Transaction breaker** — ✅ `CREATE TABLE` passed the guard but the engine's read-only transaction blocked it on **both** provisioned and serverless (`ERROR: transaction is read-only`); nothing was created (rolled back).
- **Failed user SQL** — ✅ Unparseable `SELECT FROM WHERE` failed closed with `SQL could not be parsed`; a nonexistent table surfaced the engine error `relation "…" does not exist`.

All 7 tools and all 3 protection classes behaved as specified across both provisioned and serverless clusters, including schema exploration on each. No writes persisted.

```

</details>


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? **N**

for the response shape. The discovery tools still return a
list of the same models, and at the default `standard` verbosity each item carries the same fields,
with one qualification: a field with no value is now omitted rather than sent as `null`. A consumer
reading keys off the JSON sees the same values; one that distinguishes an absent key from a null one
would see a difference.

**Operator-facing note.** `REDSHIFT_MAX_RESULT_ROWS` is read once at startup, so a change to it now
takes a server restart. There is no value that disables the cap; an operator who needs more rows
raises the number.

**Pre-existing behaviour documented, not changed.** End-to-end testing surfaced that `list_columns`
returns an empty list for a table that does not exist, where `list_schemas` raises for a database
that does not exist. `SHOW COLUMNS` returns nothing both for an absent table and for one the caller
lacks privileges to see, and does not distinguish them. That path is untouched by this change, so
rather than alter it here the `list_columns` description now says an empty list does not confirm the
table exists with no columns, and points at `list_tables` to check the name.

**RFC issue number**:

Checklist:

* [x] Migration process documented - the cap, its environment variable, and what to do when a
  statement exceeds it are stated in each tool's description, in the server instructions, and in a
  "Result size" section of the README.
* [x] Implement warnings (if it can live side by side) - not applicable as a warning. The change replaces silent truncation with an explicit error.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
