### PR TITLE
feat(aurora-dsql-mcp-server): use native ALTER TABLE DROP COLUMN for DSQL

### DIFF
--- a/src/aurora-dsql-mcp-server/CHANGELOG.md
+++ b/src/aurora-dsql-mcp-server/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `ALTER TABLE ASYNC ... VALIDATE CONSTRAINT` guidance to DSQL steering. CHECK constraints can now be added with `NOT VALID` and validated asynchronously, following the same async DDL pattern as `CREATE INDEX ASYNC`.
 
+### Changed
+
+- Update DSQL steering for native `ALTER TABLE ... DROP COLUMN` support. Dropping a column no longer requires the destructive Table Recreation Pattern — it is a synchronous, metadata-only change, so agents stop generating a CREATE/INSERT-SELECT/DROP/RENAME sequence for it. Steering documents the primary-key restriction, `CASCADE` for dependent objects, and the 255-active/1,600-lifetime column budget. Unlike `VALIDATE CONSTRAINT`, `DROP COLUMN` has no `ALTER TABLE ASYNC` form and returns no `job_id`.
+
 ### Security
 
 - Close read-only bypasses in `readonly_query` / `transact` (read-only mode), aligning the SQL classifier with the `postgres-mcp-server` sibling:

--- a/src/aurora-dsql-mcp-server/kiro_power/POWER.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/POWER.md
@@ -55,10 +55,10 @@ This power includes the following steering files in [steering](./steering)
   - MUST load when writing OCC retry code or mitigating commit-time conflicts
   - DSQL Connectors, manual retry pattern, conflict mitigation, idempotent transaction design
 - **ddl-migrations-overview**
-  - MUST load when performing DROP COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+  - MUST load when performing ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
   - Table recreation pattern overview, transaction rules, verify & swap pattern
 - **ddl-migrations-column-operations**
-  - Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT
+  - MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT
 - **ddl-migrations-constraint-operations**
   - Load for ADD/DROP CONSTRAINT, VALIDATE CONSTRAINT, MODIFY PRIMARY KEY, column split/merge
 - **ddl-migrations-batched**
@@ -223,9 +223,11 @@ Authorize the caller against the tenant **before** validating format or calling 
 
 **MUST** load [access-control.md](steering/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Validate the new CREATE TABLE with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. **MUST** load [ddl-migrations-column-operations.md](steering/ddl-migrations-column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and **MUST** confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Validate the new CREATE TABLE with `dsql_lint(sql=..., fix=true)` before execution.
 
 **MUST** load [ddl-migrations-overview.md](steering/ddl-migrations-overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/ddl-migrations-column-operations.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/ddl-migrations-column-operations.md
@@ -1,51 +1,73 @@
 # DDL Migrations: Column Operations
 
-Step-by-step migration patterns for column-level changes using the Table Recreation Pattern.
+Step-by-step migration patterns for column-level changes. `DROP COLUMN` runs as a direct statement; the remaining operations use the Table Recreation Pattern.
 
-**MUST read [overview.md](overview.md) first** for destructive operation warnings and the common verify & swap pattern.
+**MUST read [overview.md](overview.md) before any Table Recreation Pattern migration** for destructive operation warnings and the common verify & swap pattern.
 
 ---
 
-## DROP COLUMN Migration
+## DROP COLUMN
 
 **Goal:** Remove a column from an existing table.
 
-### Pre-Migration Validation
+DSQL supports `DROP COLUMN` directly. **MUST** issue the native statement rather than recreating the
+table — the operation is synchronous and metadata-only, so it completes immediately and never drops
+the table.
+
+The dropped column's data becomes unreachable and no rollback exists once the transaction commits,
+so **MUST** name the exact table and column to the user and obtain explicit confirmation first.
 
 ```sql
-readonly_query("SELECT COUNT(*) as total_rows FROM target_table")
-get_schema("target_table")
+transact(["ALTER TABLE target_table DROP COLUMN obsolete_column"])
 ```
 
-### Migration Steps
+Dropping a non-key column that the primary key implicitly INCLUDEs is the ordinary case and needs no
+special handling — DSQL rewrites the primary key definition automatically.
 
-#### Step 1: Create new table excluding the column
+Several `DROP COLUMN` subcommands **MAY** share one `ALTER TABLE`. The
+one-modification-per-statement rule in
+[development-guide.md](../development-guide.md) applies to `ADD COLUMN` and `ALTER COLUMN`, not to
+`DROP COLUMN`:
 
 ```sql
-transact([
-  "CREATE TABLE target_table_new (
-     id UUID PRIMARY KEY,
-     tenant_id VARCHAR(255) NOT NULL,
-     kept_column1 VARCHAR(255),
-     kept_column2 INTEGER
-     -- dropped_column is NOT included
-   )"
-])
+transact(["ALTER TABLE target_table DROP COLUMN obsolete_column, DROP COLUMN legacy_flag"])
 ```
 
-#### Step 2: Migrate data
+### Rules
 
-```sql
-transact([
-  "INSERT INTO target_table_new (id, tenant_id, kept_column1, kept_column2)
-   SELECT id, tenant_id, kept_column1, kept_column2
-   FROM target_table"
-])
-```
+- **MUST** recreate the table instead when the column is a primary key *key* column. DSQL rejects
+  that drop with `0A000 feature_not_supported`. See
+  [MODIFY PRIMARY KEY](constraint-operations.md#modify-primary-key-migration) for that path.
+- A bare drop already removes the column's indexes and its same-table constraints — `CHECK`,
+  `DEFAULT`, `UNIQUE`, and a foreign key *defined on* the column. Issue the plain statement for
+  these; adding `CASCADE` buys nothing and widens the blast radius.
+- **MUST** add `CASCADE` only when something outside the table depends on the column — a view, or a
+  foreign key in another table *referencing* it — or when a same-table `GENERATED ... STORED` column
+  is computed from it. Without `CASCADE` those cases fail with
+  `2BP01 dependent_objects_still_exist`. `CASCADE` drops the dependent objects too, so **MUST**
+  present the dependency list to the user and obtain confirmation before using it:
+  ```sql
+  transact(["ALTER TABLE target_table DROP COLUMN obsolete_column CASCADE"])
+  ```
+- **MUST** fall back to table recreation when `CASCADE` itself fails with
+  `0A000 feature_not_supported`. That means the dependency chain reaches a primary key key column —
+  for example a PK column declared `GENERATED ALWAYS AS (obsolete_column) STORED`. DSQL refuses to
+  cascade into the primary key, so no form of `DROP COLUMN` succeeds.
+- **MAY** use `IF EXISTS` for idempotent migrations. Dropping an already-dropped column otherwise
+  raises `42703 undefined_column`.
 
-For tables > 3,000 rows, use [Batched Migration Pattern](batched-migration.md).
+### Storage Impact
 
-**Step 3: Verify and swap** (see [Common Pattern](overview.md#common-verify--swap-pattern))
+The drop hides the column rather than physically removing it, so table size does not fall right
+away. Space returns as existing rows are updated. **MUST** tell the user that reclamation is
+gradual.
+
+### Column Budget
+
+A table holds at most **255 active** columns and **1,600 over its lifetime**. Attribute numbers are
+never reused, so each dropped column frees an active slot but still spends lifetime budget. A table
+churned past 1,600 columns needs recreation — a later `ADD COLUMN` returns
+`54011 too_many_columns`.
 
 ---
 
@@ -106,6 +128,8 @@ transact([
    FROM target_table"
 ])
 ```
+
+For tables > 3,000 rows, use [Batched Migration Pattern](batched-migration.md).
 
 **Step 3: Verify and swap** (see [Common Pattern](overview.md#common-verify--swap-pattern))
 

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/ddl-migrations-overview.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/ddl-migrations-overview.md
@@ -46,7 +46,6 @@ The following ALTER TABLE operations MUST use the **Table Recreation Pattern**:
 
 | Operation                      | Key Approach                                   |
 | ------------------------------ | ---------------------------------------------- |
-| DROP COLUMN                    | Exclude column from new table                  |
 | ALTER COLUMN TYPE              | Cast data type in SELECT                       |
 | ALTER COLUMN SET/DROP NOT NULL | Change constraint in new table definition      |
 | ALTER COLUMN SET/DROP DEFAULT  | Define default in new table definition         |
@@ -60,6 +59,9 @@ The following ALTER TABLE operations MUST use the **Table Recreation Pattern**:
 - `ALTER TABLE ... RENAME COLUMN` - Rename a column
 - `ALTER TABLE ... RENAME TO` - Rename a table
 - `ALTER TABLE ... ADD COLUMN` - Add a new column
+- `ALTER TABLE ... DROP COLUMN` - Drop a column. Use this instead of table recreation. Dropping a
+  primary key column is unsupported — that still requires the Table Recreation Pattern. See
+  [column-operations.md](column-operations.md#drop-column)
 
 ---
 

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/development-guide.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/development-guide.md
@@ -83,6 +83,7 @@ effortless scaling, multi-region viability, among other advantages.
   2. MUST then issue UPDATE to populate existing rows
   3. MAY then issue ALTER COLUMN to apply the constraint
 - MUST issue a **separate ALTER TABLE statement for each column** modification.
+- To drop a column, MUST issue **`ALTER TABLE t DROP COLUMN c`** — a direct, synchronous, metadata-only change; table recreation is unnecessary. Add `CASCADE` when a view, an inbound foreign key, or a `GENERATED ... STORED` column depends on it. Dropping a primary key key-column requires the Table Recreation Pattern — see [ddl-migrations/column-operations.md](ddl-migrations/column-operations.md#drop-column)
 
 ### Transaction Rules
 

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/mysql-ddl-column-changes.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/mysql-ddl-column-changes.md
@@ -17,6 +17,8 @@ ALTER TABLE table_name CHANGE COLUMN old_name new_name new_datatype;
 
 **DSQL:** MUST use **Table Recreation Pattern** — see [column-operations.md ALTER COLUMN TYPE](../ddl-migrations/column-operations.md#alter-column-type-migration) for the full step-by-step pattern including pre-migration validation and data type compatibility matrix.
 
+For tables > 3,000 rows, use [Batched Migration Pattern](ddl-batching.md).
+
 ---
 
 ## ALTER TABLE ... DROP COLUMN
@@ -27,6 +29,18 @@ ALTER TABLE table_name CHANGE COLUMN old_name new_name new_datatype;
 ALTER TABLE table_name DROP COLUMN column_name;
 ```
 
-**DSQL:** MUST use **Table Recreation Pattern** — see [column-operations.md DROP COLUMN](../ddl-migrations/column-operations.md#drop-column-migration) for the full step-by-step pattern.
+**DSQL:** identical — the statement translates 1:1 and needs no batching, because DSQL drops the
+column as a metadata-only change.
 
-For tables > 3,000 rows, use [Batched Migration Pattern](ddl-batching.md).
+```sql
+ALTER TABLE table_name DROP COLUMN column_name;
+```
+
+Two differences from MySQL:
+
+- Dropping a primary key column is unsupported. That case MUST use the **Table Recreation Pattern**.
+- A column that a view, foreign key, or `GENERATED ... STORED` column depends on requires `CASCADE`,
+  which drops those dependents too — MUST confirm the dependency list with the user first.
+
+See [column-operations.md DROP COLUMN](../ddl-migrations/column-operations.md#drop-column) for the
+full rule set, including the 255-active/1,600-lifetime column budget.

--- a/src/aurora-dsql-mcp-server/kiro_power/steering/mysql-type-mapping.md
+++ b/src/aurora-dsql-mcp-server/kiro_power/steering/mysql-type-mapping.md
@@ -133,6 +133,7 @@ These MySQL operations have direct DSQL equivalents:
 | `ALTER TABLE ... ADD COLUMN col type`      | `ALTER TABLE ... ADD COLUMN col type`               |
 | `ALTER TABLE ... RENAME COLUMN old TO new` | `ALTER TABLE ... RENAME COLUMN old TO new`          |
 | `ALTER TABLE ... RENAME TO new_name`       | `ALTER TABLE ... RENAME TO new_name`                |
+| `ALTER TABLE ... DROP COLUMN col`          | `ALTER TABLE ... DROP COLUMN col` (not a PK column) |
 | `CREATE INDEX idx ON t(col)`               | `CREATE INDEX ASYNC idx ON t(col)` (MUST use ASYNC) |
 | `DROP INDEX idx ON t`                      | `DROP INDEX idx` (MUST omit the ON clause)          |
 
@@ -145,7 +146,6 @@ These MySQL operations MUST use the **Table Recreation Pattern** in DSQL:
 | `ALTER TABLE ... MODIFY COLUMN col new_type`                   | Table recreation with type cast                               |
 | `ALTER TABLE ... CHANGE COLUMN old new new_type`               | Table recreation (type change) or RENAME COLUMN (rename only) |
 | `ALTER TABLE ... ALTER COLUMN col datatype`                    | Table recreation with type cast                               |
-| `ALTER TABLE ... DROP COLUMN col`                              | Table recreation excluding the column                         |
 | `ALTER TABLE ... ALTER COLUMN col SET DEFAULT val`             | Table recreation with DEFAULT in new definition               |
 | `ALTER TABLE ... ALTER COLUMN col DROP DEFAULT`                | Table recreation without DEFAULT                              |
 | `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE`                    | Table recreation with constraint                              |

--- a/src/aurora-dsql-mcp-server/skills/amazon-aurora-dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/amazon-aurora-dsql-skill/SKILL.md
@@ -76,13 +76,13 @@ sampled in [mcp/.mcp.json](mcp/.mcp.json)
 
 #### [ddl-migrations/overview.md](references/ddl-migrations/overview.md)
 
-**When:** MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+**When:** MUST load when performing RENAME COLUMN, ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
 **Contains:** Table recreation pattern overview, transaction rules, common verify & swap pattern
 
 #### [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)
 
-**When:** Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
-**Contains:** Step-by-step migration patterns for column-level changes
+**When:** MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
+**Contains:** Native DROP COLUMN rules; step-by-step recreation patterns for other column-level changes
 
 #### [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md)
 
@@ -278,9 +278,11 @@ Every DDL statement generated in this workflow MUST be validated with `dsql_lint
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/skills/aurora-dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/aurora-dsql-skill/SKILL.md
@@ -76,13 +76,13 @@ sampled in [mcp/.mcp.json](mcp/.mcp.json)
 
 #### [ddl-migrations/overview.md](references/ddl-migrations/overview.md)
 
-**When:** MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+**When:** MUST load when performing RENAME COLUMN, ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
 **Contains:** Table recreation pattern overview, transaction rules, common verify & swap pattern
 
 #### [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)
 
-**When:** Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
-**Contains:** Step-by-step migration patterns for column-level changes
+**When:** MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
+**Contains:** Native DROP COLUMN rules; step-by-step recreation patterns for other column-level changes
 
 #### [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md)
 
@@ -278,9 +278,11 @@ Every DDL statement generated in this workflow MUST be validated with `dsql_lint
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/skills/aws-dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/aws-dsql-skill/SKILL.md
@@ -76,13 +76,13 @@ sampled in [mcp/.mcp.json](mcp/.mcp.json)
 
 #### [ddl-migrations/overview.md](references/ddl-migrations/overview.md)
 
-**When:** MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+**When:** MUST load when performing RENAME COLUMN, ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
 **Contains:** Table recreation pattern overview, transaction rules, common verify & swap pattern
 
 #### [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)
 
-**When:** Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
-**Contains:** Step-by-step migration patterns for column-level changes
+**When:** MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
+**Contains:** Native DROP COLUMN rules; step-by-step recreation patterns for other column-level changes
 
 #### [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md)
 
@@ -278,9 +278,11 @@ Every DDL statement generated in this workflow MUST be validated with `dsql_lint
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/skills/distributed-postgres-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/distributed-postgres-skill/SKILL.md
@@ -76,13 +76,13 @@ sampled in [mcp/.mcp.json](mcp/.mcp.json)
 
 #### [ddl-migrations/overview.md](references/ddl-migrations/overview.md)
 
-**When:** MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+**When:** MUST load when performing RENAME COLUMN, ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
 **Contains:** Table recreation pattern overview, transaction rules, common verify & swap pattern
 
 #### [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)
 
-**When:** Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
-**Contains:** Step-by-step migration patterns for column-level changes
+**When:** MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
+**Contains:** Native DROP COLUMN rules; step-by-step recreation patterns for other column-level changes
 
 #### [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md)
 
@@ -278,9 +278,11 @@ Every DDL statement generated in this workflow MUST be validated with `dsql_lint
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/skills/distributed-sql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/distributed-sql-skill/SKILL.md
@@ -76,13 +76,13 @@ sampled in [mcp/.mcp.json](mcp/.mcp.json)
 
 #### [ddl-migrations/overview.md](references/ddl-migrations/overview.md)
 
-**When:** MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+**When:** MUST load when performing RENAME COLUMN, ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
 **Contains:** Table recreation pattern overview, transaction rules, common verify & swap pattern
 
 #### [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)
 
-**When:** Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
-**Contains:** Step-by-step migration patterns for column-level changes
+**When:** MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
+**Contains:** Native DROP COLUMN rules; step-by-step recreation patterns for other column-level changes
 
 #### [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md)
 
@@ -278,9 +278,11 @@ Every DDL statement generated in this workflow MUST be validated with `dsql_lint
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/SKILL.md
@@ -76,13 +76,13 @@ sampled in [mcp/.mcp.json](mcp/.mcp.json)
 
 #### [ddl-migrations/overview.md](references/ddl-migrations/overview.md)
 
-**When:** MUST load when performing DROP COLUMN, RENAME COLUMN, ALTER COLUMN TYPE, or DROP CONSTRAINT
+**When:** MUST load when performing RENAME COLUMN, ALTER COLUMN TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a primary key column
 **Contains:** Table recreation pattern overview, transaction rules, common verify & swap pattern
 
 #### [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)
 
-**When:** Load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
-**Contains:** Step-by-step migration patterns for column-level changes
+**When:** MUST load for DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT migrations
+**Contains:** Native DROP COLUMN rules; step-by-step recreation patterns for other column-level changes
 
 #### [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md)
 
@@ -278,9 +278,11 @@ Every DDL statement generated in this workflow MUST be validated with `dsql_lint
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 6: Table Recreation DDL Migration
+### Workflow 6: Column and Constraint DDL Migration
 
-DSQL does NOT support direct `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. These require the **Table Recreation Pattern**. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/ddl-migrations/column-operations.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/ddl-migrations/column-operations.md
@@ -1,51 +1,73 @@
 # DDL Migrations: Column Operations
 
-Step-by-step migration patterns for column-level changes using the Table Recreation Pattern.
+Step-by-step migration patterns for column-level changes. `DROP COLUMN` runs as a direct statement; the remaining operations use the Table Recreation Pattern.
 
-**MUST read [overview.md](overview.md) first** for destructive operation warnings and the common verify & swap pattern.
+**MUST read [overview.md](overview.md) before any Table Recreation Pattern migration** for destructive operation warnings and the common verify & swap pattern.
 
 ---
 
-## DROP COLUMN Migration
+## DROP COLUMN
 
 **Goal:** Remove a column from an existing table.
 
-### Pre-Migration Validation
+DSQL supports `DROP COLUMN` directly. **MUST** issue the native statement rather than recreating the
+table — the operation is synchronous and metadata-only, so it completes immediately and never drops
+the table.
+
+The dropped column's data becomes unreachable and no rollback exists once the transaction commits,
+so **MUST** name the exact table and column to the user and obtain explicit confirmation first.
 
 ```sql
-readonly_query("SELECT COUNT(*) as total_rows FROM target_table")
-get_schema("target_table")
+transact(["ALTER TABLE target_table DROP COLUMN obsolete_column"])
 ```
 
-### Migration Steps
+Dropping a non-key column that the primary key implicitly INCLUDEs is the ordinary case and needs no
+special handling — DSQL rewrites the primary key definition automatically.
 
-#### Step 1: Create new table excluding the column
+Several `DROP COLUMN` subcommands **MAY** share one `ALTER TABLE`. The
+one-modification-per-statement rule in
+[development-guide.md](../development-guide.md) applies to `ADD COLUMN` and `ALTER COLUMN`, not to
+`DROP COLUMN`:
 
 ```sql
-transact([
-  "CREATE TABLE target_table_new (
-     id UUID PRIMARY KEY,
-     tenant_id VARCHAR(255) NOT NULL,
-     kept_column1 VARCHAR(255),
-     kept_column2 INTEGER
-     -- dropped_column is NOT included
-   )"
-])
+transact(["ALTER TABLE target_table DROP COLUMN obsolete_column, DROP COLUMN legacy_flag"])
 ```
 
-#### Step 2: Migrate data
+### Rules
 
-```sql
-transact([
-  "INSERT INTO target_table_new (id, tenant_id, kept_column1, kept_column2)
-   SELECT id, tenant_id, kept_column1, kept_column2
-   FROM target_table"
-])
-```
+- **MUST** recreate the table instead when the column is a primary key *key* column. DSQL rejects
+  that drop with `0A000 feature_not_supported`. See
+  [MODIFY PRIMARY KEY](constraint-operations.md#modify-primary-key-migration) for that path.
+- A bare drop already removes the column's indexes and its same-table constraints — `CHECK`,
+  `DEFAULT`, `UNIQUE`, and a foreign key *defined on* the column. Issue the plain statement for
+  these; adding `CASCADE` buys nothing and widens the blast radius.
+- **MUST** add `CASCADE` only when something outside the table depends on the column — a view, or a
+  foreign key in another table *referencing* it — or when a same-table `GENERATED ... STORED` column
+  is computed from it. Without `CASCADE` those cases fail with
+  `2BP01 dependent_objects_still_exist`. `CASCADE` drops the dependent objects too, so **MUST**
+  present the dependency list to the user and obtain confirmation before using it:
+  ```sql
+  transact(["ALTER TABLE target_table DROP COLUMN obsolete_column CASCADE"])
+  ```
+- **MUST** fall back to table recreation when `CASCADE` itself fails with
+  `0A000 feature_not_supported`. That means the dependency chain reaches a primary key key column —
+  for example a PK column declared `GENERATED ALWAYS AS (obsolete_column) STORED`. DSQL refuses to
+  cascade into the primary key, so no form of `DROP COLUMN` succeeds.
+- **MAY** use `IF EXISTS` for idempotent migrations. Dropping an already-dropped column otherwise
+  raises `42703 undefined_column`.
 
-For tables > 3,000 rows, use [Batched Migration Pattern](batched-migration.md).
+### Storage Impact
 
-**Step 3: Verify and swap** (see [Common Pattern](overview.md#common-verify--swap-pattern))
+The drop hides the column rather than physically removing it, so table size does not fall right
+away. Space returns as existing rows are updated. **MUST** tell the user that reclamation is
+gradual.
+
+### Column Budget
+
+A table holds at most **255 active** columns and **1,600 over its lifetime**. Attribute numbers are
+never reused, so each dropped column frees an active slot but still spends lifetime budget. A table
+churned past 1,600 columns needs recreation — a later `ADD COLUMN` returns
+`54011 too_many_columns`.
 
 ---
 
@@ -106,6 +128,8 @@ transact([
    FROM target_table"
 ])
 ```
+
+For tables > 3,000 rows, use [Batched Migration Pattern](batched-migration.md).
 
 **Step 3: Verify and swap** (see [Common Pattern](overview.md#common-verify--swap-pattern))
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/ddl-migrations/overview.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/ddl-migrations/overview.md
@@ -46,7 +46,6 @@ The following ALTER TABLE operations MUST use the **Table Recreation Pattern**:
 
 | Operation                      | Key Approach                                   |
 | ------------------------------ | ---------------------------------------------- |
-| DROP COLUMN                    | Exclude column from new table                  |
 | ALTER COLUMN TYPE              | Cast data type in SELECT                       |
 | ALTER COLUMN SET/DROP NOT NULL | Change constraint in new table definition      |
 | ALTER COLUMN SET/DROP DEFAULT  | Define default in new table definition         |
@@ -60,6 +59,9 @@ The following ALTER TABLE operations MUST use the **Table Recreation Pattern**:
 - `ALTER TABLE ... RENAME COLUMN` - Rename a column
 - `ALTER TABLE ... RENAME TO` - Rename a table
 - `ALTER TABLE ... ADD COLUMN` - Add a new column
+- `ALTER TABLE ... DROP COLUMN` - Drop a column. Use this instead of table recreation. Dropping a
+  primary key column is unsupported — that still requires the Table Recreation Pattern. See
+  [column-operations.md](column-operations.md#drop-column)
 
 ---
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/development-guide.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/development-guide.md
@@ -83,6 +83,7 @@ effortless scaling, multi-region viability, among other advantages.
   2. MUST then issue UPDATE to populate existing rows
   3. MAY then issue ALTER COLUMN to apply the constraint
 - MUST issue a **separate ALTER TABLE statement for each column** modification.
+- To drop a column, MUST issue **`ALTER TABLE t DROP COLUMN c`** — a direct, synchronous, metadata-only change; table recreation is unnecessary. Add `CASCADE` when a view, an inbound foreign key, or a `GENERATED ... STORED` column depends on it. Dropping a primary key key-column requires the Table Recreation Pattern — see [ddl-migrations/column-operations.md](ddl-migrations/column-operations.md#drop-column)
 
 ### Transaction Rules
 

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/mysql-migrations/ddl-column-changes.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/mysql-migrations/ddl-column-changes.md
@@ -17,6 +17,8 @@ ALTER TABLE table_name CHANGE COLUMN old_name new_name new_datatype;
 
 **DSQL:** MUST use **Table Recreation Pattern** — see [column-operations.md ALTER COLUMN TYPE](../ddl-migrations/column-operations.md#alter-column-type-migration) for the full step-by-step pattern including pre-migration validation and data type compatibility matrix.
 
+For tables > 3,000 rows, use [Batched Migration Pattern](ddl-batching.md).
+
 ---
 
 ## ALTER TABLE ... DROP COLUMN
@@ -27,6 +29,18 @@ ALTER TABLE table_name CHANGE COLUMN old_name new_name new_datatype;
 ALTER TABLE table_name DROP COLUMN column_name;
 ```
 
-**DSQL:** MUST use **Table Recreation Pattern** — see [column-operations.md DROP COLUMN](../ddl-migrations/column-operations.md#drop-column-migration) for the full step-by-step pattern.
+**DSQL:** identical — the statement translates 1:1 and needs no batching, because DSQL drops the
+column as a metadata-only change.
 
-For tables > 3,000 rows, use [Batched Migration Pattern](ddl-batching.md).
+```sql
+ALTER TABLE table_name DROP COLUMN column_name;
+```
+
+Two differences from MySQL:
+
+- Dropping a primary key column is unsupported. That case MUST use the **Table Recreation Pattern**.
+- A column that a view, foreign key, or `GENERATED ... STORED` column depends on requires `CASCADE`,
+  which drops those dependents too — MUST confirm the dependency list with the user first.
+
+See [column-operations.md DROP COLUMN](../ddl-migrations/column-operations.md#drop-column) for the
+full rule set, including the 255-active/1,600-lifetime column budget.

--- a/src/aurora-dsql-mcp-server/skills/dsql-skill/references/mysql-migrations/type-mapping.md
+++ b/src/aurora-dsql-mcp-server/skills/dsql-skill/references/mysql-migrations/type-mapping.md
@@ -133,6 +133,7 @@ These MySQL operations have direct DSQL equivalents:
 | `ALTER TABLE ... ADD COLUMN col type`      | `ALTER TABLE ... ADD COLUMN col type`               |
 | `ALTER TABLE ... RENAME COLUMN old TO new` | `ALTER TABLE ... RENAME COLUMN old TO new`          |
 | `ALTER TABLE ... RENAME TO new_name`       | `ALTER TABLE ... RENAME TO new_name`                |
+| `ALTER TABLE ... DROP COLUMN col`          | `ALTER TABLE ... DROP COLUMN col` (not a PK column) |
 | `CREATE INDEX idx ON t(col)`               | `CREATE INDEX ASYNC idx ON t(col)` (MUST use ASYNC) |
 | `DROP INDEX idx ON t`                      | `DROP INDEX idx` (MUST omit the ON clause)          |
 
@@ -145,7 +146,6 @@ These MySQL operations MUST use the **Table Recreation Pattern** in DSQL:
 | `ALTER TABLE ... MODIFY COLUMN col new_type`                   | Table recreation with type cast                               |
 | `ALTER TABLE ... CHANGE COLUMN old new new_type`               | Table recreation (type change) or RENAME COLUMN (rename only) |
 | `ALTER TABLE ... ALTER COLUMN col datatype`                    | Table recreation with type cast                               |
-| `ALTER TABLE ... DROP COLUMN col`                              | Table recreation excluding the column                         |
 | `ALTER TABLE ... ALTER COLUMN col SET DEFAULT val`             | Table recreation with DEFAULT in new definition               |
 | `ALTER TABLE ... ALTER COLUMN col DROP DEFAULT`                | Table recreation without DEFAULT                              |
 | `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE`                    | Table recreation with constraint                              |


### PR DESCRIPTION
Fixes

## Summary

Mirrors [awslabs/agent-plugins#264](https://github.com/awslabs/agent-plugins/pull/264), the canonical home for DSQL agent steering. That PR was authored and reviewed first; this one carries the settled text.

Aurora DSQL shipped `ALTER TABLE ... DROP COLUMN` on [2026-08-03](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/release-notes.html), but this repo still asserted "DSQL does **NOT** support direct ... `DROP COLUMN`" and routed the operation through the destructive Table Recreation Pattern.

`DROP COLUMN` is synchronous and metadata-only. Unlike `VALIDATE CONSTRAINT` it has **no** `ALTER TABLE ASYNC` form and returns no `job_id`.

### Changes

Both agent-facing surfaces in this package are updated:

- **`skills/dsql-skill/`** (source of truth) — `SKILL.md` plus `references/development-guide.md`, `references/ddl-migrations/{overview,column-operations}.md`, `references/mysql-migrations/{ddl-column-changes,type-mapping}.md`.
  The five alias `SKILL.md` files were regenerated by the `sync-dsql-skill-aliases` pre-commit hook, **not** hand-edited — they differ from the source on the `name:` line only, and the hook is idempotent on a second pass.
- **`kiro_power/`** — `POWER.md` plus the flattened `steering/` counterparts. Each `steering/*.md` remains byte-identical to its `references/` counterpart.
- **`CHANGELOG.md`** — entry under `## Unreleased`.

Substance (identical to the canonical PR): the rule lands in the always-loaded `development-guide.md`; `column-operations.md` documents the native statement with the rules that actually bite — PK *key* columns rejected with `0A000`, `CASCADE` only for out-of-table dependents (a bare drop already sweeps the column's indexes and same-table constraints), `CASCADE` itself failing `0A000` when the dependency chain reaches a PK key column, `IF EXISTS`, gradual storage reclamation, and the 255-active / 1,600-lifetime column budget.

The `Workflow 6` sentence is now affirmative rather than "DSQL does NOT support direct ...", matching the canonical wording and the project's steering style.

Table recreation is unchanged for `ALTER COLUMN TYPE`, `SET NOT NULL`, `DROP CONSTRAINT`, and `MODIFY PRIMARY KEY`.

### User experience

**Before** — asked to drop an obsolete column, the agent produced a destructive multi-step migration: create a replacement table, `INSERT ... SELECT` every row (batched under 3,000), verify counts, `DROP TABLE`, `RENAME`, then rebuild indexes. On an 80k-row table that is minutes of work, a write outage, and an irreversible `DROP TABLE`.

**After** — the agent emits `ALTER TABLE orders DROP COLUMN legacy_promo_code`, confirms the table and column with the user first, and adds `CASCADE` only when a dependency actually requires it.

Measured against the eval suite in `awslabs/agent-plugins` (regex-graded, no cluster needed): **0/2** on the pre-change skill, **2/2** after.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

### Testing notes

Documentation-only; the MCP server implementation is untouched. Verified:

- `skills/dsql-skill/` passes skill structure/frontmatter validation; `SKILL.md` 343 lines and `POWER.md` 259, both under the 500-line cap.
- All five reference↔steering pairs byte-identical (`diff` per pair — note a recursive `diff -r` is *not* a valid check here, since subdirectory files are flattened into `steering/` filenames).
- All five alias `SKILL.md` files differ from `dsql-skill/SKILL.md` on exactly the `name:` line.
- No trailing whitespace, CRLF, or missing EOF newline in any changed file.

### Pre-existing issue noted but not fixed

The `steering/` tree was flattened without rewriting intra-document relative links, so links like `../ddl-migrations/column-operations.md` are already dead there (23 instances across the files this PR touches). This PR preserves the byte-identical mirror rather than diverging the two trees, so it neither fixes nor worsens the aggregate count. Happy to follow up with a dedicated link-rewrite pass if you'd prefer that separately.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
