### PR TITLE
fix(aws-pricing-mcp-server): remove dev-only test tools from runtime dependencies

### DIFF
--- a/src/aws-pricing-mcp-server/pyproject.toml
+++ b/src/aws-pricing-mcp-server/pyproject.toml
@@ -8,8 +8,6 @@ dependencies = [
     "mcp[cli]>=2.0.0,<3.0.0",
     "pydantic>=2.10.5",
     "boto3>=1.39.4",
-    "pytest>=8.1.1",
-    "pytest-asyncio>=0.20.3",
     "typing-extensions>=4.13.2",
     "loguru>=0.7.3",
 ]
@@ -48,6 +46,7 @@ dev = [
     "ruff>=0.9.7",
     "pyright>=1.1.398",
     "pytest>=8.0.0",
+    "pytest-asyncio>=0.20.3",
     "pytest-cov>=4.1.0",
 ]
 

--- a/src/aws-pricing-mcp-server/uv.lock
+++ b/src/aws-pricing-mcp-server/uv.lock
@@ -28,10 +28,10 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna", marker = "python_full_version < '3.14'" },
+    { name = "sniffio", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -47,7 +47,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "idna" },
+    { name = "idna", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -81,8 +81,6 @@ dependencies = [
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "typing-extensions" },
 ]
 
@@ -92,6 +90,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -102,8 +101,6 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.10.5" },
-    { name = "pytest", specifier = ">=8.1.1" },
-    { name = "pytest-asyncio", specifier = ">=0.20.3" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
 ]
 
@@ -113,6 +110,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1.398" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.20.3" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.9.7" },
 ]
@@ -516,8 +514,8 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "truststore", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/db/2ad49878b36af4cff7527c1158b083ad6d9350462f1a35685cc3ebfa7c2b/httpcore2-2.6.0.tar.gz", hash = "sha256:95b692b582402ec49b3d84c2343556e4ac4c0962c8b3d39c48d485b9ecc240ab", size = 65592, upload-time = "2026-07-14T10:48:33.816Z" }
 wheels = [
@@ -533,8 +531,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version >= '3.14'" },
+    { name = "truststore", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -550,11 +548,11 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "idna" },
-    { name = "truststore" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*' or sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "idna", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "truststore", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/17/1e142bf3c76684232a092e1e4002be07fd3403b1c2dcb15d0012ea300c8f/httpx2-2.6.0.tar.gz", hash = "sha256:5d362fd59562cf2139a60c67bb016587a70b36156a517f176c7cbf1587d1ab22", size = 92736, upload-time = "2026-07-14T10:48:35.12Z" }
 wheels = [
@@ -571,12 +569,12 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "httpcore2", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
-    { name = "idna" },
-    { name = "truststore", marker = "sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
+    { name = "httpcore2", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna", marker = "(python_full_version >= '3.14' and sys_platform != 'emscripten') or (python_full_version >= '3.12' and sys_platform == 'emscripten')" },
+    { name = "truststore", marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*' and sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
@@ -1576,8 +1574,8 @@ name = "uvicorn"
 version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568, upload-time = "2024-12-15T13:33:30.42Z" }


### PR DESCRIPTION
## Problem

`awslabs.aws-pricing-mcp-server` declares `pytest` and `pytest-asyncio` in `[project].dependencies`, making them **runtime** dependencies. Anyone installing the server gets the test framework and its full dependency chain pushed into their environment.

`pytest` is also already declared in the `[dependency-groups].dev` group, so that entry is redundant on top of being misplaced. `pytest-asyncio` is **not** in the dev group — it exists only as a runtime dependency.

## Why it matters

- **Users pay for a developer tool they never invoke.** Resolving the runtime dependency set pulls in 7 packages that exist purely to run tests.
- **The naive fix breaks the package.** Simply deleting both lines would leave the dev group without `pytest-asyncio`, and this package sets `asyncio_mode = "auto"` with async tests throughout — the suite would stop running. So `pytest-asyncio` is *moved* into the dev group, not dropped.

## What changed

Two lines removed from `[project].dependencies`, one line added to `[dependency-groups].dev`, plus the regenerated `uv.lock`:

```diff
     "boto3>=1.39.4",
-    "pytest>=8.1.1",
-    "pytest-asyncio>=0.20.3",
     "typing-extensions>=4.13.2",
```

```diff
     "pytest>=8.0.0",
+    "pytest-asyncio>=0.20.3",
     "pytest-cov>=4.1.0",
```

No source code is touched.

## Verification

**Before** — the resolved runtime dependency set contains the test stack:

```
$ uv pip compile pyproject.toml --python-version 3.10
...
pytest==9.1.1
pytest-asyncio==1.4.0
iniconfig==2.3.0      # via pytest
pluggy==1.6.0         # via pytest
...
52 packages
```

**After** — gone:

```
$ uv pip compile pyproject.toml --python-version 3.10
...
45 packages
```

Seven packages dropped from the runtime set: `pytest`, `pytest-asyncio`, `backports-asyncio-runner`, `iniconfig`, `packaging`, `pluggy`, `tomli`.

**Test suite still passes**, which is what proves the dev group placement is sufficient (an unmoved `pytest-asyncio` would have failed collection here):

```
$ uv run pytest tests/ -q
251 passed in 4.18s
TOTAL   1461 stmts   174 miss   88% cover
```

## Scope

This is the second package in the sweep that issue #529 asks for (*"this happens in numerous packages in awslabs/mcp. All packages should be reviewed for `pytest-*` and formatter related dependencies (`ruff`, `pyright`)"*). The first was `amazon-sns-sqs-mcp-server` in #4557.

I scanned all 59 packages under `src/` for dev-only tools declared in `[project].dependencies`. Four are affected in total:

| Package | Misplaced tools | Status |
|---|---|---|
| `amazon-sns-sqs-mcp-server` | pytest | #4557 |
| `aws-pricing-mcp-server` | pytest, pytest-asyncio | **this PR** |
| `aws-support-mcp-server` | pre-commit, pytest, pytest-asyncio, pytest-cov, virtualenv | not included |
| `well-architected-security-mcp-server` | pytest, pytest-asyncio, pytest-cov, pytest-mock, ruff, pyright | not included |

The remaining two are deliberately left out because neither is a clean deletion and both need a maintainer call:

- **`aws-support-mcp-server`** declares dev dependencies in *two* places — `[dependency-groups].dev` and `[project.optional-dependencies].dev` — with conflicting pins (`pytest>=9.0.3` vs `pytest>=7.0.0`). Cleaning up the runtime list is safe, but which of the two groups should be authoritative is a decision I should not make unilaterally.
- **`well-architected-security-mcp-server`** has *no* dev group and no optional-dependencies at all, so its six tools would have to be **moved into a newly created group**. Both conventions exist elsewhere in this repo, so the choice of which to introduce belongs to the maintainers.

Happy to follow up on either once you tell me the preferred shape. Deliberately **not** using a closing keyword on #529, since two packages remain.

Refs #529

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
