### PR TITLE
fix(aws-support-mcp-server): remove dev-only tools from runtime dependencies

### DIFF
--- a/src/aws-support-mcp-server/pyproject.toml
+++ b/src/aws-support-mcp-server/pyproject.toml
@@ -13,19 +13,14 @@ dependencies = [
     "lxml>=6.1.0",
     "markdownify>=0.13.1",
     "mcp[cli]>=1.23.0",
-    "pre-commit>=4.2.0",
     "protego>=0.3.1",
     "pydantic>=2.0.0",
-    "pytest>=8.3.5",
-    "pytest-asyncio>=0.26.0",
-    "pytest-cov>=6.1.1",
     "python-dotenv>=1.2.2",
     "python-multipart>=0.0.27",
     "readabilipy>=0.2.0",
     "requests>=2.33.0",
     "starlette>=0.49.1",
     "urllib3>=2.6.3",
-    "virtualenv>=20.36.1",
 ]
 
 authors = [
@@ -135,4 +130,6 @@ dev = [
     "pre-commit>=4.2.0",
     "pyright>=1.1.400",
     "pytest>=9.0.3",
+    "pytest-asyncio>=0.26.0",
+    "pytest-cov>=6.1.1",
 ]

--- a/src/aws-support-mcp-server/uv.lock
+++ b/src/aws-support-mcp-server/uv.lock
@@ -88,19 +88,14 @@ dependencies = [
     { name = "lxml" },
     { name = "markdownify" },
     { name = "mcp", extra = ["cli"] },
-    { name = "pre-commit" },
     { name = "protego" },
     { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "readabilipy" },
     { name = "requests" },
     { name = "starlette" },
     { name = "urllib3" },
-    { name = "virtualenv" },
 ]
 
 [package.optional-dependencies]
@@ -118,6 +113,8 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -130,16 +127,12 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "markdownify", specifier = ">=0.13.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "protego", specifier = ">=0.3.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.350" },
-    { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.27" },
@@ -148,7 +141,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.291" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "urllib3", specifier = ">=2.6.3" },
-    { name = "virtualenv", specifier = ">=20.36.1" },
 ]
 provides-extras = ["dev"]
 
@@ -157,6 +149,8 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
 ]
 
 [[package]]
@@ -1968,8 +1962,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Problem

`awslabs.aws-support-mcp-server` declares five dev-only tools in `[project].dependencies`, making them **runtime** dependencies: `pre-commit`, `pytest`, `pytest-asyncio`, `pytest-cov` and `virtualenv`. Anyone installing the server gets the entire test and lint toolchain pushed into their environment.

This is the largest instance of the problem in the repo — 14 packages enter the resolved runtime set purely to support development.

## Why it matters

- **Users pay for a toolchain they never invoke.** The `pre-commit` entry alone drags in `cfgv`, `distlib`, `identify`, `nodeenv` and `virtualenv`; the pytest entries add `iniconfig`, `pluggy` and `coverage`.
- **A naive delete breaks the test suite.** `pytest-asyncio` and `pytest-cov` are **not** in the `[dependency-groups].dev` group, and this package sets `asyncio_mode = "auto"` plus `[tool.coverage.*]` config. Deleting them outright would stop the suite from running, so they are *moved* rather than dropped.

## What changed

Five entries removed from `[project].dependencies`, two added to `[dependency-groups].dev`, plus the regenerated `uv.lock`:

```diff
     "mcp[cli]>=1.23.0",
-    "pre-commit>=4.2.0",
     "protego>=0.3.1",
     "pydantic>=2.0.0",
-    "pytest>=8.3.5",
-    "pytest-asyncio>=0.26.0",
-    "pytest-cov>=6.1.1",
     "python-dotenv>=1.2.2",
...
     "urllib3>=2.6.3",
-    "virtualenv>=20.36.1",
 ]
```

```diff
     "pytest>=9.0.3",
+    "pytest-asyncio>=0.26.0",
+    "pytest-cov>=6.1.1",
 ]
```

Per-entry reasoning:

| Entry | Disposition | Why |
|---|---|---|
| `pre-commit` | deleted | already in `[dependency-groups].dev` |
| `pytest` | deleted | already in `[dependency-groups].dev` (at a stricter `>=9.0.3`) |
| `pytest-asyncio` | **moved to dev** | required by `asyncio_mode = "auto"`, absent from the dev group |
| `pytest-cov` | **moved to dev** | `[tool.coverage.*]` config present, absent from the dev group |
| `virtualenv` | deleted | transitive dependency of `pre-commit`; no direct use in the package |

No source code is touched.

## Verification

**Before** — the resolved runtime set carries the full toolchain:

```
$ uv pip compile pyproject.toml --python-version 3.10
...
pre-commit==4.6.2
pytest==9.1.1
pytest-asyncio==1.4.0
pytest-cov==7.1.0
virtualenv==21.7.7
cfgv==3.5.0 / distlib==0.4.3 / identify==2.6.19 / nodeenv==1.10.0
coverage==7.16.0 / iniconfig==2.3.0 / pluggy==1.6.0
...
108 packages
```

**After** — all gone:

```
$ uv pip compile pyproject.toml --python-version 3.10
...
94 packages
```

Fourteen packages dropped: `pre-commit`, `pytest`, `pytest-asyncio`, `pytest-cov`, `virtualenv`, `backports-asyncio-runner`, `cfgv`, `coverage`, `distlib`, `identify`, `iniconfig`, `nodeenv`, `pluggy`, `python-discovery`.

**Test suite still passes**, which is what proves the dev-group placement is sufficient (an unmoved `pytest-asyncio` would have broken `asyncio_mode = "auto"` collection here):

```
$ uv run pytest tests/ -q
194 passed, 24 warnings in 14.98s
```

The 24 warnings are pre-existing Pydantic V2 deprecation notices, unrelated to this change.

## Deliberately out of scope

This package declares dev dependencies in **two** places with conflicting pins:

- `[dependency-groups].dev` → `pytest>=9.0.3`
- `[project.optional-dependencies].dev` → `pytest>=7.0.0`

I have **not** touched `[project.optional-dependencies]`, and I did not try to consolidate the two. Which group should be authoritative is a maintainer decision, and this PR does not depend on the answer: `uv run` resolves `[dependency-groups]`, so making that group complete is sufficient to keep the suite green either way. Happy to follow up with a consolidation if you tell me which one you want to keep.

## Scope

Third package in the sweep issue #529 asks for (*"All packages should be reviewed for `pytest-*` and formatter related dependencies (`ruff`, `pyright`)"*). Running tally from a scan of all 59 packages under `src/`:

| Package | Misplaced tools | Status |
|---|---|---|
| `amazon-sns-sqs-mcp-server` | pytest | #4557 |
| `aws-pricing-mcp-server` | pytest, pytest-asyncio | #4558 |
| `aws-support-mcp-server` | pre-commit, pytest, pytest-asyncio, pytest-cov, virtualenv | **this PR** |
| `well-architected-security-mcp-server` | pytest, pytest-asyncio, pytest-cov, pytest-mock, ruff, pyright | not yet |

The last one is held back because it has **no** dev group and no optional-dependencies at all, so its six tools need a **newly created** group — and both conventions exist elsewhere in this repo, so which one to introduce is your call. Tell me the preferred shape and I will send it.

No closing keyword on #529, since one package remains.

Refs #529

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
