### PR TITLE
fix(aws-api-mcp-server): support mcp SDK v2 McpError rename

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/aws/service.py
@@ -44,9 +44,14 @@ from fastmcp import Context
 from fastmcp.server.elicitation import AcceptedElicitation
 from io import StringIO
 from loguru import logger
-from mcp.shared.exceptions import McpError
 from mcp.types import METHOD_NOT_FOUND
 from typing import Any
+
+
+try:  # mcp SDK v2 renamed McpError -> MCPError; no alias is kept for the old spelling.
+    from mcp.shared.exceptions import MCPError  # pyright: ignore[reportAttributeAccessIssue]
+except ImportError:  # mcp SDK v1
+    from mcp.shared.exceptions import McpError as MCPError
 
 
 async def request_consent(cli_command: str, ctx: Context):
@@ -64,7 +69,7 @@ async def request_consent(cli_command: str, ctx: Context):
             error_message = 'User rejected the execution of the command.'
             await ctx.error(error_message)
             raise AwsApiMcpError(error_message)
-    except McpError as e:
+    except MCPError as e:
         if e.error.code == METHOD_NOT_FOUND:
             error_message = 'Client does not support elicitation. Use a different client or update the server configuration.'
             logger.error(error_message)


### PR DESCRIPTION
## Problem

`awslabs.aws-api-mcp-server` fails to start on a fresh install that resolves `mcp>=2`:

```
File ".../awslabs/aws_api_mcp_server/core/aws/service.py", line 47
    from mcp.shared.exceptions import McpError
ImportError: cannot import name 'McpError' from 'mcp.shared.exceptions'. Did you mean: 'MCPError'?
```

SDK v2 renamed `McpError` to `MCPError` and kept no alias for the old spelling (verified: `mcp 1.29.0` exports `McpError`, `mcp 2.1.1` exports `MCPError`).

`service.py` is the only place this server imports the SDK exception; everything else named `*McpError` is the server's own `AwsApiMcpError`.

## Why it surfaced now

`pyproject.toml` carries a note from #4448 saying the server was left on v1 because fastmcp 3.x pinned `mcp<2` and "only the unreleased fastmcp 4.0 lifts that ceiling."

fastmcp 4.0 has since shipped, and `fastmcp-slim 4.0.0` requires `mcp>=2.0.0,<3.0.0`. With `fastmcp>=3.4.3` and `mcp>=1.23.0` (no upper bound), a fresh resolve now picks fastmcp 4.0.0 + mcp 2.1.1, and the import breaks.

`uv.lock` still pins mcp 1.29.0, so CI and local dev are unaffected — only installs that resolve from PyPI (`uvx awslabs.aws-api-mcp-server@latest`) hit this.

## Change

Guard the import so it works on both majors, matching what `mcp>=1.23.0` already allows:

```python
try:  # mcp SDK v2 renamed McpError -> MCPError; no alias is kept for the old spelling.
    from mcp.shared.exceptions import MCPError
except ImportError:  # mcp SDK v1
    from mcp.shared.exceptions import McpError as MCPError
```

`e.error.code` at the catch site is unchanged — v2 still exposes `.error` (verified: `MCPError(code=-32601, message=...).error.code == -32601`).

No `ErrorData(...)` call sites exist in this server, so the v2 constructor flattening described in `scripts/migrate-mcp-v2.py` does not apply here.

## Verification

- `uv run --frozen pytest` (lock env, mcp 1.29.0): **729 passed**
- `ruff check` / `ruff format --check` (v0.14.10, matching `.pre-commit-config.yaml`): clean
- mcp 2.1.1 + fastmcp 4.0.0: server completes MCP `initialize` (`AWS-API-MCP 4.0.0`)
- mcp 1.29.0 + fastmcp 3.x: import resolves to `McpError` via the fallback

## Scope

Minimal fix so the published package installs and runs today. A full v2 port of this server (bumping `mcp>=2.0.0` and refreshing `uv.lock` to fastmcp 4.0) is a separate change; this shim can be dropped then.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
