### PR TITLE
fix(aws-iac-mcp-server): cap fastmcp<4 to prevent 4.0 startup crash

### DIFF
--- a/src/aws-iac-mcp-server/pyproject.toml
+++ b/src/aws-iac-mcp-server/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
     "botocore>=1.34.0",
     "pyyaml>=6.0.0",
     "guardpycfn>=0.1.0",
-    "fastmcp>=3.2.0",
+    # Capped <4: this server imports fastmcp.server.proxy.ProxyClient, which fastmcp 4.0
+    # removed (relocated to fastmcp.server.providers.proxy). Stay on the 3.x line until a
+    # deliberate 4.0 migration. See awslabs/mcp#4567.
+    "fastmcp>=3.2.0,<4",
     "loguru>=0.7.0",
 ]
 license = {text = "Apache-2.0"}

--- a/src/aws-iac-mcp-server/uv.lock
+++ b/src/aws-iac-mcp-server/uv.lock
@@ -145,7 +145,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.76" },
     { name = "botocore", specifier = ">=1.34.0" },
     { name = "cfn-lint", specifier = ">=0.83.0" },
-    { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "fastmcp", specifier = ">=3.2.0,<4" },
     { name = "guardpycfn", specifier = ">=0.1.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },


### PR DESCRIPTION
Fixes #4567

## Summary

`awslabs.aws-iac-mcp-server` crashes on startup when a fresh install resolves **FastMCP 4.0.0**. The server imports `ProxyClient` from `fastmcp.server.proxy`, a module that FastMCP 4.0 **removed** (relocated to `fastmcp.server.providers.proxy`). With the previously uncapped `fastmcp>=3.2.0`, `uvx ...@latest` pulls 4.0.0 and the server never comes up:

```
ModuleNotFoundError: No module named 'fastmcp.server.proxy'
```

### Changes

- `src/aws-iac-mcp-server/pyproject.toml`: `fastmcp>=3.2.0` → `fastmcp>=3.2.0,<4` (with an explanatory comment).
- `src/aws-iac-mcp-server/uv.lock`: mirror the specifier change (resolved `fastmcp` stays at 3.4.3; no other lock churn).

This is the **minimum-intervention unblock** — option 1 from the issue. The full FastMCP 4.0 migration (new import paths + `FastMCP.as_proxy()` → `create_proxy()`) is deferred to a follow-up, as is the advisory `<4` cap for the 11 other uncapped-but-non-crashing servers.

### User experience

- **Before:** `uvx awslabs.aws-iac-mcp-server@latest` crashes at import (`ModuleNotFoundError: No module named 'fastmcp.server.proxy'`), server never starts.
- **After:** installs stay on the 3.x line; the server boots normally over stdio.

Verified locally: with the cap, the previously-crashing import resolves and the server boots cleanly on **fastmcp 3.4.3** (`uv run --frozen awslabs.aws-iac-mcp-server` shows `Server: aws-iac-mcp-server, 3.4.3`). Full test suite passes (149 passed).

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (N)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)