### PR TITLE
fix(iam-mcp-server): correct iam:GetGroupsForUser to iam:ListGroupsForUser in README

### DIFF
--- a/src/iam-mcp-server/README.md
+++ b/src/iam-mcp-server/README.md
@@ -102,7 +102,7 @@ The AWS credentials used by this server need the following IAM permissions:
                 "iam:GetRolePolicy",
                 "iam:PutUserPolicy",
                 "iam:PutRolePolicy",
-                "iam:GetGroupsForUser",
+                "iam:ListGroupsForUser",
                 "iam:ListAccessKeys",
                 "iam:CreateAccessKey",
                 "iam:DeleteAccessKey",


### PR DESCRIPTION
Fixes

## Summary

### Changes

The `Required IAM Permissions` policy in `src/iam-mcp-server/README.md` grants `iam:GetGroupsForUser`. The permission the server actually needs is `iam:ListGroupsForUser`, which the policy does not grant.

**The self-contained part**, checkable without leaving the repo: `server.py` calls `iam.list_groups_for_user()` in two places — [`get_user`](https://github.com/awslabs/mcp/blob/main/src/iam-mcp-server/awslabs/iam_mcp_server/server.py#L308) and [`get_group`](https://github.com/awslabs/mcp/blob/main/src/iam-mcp-server/awslabs/iam_mcp_server/server.py#L464). That API is authorized by `iam:ListGroupsForUser`, and `iam:ListGroupsForUser` does not appear anywhere in the documented policy.

**On `iam:GetGroupsForUser` not existing**, three checks, stated as performed:

1. `https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetGroupsForUser.html` redirects to the API Reference index, while [`API_ListGroupsForUser.html`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListGroupsForUser.html) resolves to a real page.
2. botocore’s bundled IAM service model lists `ListGroupsForUser` and has no `GetGroupsForUser`.
3. [`iann0036/iam-dataset`](https://github.com/iann0036/iam-dataset), generated from the Service Authorization Reference, lists 190 IAM privileges including `ListGroupsForUser` and not `GetGroupsForUser`. That dataset does include permission-only actions such as `iam:PassRole`, so the absence is not just "it has no API operation".

One line, docs only. No code change.

### User experience

**Before:** an operator copies the documented policy verbatim. IAM accepts it — a policy naming a non-existent action is still a valid policy and simply grants nothing — so there is no error at creation time to hint at the problem. `get_user` and `get_group` then fail at runtime with `AccessDenied` on `iam:ListGroupsForUser`, a permission the policy looks like it covers.

**After:** the documented policy grants the permission the code calls, and both tools work as documented.

### Note, not changed here

`iam:RemoveUserFromGroup` appears twice in the same policy. Harmless, and left alone to keep this diff to one line — happy to fold it in if you would prefer.

## Checklist

If your change does not seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N**

**RFC issue number**: n/a — single-line documentation correction.

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).