### PR TITLE
fix(bedrock-kb-retrieval-mcp-server): support managed knowledge bases and add agentic retrieval

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -407,7 +407,7 @@
         "filename": "src/bedrock-kb-retrieval-mcp-server/README.md",
         "hashed_secret": "057903c2553b3682d069157a6e8ae538eab79250",
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 188,
         "is_secret": false
       }
     ],
@@ -1266,5 +1266,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-28T17:21:25Z"
+  "generated_at": "2026-09-02T22:55:13Z"
 }

--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -22,8 +22,14 @@ MCP server for accessing Amazon Bedrock Knowledge Bases
 - Include or exclude specific data sources
 - Prioritize results from specific data sources
 
-### Rerank results
+### Support both managed and vector knowledge bases
 
+* Works with vector knowledge bases (`type: VECTOR`) and managed knowledge bases (`type: MANAGED`)
+* The knowledge base type is detected automatically and the correct `Retrieve` configuration is sent (`vectorSearchConfiguration` or `managedSearchConfiguration`)
+* Data-source filtering uses the metadata key appropriate to the knowledge base type
+* The `ListKnowledgeBases` tool reports each knowledge base's `type`
+
+### Rerank results
 - Improve relevance of retrieval results
 - Use Amazon Bedrock reranking capabilities
 - Sort results by relevance to your query

--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -29,6 +29,14 @@ MCP server for accessing Amazon Bedrock Knowledge Bases
 * Optional condensed trace of the agent's planning and retrieval steps
 * Managed knowledge bases only; the tool rejects other types with a clear message
 
+### Reach ACL-protected content
+
+* Pass `user_id` to retrieve content from ACL-aware data sources (SharePoint, OneDrive,
+  Confluence with per-document ACLs)
+* Without it, that content is inaccessible, and agentic retrieval's full-document
+  expansion step fails with "UserContext is required for ACL-aware data sources"
+* Results are filtered to what that user is authorised to see
+
 ### Support both managed and vector knowledge bases
 
 * Works with vector knowledge bases (`type: VECTOR`) and managed knowledge bases (`type: MANAGED`)
@@ -63,7 +71,7 @@ If you intend to use reranking functionality, your Bedrock Knowledge Base needs 
 
 1. Your IAM role must have permissions for both `bedrock:Rerank` and `bedrock:InvokeModel` actions
 2. The Amazon Bedrock Knowledge Bases service role must also have these permissions
-3. Reranking is only available in specific regions. Please refer to the official [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/rerank-supported.html) for an up to date list of supported regions.
+3. Reranking availability differs **per model**: `amazon.rerank-v1:0` is not offered in `us-east-1`, while `cohere.rerank-v3-5:0` is. The server validates the (region, model) pair and fails fast with a clear message. Please refer to the official [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/rerank-supported.html) for an up to date list of supported regions.
 4. Enable model access for the available reranking models in the specified region.
 
 ### Agentic Retrieval Requirements

--- a/src/bedrock-kb-retrieval-mcp-server/README.md
+++ b/src/bedrock-kb-retrieval-mcp-server/README.md
@@ -22,6 +22,13 @@ MCP server for accessing Amazon Bedrock Knowledge Bases
 - Include or exclude specific data sources
 - Prioritize results from specific data sources
 
+### Agentic retrieval on managed knowledge bases
+
+* Plan a multi-step retrieval strategy and synthesise a cited answer
+* Search several knowledge bases in one call
+* Optional condensed trace of the agent's planning and retrieval steps
+* Managed knowledge bases only; the tool rejects other types with a clear message
+
 ### Support both managed and vector knowledge bases
 
 * Works with vector knowledge bases (`type: VECTOR`) and managed knowledge bases (`type: MANAGED`)
@@ -58,6 +65,19 @@ If you intend to use reranking functionality, your Bedrock Knowledge Base needs 
 2. The Amazon Bedrock Knowledge Bases service role must also have these permissions
 3. Reranking is only available in specific regions. Please refer to the official [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/rerank-supported.html) for an up to date list of supported regions.
 4. Enable model access for the available reranking models in the specified region.
+
+### Agentic Retrieval Requirements
+
+The `AgenticQueryKnowledgeBases` tool calls `AgenticRetrieveStream`, which is supported for
+**managed knowledge bases only** (`type: MANAGED`). It plans a retrieval strategy and, unless
+you pass `generate_response=false`, invokes a foundation model to write a cited answer.
+
+1. Your IAM role needs `bedrock:AgenticRetrieveStream` on the knowledge base, in addition to
+   the permissions listed above
+2. Because it invokes a foundation model, it costs materially more per call than
+   `QueryKnowledgeBases`. Pass `generate_response=false` for retrieval without synthesis
+3. `RetrieveAndGenerate` is not supported for managed knowledge bases, so agentic retrieval
+   with `generate_response=true` is the way to get a generated answer from one
 
 ### Controlling Reranking
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/agentic.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/agentic.py
@@ -136,6 +136,8 @@ async def agentic_retrieve_knowledge_bases(
     data_source_ids: Optional[list[str]] = None,
     max_agent_iterations: Optional[int] = None,
     include_trace: bool = False,
+    user_id: Optional[str] = None,
+    next_token: Optional[str] = None,
 ) -> str:
     """Run agentic retrieval across one or more managed knowledge bases.
 
@@ -152,6 +154,12 @@ async def agentic_retrieve_knowledge_bases(
         data_source_ids: Restrict retrieval to these data sources.
         max_agent_iterations: Cap on agent planning iterations (minimum 2).
         include_trace: Include a condensed per-step trace of the agent's work.
+        user_id: End-user identity for access-control filtering. Required to reach content
+            in ACL-aware data sources; without it the agent's full-document expansion step
+            fails with "UserContext is required for ACL-aware data sources" and such
+            content stays inaccessible.
+        next_token: Continuation token from a previous call's ``nextToken``, to fetch the
+            next page of results.
 
     Returns:
         A JSON object as a string, with ``results`` always present and ``answer`` /
@@ -181,6 +189,10 @@ async def agentic_retrieve_knowledge_bases(
         'agenticRetrieveConfiguration': agentic_configuration,
         'generateResponse': generate_response,
     }
+    if user_id:
+        request['userContext'] = {'userId': user_id}
+    if next_token:
+        request['nextToken'] = next_token
 
     response = kb_agent_client.agentic_retrieve_stream(**request)
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/agentic.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/agentic.py
@@ -1,0 +1,252 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Agentic retrieval against Amazon Bedrock Managed Knowledge Bases.
+
+``AgenticRetrieveStream`` plans a retrieval strategy, issues one or more searches
+across the knowledge bases it is given, and optionally synthesises a cited answer.
+It is a **streaming** operation, whereas an MCP tool call returns a single result, so
+this module consumes the whole event stream and returns one aggregated payload.
+
+Stream shape (observed against a live managed knowledge base):
+
+* ``traceEvent``    -- a handful of step/status transitions (Planning, Retrieval, ...)
+* ``responseEvent`` -- the answer, streamed in many small text chunks (~440 for a
+  3 KB answer). Only emitted when ``generateResponse`` is true.
+* ``result``        -- a single terminal event carrying the retrieved items and, when
+  requested, the complete ``generatedResponse`` (answer plus citations).
+
+Because the terminal ``result`` event already contains the whole answer, the streamed
+chunks are only used as a fallback. Forwarding raw events to the model is deliberately
+not offered: a single default call emits hundreds of them, which would crowd out the
+content the model actually needs.
+"""
+
+import json
+from .kb_types import is_managed_knowledge_base
+from loguru import logger
+from typing import TYPE_CHECKING, Any, Optional
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_bedrock_agent.client import AgentsforBedrockClient
+    from mypy_boto3_bedrock_agent_runtime.client import AgentsforBedrockRuntimeClient
+else:
+    AgentsforBedrockClient = object
+    AgentsforBedrockRuntimeClient = object
+
+
+# Managed knowledge bases expose data-source identity under this key. Agentic
+# retrieval only supports managed knowledge bases, so the vector reserved key
+# (``x-amz-bedrock-kb-data-source-id``) never applies here.
+MANAGED_DATA_SOURCE_ID_KEY = '_data_source_id'
+
+# Stream members that carry a modelled service error rather than content.
+_ERROR_EVENT_KEYS = (
+    'internalServerException',
+    'validationException',
+    'resourceNotFoundException',
+    'serviceQuotaExceededException',
+    'throttlingException',
+    'accessDeniedException',
+    'conflictException',
+    'dependencyFailedException',
+    'badGatewayException',
+)
+
+
+class AgenticRetrievalError(Exception):
+    """An error reported inside the agentic retrieval event stream."""
+
+
+def _result_item(item: dict, index: int) -> dict:
+    """Flatten one result item into something compact and JSON-safe."""
+    content = item.get('content', {}) or {}
+    flattened: dict[str, Any] = {
+        'index': index,
+        'text': content.get('text', ''),
+        'mimeType': content.get('mimeType', ''),
+        'metadata': item.get('metadata', {}) or {},
+        'knowledgeBaseId': (item.get('sourceRetriever', {}) or {}).get('identifier', ''),
+    }
+    # byteContent is a Blob and is not JSON serialisable. Flag its presence rather
+    # than dropping it silently, and never attempt to embed it.
+    if content.get('byteContent') is not None:
+        flattened['binaryContentOmitted'] = True
+    return flattened
+
+
+def _citation(citation: dict) -> dict:
+    """Flatten a citation, resolving references down to result indexes."""
+    return {
+        'startIndex': citation.get('startIndex'),
+        'endIndex': citation.get('endIndex'),
+        'resultIndexes': [
+            reference.get('resultIndex') for reference in citation.get('references', []) or []
+        ],
+    }
+
+
+def _build_retrievers(
+    knowledge_base_ids: list[str],
+    data_source_ids: Optional[list[str]],
+    number_of_results: Optional[int],
+) -> list[dict]:
+    """Build the ``retrievers`` list, applying retrieval overrides when asked for."""
+    overrides: dict[str, Any] = {}
+    if number_of_results is not None:
+        overrides['maxNumberOfResults'] = number_of_results
+    if data_source_ids:
+        overrides['filter'] = {'in': {'key': MANAGED_DATA_SOURCE_ID_KEY, 'value': data_source_ids}}
+
+    retrievers = []
+    for knowledge_base_id in knowledge_base_ids:
+        knowledge_base: dict[str, Any] = {'knowledgeBaseId': knowledge_base_id}
+        if overrides:
+            knowledge_base['retrievalOverrides'] = overrides
+        retrievers.append({'configuration': {'knowledgeBase': knowledge_base}})
+    return retrievers
+
+
+def _raise_if_error_event(event: dict) -> None:
+    """Convert a modelled error event into an exception."""
+    for key in _ERROR_EVENT_KEYS:
+        if key in event:
+            message = (event[key] or {}).get('message', '')
+            raise AgenticRetrievalError(f'{key}: {message}')
+
+
+async def agentic_retrieve_knowledge_bases(
+    query: str,
+    knowledge_base_ids: list[str],
+    kb_agent_client: AgentsforBedrockRuntimeClient,
+    kb_agent_mgmt_client: Optional[AgentsforBedrockClient] = None,
+    generate_response: bool = True,
+    number_of_results: Optional[int] = None,
+    data_source_ids: Optional[list[str]] = None,
+    max_agent_iterations: Optional[int] = None,
+    include_trace: bool = False,
+) -> str:
+    """Run agentic retrieval across one or more managed knowledge bases.
+
+    Args:
+        query: The natural language question.
+        knowledge_base_ids: Managed knowledge bases to search. More than one may be
+            given; the agent decides which to search and may search several.
+        kb_agent_client: The Bedrock agent runtime client.
+        kb_agent_mgmt_client: Management client, used to reject non-managed knowledge
+            bases up front with a clear message. Optional -- when omitted the service
+            still rejects them, just less legibly.
+        generate_response: Whether to synthesise a cited answer from the results.
+        number_of_results: Maximum results per retriever.
+        data_source_ids: Restrict retrieval to these data sources.
+        max_agent_iterations: Cap on agent planning iterations (minimum 2).
+        include_trace: Include a condensed per-step trace of the agent's work.
+
+    Returns:
+        A JSON object as a string, with ``results`` always present and ``answer`` /
+        ``citations`` present when ``generate_response`` is true.
+    """
+    if not knowledge_base_ids:
+        raise ValueError('At least one knowledge base ID is required.')
+
+    # Agentic retrieval is only supported for managed knowledge bases. Checking up
+    # front turns an opaque service ValidationException into an actionable message.
+    for knowledge_base_id in knowledge_base_ids:
+        managed = is_managed_knowledge_base(knowledge_base_id, kb_agent_mgmt_client)
+        if managed is False:
+            raise ValueError(
+                f'Knowledge base {knowledge_base_id} is not a managed knowledge base. '
+                'Agentic retrieval supports managed knowledge bases only -- use the '
+                'QueryKnowledgeBases tool for vector knowledge bases.'
+            )
+
+    agentic_configuration: dict[str, Any] = {}
+    if max_agent_iterations is not None:
+        agentic_configuration['maxAgentIteration'] = max_agent_iterations
+
+    request: dict[str, Any] = {
+        'messages': [{'role': 'user', 'content': {'text': query}}],
+        'retrievers': _build_retrievers(knowledge_base_ids, data_source_ids, number_of_results),
+        'agenticRetrieveConfiguration': agentic_configuration,
+        'generateResponse': generate_response,
+    }
+
+    response = kb_agent_client.agentic_retrieve_stream(**request)
+
+    results: list[dict] = []
+    citations: list[dict] = []
+    answer = ''
+    streamed_chunks: list[str] = []
+    trace: list[dict] = []
+    warnings: list[str] = []
+    failures: list[str] = []
+    next_token = None
+
+    for event in response['stream']:
+        _raise_if_error_event(event)
+
+        if 'result' in event:
+            result_event = event['result']
+            for item in result_event.get('results', []) or []:
+                results.append(_result_item(item, len(results)))
+            generated = result_event.get('generatedResponse') or {}
+            if generated.get('answer'):
+                answer = generated['answer']
+            citations = [_citation(c) for c in generated.get('citations', []) or []]
+            next_token = result_event.get('nextToken') or next_token
+
+        elif 'responseEvent' in event:
+            # Streamed answer chunks. The terminal result event normally carries the
+            # complete answer, so these are only a fallback.
+            streamed_chunks.append(event['responseEvent'].get('text', ''))
+
+        elif 'traceEvent' in event:
+            attributes = event['traceEvent'].get('attributes', {}) or {}
+            for warning in attributes.get('warnings', []) or []:
+                message = (warning.get('message') or {}).get('message')
+                guardrail = warning.get('guardrail') or {}
+                warnings.append(message or guardrail.get('message') or json.dumps(warning))
+            for failure in attributes.get('failures', []) or []:
+                failures.append(failure.get('message', ''))
+            if include_trace:
+                trace.append(
+                    {
+                        'step': attributes.get('step'),
+                        'status': attributes.get('status'),
+                        'message': attributes.get('message'),
+                    }
+                )
+
+    if not answer and streamed_chunks:
+        answer = ''.join(streamed_chunks)
+
+    payload: dict[str, Any] = {'knowledgeBaseIds': knowledge_base_ids, 'results': results}
+    if generate_response:
+        payload['answer'] = answer
+        payload['citations'] = citations
+    if include_trace:
+        payload['trace'] = trace
+    if warnings:
+        payload['warnings'] = warnings
+    if failures:
+        payload['failures'] = failures
+    if next_token:
+        payload['nextToken'] = next_token
+
+    if not results:
+        logger.info(
+            f'Agentic retrieval returned no results for knowledge bases {knowledge_base_ids}'
+        )
+
+    return json.dumps(payload)

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/discovery.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/discovery.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ..models import KnowledgeBaseMapping
+from .kb_types import cache_knowledge_base_type
 from loguru import logger
 from typing import TYPE_CHECKING
 
@@ -52,20 +53,29 @@ async def discover_knowledge_bases(
             kb_name = kb.get('name')
             kb_description = kb.get('description', '')
 
-            kb_arn = (
-                agent_client.get_knowledge_base(knowledgeBaseId=kb_id)
-                .get('knowledgeBase', {})
-                .get('knowledgeBaseArn')
+            kb_response = agent_client.get_knowledge_base(knowledgeBaseId=kb_id).get(
+                'knowledgeBase', {}
             )
+            kb_arn = kb_response.get('knowledgeBaseArn')
+            # MANAGED knowledge bases require a different Retrieve configuration than
+            # vector knowledge bases. Capture the type here -- get_knowledge_base is
+            # already being called for the ARN, so this costs no extra API call.
+            kb_type = kb_response.get('knowledgeBaseConfiguration', {}).get('type', '')
 
             tags = agent_client.list_tags_for_resource(resourceArn=kb_arn).get('tags', {})
             if tag_key in tags and tags[tag_key] == 'true':
                 logger.debug(f'KB Name: {kb_name}')
-                kb_data.append((kb_id, kb_name, kb_description))
+                cache_knowledge_base_type(kb_id, kb_type)
+                kb_data.append((kb_id, kb_name, kb_description, kb_type))
 
     # Then, for each matching knowledge base, collect its data sources
-    for kb_id, kb_name, kb_description in kb_data:
-        result[kb_id] = {'name': kb_name, 'description': kb_description, 'data_sources': []}
+    for kb_id, kb_name, kb_description, kb_type in kb_data:
+        result[kb_id] = {
+            'name': kb_name,
+            'description': kb_description,
+            'type': kb_type,
+            'data_sources': [],
+        }
 
         # Collect data sources for this knowledge base
         data_sources = []

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/kb_types.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/kb_types.py
@@ -30,6 +30,7 @@ else:
 
 
 MANAGED_KB_TYPE = 'MANAGED'
+VECTOR_KB_TYPE = 'VECTOR'
 
 MANAGED_SEARCH_CONFIGURATION = 'managedSearchConfiguration'
 VECTOR_SEARCH_CONFIGURATION = 'vectorSearchConfiguration'
@@ -41,7 +42,9 @@ VECTOR_SEARCH_CONFIGURATION = 'vectorSearchConfiguration'
 MANAGED_DATA_SOURCE_ID_KEY = '_data_source_id'
 VECTOR_DATA_SOURCE_ID_KEY = 'x-amz-bedrock-kb-data-source-id'
 
-# Knowledge base id -> knowledgeBaseConfiguration.type
+# Knowledge base id -> knowledgeBaseConfiguration.type.
+# Keyed by id alone, which is safe because a server process talks to one account and
+# region, and a knowledge base's type never changes for its lifetime.
 _KB_TYPE_CACHE: dict[str, str] = {}
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/kb_types.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/kb_types.py
@@ -1,0 +1,107 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Knowledge base type detection.
+
+Managed knowledge bases (``type: MANAGED``) and vector knowledge bases take
+different ``Retrieve`` configurations, and expose data-source identity under
+different metadata keys. Sending the wrong shape either fails outright or --
+worse -- silently returns zero results.
+"""
+
+from loguru import logger
+from typing import TYPE_CHECKING, Optional
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_bedrock_agent.client import AgentsforBedrockClient
+else:
+    AgentsforBedrockClient = object
+
+
+MANAGED_KB_TYPE = 'MANAGED'
+
+MANAGED_SEARCH_CONFIGURATION = 'managedSearchConfiguration'
+VECTOR_SEARCH_CONFIGURATION = 'vectorSearchConfiguration'
+
+# Managed knowledge bases surface data-source identity as ``_data_source_id``.
+# Vector knowledge bases use the ``x-amz-bedrock-kb-*`` reserved keys. Filtering a
+# managed knowledge base on the vector key is accepted by the API but matches
+# nothing, so the caller sees an empty result set rather than an error.
+MANAGED_DATA_SOURCE_ID_KEY = '_data_source_id'
+VECTOR_DATA_SOURCE_ID_KEY = 'x-amz-bedrock-kb-data-source-id'
+
+# Knowledge base id -> knowledgeBaseConfiguration.type
+_KB_TYPE_CACHE: dict[str, str] = {}
+
+
+def cache_knowledge_base_type(knowledge_base_id: str, knowledge_base_type: str) -> None:
+    """Record a knowledge base's type so ``Retrieve`` calls can skip the lookup."""
+    if knowledge_base_id and knowledge_base_type:
+        _KB_TYPE_CACHE[knowledge_base_id] = knowledge_base_type
+
+
+def clear_knowledge_base_type_cache() -> None:
+    """Clear the cache. Intended for tests."""
+    _KB_TYPE_CACHE.clear()
+
+
+def get_knowledge_base_type(
+    knowledge_base_id: str,
+    agent_mgmt_client: Optional[AgentsforBedrockClient] = None,
+) -> str:
+    """Resolve a knowledge base's type, preferring the discovery-populated cache.
+
+    Returns an empty string when the type cannot be determined -- for example when
+    the caller lacks ``bedrock:GetKnowledgeBase``. Callers must treat an empty
+    string as "unknown" and fall back rather than assuming a type.
+    """
+    cached = _KB_TYPE_CACHE.get(knowledge_base_id)
+    if cached:
+        return cached
+
+    if agent_mgmt_client is None:
+        return ''
+
+    try:
+        response = agent_mgmt_client.get_knowledge_base(knowledgeBaseId=knowledge_base_id)
+    except Exception as exc:  # noqa: BLE001 - lookup is best-effort
+        logger.warning(f'Could not determine type of knowledge base {knowledge_base_id}: {exc}')
+        return ''
+
+    kb_type = (
+        response.get('knowledgeBase', {}).get('knowledgeBaseConfiguration', {}).get('type', '')
+    )
+    cache_knowledge_base_type(knowledge_base_id, kb_type)
+    return kb_type
+
+
+def is_managed_knowledge_base(
+    knowledge_base_id: str,
+    agent_mgmt_client: Optional[AgentsforBedrockClient] = None,
+) -> Optional[bool]:
+    """Return True/False for managed, or None when the type is unknown."""
+    kb_type = get_knowledge_base_type(knowledge_base_id, agent_mgmt_client)
+    if not kb_type:
+        return None
+    return kb_type == MANAGED_KB_TYPE
+
+
+def search_configuration_key(managed: bool) -> str:
+    """Return the ``retrievalConfiguration`` key for the knowledge base type."""
+    return MANAGED_SEARCH_CONFIGURATION if managed else VECTOR_SEARCH_CONFIGURATION
+
+
+def data_source_id_metadata_key(managed: bool) -> str:
+    """Return the metadata key holding data-source identity for the KB type."""
+    return MANAGED_DATA_SOURCE_ID_KEY if managed else VECTOR_DATA_SOURCE_ID_KEY

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
@@ -12,18 +12,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from .kb_types import (
+    data_source_id_metadata_key,
+    is_managed_knowledge_base,
+    search_configuration_key,
+)
 from loguru import logger
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 
 if TYPE_CHECKING:
+    from mypy_boto3_bedrock_agent.client import AgentsforBedrockClient
     from mypy_boto3_bedrock_agent_runtime.client import AgentsforBedrockRuntimeClient
     from mypy_boto3_bedrock_agent_runtime.type_defs import (
         KnowledgeBaseRetrievalConfigurationTypeDef,
     )
 else:
+    AgentsforBedrockClient = object
     AgentsforBedrockRuntimeClient = object
     KnowledgeBaseRetrievalConfigurationTypeDef = object
+
+
+def _is_search_configuration_mismatch(exc: Exception) -> bool:
+    """Whether the error indicates the wrong search configuration shape was sent.
+
+    The API rejects a mismatch with a ValidationException naming the configuration it
+    expected, for example: "vectorSearchConfiguration is not supported for managed
+    knowledge bases. Use managedSearchConfiguration instead."
+    """
+    message = str(exc)
+    if 'ValidationException' not in type(exc).__name__ and 'ValidationException' not in message:
+        return False
+    return 'managedSearchConfiguration' in message or 'vectorSearchConfiguration' in message
+
+
+def _build_retrieval_configuration(
+    managed: bool,
+    number_of_results: int,
+    region_name: str,
+    reranking: bool,
+    reranking_model_name: Literal['COHERE', 'AMAZON'],
+    data_source_ids: Optional[list[str]],
+) -> 'KnowledgeBaseRetrievalConfigurationTypeDef':
+    """Build a ``retrievalConfiguration`` for the knowledge base type."""
+    config_key = search_configuration_key(managed)
+    search_configuration: dict = {'numberOfResults': number_of_results}
+
+    if data_source_ids:
+        search_configuration['filter'] = {
+            'in': {
+                'key': data_source_id_metadata_key(managed),
+                'value': data_source_ids,
+            }
+        }
+
+    if reranking:
+        model_name_mapping = {
+            'COHERE': 'cohere.rerank-v3-5:0',
+            'AMAZON': 'amazon.rerank-v1:0',
+        }
+        search_configuration['rerankingConfiguration'] = {
+            'type': 'BEDROCK_RERANKING_MODEL',
+            'bedrockRerankingConfiguration': {
+                'modelConfiguration': {
+                    'modelArn': f'arn:aws:bedrock:{region_name}::foundation-model/{model_name_mapping[reranking_model_name]}'
+                },
+            },
+        }
+
+    return {config_key: search_configuration}  # type: ignore[return-value]
 
 
 async def query_knowledge_base(
@@ -34,6 +91,7 @@ async def query_knowledge_base(
     reranking: bool = False,
     reranking_model_name: Literal['COHERE', 'AMAZON'] = 'AMAZON',
     data_source_ids: list[str] | None = None,
+    kb_agent_mgmt_client: Optional[AgentsforBedrockClient] = None,
 ) -> str:
     """# Amazon Bedrock Knowledge Base query tool.
 
@@ -45,6 +103,10 @@ async def query_knowledge_base(
         reranking (bool): Whether to rerank the results. Can be globally configured using the BEDROCK_KB_RERANKING_ENABLED environment variable.
         reranking_model_name (Literal['COHERE', 'AMAZON']): The name of the reranking model to use.
         data_source_ids (list[str] | None): The data source IDs to filter the knowledge base by.
+        kb_agent_mgmt_client (AgentsforBedrockClient | None): Management client used to
+            determine whether the knowledge base is managed. Optional -- when omitted,
+            the type is taken from the discovery cache, and an incorrect guess is
+            recovered from by retrying with the other configuration shape.
 
     ## Warning: You must use the `ListKnowledgeBases` tool to get the knowledge base ID and optionally a data source ID first.
 
@@ -62,39 +124,49 @@ async def query_knowledge_base(
             f'Reranking is not supported in region {kb_agent_client.meta.region_name}'
         )
 
-    retrieve_request: KnowledgeBaseRetrievalConfigurationTypeDef = {
-        'vectorSearchConfiguration': {
-            'numberOfResults': number_of_results,
-        }
-    }
+    region_name = kb_agent_client.meta.region_name
+    managed = is_managed_knowledge_base(knowledge_base_id, kb_agent_mgmt_client)
 
-    if data_source_ids:
-        retrieve_request['vectorSearchConfiguration']['filter'] = {  # type: ignore
-            'in': {
-                'key': 'x-amz-bedrock-kb-data-source-id',
-                'value': data_source_ids,  # type: ignore
-            }
-        }
-
-    if reranking:
-        model_name_mapping = {
-            'COHERE': 'cohere.rerank-v3-5:0',
-            'AMAZON': 'amazon.rerank-v1:0',
-        }
-        retrieve_request['vectorSearchConfiguration']['rerankingConfiguration'] = {
-            'type': 'BEDROCK_RERANKING_MODEL',
-            'bedrockRerankingConfiguration': {
-                'modelConfiguration': {
-                    'modelArn': f'arn:aws:bedrock:{kb_agent_client.meta.region_name}::foundation-model/{model_name_mapping[reranking_model_name]}'
-                },
-            },
-        }
-
-    response = kb_agent_client.retrieve(
-        knowledgeBaseId=knowledge_base_id,
-        retrievalQuery={'text': query},
-        retrievalConfiguration=retrieve_request,
+    # An unknown type defaults to the vector shape, matching prior behaviour. If that
+    # guess is wrong the API says so explicitly, and the retry below corrects it.
+    attempt_managed = bool(managed)
+    retrieve_request = _build_retrieval_configuration(
+        managed=attempt_managed,
+        number_of_results=number_of_results,
+        region_name=region_name,
+        reranking=reranking,
+        reranking_model_name=reranking_model_name,
+        data_source_ids=data_source_ids,
     )
+
+    try:
+        response = kb_agent_client.retrieve(
+            knowledgeBaseId=knowledge_base_id,
+            retrievalQuery={'text': query},
+            retrievalConfiguration=retrieve_request,
+        )
+    except Exception as exc:  # noqa: BLE001 - inspect message to recover from a type mismatch
+        if managed is not None or not _is_search_configuration_mismatch(exc):
+            raise
+        logger.info(
+            f'Knowledge base {knowledge_base_id} rejected the '
+            f'{search_configuration_key(attempt_managed)} shape; retrying as '
+            f'{"vector" if attempt_managed else "managed"}.'
+        )
+        retrieve_request = _build_retrieval_configuration(
+            managed=not attempt_managed,
+            number_of_results=number_of_results,
+            region_name=region_name,
+            reranking=reranking,
+            reranking_model_name=reranking_model_name,
+            data_source_ids=data_source_ids,
+        )
+        response = kb_agent_client.retrieve(
+            knowledgeBaseId=knowledge_base_id,
+            retrievalQuery={'text': query},
+            retrievalConfiguration=retrieve_request,
+        )
+
     results = response['retrievalResults']
     documents: list[dict] = []
     for result in results:

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/knowledgebases/retrieval.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 import json
 from .kb_types import (
+    MANAGED_KB_TYPE,
+    VECTOR_KB_TYPE,
+    cache_knowledge_base_type,
     data_source_id_metadata_key,
     is_managed_knowledge_base,
     search_configuration_key,
@@ -31,6 +34,22 @@ else:
     AgentsforBedrockClient = object
     AgentsforBedrockRuntimeClient = object
     KnowledgeBaseRetrievalConfigurationTypeDef = object
+
+
+# Model id for each reranking model name this server accepts.
+RERANKING_MODEL_IDS = {
+    'COHERE': 'cohere.rerank-v3-5:0',
+    'AMAZON': 'amazon.rerank-v1:0',
+}
+
+# Regions each reranking model is actually offered in. Availability differs per model:
+# Amazon's reranking model is not offered in us-east-1, even though that region otherwise
+# supports Bedrock reranking, so a single flat region allowlist lets a request through that
+# then fails at the API with an opaque error.
+RERANKING_MODEL_REGIONS = {
+    'COHERE': {'us-west-2', 'us-east-1', 'ap-northeast-1', 'ca-central-1', 'eu-central-1'},
+    'AMAZON': {'us-west-2', 'ap-northeast-1', 'ca-central-1', 'eu-central-1'},
+}
 
 
 def _is_search_configuration_mismatch(exc: Exception) -> bool:
@@ -67,15 +86,11 @@ def _build_retrieval_configuration(
         }
 
     if reranking:
-        model_name_mapping = {
-            'COHERE': 'cohere.rerank-v3-5:0',
-            'AMAZON': 'amazon.rerank-v1:0',
-        }
         search_configuration['rerankingConfiguration'] = {
             'type': 'BEDROCK_RERANKING_MODEL',
             'bedrockRerankingConfiguration': {
                 'modelConfiguration': {
-                    'modelArn': f'arn:aws:bedrock:{region_name}::foundation-model/{model_name_mapping[reranking_model_name]}'
+                    'modelArn': f'arn:aws:bedrock:{region_name}::foundation-model/{RERANKING_MODEL_IDS[reranking_model_name]}'
                 },
             },
         }
@@ -92,6 +107,7 @@ async def query_knowledge_base(
     reranking_model_name: Literal['COHERE', 'AMAZON'] = 'AMAZON',
     data_source_ids: list[str] | None = None,
     kb_agent_mgmt_client: Optional[AgentsforBedrockClient] = None,
+    user_id: str | None = None,
 ) -> str:
     """# Amazon Bedrock Knowledge Base query tool.
 
@@ -103,6 +119,9 @@ async def query_knowledge_base(
         reranking (bool): Whether to rerank the results. Can be globally configured using the BEDROCK_KB_RERANKING_ENABLED environment variable.
         reranking_model_name (Literal['COHERE', 'AMAZON']): The name of the reranking model to use.
         data_source_ids (list[str] | None): The data source IDs to filter the knowledge base by.
+        user_id (str | None): End-user identity for access-control filtering. Required to
+            reach content in ACL-aware data sources (for example SharePoint, OneDrive or
+            Confluence with per-document ACLs); such content is otherwise inaccessible.
         kb_agent_mgmt_client (AgentsforBedrockClient | None): Management client used to
             determine whether the knowledge base is managed. Optional -- when omitted,
             the type is taken from the discovery cache, and an incorrect guess is
@@ -113,18 +132,15 @@ async def query_knowledge_base(
     ## Returns:
     - A string containing the results of the query.
     """
-    if reranking and kb_agent_client.meta.region_name not in [
-        'us-west-2',
-        'us-east-1',
-        'ap-northeast-1',
-        'ca-central-1',
-        'eu-central-1',
-    ]:
-        raise ValueError(
-            f'Reranking is not supported in region {kb_agent_client.meta.region_name}'
-        )
-
     region_name = kb_agent_client.meta.region_name
+
+    if reranking:
+        supported = RERANKING_MODEL_REGIONS.get(reranking_model_name, set())
+        if region_name not in supported:
+            raise ValueError(
+                f"The '{reranking_model_name}' reranking model is not available in region "
+                f'{region_name}. Supported regions: {sorted(supported)}'
+            )
     managed = is_managed_knowledge_base(knowledge_base_id, kb_agent_mgmt_client)
 
     # An unknown type defaults to the vector shape, matching prior behaviour. If that
@@ -139,11 +155,16 @@ async def query_knowledge_base(
         data_source_ids=data_source_ids,
     )
 
+    extra_args: dict = {}
+    if user_id:
+        extra_args['userContext'] = {'userId': user_id}
+
     try:
         response = kb_agent_client.retrieve(
             knowledgeBaseId=knowledge_base_id,
             retrievalQuery={'text': query},
             retrievalConfiguration=retrieve_request,
+            **extra_args,
         )
     except Exception as exc:  # noqa: BLE001 - inspect message to recover from a type mismatch
         if managed is not None or not _is_search_configuration_mismatch(exc):
@@ -165,18 +186,24 @@ async def query_knowledge_base(
             knowledgeBaseId=knowledge_base_id,
             retrievalQuery={'text': query},
             retrievalConfiguration=retrieve_request,
+            **extra_args,
+        )
+        # The retry succeeded, so the type is now known. Record it: otherwise every
+        # subsequent call would pay the same failed attempt before recovering.
+        cache_knowledge_base_type(
+            knowledge_base_id, VECTOR_KB_TYPE if attempt_managed else MANAGED_KB_TYPE
         )
 
     results = response['retrievalResults']
     documents: list[dict] = []
     for result in results:
-        if result['content'].get('type') == 'IMAGE':
+        if (result.get('content') or {}).get('type') == 'IMAGE':
             logger.warning('Images are not supported at this time. Skipping...')
             continue
         else:
             documents.append(
                 {
-                    'content': result['content'],
+                    'content': result.get('content', {}),
                     'location': result.get('location', ''),
                     'score': result.get('score', ''),
                 }

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/models.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/models.py
@@ -26,6 +26,7 @@ class KnowledgeBase(TypedDict):
 
     name: str
     description: str
+    type: str
     data_sources: List[DataSource]
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -16,6 +16,9 @@
 import json
 import os
 import sys
+from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.agentic import (
+    agentic_retrieve_knowledge_bases,
+)
 from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.clients import (
     get_bedrock_agent_client,
     get_bedrock_agent_runtime_client,
@@ -73,9 +76,10 @@ mcp = MCPServer(
     The AWS Labs Bedrock Knowledge Bases Retrieval MCP Server provides access to Amazon Bedrock Knowledge Bases for retrieving relevant information through natural language queries.
 
     ## Usage Workflow:
-    1. ALWAYS start by using the ListKnowledgeBases tool to discover available knowledge bases and their data sources
+    1. ALWAYS start by using the ListKnowledgeBases tool to discover available knowledge bases, their data sources, and their type
     2. Use the QueryKnowledgeBases tool to search specific knowledge bases with your natural language queries
     3. You can make multiple calls to QueryKnowledgeBases with different queries or targeting different knowledge bases
+    4. For MANAGED knowledge bases, the AgenticQueryKnowledgeBases tool can plan a multi-step retrieval and synthesise a cited answer. Prefer it for questions needing reasoning across several data sources; it invokes a foundation model and so costs more per call than QueryKnowledgeBases.
 
     ## Important Notes:
     - Knowledge bases contain structured data from various data sources (documents, websites, databases)
@@ -189,6 +193,79 @@ async def query_knowledge_bases_tool(
         reranking_model_name=reranking_model_name,
         data_source_ids=data_source_ids,
         kb_agent_mgmt_client=kb_agent_mgmt_client,
+    )
+
+
+@mcp.tool(name='AgenticQueryKnowledgeBases')
+async def agentic_query_knowledge_bases_tool(
+    query: str = Field(
+        ..., description='A natural language question to answer from the knowledge bases'
+    ),
+    knowledge_base_ids: List[str] = Field(
+        ...,
+        description='Managed knowledge base IDs to search. Must be IDs from the ListKnowledgeBases tool whose "type" is MANAGED. More than one may be given, and the agent decides which to search.',
+    ),
+    generate_response: bool = Field(
+        True,
+        description='Whether to synthesise a cited answer from the retrieved results. Set false to get results only, which is faster and cheaper.',
+    ),
+    number_of_results: Optional[int] = Field(
+        None, description='Maximum number of results per knowledge base.'
+    ),
+    data_source_ids: Optional[List[str]] = Field(
+        None,
+        description='Restrict retrieval to these data source IDs, from the ListKnowledgeBases tool.',
+    ),
+    max_agent_iterations: Optional[int] = Field(
+        None, description='Cap on the agent planning iterations (minimum 2).'
+    ),
+    include_trace: bool = Field(
+        False,
+        description="Include a condensed per-step trace of the agent's planning and retrieval. Useful for debugging why results were or were not found.",
+    ),
+) -> str:
+    """Answer a question from Amazon Bedrock **managed** knowledge bases using agentic retrieval.
+
+    Agentic retrieval plans a strategy, runs one or more searches across the knowledge
+    bases you give it, and optionally synthesises an answer with citations. Prefer it over
+    QueryKnowledgeBases for questions that need multi-step reasoning, span several data
+    sources or knowledge bases, or benefit from a written answer rather than raw passages.
+
+    ## Usage Requirements
+    - You MUST first use the ListKnowledgeBases tool to get valid knowledge base IDs
+    - This tool supports MANAGED knowledge bases only. For a knowledge base whose `type`
+      is not MANAGED, use QueryKnowledgeBases instead.
+
+    ## Choosing between this tool and QueryKnowledgeBases
+    - QueryKnowledgeBases: a single search, returns ranked passages. Cheaper and faster.
+    - AgenticQueryKnowledgeBases: multi-step planning, optional synthesised answer with
+      citations. Invokes a foundation model, so it costs more per call.
+
+    ## Tool output format
+    A single JSON object:
+    - `results`: retrieved items, each with `index`, `text`, `mimeType`, `metadata` and
+      `knowledgeBaseId`
+    - `answer`: the synthesised answer (only when `generate_response` is true)
+    - `citations`: spans of the answer mapped to `resultIndexes` into `results`
+    - `trace`: condensed per-step trace (only when `include_trace` is true)
+    - `warnings` / `failures` / `nextToken`: present only when non-empty
+
+    ## Interpretation Best Practices
+    1. When an answer is present, use the citations to attribute claims to specific results
+    2. Cross-check the answer against the `results` text rather than trusting it blindly
+    3. If results are empty, retry with `include_trace=true` to see what the agent searched
+    4. Narrow with `data_source_ids` when you know which source should hold the answer
+    """
+    return await agentic_retrieve_knowledge_bases(
+        query=query,
+        knowledge_base_ids=knowledge_base_ids,
+        kb_agent_client=kb_runtime_client,
+        kb_agent_mgmt_client=kb_agent_mgmt_client,
+        generate_response=generate_response,
+        number_of_results=number_of_results,
+        data_source_ids=data_source_ids,
+        max_agent_iterations=max_agent_iterations,
+        include_trace=include_trace,
     )
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -157,6 +157,10 @@ async def query_knowledge_bases_tool(
         None,
         description='The data source IDs to filter the knowledge base by. It must be a list of valid data source IDs from the ListKnowledgeBases tool',
     ),
+    user_id: Optional[str] = Field(
+        None,
+        description='End-user identity for access-control filtering. Required to reach content in ACL-aware data sources such as SharePoint, OneDrive or Confluence with per-document ACLs; that content is otherwise inaccessible. Omit for data sources without ACLs.',
+    ),
 ) -> str:
     """Query an Amazon Bedrock Knowledge Base using natural language.
 
@@ -193,6 +197,7 @@ async def query_knowledge_bases_tool(
         reranking_model_name=reranking_model_name,
         data_source_ids=data_source_ids,
         kb_agent_mgmt_client=kb_agent_mgmt_client,
+        user_id=user_id,
     )
 
 
@@ -222,6 +227,14 @@ async def agentic_query_knowledge_bases_tool(
     include_trace: bool = Field(
         False,
         description="Include a condensed per-step trace of the agent's planning and retrieval. Useful for debugging why results were or were not found.",
+    ),
+    user_id: Optional[str] = Field(
+        None,
+        description='End-user identity for access-control filtering. Required to reach content in ACL-aware data sources such as SharePoint, OneDrive or Confluence with per-document ACLs; that content is otherwise inaccessible. Omit for data sources without ACLs.',
+    ),
+    next_token: Optional[str] = Field(
+        None,
+        description="Continuation token from a previous call's `nextToken`, to fetch the next page of results.",
     ),
 ) -> str:
     """Answer a question from Amazon Bedrock **managed** knowledge bases using agentic retrieval.
@@ -266,6 +279,8 @@ async def agentic_query_knowledge_bases_tool(
         data_source_ids=data_source_ids,
         max_agent_iterations=max_agent_iterations,
         include_trace=include_trace,
+        user_id=user_id,
+        next_token=next_token,
     )
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -188,6 +188,7 @@ async def query_knowledge_bases_tool(
         reranking=reranking,
         reranking_model_name=reranking_model_name,
         data_source_ids=data_source_ids,
+        kb_agent_mgmt_client=kb_agent_mgmt_client,
     )
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
+++ b/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Knowl
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "boto3>=1.37.24",
+    "boto3>=1.43.0",
     "loguru>=0.7.3",
     "mcp[cli]>=2.0.0,<3.0.0",
     "pydantic>=2.11.1",
@@ -45,7 +45,7 @@ Changelog = "https://github.com/awslabs/mcp/blob/main/src/bedrock-kb-retrieval-m
 
 [dependency-groups]
 dev = [
-    "boto3-stubs[bedrock-agent,bedrock-agent-runtime]>=1.37.24",
+    "boto3-stubs[bedrock-agent,bedrock-agent-runtime]>=1.43.0",
     "commitizen>=4.4.1",
     "pre-commit>=4.2.0",
     "pyright>=1.1.398",

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_agentic.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_agentic.py
@@ -320,3 +320,58 @@ class TestAgenticGuards:
         )
         assert payload['results'][0]['binaryContentOmitted'] is True
         assert 'byteContent' not in payload['results'][0]
+
+
+class TestAgenticUserContext:
+    """Tests for end-user identity propagation in agentic retrieval."""
+
+    @pytest.mark.asyncio
+    async def test_user_id_sent_as_user_context(self):
+        """A user id is sent as userContext so ACL-aware data sources are reachable."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+            user_id='user@example.com',
+        )
+        request = client.agentic_retrieve_stream.call_args[1]
+        assert request['userContext'] == {'userId': 'user@example.com'}
+
+    @pytest.mark.asyncio
+    async def test_user_context_omitted_when_no_user_id(self):
+        """No userContext key is sent when no user id is supplied."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+        )
+        assert 'userContext' not in client.agentic_retrieve_stream.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_next_token_forwarded_for_pagination(self):
+        """A continuation token is forwarded so a surfaced nextToken is usable."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+            next_token='tok-abc',
+        )
+        assert client.agentic_retrieve_stream.call_args[1]['nextToken'] == 'tok-abc'
+
+    @pytest.mark.asyncio
+    async def test_next_token_omitted_when_absent(self):
+        """No nextToken key is sent when none is supplied."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+        )
+        assert 'nextToken' not in client.agentic_retrieve_stream.call_args[1]

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_agentic.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_agentic.py
@@ -1,0 +1,322 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for agentic retrieval."""
+
+import json
+import pytest
+from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.agentic import (
+    MANAGED_DATA_SOURCE_ID_KEY,
+    AgenticRetrievalError,
+    agentic_retrieve_knowledge_bases,
+)
+from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.kb_types import (
+    clear_knowledge_base_type_cache,
+)
+from unittest.mock import MagicMock
+
+
+def result_event(count=2, answer='The answer.', citations=True):
+    """Build a terminal result event with `count` results."""
+    event = {
+        'result': {
+            'results': [
+                {
+                    'content': {'text': f'passage {i}', 'mimeType': 'text/plain'},
+                    'metadata': {MANAGED_DATA_SOURCE_ID_KEY: f'ds-{i}'},
+                    'sourceRetriever': {'identifier': 'kb-managed-1'},
+                }
+                for i in range(count)
+            ]
+        }
+    }
+    if answer is not None:
+        generated = {'answer': answer}
+        if citations:
+            generated['citations'] = [
+                {'startIndex': 0, 'endIndex': 10, 'references': [{'resultIndex': 0}]}
+            ]
+        event['result']['generatedResponse'] = generated
+    return event
+
+
+def trace_event(step='Planning', status='SUCCEEDED', message='done', **extra):
+    """Build a trace event."""
+    return {
+        'traceEvent': {'attributes': {'step': step, 'status': status, 'message': message, **extra}}
+    }
+
+
+def runtime_client(stream):
+    """Runtime client stub returning the given stream."""
+    client = MagicMock()
+    client.meta.region_name = 'us-west-2'
+    client.agentic_retrieve_stream.return_value = {'stream': stream}
+    return client
+
+
+def mgmt_client(kb_type='MANAGED'):
+    """Management client stub returning the given knowledge base type."""
+    client = MagicMock()
+    client.get_knowledge_base.return_value = {
+        'knowledgeBase': {'knowledgeBaseConfiguration': {'type': kb_type}}
+    }
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear the knowledge base type cache around each test."""
+    clear_knowledge_base_type_cache()
+    yield
+    clear_knowledge_base_type_cache()
+
+
+class TestAgenticRetrieval:
+    """Tests for aggregating the agentic retrieval stream."""
+
+    @pytest.mark.asyncio
+    async def test_aggregates_results_answer_and_citations(self):
+        """Results, answer and citations are all surfaced."""
+        client = runtime_client([trace_event(), result_event()])
+        payload = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=client,
+                kb_agent_mgmt_client=mgmt_client(),
+            )
+        )
+        assert payload['answer'] == 'The answer.'
+        assert len(payload['results']) == 2
+        assert payload['citations'] == [{'startIndex': 0, 'endIndex': 10, 'resultIndexes': [0]}]
+        assert payload['results'][0]['index'] == 0
+        assert payload['results'][0]['text'] == 'passage 0'
+        assert payload['results'][0]['knowledgeBaseId'] == 'kb-managed-1'
+
+    @pytest.mark.asyncio
+    async def test_generate_response_false_omits_answer(self):
+        """With generation off, answer and citations keys are absent."""
+        client = runtime_client([result_event(answer=None)])
+        payload = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=client,
+                kb_agent_mgmt_client=mgmt_client(),
+                generate_response=False,
+            )
+        )
+        assert 'answer' not in payload
+        assert 'citations' not in payload
+        assert len(payload['results']) == 2
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_streamed_chunks_when_no_generated_answer(self):
+        """Streamed responseEvent chunks are joined if the result carries no answer."""
+        stream = [
+            {'responseEvent': {'text': 'Hello '}},
+            {'responseEvent': {'text': 'world'}},
+            result_event(answer=None),
+        ]
+        payload = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client(stream),
+                kb_agent_mgmt_client=mgmt_client(),
+            )
+        )
+        assert payload['answer'] == 'Hello world'
+
+    @pytest.mark.asyncio
+    async def test_trace_only_included_when_requested(self):
+        """The condensed trace is opt-in."""
+        stream = [trace_event(step='Retrieval', status='SUCCEEDED'), result_event()]
+
+        without = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client(stream),
+                kb_agent_mgmt_client=mgmt_client(),
+            )
+        )
+        assert 'trace' not in without
+
+        with_trace = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client(stream),
+                kb_agent_mgmt_client=mgmt_client(),
+                include_trace=True,
+            )
+        )
+        assert with_trace['trace'] == [
+            {'step': 'Retrieval', 'status': 'SUCCEEDED', 'message': 'done'}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_data_source_filter_uses_managed_key(self):
+        """Data-source filtering uses the managed metadata key, via retrievalOverrides."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+            data_source_ids=['ds-1'],
+            number_of_results=5,
+        )
+        request = client.agentic_retrieve_stream.call_args[1]
+        overrides = request['retrievers'][0]['configuration']['knowledgeBase'][
+            'retrievalOverrides'
+        ]
+        assert overrides['maxNumberOfResults'] == 5
+        assert overrides['filter'] == {
+            'in': {'key': MANAGED_DATA_SOURCE_ID_KEY, 'value': ['ds-1']}
+        }
+
+    @pytest.mark.asyncio
+    async def test_multiple_knowledge_bases_become_multiple_retrievers(self):
+        """Each knowledge base id becomes its own retriever."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1', 'kb-managed-2'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+        )
+        retrievers = client.agentic_retrieve_stream.call_args[1]['retrievers']
+        assert [r['configuration']['knowledgeBase']['knowledgeBaseId'] for r in retrievers] == [
+            'kb-managed-1',
+            'kb-managed-2',
+        ]
+
+    @pytest.mark.asyncio
+    async def test_max_agent_iterations_passed_through(self):
+        """The agent iteration cap is forwarded when supplied."""
+        client = runtime_client([result_event()])
+        await agentic_retrieve_knowledge_bases(
+            query='q',
+            knowledge_base_ids=['kb-managed-1'],
+            kb_agent_client=client,
+            kb_agent_mgmt_client=mgmt_client(),
+            max_agent_iterations=3,
+        )
+        config = client.agentic_retrieve_stream.call_args[1]['agenticRetrieveConfiguration']
+        assert config['maxAgentIteration'] == 3
+
+    @pytest.mark.asyncio
+    async def test_warnings_and_failures_surfaced(self):
+        """Trace warnings and failures are collected even without include_trace."""
+        stream = [
+            trace_event(
+                warnings=[{'message': {'message': 'a warning'}}],
+                failures=[{'message': 'a failure'}],
+            ),
+            result_event(),
+        ]
+        payload = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client(stream),
+                kb_agent_mgmt_client=mgmt_client(),
+            )
+        )
+        assert payload['warnings'] == ['a warning']
+        assert payload['failures'] == ['a failure']
+
+
+class TestAgenticGuards:
+    """Tests for input validation and error handling."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_vector_knowledge_base(self):
+        """A non-managed knowledge base is rejected with an actionable message."""
+        with pytest.raises(ValueError, match='not a managed knowledge base'):
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-vector-1'],
+                kb_agent_client=runtime_client([result_event()]),
+                kb_agent_mgmt_client=mgmt_client('VECTOR'),
+            )
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_type_unknown(self):
+        """An unknown type does not block the call; the service still validates."""
+        payload = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client([result_event()]),
+                kb_agent_mgmt_client=None,
+            )
+        )
+        assert len(payload['results']) == 2
+
+    @pytest.mark.asyncio
+    async def test_requires_at_least_one_knowledge_base(self):
+        """An empty knowledge base list is rejected."""
+        with pytest.raises(ValueError, match='At least one knowledge base'):
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=[],
+                kb_agent_client=runtime_client([]),
+                kb_agent_mgmt_client=mgmt_client(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_event_in_stream_raises(self):
+        """A modelled error event in the stream is raised, not silently dropped."""
+        stream = [{'validationException': {'message': 'bad input'}}]
+        with pytest.raises(AgenticRetrievalError, match='validationException: bad input'):
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client(stream),
+                kb_agent_mgmt_client=mgmt_client(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_binary_content_flagged_not_embedded(self):
+        """Binary content is flagged rather than embedded, since Blobs are not JSON safe."""
+        stream = [
+            {
+                'result': {
+                    'results': [
+                        {
+                            'content': {
+                                'text': 'caption',
+                                'mimeType': 'image/png',
+                                'byteContent': b'\x89PNG',
+                            },
+                            'sourceRetriever': {'identifier': 'kb-managed-1'},
+                        }
+                    ]
+                }
+            }
+        ]
+        payload = json.loads(
+            await agentic_retrieve_knowledge_bases(
+                query='q',
+                knowledge_base_ids=['kb-managed-1'],
+                kb_agent_client=runtime_client(stream),
+                kb_agent_mgmt_client=mgmt_client(),
+                generate_response=False,
+            )
+        )
+        assert payload['results'][0]['binaryContentOmitted'] is True
+        assert 'byteContent' not in payload['results'][0]

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_managed_kb.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_managed_kb.py
@@ -1,0 +1,240 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for managed knowledge base retrieval."""
+
+import pytest
+from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.kb_types import (
+    MANAGED_DATA_SOURCE_ID_KEY,
+    VECTOR_DATA_SOURCE_ID_KEY,
+    clear_knowledge_base_type_cache,
+    get_knowledge_base_type,
+    is_managed_knowledge_base,
+)
+from awslabs.bedrock_kb_retrieval_mcp_server.knowledgebases.retrieval import query_knowledge_base
+from unittest.mock import MagicMock
+
+
+RESPONSE = {
+    'retrievalResults': [
+        {
+            'content': {'text': 'managed result', 'type': 'TEXT'},
+            'location': {'s3Location': {'uri': 's3://bucket/doc.pdf'}, 'type': 'S3'},
+            'score': 0.9,
+        }
+    ]
+}
+
+
+def mgmt_client(kb_type):
+    """Management client stub returning the given knowledge base type."""
+    client = MagicMock()
+    client.get_knowledge_base.return_value = {
+        'knowledgeBase': {'knowledgeBaseConfiguration': {'type': kb_type}}
+    }
+    return client
+
+
+def runtime_client(region='us-west-2'):
+    """Runtime client stub."""
+    client = MagicMock()
+    client.meta.region_name = region
+    client.retrieve.return_value = RESPONSE
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_knowledge_base_type_cache()
+    yield
+    clear_knowledge_base_type_cache()
+
+
+class TestKnowledgeBaseTypeDetection:
+    """Tests for knowledge base type detection."""
+
+    def test_detects_managed(self):
+        """Managed knowledge bases are detected as managed."""
+        assert is_managed_knowledge_base('kb-1', mgmt_client('MANAGED')) is True
+
+    def test_detects_vector(self):
+        """Vector knowledge bases are not detected as managed."""
+        assert is_managed_knowledge_base('kb-1', mgmt_client('VECTOR')) is False
+
+    def test_unknown_without_client(self):
+        """Type is unknown when no management client is supplied."""
+        assert is_managed_knowledge_base('kb-1', None) is None
+
+    def test_unknown_when_lookup_denied(self):
+        """Type is unknown when the lookup call fails."""
+        client = MagicMock()
+        client.get_knowledge_base.side_effect = Exception('AccessDeniedException')
+        assert is_managed_knowledge_base('kb-1', client) is None
+
+    def test_result_is_cached(self):
+        """The type lookup is performed only once per knowledge base."""
+        client = mgmt_client('MANAGED')
+        get_knowledge_base_type('kb-1', client)
+        get_knowledge_base_type('kb-1', client)
+        assert client.get_knowledge_base.call_count == 1
+
+
+class TestManagedRetrieval:
+    """Tests that managed knowledge bases get the managed configuration."""
+
+    @pytest.mark.asyncio
+    async def test_managed_kb_uses_managed_search_configuration(self):
+        """Managed knowledge bases receive managedSearchConfiguration."""
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=mgmt_client('MANAGED'),
+        )
+        config = kb_client.retrieve.call_args[1]['retrievalConfiguration']
+        assert 'managedSearchConfiguration' in config
+        assert 'vectorSearchConfiguration' not in config
+
+    @pytest.mark.asyncio
+    async def test_vector_kb_still_uses_vector_search_configuration(self):
+        """Vector knowledge bases keep vectorSearchConfiguration."""
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=mgmt_client('VECTOR'),
+        )
+        config = kb_client.retrieve.call_args[1]['retrievalConfiguration']
+        assert 'vectorSearchConfiguration' in config
+        assert 'managedSearchConfiguration' not in config
+
+    @pytest.mark.asyncio
+    async def test_managed_kb_filters_on_underscore_data_source_id(self):
+        """Managed KBs expose data-source identity as ``_data_source_id``.
+
+        Filtering on the vector key is accepted by the API but matches nothing, so
+        this assertion guards against silently empty results.
+        """
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            data_source_ids=['ds-1'],
+            kb_agent_mgmt_client=mgmt_client('MANAGED'),
+        )
+        config = kb_client.retrieve.call_args[1]['retrievalConfiguration']
+        assert config['managedSearchConfiguration']['filter'] == {
+            'in': {'key': MANAGED_DATA_SOURCE_ID_KEY, 'value': ['ds-1']}
+        }
+
+    @pytest.mark.asyncio
+    async def test_vector_kb_filters_on_reserved_key(self):
+        """Vector knowledge bases filter on the reserved data-source key."""
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            data_source_ids=['ds-1'],
+            kb_agent_mgmt_client=mgmt_client('VECTOR'),
+        )
+        config = kb_client.retrieve.call_args[1]['retrievalConfiguration']
+        assert config['vectorSearchConfiguration']['filter'] == {
+            'in': {'key': VECTOR_DATA_SOURCE_ID_KEY, 'value': ['ds-1']}
+        }
+
+    @pytest.mark.asyncio
+    async def test_managed_kb_reranking_nested_under_managed_configuration(self):
+        """Reranking is nested under the managed configuration."""
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            reranking=True,
+            kb_agent_mgmt_client=mgmt_client('MANAGED'),
+        )
+        config = kb_client.retrieve.call_args[1]['retrievalConfiguration']
+        reranking = config['managedSearchConfiguration']['rerankingConfiguration']
+        assert reranking['type'] == 'BEDROCK_RERANKING_MODEL'
+
+
+class TestConfigurationMismatchFallback:
+    """Tests recovery when the knowledge base type could not be determined."""
+
+    @pytest.mark.asyncio
+    async def test_retries_as_managed_when_vector_rejected(self):
+        """Without a management client the vector shape is tried, then corrected."""
+
+        class ValidationException(Exception):
+            pass
+
+        kb_client = runtime_client()
+        kb_client.retrieve.side_effect = [
+            ValidationException(
+                'An error occurred (ValidationException) when calling the Retrieve '
+                'operation: Incompatible configuration: vectorSearchConfiguration is '
+                'not supported for managed knowledge bases. Use '
+                'managedSearchConfiguration instead.'
+            ),
+            RESPONSE,
+        ]
+
+        result = await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=None,
+        )
+
+        assert 'managed result' in result
+        assert kb_client.retrieve.call_count == 2
+        first = kb_client.retrieve.call_args_list[0][1]['retrievalConfiguration']
+        second = kb_client.retrieve.call_args_list[1][1]['retrievalConfiguration']
+        assert 'vectorSearchConfiguration' in first
+        assert 'managedSearchConfiguration' in second
+
+    @pytest.mark.asyncio
+    async def test_unrelated_errors_are_not_retried(self):
+        """Errors unrelated to configuration shape propagate unchanged."""
+        kb_client = runtime_client()
+        kb_client.retrieve.side_effect = Exception('ResourceNotFoundException')
+
+        with pytest.raises(Exception, match='ResourceNotFoundException'):
+            await query_knowledge_base(
+                query='q',
+                knowledge_base_id='kb-1',
+                kb_agent_client=kb_client,
+                kb_agent_mgmt_client=None,
+            )
+        assert kb_client.retrieve.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_type_was_known(self):
+        """A known type means a mismatch is a real error, not a bad guess."""
+        kb_client = runtime_client()
+        kb_client.retrieve.side_effect = Exception(
+            'ValidationException: managedSearchConfiguration is not supported'
+        )
+
+        with pytest.raises(Exception, match='ValidationException'):
+            await query_knowledge_base(
+                query='q',
+                knowledge_base_id='kb-1',
+                kb_agent_client=kb_client,
+                kb_agent_mgmt_client=mgmt_client('MANAGED'),
+            )
+        assert kb_client.retrieve.call_count == 1

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_managed_kb.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_managed_kb.py
@@ -238,3 +238,142 @@ class TestConfigurationMismatchFallback:
                 kb_agent_mgmt_client=mgmt_client('MANAGED'),
             )
         assert kb_client.retrieve.call_count == 1
+
+
+class TestUserContext:
+    """Tests for end-user identity propagation."""
+
+    @pytest.mark.asyncio
+    async def test_user_id_sent_as_user_context(self):
+        """A user id is sent as userContext, which ACL-aware data sources require."""
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=mgmt_client('MANAGED'),
+            user_id='user@example.com',
+        )
+        assert kb_client.retrieve.call_args[1]['userContext'] == {'userId': 'user@example.com'}
+
+    @pytest.mark.asyncio
+    async def test_user_context_omitted_when_no_user_id(self):
+        """No userContext key is sent when no user id is supplied."""
+        kb_client = runtime_client()
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=mgmt_client('MANAGED'),
+        )
+        assert 'userContext' not in kb_client.retrieve.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_user_context_preserved_across_fallback_retry(self):
+        """The user id survives the retry when the search configuration is corrected."""
+
+        class ValidationException(Exception):
+            pass
+
+        kb_client = runtime_client()
+        kb_client.retrieve.side_effect = [
+            ValidationException(
+                'ValidationException: vectorSearchConfiguration is not supported for '
+                'managed knowledge bases. Use managedSearchConfiguration instead.'
+            ),
+            RESPONSE,
+        ]
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=None,
+            user_id='user@example.com',
+        )
+        assert kb_client.retrieve.call_count == 2
+        for call in kb_client.retrieve.call_args_list:
+            assert call[1]['userContext'] == {'userId': 'user@example.com'}
+
+
+class TestRerankingRegionValidation:
+    """Tests that reranking availability is validated per model, not per region alone."""
+
+    @pytest.mark.asyncio
+    async def test_amazon_model_rejected_in_us_east_1(self):
+        """The Amazon reranking model is not offered in us-east-1 and must be refused."""
+        kb_client = runtime_client(region='us-east-1')
+        with pytest.raises(ValueError, match="'AMAZON' reranking model is not available"):
+            await query_knowledge_base(
+                query='q',
+                knowledge_base_id='kb-1',
+                kb_agent_client=kb_client,
+                kb_agent_mgmt_client=mgmt_client('MANAGED'),
+                reranking=True,
+                reranking_model_name='AMAZON',
+            )
+        kb_client.retrieve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cohere_model_allowed_in_us_east_1(self):
+        """The Cohere reranking model is offered in us-east-1 and must be allowed."""
+        kb_client = runtime_client(region='us-east-1')
+        await query_knowledge_base(
+            query='q',
+            knowledge_base_id='kb-1',
+            kb_agent_client=kb_client,
+            kb_agent_mgmt_client=mgmt_client('MANAGED'),
+            reranking=True,
+            reranking_model_name='COHERE',
+        )
+        config = kb_client.retrieve.call_args[1]['retrievalConfiguration']
+        arn = config['managedSearchConfiguration']['rerankingConfiguration'][
+            'bedrockRerankingConfiguration'
+        ]['modelConfiguration']['modelArn']
+        assert 'cohere.rerank-v3-5:0' in arn
+
+    @pytest.mark.asyncio
+    async def test_both_models_allowed_in_us_west_2(self):
+        """Both reranking models are offered in us-west-2."""
+        for model in ('AMAZON', 'COHERE'):
+            kb_client = runtime_client()
+            await query_knowledge_base(
+                query='q',
+                knowledge_base_id='kb-1',
+                kb_agent_client=kb_client,
+                kb_agent_mgmt_client=mgmt_client('MANAGED'),
+                reranking=True,
+                reranking_model_name=model,
+            )
+            kb_client.retrieve.assert_called_once()
+
+
+class TestFallbackCachesLearnedType:
+    """Tests that a recovered type is remembered."""
+
+    @pytest.mark.asyncio
+    async def test_successful_retry_caches_type_so_next_call_is_direct(self):
+        """After recovering, a second call goes straight to the correct shape."""
+
+        class ValidationException(Exception):
+            pass
+
+        kb_client = runtime_client()
+        kb_client.retrieve.side_effect = [
+            ValidationException(
+                'ValidationException: vectorSearchConfiguration is not supported for '
+                'managed knowledge bases. Use managedSearchConfiguration instead.'
+            ),
+            RESPONSE,
+            RESPONSE,
+        ]
+        for _ in range(2):
+            await query_knowledge_base(
+                query='q',
+                knowledge_base_id='kb-1',
+                kb_agent_client=kb_client,
+                kb_agent_mgmt_client=None,
+            )
+        # 2 calls for the first query (failed + retry), 1 for the second: 3 total, not 4.
+        assert kb_client.retrieve.call_count == 3
+        last = kb_client.retrieve.call_args_list[-1][1]['retrievalConfiguration']
+        assert 'managedSearchConfiguration' in last

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_retrieval.py
@@ -155,7 +155,7 @@ class TestQueryKnowledgeBase:
             )
 
         # Check that the error message is correct
-        assert 'Reranking is not supported in region eu-west-1' in str(excinfo.value)
+        assert 'reranking model is not available in region eu-west-1' in str(excinfo.value)
 
         # Check that the client methods were not called
         mock_bedrock_agent_runtime_client.retrieve.assert_not_called()

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
@@ -134,6 +134,7 @@ class TestQueryKnowledgeBasesTool:
             reranking=True,
             reranking_model_name='AMAZON',
             data_source_ids=['ds-12345', 'ds-67890'],
+            kb_agent_mgmt_client=mock.ANY,  # We can't directly access the global variable in tests
         )
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/tests/test_server.py
@@ -118,6 +118,7 @@ class TestQueryKnowledgeBasesTool:
             reranking=True,
             reranking_model_name='AMAZON',
             data_source_ids=['ds-12345', 'ds-67890'],
+            user_id=None,
         )
 
         # Check that the result is correct
@@ -135,6 +136,7 @@ class TestQueryKnowledgeBasesTool:
             reranking_model_name='AMAZON',
             data_source_ids=['ds-12345', 'ds-67890'],
             kb_agent_mgmt_client=mock.ANY,  # We can't directly access the global variable in tests
+            user_id=None,
         )
 
 

--- a/src/bedrock-kb-retrieval-mcp-server/uv.lock
+++ b/src/bedrock-kb-retrieval-mcp-server/uv.lock
@@ -36,10 +36,10 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten') or (python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna", marker = "python_full_version < '3.14'" },
+    { name = "sniffio", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -56,7 +56,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "idna" },
+    { name = "idna", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -106,7 +106,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.37.24" },
+    { name = "boto3", specifier = ">=1.43.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.11.1" },
@@ -114,7 +114,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "boto3-stubs", extras = ["bedrock-agent", "bedrock-agent-runtime"], specifier = ">=1.37.24" },
+    { name = "boto3-stubs", extras = ["bedrock-agent", "bedrock-agent-runtime"], specifier = ">=1.43.0" },
     { name = "commitizen", specifier = ">=4.4.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyright", specifier = ">=1.1.398" },
@@ -126,30 +126,30 @@ dev = [
 
 [[package]]
 name = "boto3"
-version = "1.38.17"
+version = "1.43.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/dd/68ea8ab6dfbed46b75fcfe0bbd5ae19e4d3ef094b749ff8d944398e90f2d/boto3-1.38.17.tar.gz", hash = "sha256:6058feef976ece2878ad3555f39933e63d20d02e2bbd40610ab2926d4555710a", size = 111803, upload-time = "2025-05-15T19:35:17.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a0/b8693637bee21e266a52f3e1b8bb9fe4897934aa62c55cc132f8721c1b8f/boto3-1.43.86.tar.gz", hash = "sha256:aca7b5d7f31a90ad37bec773552ec9bfb57e0029c9aa0f0f4d51d5bf9607b1c4", size = 112685, upload-time = "2026-09-01T19:24:02.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/89/634155fb209f50fd98da1cb11480bcdf6ed8d8ab68800d91cdb2bf59a8af/boto3-1.38.17-py3-none-any.whl", hash = "sha256:9b56c98fe7acb6559c24dacd838989878c60f3df2fb8ca5f311128419fd9f953", size = 139937, upload-time = "2025-05-15T19:35:14.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/dd/f4874f7bab882a778178b03965b1474c63f2e8bd2eea5dd714f06b0e8713/boto3-1.43.86-py3-none-any.whl", hash = "sha256:94543a5ce482df8bb6a0bf8a944bf5ccf6625889b1df0d7886dfc3311ebd4169", size = 140026, upload-time = "2026-09-01T19:24:00.638Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.37.24"
+version = "1.43.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/ba/2cae12b5f2c4c6273d7192d94cd34a026be44f7c0cb3409023a508f80eb8/boto3_stubs-1.37.24.tar.gz", hash = "sha256:42f7c1b3da40eb074ffc830b26417c9af86546a609fd8563d7af4deade3b5194", size = 99107, upload-time = "2025-03-31T19:47:41.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/ba/4d5c3c43f176d5d2f95c5de1e05a7673b37aa1e376942d3b180fdd136548/boto3_stubs-1.43.86.tar.gz", hash = "sha256:4413fa83bbf4cb212cbbba7d9edee85865ef9681483e1e029e2531b3336a9b82", size = 104602, upload-time = "2026-09-01T19:41:52.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/29/8f3fa7bbcd52fda7e36b429d9428196929ebc4f90763bc824f899bfb79a2/boto3_stubs-1.37.24-py3-none-any.whl", hash = "sha256:0c085621dcfb861be1b3066aaed294eca37a2f99d9e737b41dc2de3a26498c27", size = 68646, upload-time = "2025-03-31T19:47:35.75Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e9/8ac1d9e40e306cb6699f2e2ccc9c0292029b013bdc17886c3dcb3ccc9d88/boto3_stubs-1.43.86-py3-none-any.whl", hash = "sha256:7b79812aa0284dce548a9a131da4acc35109639320863ba899a1548a3b77f213", size = 71511, upload-time = "2026-09-01T19:41:47.684Z" },
 ]
 
 [package.optional-dependencies]
@@ -162,16 +162,16 @@ bedrock-agent-runtime = [
 
 [[package]]
 name = "botocore"
-version = "1.38.17"
+version = "1.43.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/73/8b831403be00dbea152d4827929a5772f58e0413dd3e6b6d4b3592d88d39/botocore-1.38.17.tar.gz", hash = "sha256:f2db4c4bdcfbc41d78bfe73b9affe7d217c7840f8ce120cff815536969418b18", size = 13903448, upload-time = "2025-05-15T19:35:05.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/77/0ed1c398b7d3aa5d02c1b15df32a049e07961339fe41640af1440079c2f7/botocore-1.43.86.tar.gz", hash = "sha256:0e943c77ab6a54aaaf4d57e6026ede5c3dca341af71ce91f71849a6eae9d5dbf", size = 16059433, upload-time = "2026-09-01T19:23:57.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/fc/9c08db2e89055999e996fee3537cbbfb4ed8ebf0d4ab1b1045e1819b76d8/botocore-1.38.17-py3-none-any.whl", hash = "sha256:ec75cf02fbd3dbec18187085ce387761eab16afdccfd0774fd168db3689c6cb6", size = 13564514, upload-time = "2025-05-15T19:35:00.231Z" },
+    { url = "https://files.pythonhosted.org/packages/41/59/eb95d57ea576feaf1693f5e914f9f27ff9961429cf9ecbc85cef610a6d84/botocore-1.43.86-py3-none-any.whl", hash = "sha256:4efc7fbd6e7616edbd55623bb585a044906149b9a5d3d8558420506526e5a5ac", size = 15751556, upload-time = "2026-09-01T19:23:54.013Z" },
 ]
 
 [[package]]
@@ -191,7 +191,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -558,8 +558,8 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten') or (python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "truststore", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/db/2ad49878b36af4cff7527c1158b083ad6d9350462f1a35685cc3ebfa7c2b/httpcore2-2.6.0.tar.gz", hash = "sha256:95b692b582402ec49b3d84c2343556e4ac4c0962c8b3d39c48d485b9ecc240ab", size = 65592, upload-time = "2026-07-14T10:48:33.816Z" }
 wheels = [
@@ -576,8 +576,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version >= '3.14'" },
+    { name = "truststore", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -594,11 +594,11 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten') or (python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "idna" },
-    { name = "truststore" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*' or sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "idna", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "truststore", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/17/1e142bf3c76684232a092e1e4002be07fd3403b1c2dcb15d0012ea300c8f/httpx2-2.6.0.tar.gz", hash = "sha256:5d362fd59562cf2139a60c67bb016587a70b36156a517f176c7cbf1587d1ab22", size = 92736, upload-time = "2026-07-14T10:48:35.12Z" }
 wheels = [
@@ -617,12 +617,12 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "httpcore2", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
-    { name = "idna" },
-    { name = "truststore", marker = "sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
+    { name = "httpcore2", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna", marker = "(python_full_version >= '3.14' and sys_platform != 'emscripten') or (python_full_version >= '3.12' and sys_platform == 'emscripten')" },
+    { name = "truststore", marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*' and sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
@@ -853,26 +853,26 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-bedrock-agent"
-version = "1.37.20"
+version = "1.43.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/61/a35f27afd988d552cdc8f606e6254eb9d5e16904babf2bfad05d16f1b0aa/mypy_boto3_bedrock_agent-1.37.20.tar.gz", hash = "sha256:68ff06c80d35dcf98388afdfe73fe8448b1f356b3f961fa07547ce6514ca98be", size = 51132, upload-time = "2025-03-25T19:25:31.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/8b/5c4f86073bd9b844855af59341313f5b097ad88c7ad99d0d29fa3e9a6b4c/mypy_boto3_bedrock_agent-1.43.83.tar.gz", hash = "sha256:575c51f03988a509897433abebcabad87730c3eb72314d636c9584f2dfcd2ed0", size = 55336, upload-time = "2026-08-28T19:47:01.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/69/23f3a787aa4a6d333aa705213355af871f15fa33a9a51c9ea5a1b89c321b/mypy_boto3_bedrock_agent-1.37.20-py3-none-any.whl", hash = "sha256:0998168026a02a770182b39ff0eed6e1d48963f398961a5504bc0c91d3d00a4e", size = 57293, upload-time = "2025-03-25T19:25:26.953Z" },
+    { url = "https://files.pythonhosted.org/packages/39/12/1de0a8767b900087f99a9bc127dd594251b7b081e4f8495408e21a0f2618/mypy_boto3_bedrock_agent-1.43.83-py3-none-any.whl", hash = "sha256:a9e35e99e2ba4241c57e9653e262b2e491857126cc37de9bfe7d5053f1da6155", size = 62271, upload-time = "2026-08-28T19:46:59.831Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-agent-runtime"
-version = "1.37.22"
+version = "1.43.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/f0/5756c2263eca00b7932e543fcaab1f79a24edb49ff1f3f2e1276d5999b24/mypy_boto3_bedrock_agent_runtime-1.37.22.tar.gz", hash = "sha256:5b70873103fd14862dca9cd8b38075bedbe7747c171ecfe3ea99830b9d9e4d91", size = 38322, upload-time = "2025-03-27T19:42:22.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/b1/283fbbc99cb8f25f039ac489aff0c905d18df76df4c16af31fc3a05d0b5c/mypy_boto3_bedrock_agent_runtime-1.43.73.tar.gz", hash = "sha256:80fcdf1f8540e5e5670212ea2dbf381ba5843e1fb1f062f27b5f2220e88ffaca", size = 46976, upload-time = "2026-08-17T21:16:45.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/27/d9444b08c093eac85bdab7f60f3c9a8a701b1b4f28415afcaab7bb933dfe/mypy_boto3_bedrock_agent_runtime-1.37.22-py3-none-any.whl", hash = "sha256:402d424a9080ea3b8f6d353b9b50110a80758a44d8fa8c9b91d065459676a886", size = 46334, upload-time = "2025-03-27T19:42:17.618Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6f/f0b6810457951ad9dc6ec01d97265cca34abe771c46936e39cd7aa0c961c/mypy_boto3_bedrock_agent_runtime-1.43.73-py3-none-any.whl", hash = "sha256:abafe2b0c52d267a9f5d7decf9aa3415d9529f6e261a213ae35d69a35bcd8ffd", size = 56503, upload-time = "2026-08-17T21:16:41.692Z" },
 ]
 
 [[package]]
@@ -1461,14 +1461,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.12.0"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/9e/73b14aed38ee1f62cd30ab93cd0072dec7fb01f3033d116875ae3e7b8b44/s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c", size = 149178, upload-time = "2025-04-22T21:08:09.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/64/d2b49620039b82688aeebd510bd62ff4cdcdb86cbf650cc72ae42c5254a3/s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18", size = 84773, upload-time = "2025-04-22T21:08:08.265Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]
@@ -1660,8 +1660,8 @@ name = "uvicorn"
 version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568, upload-time = "2024-12-15T13:33:30.42Z" }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Amazon Bedrock **managed** knowledge bases (`knowledgeBaseConfiguration.type == "MANAGED"`)
do not work with this server today, and there is no way to get a generated answer from one.
This makes both work.

### Changes

#### 1. `QueryKnowledgeBases` failed on every call against a managed knowledge base

`retrieval.py` always sent `retrievalConfiguration={'vectorSearchConfiguration': {...}}`,
which `Retrieve` rejects for a managed knowledge base:

```
ValidationException: Incompatible configuration: vectorSearchConfiguration is not
supported for managed knowledge bases. Use managedSearchConfiguration instead.
```

`ListKnowledgeBases` discovers such a knowledge base happily, so it looks usable and then
fails on every query.

There is a quieter second half. Managed knowledge bases expose data-source identity as
`_data_source_id`, not the `x-amz-bedrock-kb-*` reserved keys. Filtering a managed
knowledge base on the vector key is **accepted by the API and matches nothing**, so
`data_source_ids` returns an empty result set with no error and the caller concludes the
data source is empty. Fixing only the configuration key would leave `data_source_ids`
silently broken.

- Detect the knowledge base type and send the matching search configuration. The type comes
  from the `get_knowledge_base` call `discover_knowledge_bases` already makes for the ARN,
  so the common path costs no extra API call, and it is cached per knowledge base id.
- Filter on the metadata key appropriate to the type.
- Nest `rerankingConfiguration` under whichever search configuration is in use.
- Degrade gracefully when the type cannot be determined (for example a caller without
  `bedrock:GetKnowledgeBase`): retry once with the other shape if the API rejects it by
  name, then cache what that retry proved so later calls go direct. Errors unrelated to
  configuration shape are not retried, and neither is a mismatch on a knowledge base whose
  type was already known.
- `ListKnowledgeBases` reports each knowledge base's `type`, so a client can tell which
  tool applies.
- Raise the `boto3` floor to `>=1.43.0`. `managedSearchConfiguration` first appears in the
  `Retrieve` input model there; 1.42.50 does not have it, and the previously declared floor
  resolves to a version that fails client-side parameter validation before a request is sent.

Vector knowledge base behaviour is unchanged.

#### 2. New tool: `AgenticQueryKnowledgeBases`

`RetrieveAndGenerate` rejects managed knowledge bases outright
(`ValidationException: This operation is not supported for managed knowledge bases.`), so
`AgenticRetrieveStream` is the only way to get a generated answer from one. This server did
not expose it.

`AgenticRetrieveStream` is a streaming operation whereas an MCP tool call returns a single
result, so the stream is consumed server-side and returned as one aggregate. Observed shape
for a default call: 4 trace events, ~440 `responseEvent` answer chunks, and a single
terminal `result` event. The terminal event already carries the complete answer and
citations, so the streamed chunks are only a fallback. Raw events are deliberately not
forwarded — there are hundreds per call and they would crowd out the content the model
actually needs.

Returns a single JSON object: `results` always; `answer` and `citations` when
`generate_response` is true; `trace` when `include_trace` is true; `warnings`, `failures`
and `nextToken` only when non-empty.

- Managed knowledge bases only — verified: a vector knowledge base returns
  `Knowledge Base with id ... is not supported for Agent...`. The type is checked up front
  and reported actionably, reusing the detection above.
- Data-source filtering goes through `retrievalOverrides` with the managed metadata key.
- Several knowledge base ids become several retrievers in one call.
- Accepts `next_token`, so the `nextToken` it surfaces is actually usable.
- Modelled error events inside the stream are raised rather than silently dropped.
- `byteContent` is a `Blob` and not JSON serialisable; its presence is flagged rather than
  embedded.

#### 3. ACL-protected content was unreachable

Neither tool exposed `userContext`, so content in data sources with per-document ACLs
(SharePoint, OneDrive, Confluence) could not be retrieved. Agentic retrieval degraded
partially rather than loudly: its full-document expansion step failed with
`UserContext is required for ACL-aware data sources` while still returning a partial result.

Both tools now take an optional `user_id`.

#### 4. Reranking availability is per model, not per region

A single flat region allowlist let `reranking_model_name='AMAZON'` through in `us-east-1`,
where that model is not offered, so the request failed at the API with an opaque error
instead of failing fast. Verified with `ListFoundationModels` across 12 regions:
`amazon.rerank-v1:0` is offered in `us-west-2`, `eu-central-1`, `ca-central-1` and
`ap-northeast-1` but **not** `us-east-1`; `cohere.rerank-v3-5:0` is offered in all five.
Validation is now per `(region, model)` and names the supported regions.

### User experience

**Before** — with a managed knowledge base:

- `QueryKnowledgeBases` fails 100% of the time with a `ValidationException`
- No way to get a generated answer
- ACL-protected content is unreachable
- `AMAZON` reranking in `us-east-1` fails with an opaque error

**After**:

- `QueryKnowledgeBases` works, and `data_source_ids` actually scopes results
- `AgenticQueryKnowledgeBases` returns a cited answer, or results only via
  `generate_response=false`
- `user_id` reaches ACL-protected content, filtered to that user's authorised subset
- Unavailable `(region, model)` reranking pairs fail immediately with the supported list
- `ListKnowledgeBases` reports `type`, so a client can pick the right tool

## Testing

`75` unit tests pass; `ruff check` and `ruff format` clean.

Unit tests alone were not treated as sufficient: mocking the runtime client hides both
Retrieve bugs, since neither client-side parameter validation nor the server's filter-key
semantics are exercised. So everything was also verified against **live managed and vector
knowledge bases** in `us-west-2`, both directly and end to end over MCP JSON-RPC.

**End to end over MCP — 10/10:** tools registered; `ListKnowledgeBases` reports `type` for
both kinds; Retrieve on managed (previously always failed); Retrieve on vector (unchanged);
Retrieve `data_source_ids` on managed returns results (previously 0, silently); agentic
answer with 13 citations over 10 results; `generate_response=false` honouring
`number_of_results`; `include_trace`; agentic `data_source_ids` scoped to exactly the
requested source; vector knowledge base refused with an actionable message.

**Input-combination matrix — 34/34**, covering Retrieve × knowledge base type × reranking
model, data-source filters (valid / multiple / non-existent), `number_of_results` bounds
(1 / 10 / 100 / 101 / 0), type-detection modes (management client present, absent, bogus id),
and agentic × `generate_response` × `include_trace` × iteration caps × retriever sets
(one, two, managed+vector, vector only, empty, bogus).

Specific behaviours confirmed live rather than only mocked:

- **Reranking under `managedSearchConfiguration` succeeds** with both `AMAZON` and `COHERE`
  on a managed knowledge base.
- **The filter-key fix genuinely discriminates:** filtering to each of three data sources in
  turn returned results only from that source (20 / 20 / 12), a non-existent id returned 0,
  and the vector key returned 0 against the same knowledge base that returns 20 unfiltered.
- **The fallback retry recovers and then stops paying for it:** with no management client the
  vector shape is attempted, rejected, retried as managed, and the learned type cached.
- **`user_id` resolves the ACL failure:** without it the run reports
  `UserContext is required for ACL-aware data sources`; with it the failure clears and
  results narrow to the user's authorised subset.
- **Multiple knowledge bases in one call** returned results spanning both.

Not reproducible in my environment, and therefore only unit tested: warning/failure
surfacing, binary-content flagging, in-stream modelled error events, and `nextToken`
pagination (the service never returned a token for my corpus).

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) **N**

New parameters are optional and appended after existing ones, so positional callers are
unaffected and omitting them preserves current behaviour. Vector knowledge base behaviour is
unchanged. The reranking region check now refuses an unavailable `(region, model)` pair that
previously passed the check and then failed at the API — a clearer failure for a request that
could not have succeeded.

**RFC issue number**: n/a — this is a fix plus a tool on an existing server, not a new server.

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Notes for reviewers

- `memoryConfiguration` exists on `AgenticRetrieveStream` in newer models but is not in the
  public botocore version pinned here, so it is not exposed. Straightforward to add later.
- The agentic tool is registered unconditionally. If you would prefer it behind an
  environment flag like `BEDROCK_KB_RERANKING_ENABLED`, say so and I will gate it — it
  invokes a foundation model and so costs more per call than `QueryKnowledgeBases`.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
