### PR TITLE
fix(dynamodb-mcp-server): validate and escape schema names in Python generator

### DIFF
--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/cross_table_validator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/cross_table_validator.py
@@ -18,6 +18,11 @@ This module provides validation for cross_table_access_patterns in schema.json f
 supporting atomic transactions (TransactWrite, TransactGet) and future operation types.
 """
 
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.name_validator import (
+    validate_literal_safe,
+    validate_prose_safe,
+    validate_python_identifier,
+)
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.schema_definitions import (
     ParameterType,
     validate_parameter_core,
@@ -125,6 +130,13 @@ class CrossTableValidator:
             'return_type',
         }
         errors.extend(validate_required_fields(pattern, required_fields, path))
+
+        # The pattern name becomes a generated method name in the transaction service, and the
+        # description is written into its docstring, so both are constrained before rendering.
+        if 'name' in pattern:
+            errors.extend(validate_python_identifier(pattern['name'], f'{path}.name'))
+        if isinstance(pattern.get('description'), str):
+            errors.extend(validate_prose_safe(pattern['description'], f'{path}.description'))
 
         # Validate pattern_id uniqueness (global across all patterns)
         if 'pattern_id' in pattern:
@@ -250,6 +262,13 @@ class CrossTableValidator:
                 entity_inv, entity_path, schema, operation, table_map
             )
             errors.extend(entity_errors)
+
+            # The condition is written into comments in the generated transaction service,
+            # where a newline would end the comment and leave the rest as live code.
+            if isinstance(entity_inv, dict) and isinstance(entity_inv.get('condition'), str):
+                errors.extend(
+                    validate_literal_safe(entity_inv['condition'], f'{entity_path}.condition')
+                )
 
         return errors
 

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/filter_expression_validator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/filter_expression_validator.py
@@ -19,6 +19,9 @@ ensuring fields exist, operators/functions are supported, parameter requirements
 are met, and key attributes are not used in filter expressions.
 """
 
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.name_validator import (
+    validate_literal_safe,
+)
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.schema_definitions import (
     VALID_FILTER_FUNCTIONS,
     VALID_FILTER_LOGICAL_OPERATORS,
@@ -231,6 +234,21 @@ class FilterExpressionValidator:
                 )
             )
             return errors
+
+        # Parameter references are written into the generated method docstring and into
+        # comments describing the filter, so they are checked for characters that would end
+        # the docstring or the comment and leave the remainder as live code.
+        for param_key in ('param', 'param2'):
+            if isinstance(condition.get(param_key), str):
+                errors.extend(
+                    validate_literal_safe(condition[param_key], f'{condition_path}.{param_key}')
+                )
+        if isinstance(condition.get('params'), list):
+            for i, param_ref in enumerate(condition['params']):
+                if isinstance(param_ref, str):
+                    errors.extend(
+                        validate_literal_safe(param_ref, f'{condition_path}.params[{i}]')
+                    )
 
         # Validate parameter requirements
         if operator == 'between':

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/name_validator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/name_validator.py
@@ -1,0 +1,358 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation of schema-supplied names that are interpolated into generated source code.
+
+The generators render source code through Jinja2 with autoescaping disabled, because
+autoescaping is HTML-oriented and would corrupt code syntax. Nothing downstream escapes
+schema values, so every name taken from schema.json reaches the generated source verbatim.
+This module is the gate that makes that safe: a name that could alter the structure of the
+generated code is rejected here, before any template is rendered.
+
+Names land in two kinds of position in the generated code, and each needs a different rule:
+
+Identifier positions
+    Class names, ``def`` names, parameter names, attribute accesses and import names --
+    for example ``class {{ entity_name }}`` and ``{{ field.name }}: str``. Escaping is not
+    possible in an identifier position, so the value must itself be a valid, non-keyword
+    Python identifier. This is not a new restriction in practice: a value that is not an
+    identifier has never produced importable generated code, it produced a SyntaxError or
+    silently broken output.
+
+String-literal positions
+    Values that only ever appear inside a quoted string, a docstring or a comment -- for
+    example ``entity_type="{{ entity_config.entity_type }}"``. DynamoDB itself allows
+    almost any character in an attribute name, so these are deliberately NOT restricted to
+    an identifier; they are checked only for the few characters that let a value escape its
+    enclosing context: quotes and backslashes (which terminate a string literal), and
+    newlines (which end a comment and can close a docstring). Ordinary characters such as
+    spaces, ``#`` and non-ASCII text remain valid.
+
+Key templates
+    ``pk_template`` / ``sk_template`` need a third rule because they are rendered into
+    f-strings, where ``{`` and ``}`` are live expression syntax rather than literal text.
+    A brace region that does not match the supported ``{placeholder}`` form is rejected, so
+    a value like ``{__import__('os').system('...')}`` cannot reach an f-string and execute
+    when the generated module is imported. Note that this is not covered by the placeholder
+    extraction in KeyTemplateParser: that regex matches only a brace region whose contents are
+    word characters, and silently ignores any other brace region, which is the dangerous case.
+"""
+
+import keyword
+import re
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.validation_utils import (
+    ValidationError,
+)
+
+
+# Characters that let a value break out of the context it is interpolated into.
+# Quotes and backslashes terminate or escape a Python string literal; newlines end a
+# comment and can close a docstring, turning the remainder of the value into live code.
+_LITERAL_BREAKING_CHARS: dict[str, str] = {
+    '"': 'double quote',
+    "'": 'single quote',
+    '\\': 'backslash',
+    '\n': 'newline',
+    '\r': 'carriage return',
+}
+
+# A brace region inside a key template must be a supported placeholder: a parameter name
+# with an optional format spec, e.g. {user_id} or {score:05d}. Anything else, including a
+# stray or unmatched brace, is rejected because these templates are rendered into
+# f-strings where braces are executable syntax.
+_PLACEHOLDER_PATTERN = re.compile(r'\{(\w+)(?::[^{}]*)?\}')
+_ANY_BRACE_REGION = re.compile(r'\{[^{}]*\}|[{}]')
+
+# A value that is concatenated into a larger identifier only has to be made of identifier
+# characters; it may start with a digit because it never stands alone.
+_IDENTIFIER_FRAGMENT_PATTERN = re.compile(r'[A-Za-z0-9_]+')
+
+
+def _describe_breaking_chars(value: str) -> list[str]:
+    """Return human-readable names of the literal-breaking characters present in value."""
+    return [name for char, name in _LITERAL_BREAKING_CHARS.items() if char in value]
+
+
+def validate_python_identifier(value: object, field_path: str) -> list[ValidationError]:
+    """Validate a name that reaches an identifier position in the generated code.
+
+    Args:
+        value: The name to validate
+        field_path: Full field path for error messages, e.g. 'tables[0].entities.User'
+
+    Returns:
+        List of validation errors, empty when the name is a safe identifier
+    """
+    if not isinstance(value, str):
+        return [
+            ValidationError(
+                path=field_path,
+                message=f'Name must be a string, found {type(value).__name__}',
+                suggestion='Use a string that is a valid Python identifier',
+            )
+        ]
+
+    if not value.isidentifier():
+        return [
+            ValidationError(
+                path=field_path,
+                message=(
+                    f"Name '{value}' is not a valid Python identifier, so it cannot be used "
+                    'in generated code'
+                ),
+                suggestion=(
+                    'Use only letters, digits and underscores, and do not start with a digit'
+                ),
+            )
+        ]
+
+    # Soft keywords (match, case, type, _) are only reserved in specific syntactic
+    # positions, but they are rejected here too: they are never a sensible name and
+    # allowing them would make the safety of the generated code depend on context.
+    if keyword.iskeyword(value) or keyword.issoftkeyword(value):
+        return [
+            ValidationError(
+                path=field_path,
+                message=f"Name '{value}' is a reserved Python keyword",
+                suggestion='Choose a name that is not a Python keyword',
+            )
+        ]
+
+    return []
+
+
+def validate_identifier_fragment(value: object, field_path: str) -> list[ValidationError]:
+    """Validate a value that is concatenated into a larger generated identifier.
+
+    Used for values that only ever appear as a suffix, such as a GSI name in
+    ``build_gsi_pk_for_lookup_{{ safe_name }}``. Because the value never stands alone it may
+    begin with a digit and may coincide with a keyword -- ``..._lookup_0`` and
+    ``..._lookup_class`` are both valid identifiers -- so only the character set is checked.
+
+    Args:
+        value: The fragment to validate
+        field_path: Full field path for error messages
+
+    Returns:
+        List of validation errors, empty when the fragment is safe to concatenate
+    """
+    if not isinstance(value, str):
+        return [
+            ValidationError(
+                path=field_path,
+                message=f'Name must be a string, found {type(value).__name__}',
+                suggestion='Use a string containing only letters, digits and underscores',
+            )
+        ]
+
+    if not _IDENTIFIER_FRAGMENT_PATTERN.fullmatch(value):
+        return [
+            ValidationError(
+                path=field_path,
+                message=(
+                    f"Name '{value}' cannot be used to build a method name in the generated code"
+                ),
+                suggestion=(
+                    'Use only letters, digits, underscores and hyphens (a hyphen is '
+                    'converted to an underscore)'
+                ),
+            )
+        ]
+
+    return []
+
+
+def validate_literal_safe(
+    value: object, field_path: str, *, allow_braces: bool = False
+) -> list[ValidationError]:
+    """Validate a name that only reaches string-literal, docstring or comment positions.
+
+    Any character DynamoDB permits is accepted except those that would let the value
+    escape its enclosing string literal, docstring or comment.
+
+    Args:
+        value: The value to validate
+        field_path: Full field path for error messages
+        allow_braces: Permit braces, for a key template whose brace regions are checked
+            separately by validate_key_template. Leave this False for every other value:
+            some string-literal positions are f-strings, where a brace executes.
+
+    Returns:
+        List of validation errors, empty when the value cannot break out of a literal
+    """
+    if not isinstance(value, str):
+        return [
+            ValidationError(
+                path=field_path,
+                message=f'Value must be a string, found {type(value).__name__}',
+                suggestion='Use a string value',
+            )
+        ]
+
+    found = _describe_breaking_chars(value)
+
+    # Braces are rejected unless the caller is validating a key template, which uses them
+    # for placeholders and checks each brace region itself. Several values that reach only
+    # string literals (a table name, for example) are also rendered inside f-strings in the
+    # usage examples, where a brace is a live expression rather than literal text, so a
+    # brace alone is enough to inject code without ever closing the quote.
+    if not allow_braces and ('{' in value or '}' in value):
+        found.append('brace')
+
+    if found:
+        return [
+            ValidationError(
+                path=field_path,
+                message=(
+                    f'Value must not contain {", ".join(found)}, because it is written into '
+                    'generated source code'
+                ),
+                suggestion=(
+                    'Remove quote, backslash, newline and brace characters from the value'
+                ),
+            )
+        ]
+
+    return []
+
+
+def validate_prose_safe(value: object, field_path: str) -> list[ValidationError]:
+    """Validate free-text prose, such as an access pattern description.
+
+    Prose is held to a different rule than a name because an apostrophe is ordinary in
+    English ("Get courier's active delivery") and rejecting it would be a pointless
+    restriction. Every position a description reaches is a docstring, a comment or a
+    double-quoted string, so an apostrophe cannot terminate any of them.
+
+    A double quote, backslash and newline are still rejected, and so are braces: one
+    description site is rendered inside an f-string, where a brace is a live expression
+    rather than literal text.
+
+    Args:
+        value: The prose value to validate
+        field_path: Full field path for error messages
+
+    Returns:
+        List of validation errors, empty when the prose cannot break out of its context
+    """
+    if not isinstance(value, str):
+        return [
+            ValidationError(
+                path=field_path,
+                message=f'Value must be a string, found {type(value).__name__}',
+                suggestion='Use a string value',
+            )
+        ]
+
+    found = [
+        name for char, name in _LITERAL_BREAKING_CHARS.items() if char != "'" and char in value
+    ]
+    if '{' in value or '}' in value:
+        found.append('brace')
+
+    if found:
+        return [
+            ValidationError(
+                path=field_path,
+                message=(
+                    f'Value must not contain {", ".join(found)}, because it is written into '
+                    'generated source code'
+                ),
+                suggestion=(
+                    'Remove double quote, backslash, newline and brace characters; an '
+                    'apostrophe is allowed'
+                ),
+            )
+        ]
+
+    return []
+
+
+def validate_default_value(value: object, field_path: str) -> list[ValidationError]:
+    """Validate a parameter default, which is rendered into a generated def signature.
+
+    A default is emitted as an expression in the signature, so it is evaluated when the
+    module is imported rather than when the method is called. A string default that escapes
+    its quotes therefore executes at import time.
+
+    Only string defaults need checking. A non-string default taken from JSON is one of
+    int, float, bool, None, list or dict, and is rendered through Python's own repr of the
+    parsed value, which quotes and escapes its contents correctly.
+
+    Args:
+        value: The default value to validate
+        field_path: Full field path for error messages
+
+    Returns:
+        List of validation errors, empty when the default is safe to render
+    """
+    if not isinstance(value, str):
+        return []
+
+    return validate_literal_safe(value, field_path)
+
+
+def validate_key_template(value: object, field_path: str) -> list[ValidationError]:
+    """Validate a pk_template / sk_template value.
+
+    Key templates are rendered into f-strings, so in addition to the literal-safety rule
+    every brace region must be a supported ``{placeholder}`` and every placeholder name
+    must be a usable identifier.
+
+    Args:
+        value: The template to validate
+        field_path: Full field path for error messages
+
+    Returns:
+        List of validation errors, empty when the template is safe to render
+    """
+    errors = validate_literal_safe(value, field_path, allow_braces=True)
+    if errors:
+        return errors
+
+    # validate_literal_safe has already rejected a non-string, but the check is repeated
+    # rather than asserted: an assert is removed under python -O, and this is a security
+    # boundary that must not depend on assertions being enabled.
+    if not isinstance(value, str):
+        return [
+            ValidationError(
+                path=field_path,
+                message=f'Template must be a string, found {type(value).__name__}',
+                suggestion='Use a string template such as USER#{user_id}',
+            )
+        ]
+
+    for region in _ANY_BRACE_REGION.findall(value):
+        if not _PLACEHOLDER_PATTERN.fullmatch(region):
+            return [
+                ValidationError(
+                    path=field_path,
+                    message=(
+                        f"Template '{value}' contains an unsupported brace expression '{region}'"
+                    ),
+                    suggestion=(
+                        'Use placeholders of the form {field_name} or {field_name:format}, '
+                        'and do not use a bare { or } character'
+                    ),
+                )
+            ]
+
+    for placeholder_name in _PLACEHOLDER_PATTERN.findall(value):
+        placeholder_errors = validate_python_identifier(
+            placeholder_name, f'{field_path} placeholder {{{placeholder_name}}}'
+        )
+        if placeholder_errors:
+            return placeholder_errors
+
+    return []

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/name_validator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/name_validator.py
@@ -323,8 +323,9 @@ def validate_key_template(value: object, field_path: str) -> list[ValidationErro
 
     # validate_literal_safe has already rejected a non-string, but the check is repeated
     # rather than asserted: an assert is removed under python -O, and this is a security
-    # boundary that must not depend on assertions being enabled.
-    if not isinstance(value, str):
+    # boundary that must not depend on assertions being enabled. It is unreachable through
+    # this function, hence the coverage exclusion.
+    if not isinstance(value, str):  # pragma: no cover - defensive, unreachable via this path
         return [
             ValidationError(
                 path=field_path,

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/name_validator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/name_validator.py
@@ -317,15 +317,10 @@ def validate_key_template(value: object, field_path: str) -> list[ValidationErro
     Returns:
         List of validation errors, empty when the template is safe to render
     """
-    errors = validate_literal_safe(value, field_path, allow_braces=True)
-    if errors:
-        return errors
-
-    # validate_literal_safe has already rejected a non-string, but the check is repeated
-    # rather than asserted: an assert is removed under python -O, and this is a security
-    # boundary that must not depend on assertions being enabled. It is unreachable through
-    # this function, hence the coverage exclusion.
-    if not isinstance(value, str):  # pragma: no cover - defensive, unreachable via this path
+    # Checked before delegating so the string type is established for the brace scanning
+    # below. validate_literal_safe would also reject a non-string, but relying on that would
+    # leave this function's own type narrowing implicit.
+    if not isinstance(value, str):
         return [
             ValidationError(
                 path=field_path,
@@ -333,6 +328,10 @@ def validate_key_template(value: object, field_path: str) -> list[ValidationErro
                 suggestion='Use a string template such as USER#{user_id}',
             )
         ]
+
+    errors = validate_literal_safe(value, field_path, allow_braces=True)
+    if errors:
+        return errors
 
     for region in _ANY_BRACE_REGION.findall(value):
         if not _PLACEHOLDER_PATTERN.fullmatch(region):

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/schema_definitions.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/schema_definitions.py
@@ -18,6 +18,11 @@ This module defines all the valid values and structures expected in schema.json 
 used for code generation. It serves as the single source of truth for schema validation.
 """
 
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.name_validator import (
+    validate_default_value,
+    validate_prose_safe,
+    validate_python_identifier,
+)
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.validation_utils import (
     ValidationError,
 )
@@ -422,16 +427,30 @@ def validate_parameter_core(
     # Validate parameter name uniqueness
     if 'name' in param:
         param_name = param['name']
-        if param_name in param_names:
-            errors.append(
-                ValidationError(
-                    path=f'{path}.name',
-                    message=f"Duplicate parameter name '{param_name}'",
-                    suggestion='Parameter names must be unique within an access pattern',
+        # The parameter name becomes a generated function parameter and local variable.
+        name_errors = validate_python_identifier(param_name, f'{path}.name')
+        errors.extend(name_errors)
+
+        if not name_errors:
+            if param_name in param_names:
+                errors.append(
+                    ValidationError(
+                        path=f'{path}.name',
+                        message=f"Duplicate parameter name '{param_name}'",
+                        suggestion='Parameter names must be unique within an access pattern',
+                    )
                 )
-            )
-        else:
-            param_names.add(param_name)
+            else:
+                param_names.add(param_name)
+
+    # The default is rendered as an expression in a generated def signature, which Python
+    # evaluates at import time, so an unescaped string default executes on import.
+    if 'default' in param:
+        errors.extend(validate_default_value(param['default'], f'{path}.default'))
+
+    # The parameter description is written into the generated method docstring.
+    if isinstance(param.get('description'), str):
+        errors.extend(validate_prose_safe(param['description'], f'{path}.description'))
 
     # Validate parameter type using shared enum
     if 'type' in param:

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/schema_validator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/core/schema_validator.py
@@ -31,6 +31,13 @@ from awslabs.dynamodb_mcp_server.repo_generation_tool.core.gsi_validator import 
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.key_template_parser import (
     KeyTemplateParser,
 )
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.name_validator import (
+    validate_identifier_fragment,
+    validate_key_template,
+    validate_literal_safe,
+    validate_prose_safe,
+    validate_python_identifier,
+)
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.range_query_validator import (
     RangeQueryValidator,
 )
@@ -50,6 +57,7 @@ from awslabs.dynamodb_mcp_server.repo_generation_tool.core.schema_definitions im
     validate_parameter_core,
     validate_required_fields,
 )
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.utils import to_snake_case
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.validation_utils import (
     ValidationResult,
 )
@@ -209,6 +217,40 @@ class SchemaValidator:
         if 'entities' in table:
             self._validate_entities(table['entities'], f'{path}.entities', table_index)
 
+        # Table-level GSI definitions are not character-checked by GSIValidator, which
+        # validates their structure. Their key attribute names reach Key('...') string
+        # literals in generated query code, and the index name reaches string literals and
+        # comments, so both are checked here.
+        gsi_list = table.get('gsi_list')
+        if isinstance(gsi_list, list):
+            for i, gsi in enumerate(gsi_list):
+                if not isinstance(gsi, dict):
+                    continue
+                gsi_path = f'{path}.gsi_list[{i}]'
+                if isinstance(gsi.get('name'), str):
+                    self.result.add_errors(validate_literal_safe(gsi['name'], f'{gsi_path}.name'))
+                # A GSI key may be a single attribute name or a list of them for a
+                # multi-attribute composite key.
+                for key_field in ('partition_key', 'sort_key'):
+                    key_value = gsi.get(key_field)
+                    if isinstance(key_value, str):
+                        self.result.add_errors(
+                            validate_literal_safe(key_value, f'{gsi_path}.{key_field}')
+                        )
+                    elif isinstance(key_value, list):
+                        for j, attr in enumerate(key_value):
+                            if isinstance(attr, str):
+                                self.result.add_errors(
+                                    validate_literal_safe(attr, f'{gsi_path}.{key_field}[{j}]')
+                                )
+                included = gsi.get('included_attributes')
+                if isinstance(included, list):
+                    for j, attr in enumerate(included):
+                        if isinstance(attr, str):
+                            self.result.add_errors(
+                                validate_literal_safe(attr, f'{gsi_path}.included_attributes[{j}]')
+                            )
+
     def _validate_table_config(self, table_config: Any, path: str = 'table_config') -> None:
         """Validate table_config section."""
         if not isinstance(table_config, dict):
@@ -228,6 +270,15 @@ class SchemaValidator:
                 for error in field_errors:
                     self.result.errors.append(error)
                     self.result.is_valid = False
+
+        # The table name and key attribute names are written into string literals in the
+        # generated code. DynamoDB allows almost any character in an attribute name, so these
+        # are checked only for characters that would break out of the enclosing literal.
+        for field in ('table_name', 'partition_key', 'sort_key'):
+            if isinstance(table_config.get(field), str):
+                self.result.add_errors(
+                    validate_literal_safe(table_config[field], f'{path}.{field}')
+                )
 
     def _validate_entities(
         self, entities: Any, path: str = 'entities', table_index: int = 0
@@ -250,6 +301,12 @@ class SchemaValidator:
 
         # Check for global entity name uniqueness
         for entity_name in entities.keys():
+            # The entity name becomes a generated class name and an import name, so it must
+            # be a usable Python identifier.
+            self.result.add_errors(
+                validate_python_identifier(entity_name, f'{path}.{entity_name}')
+            )
+
             if entity_name in self.global_entity_names:
                 self.result.add_error(
                     f'{path}.{entity_name}',
@@ -296,6 +353,42 @@ class SchemaValidator:
                     f"Missing required field '{field}'",
                     f"Add '{field}' field using template syntax like 'USER#{{user_id}}' or 'PROFILE#{{id}}#{{timestamp}}'. Parameters are automatically extracted from {{field_name}} placeholders",
                 )
+
+        # The entity type reaches string literals in the generated code, and the key templates
+        # are rendered into f-strings where braces are executable syntax.
+        if isinstance(entity_config.get('entity_type'), str):
+            self.result.add_errors(
+                validate_literal_safe(entity_config['entity_type'], f'{path}.entity_type')
+            )
+        for template_field in ('pk_template', 'sk_template'):
+            if isinstance(entity_config.get(template_field), str):
+                self.result.add_errors(
+                    validate_key_template(
+                        entity_config[template_field], f'{path}.{template_field}'
+                    )
+                )
+
+        # A GSI mapping name becomes a suffix of generated method names via to_snake_case,
+        # which does not sanitise, and its key templates are rendered into f-strings.
+        gsi_mappings = entity_config.get('gsi_mappings')
+        if isinstance(gsi_mappings, list):
+            for i, mapping in enumerate(gsi_mappings):
+                if not isinstance(mapping, dict):
+                    continue
+                mapping_path = f'{path}.gsi_mappings[{i}]'
+                if isinstance(mapping.get('name'), str):
+                    self.result.add_errors(
+                        validate_identifier_fragment(
+                            to_snake_case(mapping['name']), f'{mapping_path}.name'
+                        )
+                    )
+                for template_field in ('pk_template', 'sk_template'):
+                    if isinstance(mapping.get(template_field), str):
+                        self.result.add_errors(
+                            validate_key_template(
+                                mapping[template_field], f'{mapping_path}.{template_field}'
+                            )
+                        )
 
         # Validate sk_template if present (it's optional)
         if 'sk_template' in entity_config:
@@ -367,14 +460,22 @@ class SchemaValidator:
         # Validate field name uniqueness
         if 'name' in field:
             field_name = field['name']
-            if field_name in field_names:
-                self.result.add_error(
-                    f'{path}.name',
-                    f"Duplicate field name '{field_name}'",
-                    'Field names must be unique within an entity',
-                )
-            else:
-                field_names.add(field_name)
+            # The field name becomes a class attribute annotation and a keyword argument in
+            # the generated code, so it must be a usable Python identifier.
+            name_errors = validate_python_identifier(field_name, f'{path}.name')
+            self.result.add_errors(name_errors)
+
+            # Only track uniqueness for a name that validated, so that an unusable value
+            # (for example a non-string) is reported once rather than also being compared.
+            if not name_errors:
+                if field_name in field_names:
+                    self.result.add_error(
+                        f'{path}.name',
+                        f"Duplicate field name '{field_name}'",
+                        'Field names must be unique within an entity',
+                    )
+                else:
+                    field_names.add(field_name)
 
         # Validate field type
         if 'type' in field:
@@ -450,14 +551,32 @@ class SchemaValidator:
         # Validate pattern name uniqueness within entity
         if 'name' in pattern:
             pattern_name = pattern['name']
-            if pattern_name in pattern_names:
-                self.result.add_error(
-                    f'{path}.name',
-                    f"Duplicate pattern name '{pattern_name}' in entity '{entity_name}'",
-                    'Pattern names must be unique within an entity',
-                )
-            else:
-                pattern_names.add(pattern_name)
+            # The pattern name becomes a generated method name.
+            name_errors = validate_python_identifier(pattern_name, f'{path}.name')
+            self.result.add_errors(name_errors)
+
+            if not name_errors:
+                if pattern_name in pattern_names:
+                    self.result.add_error(
+                        f'{path}.name',
+                        f"Duplicate pattern name '{pattern_name}' in entity '{entity_name}'",
+                        'Pattern names must be unique within an entity',
+                    )
+                else:
+                    pattern_names.add(pattern_name)
+
+        # The description is written into generated docstrings, comments and double-quoted
+        # strings, so it is held to the prose rule rather than the stricter literal rule.
+        if isinstance(pattern.get('description'), str):
+            self.result.add_errors(
+                validate_prose_safe(pattern['description'], f'{path}.description')
+            )
+
+        # The index name is written into a string literal and a comment in the generated code.
+        if isinstance(pattern.get('index_name'), str):
+            self.result.add_errors(
+                validate_literal_safe(pattern['index_name'], f'{path}.index_name')
+            )
 
         # Validate operation
         if 'operation' in pattern:

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/generators/jinja2_generator.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/generators/jinja2_generator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 from awslabs.dynamodb_mcp_server.repo_generation_tool.core.key_template_parser import (
     KeyTemplateParser,
@@ -69,9 +70,15 @@ class Jinja2Generator(BaseGenerator):
         # This is appropriate because:
         # 1. We're generating source code (Python, TypeScript, etc.), not HTML/XML
         # 2. HTML escaping would corrupt code syntax (e.g., <, >, & in code)
-        # 3. All template inputs come from validated schema files, not user web input
-        # 4. Generated code is written to files, not rendered in browsers
-        # Security: Schema validation ensures all inputs are safe before template rendering
+        # 3. Generated code is written to files, not rendered in browsers
+        #
+        # Security: because nothing is escaped here, schema values must not be able to alter
+        # the structure of the generated code. That is enforced ahead of rendering by
+        # core.name_validator, which is applied during schema validation: names reaching
+        # identifier positions must be valid non-keyword Python identifiers, values reaching
+        # string literals cannot contain quotes, backslashes or newlines, and key templates
+        # may only contain supported {placeholder} brace expressions. Rendering an
+        # unvalidated schema through this environment is not safe.
         self.env = Environment(  # nosec B701 - Content is NOT HTML and NOT served
             loader=FileSystemLoader(templates_dir),
             autoescape=False,  # Explicitly disabled for code generation (not HTML)
@@ -590,7 +597,13 @@ class Jinja2Generator(BaseGenerator):
                     if param.get('default') is not None:
                         default_val = param['default']
                         if isinstance(default_val, str):
-                            default_val = f'"{default_val}"'
+                            # json.dumps produces a correctly escaped double-quoted literal.
+                            # Schema validation already rejects a default that could break
+                            # out of the quotes, but this must not be the only thing standing
+                            # between a schema value and an expression in a def signature,
+                            # which Python evaluates at import time. ensure_ascii is off so
+                            # non-ASCII defaults are not rewritten as escape sequences.
+                            default_val = json.dumps(default_val, ensure_ascii=False)
                         param_str += f' = {default_val}'
                         defaults.append(param_str)
                     else:

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/languages/python/usage_data_formatter.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/repo_generation_tool/languages/python/usage_data_formatter.py
@@ -49,8 +49,19 @@ class PythonUsageDataFormatter(UsageDataFormatterInterface):
             return self._format_string_value(value)
 
     def _escape_string(self, value: str) -> str:
-        """Escape backslashes and quotes in string."""
-        return value.replace('\\', '\\\\').replace('"', '\\"')
+        """Escape a value for embedding in a double-quoted Python string literal.
+
+        Backslashes and double quotes are escaped so the value cannot terminate the literal.
+        Newlines and carriage returns are escaped too: a raw newline inside a single-line
+        literal is a syntax error, so leaving it unescaped turned a usage_data value into
+        broken generated code.
+        """
+        return (
+            value.replace('\\', '\\\\')
+            .replace('"', '\\"')
+            .replace('\r', '\\r')
+            .replace('\n', '\\n')
+        )
 
     def _format_string_value(self, value: Any) -> str:
         """Format value as Python string literal."""

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
@@ -386,6 +386,24 @@ HOSTILE_SCHEMAS = {
         'gsi_list',
         [{'name': "ByX\n    __import__('os').system('id')", 'partition_key': 'gsi_pk'}],
     ),
+    # A composite GSI key is a list of attribute names, each reaching a Key('...') literal.
+    'gsi_list_composite_partition_key': lambda s: s['tables'][0].__setitem__(
+        'gsi_list',
+        [{'name': 'ByX', 'partition_key': ['gsi_pk', PAYLOAD_LITERAL]}],
+    ),
+    'gsi_list_composite_sort_key': lambda s: s['tables'][0].__setitem__(
+        'gsi_list',
+        [{'name': 'ByX', 'partition_key': 'gsi_pk', 'sort_key': ['a', PAYLOAD_LITERAL]}],
+    ),
+    'gsi_list_included_attributes': lambda s: s['tables'][0].__setitem__(
+        'gsi_list',
+        [{
+            'name': 'ByX',
+            'partition_key': 'gsi_pk',
+            'projection_type': 'INCLUDE',
+            'included_attributes': ['ok', PAYLOAD_LITERAL],
+        }],
+    ),
 }
 
 
@@ -433,3 +451,25 @@ class TestGenerationRejectsInjection:
 
         assert not result.success, f'{vector} was not rejected'
         assert not (out_dir / 'entities.py').exists(), f'{vector} wrote generated code'
+
+    def test_malformed_gsi_list_entry_does_not_crash(self, tmp_path):
+        """A gsi_list entry that is not an object is skipped by the name checks.
+
+        Structural validation reports the malformed entry; the name checks must not raise
+        while walking past it.
+        """
+        schema = _schema_with(
+            lambda s: s['tables'][0].__setitem__('gsi_list', ['not-an-object', 42])
+        )
+        schema_path = _write_schema(tmp_path, schema)
+
+        result = generate(
+            str(schema_path),
+            output_dir=str(tmp_path / 'out'),
+            language='python',
+            generate_sample_usage=False,
+            no_lint=True,
+            allowed_base_dirs=[tmp_path],
+        )
+
+        assert not result.success

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
@@ -222,6 +222,26 @@ class TestValidateProseSafe:
         assert validate_prose_safe(value, 'path') != []
 
 
+class TestNonStringValues:
+    """Every validator reports a non-string value rather than raising."""
+
+    @pytest.mark.parametrize(
+        'validator',
+        [
+            validate_identifier_fragment,
+            validate_literal_safe,
+            validate_prose_safe,
+            validate_key_template,
+        ],
+    )
+    @pytest.mark.parametrize('value', [None, 1, [], {}, True])
+    def test_reports_non_string(self, validator, value):
+        """A non-string is rejected with an error, not an exception."""
+        errors = validator(value, 'path')
+        assert len(errors) == 1
+        assert errors[0].path == 'path'
+
+
 BENIGN_SCHEMA = {
     'tables': [
         {

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
@@ -397,12 +397,14 @@ HOSTILE_SCHEMAS = {
     ),
     'gsi_list_included_attributes': lambda s: s['tables'][0].__setitem__(
         'gsi_list',
-        [{
-            'name': 'ByX',
-            'partition_key': 'gsi_pk',
-            'projection_type': 'INCLUDE',
-            'included_attributes': ['ok', PAYLOAD_LITERAL],
-        }],
+        [
+            {
+                'name': 'ByX',
+                'partition_key': 'gsi_pk',
+                'projection_type': 'INCLUDE',
+                'included_attributes': ['ok', PAYLOAD_LITERAL],
+            }
+        ],
     ),
 }
 

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_name_validator.py
@@ -1,0 +1,415 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for name validation of values interpolated into generated source code.
+
+The generators render code with Jinja2 autoescaping disabled, so a schema name that can
+alter the structure of the generated code must be rejected during schema validation. These
+tests cover the validator directly and then assert end to end that a hostile schema does not
+produce a generated file.
+"""
+
+import copy
+import json
+import keyword
+import pytest
+from awslabs.dynamodb_mcp_server.repo_generation_tool.codegen import generate
+from awslabs.dynamodb_mcp_server.repo_generation_tool.core.name_validator import (
+    validate_default_value,
+    validate_identifier_fragment,
+    validate_key_template,
+    validate_literal_safe,
+    validate_prose_safe,
+    validate_python_identifier,
+)
+
+
+class TestValidatePythonIdentifier:
+    """Names that reach identifier positions must be usable Python identifiers."""
+
+    @pytest.mark.parametrize('value', ['user_id', 'User', '_private', 'a1', 'CamelCase'])
+    def test_accepts_valid_identifiers(self, value):
+        """A valid, non-keyword identifier is accepted."""
+        assert validate_python_identifier(value, 'path') == []
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            'has space',
+            '1leading_digit',
+            'has-hyphen',
+            'has.dot',
+            '',
+            'trailing_newline\n',
+            "_ = None\n    __import__('os').system('id')\n    _j",
+            'quote"inside',
+        ],
+    )
+    def test_rejects_non_identifiers(self, value):
+        """A value that is not a valid identifier is rejected."""
+        errors = validate_python_identifier(value, 'path')
+        assert len(errors) == 1
+        assert errors[0].path == 'path'
+
+    @pytest.mark.parametrize('value', ['class', 'def', 'import', 'return', 'lambda'])
+    def test_rejects_keywords(self, value):
+        """A reserved keyword is rejected."""
+        assert validate_python_identifier(value, 'path') != []
+
+    @pytest.mark.parametrize('value', keyword.softkwlist)
+    def test_rejects_soft_keywords(self, value):
+        """A soft keyword is rejected.
+
+        Which names are soft keywords depends on the Python version, so the set is taken
+        from the keyword module rather than hard-coded.
+        """
+        if not value.isidentifier():
+            pytest.skip(f'{value!r} is not an identifier on this Python version')
+        assert validate_python_identifier(value, 'path') != []
+
+    @pytest.mark.parametrize('value', [None, 1, [], {}])
+    def test_rejects_non_strings(self, value):
+        """A non-string value is reported rather than raising."""
+        assert validate_python_identifier(value, 'path') != []
+
+
+class TestValidateIdentifierFragment:
+    """Names concatenated into a larger identifier only need identifier characters."""
+
+    @pytest.mark.parametrize('value', ['ByEmail', '0', 'a_b', '2024', 'x1'])
+    def test_accepts_identifier_characters(self, value):
+        """A fragment may start with a digit because it never stands alone."""
+        assert validate_identifier_fragment(value, 'path') == []
+
+    @pytest.mark.parametrize('value', ['{', 'has space', 'a(b', 'x\ny', '', 'a"b'])
+    def test_rejects_other_characters(self, value):
+        """A fragment containing anything else is rejected."""
+        assert validate_identifier_fragment(value, 'path') != []
+
+
+class TestValidateLiteralSafe:
+    """Values reaching string literals may be anything that cannot break out of one."""
+
+    @pytest.mark.parametrize(
+        'value',
+        ['pk', 'attr name', 'has-hyphen', 'has.dot', 'unicode café', 'hash#inside'],
+    )
+    def test_accepts_values_that_cannot_escape_a_literal(self, value):
+        """DynamoDB permits these, and none of them can terminate a literal."""
+        assert validate_literal_safe(value, 'path') == []
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            'ends"here',
+            "ends'here",
+            'back\\slash',
+            'new\nline',
+            'carriage\rreturn',
+            'Users"; __import__("os").system("id"); x = "',
+            # Braces are rejected because several string-literal sites are f-strings, where
+            # a brace is a live expression and no quote needs to be closed.
+            'a{b}',
+            'Users{__import__("os").system("id")}',
+        ],
+    )
+    def test_rejects_literal_breaking_characters(self, value):
+        """Quotes, backslashes, newlines and braces are rejected."""
+        assert validate_literal_safe(value, 'path') != []
+
+    def test_allows_braces_when_caller_opts_in(self):
+        """A key template checks its own brace regions, so it opts out of the brace rule."""
+        assert validate_literal_safe('USER#{id}', 'path', allow_braces=True) == []
+        assert validate_literal_safe('USER#{id}', 'path') != []
+
+
+class TestValidateDefaultValue:
+    """A parameter default is an expression in a def signature, evaluated at import."""
+
+    @pytest.mark.parametrize('value', ['abc', 'a b', 10, 1.5, True, None, [], {}])
+    def test_accepts_safe_defaults(self, value):
+        """Ordinary defaults, including non-strings, are accepted."""
+        assert validate_default_value(value, 'path') == []
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            '" or __import__("os").system("id") or "',
+            'a"b',
+            'back\\slash',
+            'new\nline',
+            'brace{here}',
+        ],
+    )
+    def test_rejects_string_defaults_that_escape_the_literal(self, value):
+        """A string default that can break out of its quotes is rejected."""
+        assert validate_default_value(value, 'path') != []
+
+
+class TestValidateKeyTemplate:
+    """Key templates are rendered into f-strings, so braces are executable syntax."""
+
+    @pytest.mark.parametrize(
+        'value',
+        ['USER#{user_id}', 'PROFILE#{id}#{ts}', 'STATIC', '{score:05d}', '{price:.2f}'],
+    )
+    def test_accepts_supported_placeholders(self, value):
+        """Supported placeholder forms, including format specs, are accepted."""
+        assert validate_key_template(value, 'path') == []
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            # A brace expression that is not a placeholder becomes a live f-string
+            # expression. KeyTemplateParser's own regex ignores these, which is why they
+            # must be rejected here.
+            "USER#{__import__('os').system('id')}",
+            '{obj.attr}',
+            'unmatched{',
+            'unmatched}',
+            'A#{user_id}}',
+            '{}',
+            # A placeholder name that is not a usable identifier reaches a lambda parameter.
+            '{1bad}',
+            # Breaking out of the enclosing f-string quote.
+            'USER#{user_id}"; __import__("os").system("id"); #',
+        ],
+    )
+    def test_rejects_unsupported_brace_expressions(self, value):
+        """Anything other than a supported placeholder is rejected."""
+        assert validate_key_template(value, 'path') != []
+
+
+class TestValidateProseSafe:
+    """Descriptions are prose, so an apostrophe is allowed but break-out characters are not."""
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            "Get courier's current active delivery",
+            'Update a record (idempotent) - see docs',
+            'Fetch by id & status, 50% of the time',
+            'unicode café',
+        ],
+    )
+    def test_accepts_ordinary_prose(self, value):
+        """Real descriptions, including apostrophes, are accepted."""
+        assert validate_prose_safe(value, 'path') == []
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            'ends"here',
+            'back\\slash',
+            'new\nline',
+            'brace{here}',
+            'd"""\n    __import__("os").system("id")\n    """',
+        ],
+    )
+    def test_rejects_break_out_characters(self, value):
+        """Double quotes, backslashes, newlines and braces are rejected."""
+        assert validate_prose_safe(value, 'path') != []
+
+
+BENIGN_SCHEMA = {
+    'tables': [
+        {
+            'table_config': {
+                'table_name': 'Users',
+                # A space is legal in a DynamoDB attribute name and must stay accepted.
+                'partition_key': 'attr name',
+                'sort_key': 'sk',
+            },
+            'entities': {
+                'User': {
+                    'entity_type': 'USER',
+                    'pk_template': 'USER#{user_id}',
+                    'sk_template': 'PROFILE#{created_at}',
+                    'fields': [
+                        {'name': 'user_id', 'type': 'string', 'required': True},
+                        {'name': 'created_at', 'type': 'string', 'required': True},
+                    ],
+                    'access_patterns': [
+                        {
+                            'pattern_id': 1,
+                            'name': 'get_user',
+                            'description': "Fetch a user's record",
+                            'operation': 'GetItem',
+                            'return_type': 'single_entity',
+                            'parameters': [{'name': 'user_id', 'type': 'string'}],
+                        }
+                    ],
+                }
+            },
+        }
+    ]
+}
+
+
+def _schema_with(mutate):
+    """Return a copy of the benign schema with a mutation applied."""
+    schema = copy.deepcopy(BENIGN_SCHEMA)
+    mutate(schema)
+    return schema
+
+
+def _entity(schema):
+    """Return the single entity config from a schema copy."""
+    return schema['tables'][0]['entities']['User']
+
+
+PAYLOAD_IDENTIFIER = "_ = None\n    __import__('os').system('id')\n    _j"
+PAYLOAD_LITERAL = 'x"; __import__("os").system("id"); y = "'
+
+
+HOSTILE_SCHEMAS = {
+    'field_name': lambda s: _entity(s)['fields'].append(
+        {'name': PAYLOAD_IDENTIFIER, 'type': 'string', 'required': False}
+    ),
+    'entity_name': lambda s: s['tables'][0]['entities'].update(
+        {"Bad:\n    __import__('os').system('id')\nclass X": _entity(s)}
+    ),
+    'pk_template_brace': lambda s: _entity(s).__setitem__(
+        'pk_template', "USER#{__import__('os').system('id')}"
+    ),
+    'pk_template_quote': lambda s: _entity(s).__setitem__(
+        'pk_template', 'USER#{user_id}"; __import__("os").system("id"); #'
+    ),
+    'entity_type': lambda s: _entity(s).__setitem__('entity_type', PAYLOAD_LITERAL),
+    'table_name': lambda s: s['tables'][0]['table_config'].__setitem__(
+        'table_name', PAYLOAD_LITERAL
+    ),
+    'partition_key': lambda s: s['tables'][0]['table_config'].__setitem__(
+        'partition_key', PAYLOAD_LITERAL
+    ),
+    'pattern_name': lambda s: _entity(s)['access_patterns'][0].__setitem__(
+        'name', PAYLOAD_IDENTIFIER
+    ),
+    'pattern_description': lambda s: _entity(s)['access_patterns'][0].__setitem__(
+        'description', 'd"""\n    __import__("os").system("id")\n    """'
+    ),
+    'parameter_name': lambda s: _entity(s)['access_patterns'][0]['parameters'].append(
+        {'name': PAYLOAD_IDENTIFIER, 'type': 'string'}
+    ),
+    'gsi_mapping_name': lambda s: _entity(s).__setitem__(
+        'gsi_mappings', [{'name': PAYLOAD_IDENTIFIER, 'pk_template': '{user_id}'}]
+    ),
+    'gsi_mapping_template': lambda s: _entity(s).__setitem__(
+        'gsi_mappings',
+        [{'name': 'ByEmail', 'pk_template': "E#{__import__('os').system('id')}"}],
+    ),
+    'index_name_newline': lambda s: _entity(s)['access_patterns'][0].__setitem__(
+        'index_name', "ix\n    __import__('os').system('id')"
+    ),
+    # Cross-table patterns drive the transaction service template, where the pattern name
+    # becomes a def name and the description becomes its docstring.
+    'cross_table_pattern_name': lambda s: s.__setitem__(
+        'cross_table_access_patterns',
+        [
+            {
+                'pattern_id': 90,
+                'name': PAYLOAD_IDENTIFIER,
+                'description': 'x',
+                'operation': 'TransactWrite',
+                'entities_involved': ['User'],
+                'parameters': [{'name': 'user_id', 'type': 'string'}],
+                'return_type': 'success_flag',
+            }
+        ],
+    ),
+    'cross_table_pattern_description': lambda s: s.__setitem__(
+        'cross_table_access_patterns',
+        [
+            {
+                'pattern_id': 91,
+                'name': 'do_tx',
+                'description': 'd"""\n    __import__("os").system("id")\n    """',
+                'operation': 'TransactWrite',
+                'entities_involved': ['User'],
+                'parameters': [{'name': 'user_id', 'type': 'string'}],
+                'return_type': 'success_flag',
+            }
+        ],
+    ),
+    # A parameter default is rendered into a def signature, which Python evaluates at import.
+    'parameter_default': lambda s: _entity(s)['access_patterns'][0]['parameters'][0].__setitem__(
+        'default', '" or __import__("os").system("id") or "'
+    ),
+    # A parameter description reaches the generated method docstring.
+    'parameter_description': lambda s: _entity(s)['access_patterns'][0]['parameters'][
+        0
+    ].__setitem__('description', 'd"""\n    __import__("os").system("id")\n    """'),
+    # A brace in a table name is a live expression in the usage-example f-strings.
+    'table_name_brace': lambda s: s['tables'][0]['table_config'].__setitem__(
+        'table_name', 'Users{__import__("os").system("id")}'
+    ),
+    'partition_key_brace': lambda s: s['tables'][0]['table_config'].__setitem__(
+        'partition_key', 'pk{__import__("os").system("id")}'
+    ),
+    # Table-level GSI key attributes reach Key('...') literals in generated query code.
+    'gsi_list_partition_key': lambda s: s['tables'][0].__setitem__(
+        'gsi_list',
+        [{'name': 'ByX', 'partition_key': PAYLOAD_LITERAL, 'sort_key': 'gsi_sk'}],
+    ),
+    'gsi_list_name': lambda s: s['tables'][0].__setitem__(
+        'gsi_list',
+        [{'name': "ByX\n    __import__('os').system('id')", 'partition_key': 'gsi_pk'}],
+    ),
+}
+
+
+def _write_schema(tmp_path, schema):
+    """Write a schema dict to tmp_path and return its path."""
+    schema_path = tmp_path / 'schema.json'
+    schema_path.write_text(json.dumps(schema), encoding='utf-8')
+    return schema_path
+
+
+class TestGenerationRejectsInjection:
+    """A hostile schema must not produce generated code."""
+
+    def test_benign_schema_still_generates(self, tmp_path):
+        """The fix must not reject a legitimate schema."""
+        schema_path = _write_schema(tmp_path, copy.deepcopy(BENIGN_SCHEMA))
+        out_dir = tmp_path / 'out'
+
+        result = generate(
+            str(schema_path),
+            output_dir=str(out_dir),
+            language='python',
+            generate_sample_usage=False,
+            no_lint=True,
+            allowed_base_dirs=[tmp_path],
+        )
+
+        assert result.success, [e.message for e in result.validation_result.errors]
+        assert (out_dir / 'entities.py').exists()
+
+    @pytest.mark.parametrize('vector', sorted(HOSTILE_SCHEMAS))
+    def test_hostile_schema_is_rejected_before_rendering(self, vector, tmp_path):
+        """Each injection vector fails validation and writes no code."""
+        schema_path = _write_schema(tmp_path, _schema_with(HOSTILE_SCHEMAS[vector]))
+        out_dir = tmp_path / 'out'
+
+        result = generate(
+            str(schema_path),
+            output_dir=str(out_dir),
+            language='python',
+            generate_sample_usage=False,
+            no_lint=True,
+            allowed_base_dirs=[tmp_path],
+        )
+
+        assert not result.success, f'{vector} was not rejected'
+        assert not (out_dir / 'entities.py').exists(), f'{vector} wrote generated code'

--- a/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_schema_validator.py
+++ b/src/dynamodb-mcp-server/tests/repo_generation_tool/unit/test_schema_validator.py
@@ -986,7 +986,11 @@ class TestSchemaValidator:
 
     @given(
         operation=st.sampled_from(['Query', 'Scan']),
-        index_name=st.text(min_size=1, max_size=50).filter(lambda x: x.strip() != ''),
+        # A GSI name becomes a suffix of generated method names, so it is restricted to
+        # identifier characters and hyphens. This property is about consistent_read rather
+        # than naming, so the strategy generates names that are usable in generated code;
+        # rejection of unusable names is covered by the name validator's own tests.
+        index_name=st.from_regex(r'[A-Za-z][A-Za-z0-9_-]{0,20}', fullmatch=True),
         consistent_read=st.one_of(st.just(False), st.none()),
     )
     def test_property_gsi_queries_accept_consistent_read_false_or_omitted(


### PR DESCRIPTION
## Summary

The Python data-access-layer generator (`repo_generation_tool`) renders source code through
Jinja2 with autoescaping disabled, and nothing downstream escaped schema values, so values
from `schema.json` were written into the generated code verbatim.

Schema validation did not prevent this. It checked required fields, JSON types, enum values
and uniqueness, but applied no character or identifier constraint to any name — while a
comment in `jinja2_generator.py` asserted the opposite ("Schema validation ensures all inputs
are safe before template rendering"). That comment is corrected here.

This applies to the Python generator the same discipline #4384 applied to the CDK generator.
Values are constrained during schema validation, which already gates rendering (`generate()`
returns before `create_generator()` when validation fails), so an invalid schema is rejected
before any template runs.

## Approach

A new `core/name_validator.py` holds the rules, applied according to where a value lands in
the generated code — the position determines what is possible, so one rule does not fit all:

| Position | Rule | Applies to |
|---|---|---|
| Identifier (class/def/attribute/import name) | must be a valid non-keyword Python identifier | entity names, field names, access pattern names, parameter names, key template placeholders |
| Identifier fragment (method-name suffix) | identifier characters only; may start with a digit | GSI names |
| String literal / docstring / comment | no quotes, backslashes, newlines or braces | table names, key attribute names, entity types, index names |
| Prose | as above but apostrophes allowed | descriptions |

Escaping is impossible in an identifier position, which is why those values must be rejected
rather than escaped. Conversely, DynamoDB permits almost any character in an attribute name,
so string-literal positions are *not* restricted to an identifier — spaces and non-ASCII text
remain valid.

Braces are rejected in string-literal positions because several of those positions are
f-strings, where a brace is a live expression rather than literal text.

Key templates are validated separately: they are rendered into f-strings, so a brace region
that is not a supported `{placeholder}` is rejected. The existing placeholder regex matches
only word-character placeholders and silently ignores any other brace region, so such a region
previously reached an f-string unchecked.

## Sinks covered

Beyond the names above, these reached generated code and no validator visited them:

- parameter `default` — rendered into a generated `def` signature. Validated here, and the
  generator now also escapes it with `json.dumps` so correctness does not rest on validation
  alone.
- parameter `description` — reaches the generated method docstring.
- `filter_expression` `param` / `param2` / `params[]` — reach a docstring and comments.
- cross-table pattern `name` and `description` — reach a `def` name and its docstring in the
  transaction service.
- `entities_involved[].condition` — reaches comments in the transaction service.
- table-level `gsi_list` entries — `GSIValidator` validated their structure but never their
  characters, while their key attribute names reach generated query code.

Separately, the `usage_data` string escaper handled backslashes and double quotes but not
newlines, so a newline in a sample value produced an unterminated string literal in the
generated example. It now escapes newlines and carriage returns too.

Confirmed already constrained and deliberately left alone: `range_condition` and
`projection_type` are restricted to enum allowlists; `item_type` is never interpolated and
unknown values map to `Any`; parameter `entity_type` and `entities_involved[].entity` are
membership-checked against entity names, which this change makes safe.

## Behaviour change

A schema whose entity or field names are not valid Python identifiers is now rejected with a
clear validation error instead of producing code that cannot be imported. Worth a release note.

## Testing

- New `tests/repo_generation_tool/unit/test_name_validator.py`: unit coverage per rule plus
  end-to-end assertions that a schema targeting each sink fails validation and writes no file.
- Verified per sink that a payload which previously reached generated code is now rejected. For
  the two that produced executable output, executability was confirmed beforehand by parsing
  the generated file and finding the payload as a live AST node rather than as text in a
  comment — and after the change both are rejected during validation.
- Legitimate schemas still generate unchanged, including an attribute name containing a space
  and a description containing an apostrophe (36 of the 447 descriptions in the repo fixtures
  contain apostrophes, which is why prose allows them).
- Full package suite: 1582 passed. `ruff check`, `ruff format --check` and `pyright` clean.
- `pre-commit` could not run end to end in my environment: its `gitleaks` hook cannot fetch Go
  modules through my network. The Python hooks it wraps (`ruff`, `pyright`) were run directly.

One pre-existing property test asserted that arbitrary text is a valid GSI name, which encoded
the unsafe behaviour; its strategy is narrowed to names usable in generated code, with
rejection covered by the new tests.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
