### PR TITLE
feat(mysql-mcp-server): restore --secret_arn for custom-secret auth (#3643, #4099)

### DIFF
--- a/src/mysql-mcp-server/README.md
+++ b/src/mysql-mcp-server/README.md
@@ -155,6 +155,23 @@ The MCP server uses the AWS profile specified in the AWS_PROFILE environment var
 
 Make sure the AWS profile has permissions to access the RDS Data API and the secret from AWS Secrets Manager. Wire-protocol methods (`mysqlwire` / `mysqlwire_iam`) additionally require `rds:DescribeDBClusters` / `rds:DescribeDBInstances` — see the prerequisites above. The MCP server creates a boto3 session using the specified profile to authenticate with AWS services. Your AWS IAM credentials remain on your local machine and are strictly used for accessing AWS services.
 
+#### Connecting as a least-privilege user with `--secret_arn`
+
+By default, `mysqlwire` and `rdsapi` connections read credentials from the
+cluster/instance's AWS-managed `MasterUserSecret`, which connects as the master
+user (full privileges). To connect as a dedicated least-privilege user instead
+(for example a read-only `GRANT SELECT` user), store that user's credentials in
+an AWS Secrets Manager secret and pass its ARN with `--secret_arn`:
+
+```
+uvx awslabs.mysql-mcp-server@latest --secret_arn arn:aws:secretsmanager:us-east-1:123456789012:secret:my-readonly-user
+```
+
+When provided, `--secret_arn` overrides the managed `MasterUserSecret` for the
+`mysqlwire` (non-IAM) and `rdsapi` methods. It is ignored for `mysqlwire_iam`,
+which authenticates via IAM and uses no secret. The secret must be a standard
+RDS-style secret containing at least `username` and `password`.
+
 ## Security model
 
 > **The server's read-only mode is a best-effort SQL-text safeguard, not a security boundary.**

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
@@ -63,6 +63,14 @@ readonly_query = True
 # Amazon RDS global bundle (verified against a pinned hash) is used.
 ca_bundle_path: Optional[str] = None
 
+# Operator-supplied Secrets Manager secret ARN. Set by the CLI flag
+# --secret_arn on server start. When provided, credentials are read from this
+# secret instead of the cluster/instance's AWS-managed ``MasterUserSecret``,
+# which lets the server connect as a dedicated least-privilege user rather than
+# the master user. When empty/None, the managed MasterUserSecret ARN is used
+# (the historical default). Not used by the IAM-auth connection method.
+configured_secret_arn: Optional[str] = None
+
 
 class DummyCtx(Context):
     """A dummy context class for error handling in MCP tools."""
@@ -627,6 +635,7 @@ def internal_connect_to_database(
     global db_connection_map
     global readonly_query
     global ca_bundle_path
+    global configured_secret_arn
 
     logger.info(
         f'Enter internal_connect_to_database\n'
@@ -792,6 +801,14 @@ def internal_connect_to_database(
         if existing_conn:
             return (existing_conn, _connected_response())
 
+    # If the operator supplied an explicit --secret_arn, use it instead of the
+    # AWS-managed MasterUserSecret ARN derived above. This restores the ability
+    # (removed in 1.0.21) to connect as a dedicated least-privilege user via a
+    # custom secret, and matches mssql-mcp-server. The IAM-auth method uses no
+    # secret, so it is unaffected (its secret_arn is forced to '' below).
+    if configured_secret_arn:
+        secret_arn = configured_secret_arn
+
     logger.info(
         f'About to create internal DB connections with:'
         f'enable_data_api:{enable_data_api}\n'
@@ -873,6 +890,7 @@ def main():
     global db_connection_map
     global readonly_query
     global ca_bundle_path
+    global configured_secret_arn
 
     parser = argparse.ArgumentParser(
         description='An AWS Labs Model Context Protocol (MCP) server for MySQL'
@@ -909,6 +927,20 @@ def main():
             'rotates CAs faster than the package release cadence.'
         ),
     )
+    parser.add_argument(
+        '--secret_arn',
+        default=None,
+        help=(
+            'ARN of an AWS Secrets Manager secret holding the database '
+            'credentials to connect with. When provided, it overrides the '
+            "cluster/instance's AWS-managed MasterUserSecret, letting the "
+            'server connect as a dedicated least-privilege user (e.g. a '
+            'read-only user) instead of the master user. Applies to the '
+            'RDS_API and MYSQL_WIRE_PROTOCOL connection methods; ignored for '
+            'MYSQL_WIRE_IAM_PROTOCOL, which uses IAM authentication and no '
+            'secret.'
+        ),
+    )
     args = parser.parse_args()
 
     logger.info(
@@ -925,6 +957,7 @@ def main():
 
     readonly_query = not args.allow_write_query
     ca_bundle_path = args.ca_bundle
+    configured_secret_arn = args.secret_arn
 
     try:
         if args.db_type:

--- a/src/mysql-mcp-server/tests/test_server.py
+++ b/src/mysql-mcp-server/tests/test_server.py
@@ -349,6 +349,114 @@ class TestInternalConnectToDatabaseRouting:
         # The --ca_bundle override must reach the constructor via the real path.
         assert kwargs['ca_bundle_path'] == '/tmp/operator-supplied.pem'
 
+    @patch('awslabs.mysql_mcp_server.server.configured_secret_arn', 'arn:operator-secret')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
+    @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
+    def test_operator_secret_arn_overrides_master_user_secret_wire(
+        self, mock_pool_cls, mock_get_props, mock_map
+    ):
+        """--secret_arn overrides the AWS-managed MasterUserSecret on the wire path.
+
+        Regression guard for issues #3643 / #4099: when the operator supplies a
+        custom secret ARN, MYSQL_WIRE_PROTOCOL must connect with THAT secret
+        (a dedicated least-privilege user), not the cluster's MasterUserSecret
+        (the master user). Reverting the server.py override makes this fail.
+        """
+        from awslabs.mysql_mcp_server.server import internal_connect_to_database
+
+        mock_map.get.return_value = None
+        mock_get_props.return_value = {
+            'MasterUsername': 'admin',
+            'DBClusterArn': 'arn:aws:rds:us-east-1:123:cluster:my-cluster',
+            'MasterUserSecret': {'SecretArn': 'arn:master-user-secret'},
+            'Endpoint': 'ep.rds.amazonaws.com',
+            'Port': '3306',
+            'HttpEndpointEnabled': False,
+        }
+
+        internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.AURORA_MYSQL,
+            connection_method=ConnectionMethod.MYSQL_WIRE_PROTOCOL,
+            cluster_identifier='my-cluster',
+            db_endpoint='ep.rds.amazonaws.com',
+            port=3306,
+            database='app',
+        )
+
+        kwargs = mock_pool_cls.call_args.kwargs
+        assert kwargs['secret_arn'] == 'arn:operator-secret'
+        assert kwargs['secret_arn'] != 'arn:master-user-secret'
+
+    @patch('awslabs.mysql_mcp_server.server.configured_secret_arn', 'arn:operator-secret')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
+    @patch('awslabs.mysql_mcp_server.server.RDSDataAPIConnection')
+    @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
+    def test_operator_secret_arn_overrides_master_user_secret_rds_api(
+        self, mock_pool_cls, mock_rds_cls, mock_get_props, mock_map
+    ):
+        """--secret_arn also overrides MasterUserSecret on the RDS Data API path."""
+        from awslabs.mysql_mcp_server.server import internal_connect_to_database
+
+        mock_map.get.return_value = None
+        mock_get_props.return_value = {
+            'MasterUsername': 'admin',
+            'DBClusterArn': 'arn:aws:rds:us-east-1:123:cluster:my-cluster',
+            'MasterUserSecret': {'SecretArn': 'arn:master-user-secret'},
+            'Endpoint': 'ep.rds.amazonaws.com',
+            'Port': '3306',
+            'HttpEndpointEnabled': True,
+        }
+
+        internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.AURORA_MYSQL,
+            connection_method=ConnectionMethod.RDS_API,
+            cluster_identifier='my-cluster',
+            db_endpoint='ep.rds.amazonaws.com',
+            port=3306,
+            database='app',
+        )
+
+        kwargs = mock_rds_cls.call_args.kwargs
+        assert kwargs['secret_arn'] == 'arn:operator-secret'
+
+    @patch('awslabs.mysql_mcp_server.server.configured_secret_arn', 'arn:operator-secret')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
+    @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
+    def test_operator_secret_arn_ignored_for_iam_auth(
+        self, mock_pool_cls, mock_get_props, mock_map
+    ):
+        """--secret_arn must NOT leak into IAM auth, which uses no secret."""
+        from awslabs.mysql_mcp_server.server import internal_connect_to_database
+
+        mock_map.get.return_value = None
+        mock_get_props.return_value = {
+            'MasterUsername': 'admin',
+            'DBClusterArn': 'arn:aws:rds:us-east-1:123:cluster:my-cluster',
+            'MasterUserSecret': {'SecretArn': 'arn:master-user-secret'},
+            'Endpoint': 'ep.rds.amazonaws.com',
+            'Port': '3306',
+            'HttpEndpointEnabled': False,
+        }
+
+        internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.AURORA_MYSQL,
+            connection_method=ConnectionMethod.MYSQL_WIRE_IAM_PROTOCOL,
+            cluster_identifier='my-cluster',
+            db_endpoint='ep.rds.amazonaws.com',
+            port=3306,
+            database='app',
+        )
+
+        kwargs = mock_pool_cls.call_args.kwargs
+        assert kwargs['is_iam_auth'] is True
+        assert kwargs['secret_arn'] == ''
+
     @patch('awslabs.mysql_mcp_server.server.db_connection_map')
     @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties')
     @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')


### PR DESCRIPTION
## Issues

Fixes #3643. Closes #4099.

## Problem

`mysql-mcp-server` **1.0.21** removed the ability to authenticate with an operator-supplied Secrets Manager secret: `secret_arn` is now derived **exclusively** from the cluster/instance's AWS-managed `MasterUserSecret`. This silently forces connections as the **master user** — a privilege regression (#3643) for setups that previously connected as a dedicated least-privilege user (e.g. read-only) via a custom secret. `mssql-mcp-server` still supports `--secret_arn`, so the two servers are also out of parity (#4099).

The connection layer (`AsyncmyPoolConnection` / `RDSDataAPIConnection`) already accepts an arbitrary `secret_arn` — `server.py` simply never exposed a way to set it.

## Fix

- Add a `--secret_arn` CLI flag, wired exactly like the existing `--ca_bundle` (module global `configured_secret_arn`, declared in `internal_connect_to_database` and `main`, set from `args.secret_arn`).
- When provided, it **overrides** the derived `MasterUserSecret` ARN for the `mysqlwire` (non-IAM) and `rdsapi` methods.
- It is **ignored for `mysqlwire_iam`**, which authenticates via IAM and uses no secret (that path's `secret_arn` stays `''`).
- README documents the least-privilege use case.

## Tests

Added to `tests/test_server.py::TestInternalConnectToDatabaseRouting`:

- `--secret_arn` overrides `MasterUserSecret` on the **wire** path;
- `--secret_arn` overrides it on the **RDS Data API** path;
- `--secret_arn` is **not** applied to **IAM auth** (`secret_arn == ''`).

Strict red→green verified: neutralizing the override makes the two override tests fail (connection would use `arn:master-user-secret`); the fix makes them pass, and the IAM-ignored test passes both ways. Full `test_server.py` (28 tests) green; `ruff check` / `ruff format --check` clean.

## Compatibility

No behavior change when `--secret_arn` is omitted (the managed `MasterUserSecret` is still used), so existing deployments are unaffected.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).