### PR TITLE
fix(mysql-mcp-server): resolve RDS MySQL/MariaDB by cluster_identifier alone

### DIFF
--- a/src/mysql-mcp-server/CHANGELOG.md
+++ b/src/mysql-mcp-server/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **#4589** — `connect_to_database` for `database_type=mysql` / `mariadb`
+  could not resolve a target from `cluster_identifier` alone when
+  `db_endpoint` was omitted: the only non-Aurora lookup
+  (`internal_get_instance_properties`) requires an endpoint to scan for.
+  RDS MySQL / MariaDB now try a new
+  `internal_get_instance_properties_by_identifier` (looks up a standalone
+  instance directly by identifier via `describe_db_instances`) when only
+  `cluster_identifier` is given, falling back to the existing cluster
+  lookup for `database_type=mysql` when no matching instance is found
+  (RDS Multi-AZ DB cluster case — Multi-AZ DB clusters support MySQL and
+  PostgreSQL, not MariaDB). Aurora MySQL is unaffected and continues to
+  resolve via `describe_db_clusters` directly.
+
 ## 1.0.22
 
 ### Security

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/connection/cp_api_connection.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/connection/cp_api_connection.py
@@ -199,6 +199,69 @@ def internal_get_instance_properties(target_endpoint: str, region: str) -> Dict[
     raise ValueError(not_found_error)
 
 
+def internal_get_instance_properties_by_identifier(
+    db_instance_identifier: str, region: str
+) -> Dict[str, Any]:
+    """Retrieve RDS instance properties from AWS by instance identifier.
+
+    Unlike :func:`internal_get_instance_properties` (which scans every
+    instance in the region for a matching endpoint), this looks up a
+    single standalone RDS instance directly by its identifier - the
+    counterpart to :func:`internal_get_cluster_properties` for callers
+    that only have an instance identifier and no endpoint.
+
+    Args:
+        db_instance_identifier: RDS instance identifier
+        region: AWS region (e.g., 'us-east-1')
+
+    Returns:
+        Dict[str, Any]: Instance properties from AWS RDS API
+
+    Raises:
+        ValueError: If db_instance_identifier or region is empty, or the
+            instance is not found
+        ClientError: If AWS API call fails for a reason other than
+            DBInstanceNotFound
+    """
+    if not db_instance_identifier or not region:
+        raise ValueError('db_instance_identifier and region are required')
+
+    logger.info(f"Fetching properties for instance '{db_instance_identifier}' in '{region}' ")
+
+    try:
+        rds_client = internal_create_rds_client(region)
+        response = rds_client.describe_db_instances(DBInstanceIdentifier=db_instance_identifier)
+
+        instances = response.get('DBInstances', [])
+        if not instances:
+            raise ValueError(f"Instance '{db_instance_identifier}' not found in region '{region}'")
+
+        instance_properties = instances[0]
+
+        logger.info(
+            f"Retrieved instance '{db_instance_identifier}': "
+            f'Status={instance_properties.get("DBInstanceStatus")}, '
+            f'Engine={instance_properties.get("Engine")}'
+        )
+
+        logger.debug(
+            f'Instance properties: {json.dumps(instance_properties, indent=2, default=str)}'
+        )
+
+        return instance_properties
+
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        logger.error(
+            f"AWS error fetching instance '{db_instance_identifier}': "
+            f'{error_code} - {e.response["Error"]["Message"]}'
+        )
+        raise
+    except Exception as e:
+        logger.error(f'Error fetching instance properties: {type(e).__name__}: {e}')
+        raise
+
+
 def internal_get_cluster_properties(cluster_identifier: str, region: str) -> Dict[str, Any]:
     """Retrieve RDS cluster properties from AWS.
 

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
@@ -25,6 +25,7 @@ from awslabs.mysql_mcp_server.connection.cp_api_connection import (
     internal_create_aurora_cluster,
     internal_get_cluster_properties,
     internal_get_instance_properties,
+    internal_get_instance_properties_by_identifier,
     internal_require_aws_port,
     internal_resolve_cluster_endpoint,
     setup_aurora_iam_policy_for_current_user,
@@ -604,6 +605,25 @@ def create_cluster_worker(
             async_job_status_lock.release()
 
 
+def is_db_instance_not_found(error: Exception) -> bool:
+    """Return True iff `error` means "no such DB instance", not a real failure.
+
+    :func:`internal_get_instance_properties_by_identifier` surfaces RDS's
+    ``DBInstanceNotFound`` as a ``ClientError``, but raises ``ValueError``
+    when the identifier is empty/blank rather than not-found — narrow on
+    the error code, not the exception type, so a blank identifier is not
+    mistaken for "no such instance" and silently retried as a cluster
+    lookup.
+
+    Narrow on purpose: an ``AccessDenied`` or throttling ``ClientError``
+    must propagate rather than be retried as a cluster lookup, which would
+    only fail again with a less informative error.
+    """
+    if isinstance(error, ClientError):
+        return error.response.get('Error', {}).get('Code') == 'DBInstanceNotFound'
+    return False
+
+
 def internal_connect_to_database(
     region: Annotated[str, Field(description='region')],
     database_type: Annotated[DatabaseType, Field(description='database type')],
@@ -713,7 +733,49 @@ def internal_connect_to_database(
     cluster_arn: str = ''
     secret_arn: str = ''
 
-    if cluster_identifier:
+    # RDS MySQL / MariaDB identifiers are ambiguous when no db_endpoint is
+    # supplied: the identifier can name a standalone DB instance, or — for
+    # MySQL only — an RDS Multi-AZ DB cluster. Both report Engine='mysql'
+    # but live behind different APIs (describe_db_instances vs.
+    # describe_db_clusters), so neither database_type nor the identifier
+    # string alone says which one applies. Aurora MySQL is unambiguous
+    # (always a cluster), as is any call that already supplies db_endpoint
+    # (the existing cluster/instance paths below resolve those directly).
+    # Try the instance lookup first (the common case for #3787) and fall
+    # back to the cluster lookup only when RDS reports no such instance.
+    instance_properties: Optional[Dict[str, Any]] = None
+    if cluster_identifier and not db_endpoint and database_type != DatabaseType.AURORA_MYSQL:
+        try:
+            instance_properties = internal_get_instance_properties_by_identifier(
+                cluster_identifier, region
+            )
+        except (ClientError, ValueError) as e:
+            if not is_db_instance_not_found(e):
+                raise
+            logger.info(
+                f'No DB instance matched for database_type={database_type.value!r}; '
+                f"retrying '{cluster_identifier}' as an RDS Multi-AZ DB cluster"
+            )
+
+    if instance_properties is not None:
+        # Standalone RDS instance resolved by identifier alone. Connect with
+        # the AWS-sourced host and port so the connection string never comes
+        # from caller input. A missing address or a missing/malformed AWS
+        # port fails closed — we never guess a default port.
+        masteruser = instance_properties.get('MasterUsername', '')
+        secret_arn = instance_properties.get('MasterUserSecret', {}).get('SecretArn')
+        instance_endpoint = instance_properties.get('Endpoint', {}) or {}
+        resolved_host = instance_endpoint.get('Address', '')
+        if not resolved_host:
+            raise ValueError(
+                f"AWS returned no endpoint address for instance '{cluster_identifier}'; "
+                'refusing to connect to a caller-supplied host.'
+            )
+        db_endpoint = resolved_host
+        port = internal_require_aws_port(
+            instance_endpoint.get('Port'), f"instance endpoint '{db_endpoint}'"
+        )
+    elif cluster_identifier:
         cluster_properties = internal_get_cluster_properties(
             cluster_identifier=cluster_identifier, region=region
         )

--- a/src/mysql-mcp-server/tests/test_server_internal_functions.py
+++ b/src/mysql-mcp-server/tests/test_server_internal_functions.py
@@ -334,7 +334,205 @@ class TestInternalConnectToDatabaseRDSMySQL:
         assert result_conn is mock_conn
 
 
-class TestInternalConnectToDatabaseRDSMariaDB:
+class TestInternalConnectToDatabaseIdentifierOnly:
+    """Tests for resolving RDS MySQL/MariaDB by cluster_identifier alone.
+
+    Covers the case where the caller supplies only cluster_identifier (no
+    db_endpoint) for a non-Aurora database_type: the identifier can name a
+    standalone RDS instance, or — for MySQL only — an RDS Multi-AZ DB
+    cluster. See https://github.com/awslabs/mcp/issues/4589.
+    """
+
+    @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties_by_identifier')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    def test_resolves_standalone_instance_by_identifier(
+        self, mock_map, mock_get_inst, mock_asyncmy_cls
+    ):
+        """RDS MySQL, identifier-only: resolves via describe_db_instances."""
+        mock_map.get.return_value = None
+
+        mock_get_inst.return_value = {
+            'MasterUsername': 'admin',
+            'MasterUserSecret': {'SecretArn': 'arn:secret'},
+            'Endpoint': {'Address': 'resolved-instance.rds.amazonaws.com', 'Port': 3306},
+        }
+
+        mock_conn = MagicMock()
+        mock_asyncmy_cls.return_value = mock_conn
+
+        result_conn, result_json = internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.RDS_MYSQL,
+            connection_method=ConnectionMethod.MYSQL_WIRE_PROTOCOL,
+            cluster_identifier='my-standalone-instance',
+            db_endpoint='',
+            port=3306,
+            database='testdb',
+        )
+
+        mock_get_inst.assert_called_once_with('my-standalone-instance', 'us-east-1')
+        mock_asyncmy_cls.assert_called_once()
+        assert mock_asyncmy_cls.call_args[1]['host'] == 'resolved-instance.rds.amazonaws.com'
+        assert result_conn is mock_conn
+        parsed = json.loads(result_json)
+        assert parsed['db_endpoint'] == 'resolved-instance.rds.amazonaws.com'
+
+    @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties_by_identifier')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    def test_resolves_standalone_mariadb_instance_by_identifier(
+        self, mock_map, mock_get_inst, mock_asyncmy_cls
+    ):
+        """RDS MariaDB, identifier-only: resolves via describe_db_instances too."""
+        mock_map.get.return_value = None
+
+        mock_get_inst.return_value = {
+            'MasterUsername': 'admin',
+            'MasterUserSecret': {'SecretArn': 'arn:secret'},
+            'Endpoint': {'Address': 'resolved-mariadb.rds.amazonaws.com', 'Port': 3306},
+        }
+
+        mock_conn = MagicMock()
+        mock_asyncmy_cls.return_value = mock_conn
+
+        result_conn, _ = internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.RDS_MARIADB,
+            connection_method=ConnectionMethod.MYSQL_WIRE_PROTOCOL,
+            cluster_identifier='my-mariadb-instance',
+            db_endpoint='',
+            port=3306,
+            database='testdb',
+        )
+
+        mock_get_inst.assert_called_once_with('my-mariadb-instance', 'us-east-1')
+        assert result_conn is mock_conn
+
+    @patch('awslabs.mysql_mcp_server.server.AsyncmyPoolConnection')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties_by_identifier')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    def test_falls_back_to_multi_az_cluster_when_no_instance_found(
+        self, mock_map, mock_get_inst, mock_get_cluster, mock_asyncmy_cls
+    ):
+        """RDS MySQL, identifier-only: falls back to cluster lookup when instance is not found."""
+        from botocore.exceptions import ClientError
+
+        mock_map.get.return_value = None
+
+        mock_get_inst.side_effect = ClientError(
+            error_response={'Error': {'Code': 'DBInstanceNotFound', 'Message': 'not found'}},
+            operation_name='DescribeDBInstances',
+        )
+        mock_get_cluster.return_value = {
+            'HttpEndpointEnabled': False,
+            'MasterUsername': 'admin',
+            'DBClusterArn': 'arn:aws:rds:us-east-1:123:cluster:my-multi-az-cluster',
+            'MasterUserSecret': {'SecretArn': 'arn:secret'},
+            'Endpoint': 'multi-az-writer.rds.amazonaws.com',
+            'Port': '3306',
+        }
+
+        mock_conn = MagicMock()
+        mock_asyncmy_cls.return_value = mock_conn
+
+        result_conn, result_json = internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.RDS_MYSQL,
+            connection_method=ConnectionMethod.MYSQL_WIRE_PROTOCOL,
+            cluster_identifier='my-multi-az-cluster',
+            db_endpoint='',
+            port=3306,
+            database='testdb',
+        )
+
+        mock_get_inst.assert_called_once_with('my-multi-az-cluster', 'us-east-1')
+        mock_get_cluster.assert_called_once_with(
+            cluster_identifier='my-multi-az-cluster', region='us-east-1'
+        )
+        assert result_conn is mock_conn
+        parsed = json.loads(result_json)
+        assert parsed['db_endpoint'] == 'multi-az-writer.rds.amazonaws.com'
+
+    @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties_by_identifier')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    def test_does_not_fall_back_for_mariadb(self, mock_map, mock_get_inst, mock_get_cluster):
+        """RDS MariaDB, identifier-only: no fallback since Multi-AZ DB clusters don't support MariaDB."""
+        mock_map.get.return_value = None
+        mock_get_inst.side_effect = ValueError("Instance 'x' not found in region 'us-east-1'")
+
+        with pytest.raises(ValueError, match="Instance 'x' not found"):
+            internal_connect_to_database(
+                region='us-east-1',
+                database_type=DatabaseType.RDS_MARIADB,
+                connection_method=ConnectionMethod.MYSQL_WIRE_PROTOCOL,
+                cluster_identifier='x',
+                db_endpoint='',
+                port=3306,
+                database='testdb',
+            )
+
+        mock_get_cluster.assert_not_called()
+
+    @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties_by_identifier')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    def test_access_denied_propagates_without_cluster_fallback(self, mock_map, mock_get_inst):
+        """A real AccessDenied/throttling error must propagate, not be swallowed into a retry."""
+        from botocore.exceptions import ClientError
+
+        mock_map.get.return_value = None
+        mock_get_inst.side_effect = ClientError(
+            error_response={'Error': {'Code': 'AccessDenied', 'Message': 'nope'}},
+            operation_name='DescribeDBInstances',
+        )
+
+        with pytest.raises(ClientError):
+            internal_connect_to_database(
+                region='us-east-1',
+                database_type=DatabaseType.RDS_MYSQL,
+                connection_method=ConnectionMethod.MYSQL_WIRE_PROTOCOL,
+                cluster_identifier='my-instance',
+                db_endpoint='',
+                port=3306,
+                database='testdb',
+            )
+
+    @patch('awslabs.mysql_mcp_server.server.RDSDataAPIConnection')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_cluster_properties')
+    @patch('awslabs.mysql_mcp_server.server.internal_get_instance_properties_by_identifier')
+    @patch('awslabs.mysql_mcp_server.server.db_connection_map')
+    def test_aurora_mysql_skips_identifier_lookup(
+        self, mock_map, mock_get_inst, mock_get_cluster, mock_rds_conn_cls
+    ):
+        """Aurora MySQL must go straight to describe_db_clusters, never the identifier lookup."""
+        mock_map.get.return_value = None
+        mock_get_cluster.return_value = {
+            'HttpEndpointEnabled': True,
+            'MasterUsername': 'admin',
+            'DBClusterArn': 'arn:aws:rds:us-east-1:123:cluster:aurora-1',
+            'MasterUserSecret': {'SecretArn': 'arn:secret'},
+            'Endpoint': 'aurora-writer.rds.amazonaws.com',
+            'Port': '3306',
+        }
+        mock_conn = MagicMock()
+        mock_rds_conn_cls.return_value = mock_conn
+
+        result_conn, _ = internal_connect_to_database(
+            region='us-east-1',
+            database_type=DatabaseType.AURORA_MYSQL,
+            connection_method=ConnectionMethod.RDS_API,
+            cluster_identifier='aurora-1',
+            db_endpoint='',
+            port=3306,
+            database='testdb',
+        )
+
+        mock_get_inst.assert_not_called()
+        mock_get_cluster.assert_called_once()
+        assert result_conn is mock_conn
+
     """Tests for RDS MariaDB connection.
 
     MariaDB is wire-protocol only (no Data API, no IAM auth). We exercise


### PR DESCRIPTION
### Fixes

Fixes #4589 — `connect_to_database` for `database_type=mysql` / `mariadb` could not resolve a target from `cluster_identifier` alone when `db_endpoint` was omitted.

### Summary

### Changes

The non-Aurora path in `internal_connect_to_database` only resolved a target when `db_endpoint` was supplied (`internal_get_instance_properties` scans all instances in the region for a matching endpoint). When only `cluster_identifier` was given, there was no lookup that applied.

- Add `internal_get_instance_properties_by_identifier` in `cp_api_connection.py`: looks up a standalone RDS instance directly by identifier via `describe_db_instances(DBInstanceIdentifier=...)` — the identifier-based counterpart to `internal_get_cluster_properties`.
- Use it for the identifier-only, non-Aurora call shape (`cluster_identifier` set, `db_endpoint` empty, `database_type != aurora-mysql`).
- Fall back to the existing `internal_get_cluster_properties` cluster lookup, but only when:
  - RDS reports `DBInstanceNotFound` for the identifier (narrowed to that error code specifically, so `AccessDenied`/throttling still propagate instead of being retried as a doomed cluster lookup), and
  - `database_type=mysql` (RDS Multi-AZ DB clusters support MySQL and PostgreSQL, not MariaDB — MariaDB stays instance-only and a not-found error propagates directly).
- Aurora MySQL is unaffected: it never calls the new identifier lookup and continues straight to `describe_db_clusters`, since a `cluster_identifier` always names a cluster for Aurora.
- Connects with the AWS-sourced host/port only (never the caller-supplied identifier as a host), consistent with the fail-closed approach in #4515 — a missing address or malformed/missing port raises rather than guessing a default.

### Background

This is a narrower follow-up to #3787 (closed by stale-bot on 2026-08-14, not by a fix covering this case) and a rebase of #4098 (which predates #4515 and now conflicts with it) onto current `main`. #3787's own repro always included `db_endpoint`, and the fix merged in #4515 validates/uses `db_endpoint` but does not add an identifier-only resolution path. This PR is scoped to exactly that gap — see #4589 for the full writeup, including the Multi-AZ DB cluster regression risk flagged during #4098's review (an identifier that names a Multi-AZ DB cluster, not a standalone instance, must keep resolving via `describe_db_clusters`).

### User experience

Before: `connect_to_database` with only `cluster_identifier` set (no `db_endpoint`) for `database_type=mysql`/`mariadb` had no matching resolution path.

After: Standalone RDS MySQL/MariaDB instances resolve directly by identifier. RDS Multi-AZ DB clusters (MySQL only) continue to resolve via the cluster lookup when no matching instance exists. Aurora MySQL and calls that already supply `db_endpoint` are unaffected.

### Testing

Added 7 unit tests in `test_server_internal_functions.py`:
- Standalone instance resolution by identifier for `mysql` and `mariadb`
- Multi-AZ DB cluster fallback when no instance matches (`mysql` only)
- No fallback for `mariadb` (not-found propagates directly)
- `AccessDenied`/throttling propagates rather than being swallowed into a fallback retry
- Aurora MySQL bypasses the identifier lookup entirely and goes straight to the cluster lookup

Full suite: 468 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

###  Checklist
- [x] I have reviewed the contributing guidelines
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
Is this a breaking change? N

###  Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
