### PR TITLE
feat(aws-dataprocessing-mcp-server): add injectable clients and structured errors

### DIFF
--- a/src/aws-dataprocessing-mcp-server/README.md
+++ b/src/aws-dataprocessing-mcp-server/README.md
@@ -359,6 +359,30 @@ Controls whether the MCP server adds and verifies MCP-managed tags on resources.
 * Example: `"CUSTOM_TAGS": "true"`
 * **Important**: Enabling this option means resources won't be tagged as MCP-managed. This is done at the owner's consent and responsibility, as it bypasses the built-in resource management safeguards.
 
+### Embedding handlers with custom AWS clients
+
+When composing these handlers into another MCP server, each handler accepts an optional service-aware `client_factory(service_name)` argument. If it is omitted, handlers continue to use `AwsHelper.create_boto3_client`, including the server's existing user-agent configuration and ambient AWS credential resolution.
+
+The factory can return clients created from a caller-owned boto3 session and `botocore.config.Config`, allowing the embedding application to control credentials, retries, and timeouts. Depending on the operation, the factory can also be asked for an `sts` client so account and partition checks use the same AWS identity as the service client.
+
+```python
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_query_handler import AthenaQueryHandler
+from boto3 import Session
+from botocore.config import Config
+
+session = Session(profile_name='my-profile')
+config = Config(connect_timeout=5, read_timeout=30, retries={'mode': 'standard', 'max_attempts': 3})
+
+
+def client_factory(service_name):
+    return session.client(service_name, config=config)
+
+
+handler = AthenaQueryHandler(mcp, client_factory=client_factory)
+```
+
+When an AWS `ClientError` reaches a tool error result, the existing human-readable text is preserved and `structured_content.error` contains `code`, `error_type`, `message`, `http_status`, and `request_id`. Non-AWS exceptions retain the existing text-only error result.
+
 ## Tools
 
 ### Glue Data Catalog Handler Tools

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_database_manager.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_database_manager.py
@@ -27,7 +27,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.data_catalog_models import (
     ListDatabasesData,
     UpdateDatabaseData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -46,16 +47,24 @@ class DataCatalogDatabaseManager:
     permissions and handles tagging of resources for MCP management.
     """
 
-    def __init__(self, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Data Catalog Database Manager.
 
         Args:
             allow_write: Whether to enable write operations (create-database, update-database, delete-database)
             allow_sensitive_data_access: Whether to allow access to sensitive data
+            client_factory: Optional service-aware boto3 client factory
         """
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
     async def create_database(
         self,
@@ -138,10 +147,7 @@ class DataCatalogDatabaseManager:
             error_message = f'Failed to create database {database_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def delete_database(
         self, ctx: Context, database_name: str, catalog_id: Optional[str] = None
@@ -172,8 +178,10 @@ class DataCatalogDatabaseManager:
 
                 # Construct the ARN for the database
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 database_arn = (
                     f'arn:{partition}:glue:{region}:{account_id}:database/{database_name}'
                 )
@@ -193,10 +201,7 @@ class DataCatalogDatabaseManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Database {database_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -230,10 +235,7 @@ class DataCatalogDatabaseManager:
             error_message = f'Failed to delete database {database_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_database(
         self, ctx: Context, database_name: str, catalog_id: Optional[str] = None
@@ -291,10 +293,7 @@ class DataCatalogDatabaseManager:
             error_message = f'Failed to get database {database_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_databases(
         self,
@@ -377,10 +376,7 @@ class DataCatalogDatabaseManager:
             )
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def update_database(
         self,
@@ -426,8 +422,10 @@ class DataCatalogDatabaseManager:
 
                 # Construct the ARN for the database
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 database_arn = (
                     f'arn:{partition}:glue:{region}:{account_id}:database/{database_name}'
                 )
@@ -459,10 +457,7 @@ class DataCatalogDatabaseManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Database {database_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -512,7 +507,4 @@ class DataCatalogDatabaseManager:
             error_message = f'Failed to update database {database_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_handler.py
@@ -49,7 +49,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.data_catalog_models import (
     UpdateConnectionData,
     UpdatePartitionData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -68,16 +69,24 @@ class DataCatalogManager:
     permissions and handles tagging of resources for MCP management.
     """
 
-    def __init__(self, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Data Catalog Manager.
 
         Args:
             allow_write: Whether to enable write operations (create-connection, update-connection, delete-connection, create-partition, delete-partition. update-partition, create-catalog, delete-catalog)
             allow_sensitive_data_access: Whether to allow access to sensitive data
+            client_factory: Optional service-aware boto3 client factory
         """
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
     async def create_connection(
         self,
@@ -148,10 +157,7 @@ class DataCatalogManager:
             error_message = f'Failed to create connection {connection_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def delete_connection(
         self, ctx: Context, connection_name: str, catalog_id: Optional[str] = None
@@ -179,8 +185,10 @@ class DataCatalogManager:
             try:
                 # Construct the ARN for the connection
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 connection_arn = (
                     f'arn:{partition}:glue:{region}:{account_id}:connection/{connection_name}'
                 )
@@ -197,10 +205,7 @@ class DataCatalogManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Connection {connection_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -237,10 +242,7 @@ class DataCatalogManager:
             error_message = f'Failed to delete connection {connection_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_connection(
         self,
@@ -338,10 +340,7 @@ class DataCatalogManager:
             error_message = f'Failed to get connection {connection_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_connections(
         self,
@@ -445,10 +444,7 @@ class DataCatalogManager:
             )
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def update_connection(
         self,
@@ -480,8 +476,10 @@ class DataCatalogManager:
             try:
                 # Construct the ARN for the connection
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 connection_arn = (
                     f'arn:{partition}:glue:{region}:{account_id}:connection/{connection_name}'
                 )
@@ -499,10 +497,7 @@ class DataCatalogManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Connection {connection_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -540,10 +535,7 @@ class DataCatalogManager:
             error_message = f'Failed to update connection {connection_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def test_connection(
         self,
@@ -603,10 +595,7 @@ class DataCatalogManager:
             error_message = f'Failed to test connection{" " + connection_name if connection_name else ""}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def batch_delete_connection(
         self,
@@ -630,8 +619,8 @@ class DataCatalogManager:
         try:
             # Verify each connection is MCP-managed before batch delete
             region = AwsHelper.get_or_default_aws_region()
-            account_id = catalog_id or AwsHelper.get_aws_account_id()
-            partition = AwsHelper.get_aws_partition()
+            account_id = catalog_id or AwsHelper.get_aws_account_id(self._provided_client_factory)
+            partition = AwsHelper.get_aws_partition(self._provided_client_factory)
 
             non_managed = []
             for name in connection_name_list:
@@ -688,10 +677,7 @@ class DataCatalogManager:
             error_message = f'Failed to batch delete connections: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def describe_connection_type(
         self,
@@ -749,10 +735,7 @@ class DataCatalogManager:
             error_message = f'Failed to describe connection type {connection_type}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_connection_types(
         self,
@@ -820,10 +803,7 @@ class DataCatalogManager:
             )
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_entities(
         self,
@@ -903,10 +883,7 @@ class DataCatalogManager:
             error_message = f'Failed to list entities for connection {connection_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def describe_entity(
         self,
@@ -991,10 +968,7 @@ class DataCatalogManager:
             error_message = f'Failed to describe entity {entity_name} for connection {connection_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_entity_records(
         self,
@@ -1088,10 +1062,7 @@ class DataCatalogManager:
             error_message = f'Failed to get entity records for {entity_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def create_partition(
         self,
@@ -1167,10 +1138,7 @@ class DataCatalogManager:
             error_message = f'Failed to create partition in table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def delete_partition(
         self,
@@ -1213,8 +1181,10 @@ class DataCatalogManager:
 
                 # Construct the ARN for the partition
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 partition_arn = f'arn:{partition}:glue:{region}:{account_id}:partition/{database_name}/{table_name}/{"/".join(partition_values)}'
 
                 # Check if the partition is managed by MCP
@@ -1231,10 +1201,7 @@ class DataCatalogManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Partition in table {database_name}.{table_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -1278,10 +1245,7 @@ class DataCatalogManager:
             error_message = f'Failed to delete partition from table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_partition(
         self,
@@ -1388,10 +1352,7 @@ class DataCatalogManager:
             error_message = f'Failed to get partition from table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_partitions(
         self,
@@ -1503,10 +1464,7 @@ class DataCatalogManager:
             error_message = f'Failed to list partitions in table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def update_partition(
         self,
@@ -1550,8 +1508,10 @@ class DataCatalogManager:
 
                 # Construct the ARN for the partition
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 partition_arn = f'arn:{partition}:glue:{region}:{account_id}:partition/{database_name}/{table_name}/{"/".join(partition_values)}'
 
                 # Check if the partition is managed by MCP
@@ -1579,10 +1539,7 @@ class DataCatalogManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Partition in table {database_name}.{table_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -1626,10 +1583,7 @@ class DataCatalogManager:
             error_message = f'Failed to update partition in table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def create_catalog(
         self,
@@ -1700,10 +1654,7 @@ class DataCatalogManager:
             error_message = f'Failed to create catalog {catalog_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def delete_catalog(self, ctx: Context, catalog_id: str) -> CallToolResult:
         """Delete a catalog from AWS Glue.
@@ -1730,8 +1681,10 @@ class DataCatalogManager:
 
                 # Construct the ARN for the catalog
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = AwsHelper.get_aws_account_id()  # Get actual account ID
-                partition = AwsHelper.get_aws_partition()
+                account_id = AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )  # Get actual account ID
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 catalog_arn = f'arn:{partition}:glue:{region}:{account_id}:catalog/{catalog_id}'
 
                 # Check if the catalog is managed by MCP
@@ -1748,10 +1701,7 @@ class DataCatalogManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Catalog {catalog_id} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -1781,10 +1731,7 @@ class DataCatalogManager:
             error_message = f'Failed to delete catalog {catalog_id}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_catalog(self, ctx: Context, catalog_id: str) -> CallToolResult:
         """Get details of a catalog from AWS Glue.
@@ -1858,10 +1805,7 @@ class DataCatalogManager:
             error_message = f'Failed to get catalog {catalog_id}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def import_catalog_to_glue(
         self,
@@ -1915,10 +1859,7 @@ class DataCatalogManager:
             error_message = f'Failed to import Athena data catalog {catalog_id} to Glue: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_catalogs(
         self,
@@ -2001,7 +1942,4 @@ class DataCatalogManager:
             )
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_table_manager.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/core/glue_data_catalog/data_catalog_table_manager.py
@@ -28,7 +28,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.data_catalog_models import (
     TableSummary,
     UpdateTableData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -48,16 +49,24 @@ class DataCatalogTableManager:
     on write permissions and handles tagging of resources for MCP management.
     """
 
-    def __init__(self, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Data Catalog Table Manager.
 
         Args:
             allow_write: Whether to enable write operations (create-table, update-table, delete-table)
             allow_sensitive_data_access: Whether to allow access to sensitive data
+            client_factory: Optional service-aware boto3 client factory
         """
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
     async def create_table(
         self,
@@ -148,10 +157,7 @@ class DataCatalogTableManager:
             error_message = f'Failed to create table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def delete_table(
         self,
@@ -190,8 +196,10 @@ class DataCatalogTableManager:
 
                 # Construct the ARN for the table
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 table_arn = f'arn:{partition}:glue:{region}:{account_id}:table/{database_name}/{table_name}'
 
                 # Check if the table is managed by MCP
@@ -206,10 +214,7 @@ class DataCatalogTableManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Table {database_name}.{table_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -249,10 +254,7 @@ class DataCatalogTableManager:
             error_message = f'Failed to delete table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_table(
         self,
@@ -347,10 +349,7 @@ class DataCatalogTableManager:
             error_message = f'Failed to get table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def list_tables(
         self,
@@ -463,10 +462,7 @@ class DataCatalogTableManager:
             error_message = f'Failed to list tables in database {database_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def update_table(
         self,
@@ -514,8 +510,10 @@ class DataCatalogTableManager:
 
                 # Construct the ARN for the table
                 region = AwsHelper.get_or_default_aws_region()
-                account_id = catalog_id or AwsHelper.get_aws_account_id()
-                partition = AwsHelper.get_aws_partition()
+                account_id = catalog_id or AwsHelper.get_aws_account_id(
+                    self._provided_client_factory
+                )
+                partition = AwsHelper.get_aws_partition(self._provided_client_factory)
                 table_arn = f'arn:{partition}:glue:{region}:{account_id}:table/{database_name}/{table_name}'
 
                 # Check if the table is managed by MCP
@@ -541,10 +539,7 @@ class DataCatalogTableManager:
                 if e.response['Error']['Code'] == 'EntityNotFoundException':
                     error_message = f'Table {database_name}.{table_name} not found'
                     log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
                 else:
                     raise e
 
@@ -593,10 +588,7 @@ class DataCatalogTableManager:
             error_message = f'Failed to update table {database_name}.{table_name}: {error_code} - {e.response["Error"]["Message"]}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def search_tables(
         self,
@@ -703,7 +695,4 @@ class DataCatalogTableManager:
             )
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_data_catalog_handler.py
@@ -25,7 +25,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
     ListTableMetadataData,
     UpdateDataCatalogData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -39,18 +40,27 @@ from typing import Annotated, Any, Dict, Optional
 class AthenaDataCatalogHandler:
     """Handler for Amazon Athena Data Catalog operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Athena Data Catalog handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.athena_client = AwsHelper.create_boto3_client('athena')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.athena_client = self.client_factory('athena')
 
         # Register tools
         self.mcp.tool(name='manage_aws_athena_data_catalogs')(self.manage_aws_athena_data_catalogs)
@@ -233,7 +243,10 @@ class AthenaDataCatalogHandler:
 
                 # Verify that the data catalog is managed by MCP
                 verification_result = AwsHelper.verify_athena_data_catalog_managed_by_mcp(
-                    self.athena_client, name, work_group
+                    self.athena_client,
+                    name,
+                    work_group,
+                    client_factory=self._provided_client_factory,
                 )
 
                 if not verification_result['is_valid']:
@@ -329,7 +342,10 @@ class AthenaDataCatalogHandler:
 
                 # Verify that the data catalog is managed by MCP
                 verification_result = AwsHelper.verify_athena_data_catalog_managed_by_mcp(
-                    self.athena_client, name, work_group
+                    self.athena_client,
+                    name,
+                    work_group,
+                    client_factory=self._provided_client_factory,
                 )
 
                 if not verification_result['is_valid']:
@@ -380,12 +396,7 @@ class AthenaDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_athena_data_catalogs: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[
-                    TextContent(type='text', text=error_message),
-                ],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_athena_databases_and_tables(
         self,
@@ -627,7 +638,4 @@ class AthenaDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_athena_databases_and_tables: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_query_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_query_handler.py
@@ -29,7 +29,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
     StopQueryExecutionData,
     UpdateNamedQueryData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -44,18 +45,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class AthenaQueryHandler:
     """Handler for Amazon Athena Query operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Athena Query handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.athena_client = AwsHelper.create_boto3_client('athena')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.athena_client = self.client_factory('athena')
 
         # Register tools
         self.mcp.tool(name='manage_aws_athena_query_executions')(self.manage_aws_athena_queries)
@@ -473,10 +483,7 @@ class AthenaQueryHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_athena_queries: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_athena_named_queries(
         self,
@@ -810,7 +817,4 @@ class AthenaQueryHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_athena_named_queries: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_workgroup_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/athena/athena_workgroup_handler.py
@@ -19,7 +19,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.athena_models import (
     ListWorkGroupsData,
     UpdateWorkGroupData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -33,18 +34,27 @@ from typing import Annotated, Any, Dict, Optional
 class AthenaWorkGroupHandler:
     """Handler for Amazon Athena WorkGroup operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Athena WorkGroup handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.athena_client = AwsHelper.create_boto3_client('athena')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.athena_client = self.client_factory('athena')
 
         # Register tools
         self.mcp.tool(name='manage_aws_athena_workgroups')(self.manage_aws_athena_workgroups)
@@ -209,7 +219,7 @@ class AthenaWorkGroupHandler:
 
                 # Verify that the workgroup is managed by MCP before deleting
                 workgroup_tags = AwsHelper.get_resource_tags_athena_workgroup(
-                    self.athena_client, name
+                    self.athena_client, name, client_factory=self._provided_client_factory
                 )
                 if not AwsHelper.verify_resource_managed_by_mcp(workgroup_tags):
                     error_message = f'Cannot delete workgroup {name} - it is not managed by the MCP server (missing required tags)'
@@ -294,7 +304,7 @@ class AthenaWorkGroupHandler:
 
                 # Verify that the workgroup is managed by MCP before deleting
                 workgroup_tags = AwsHelper.get_resource_tags_athena_workgroup(
-                    self.athena_client, name
+                    self.athena_client, name, client_factory=self._provided_client_factory
                 )
                 if not AwsHelper.verify_resource_managed_by_mcp(workgroup_tags):
                     error_message = f'Cannot update workgroup {name} - it is not managed by the MCP server (missing required tags)'
@@ -346,7 +356,4 @@ class AthenaWorkGroupHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_athena_workgroups: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/commons/common_resource_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/commons/common_resource_handler.py
@@ -27,7 +27,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.common_resource_models import 
     ServiceRolesData,
     UploadToS3Data,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -49,16 +50,26 @@ class CommonResourceHandler:
     services like Glue, EMR, and Athena, and managing S3 resources.
     """
 
-    def __init__(self, mcp, allow_write: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Common Resource handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
-        self.iam_client = AwsHelper.create_boto3_client('iam')
-        self.s3_client = AwsHelper.create_boto3_client('s3')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or (
+            lambda service_name: AwsHelper.create_boto3_client(service_name)
+        )
+        self.iam_client = self.client_factory('iam')
+        self.s3_client = self.client_factory('s3')
         self.allow_write = allow_write
 
         # Register IAM tools
@@ -165,10 +176,7 @@ class CommonResourceHandler:
             error_message = f'Failed to describe IAM role: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def add_inline_policy(
         self,
@@ -307,10 +315,7 @@ class CommonResourceHandler:
             error_message = f'Failed to create inline policy: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def create_data_processing_role(
         self,
@@ -479,10 +484,7 @@ class CommonResourceHandler:
             error_message = f'Failed to create IAM role: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def get_roles_for_service(
         self,
@@ -583,10 +585,7 @@ class CommonResourceHandler:
             error_message = f'Failed to list IAM roles for service {service_type}: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
 
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     # ============================================================================
     # S3 Operations
@@ -758,17 +757,11 @@ class CommonResourceHandler:
         except ClientError as e:
             error_message = f'AWS Error: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
         except Exception as e:
             error_message = f'Error: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def upload_to_s3(
         self,
@@ -853,10 +846,7 @@ class CommonResourceHandler:
                     error_message = f'Error checking bucket: {str(e)}'
 
                 log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                return CallToolResult(
-                    isError=True,
-                    content=[TextContent(type='text', text=error_message)],
-                )
+                return create_error_result(e, error_message)
 
             # Upload code content using putObject
             self.s3_client.put_object(
@@ -902,17 +892,11 @@ class CommonResourceHandler:
         except ClientError as e:
             error_message = f'AWS Error: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
         except Exception as e:
             error_message = f'Error: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def analyze_s3_usage_for_data_processing(
         self,
@@ -944,9 +928,9 @@ class CommonResourceHandler:
             )
 
             # Create necessary clients
-            glue_client = AwsHelper.create_boto3_client('glue')
-            athena_client = AwsHelper.create_boto3_client('athena')
-            emr_client = AwsHelper.create_boto3_client('emr')
+            glue_client = self.client_factory('glue')
+            athena_client = self.client_factory('athena')
+            emr_client = self.client_factory('emr')
 
             # Get buckets to analyze
             if bucket_name:
@@ -954,12 +938,9 @@ class CommonResourceHandler:
                     # Check if specific bucket exists
                     self.s3_client.head_bucket(Bucket=bucket_name)
                     buckets = [{'Name': bucket_name}]
-                except ClientError:
+                except ClientError as e:
                     error_message = f"Bucket '{bucket_name}' does not exist or is not accessible"
-                    return CallToolResult(
-                        isError=True,
-                        content=[TextContent(type='text', text=error_message)],
-                    )
+                    return create_error_result(e, error_message)
             else:
                 # Get all buckets
                 response = self.s3_client.list_buckets()
@@ -1174,17 +1155,11 @@ class CommonResourceHandler:
         except ClientError as e:
             error_message = f'AWS Error: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
         except Exception as e:
             error_message = f'Error: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     # ============================================================================
     # Helper Methods

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_ec2_cluster_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_ec2_cluster_handler.py
@@ -27,10 +27,11 @@ from awslabs.aws_dataprocessing_mcp_server.models.emr_models import (
     ModifyClusterData,
     TerminateClustersData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
 from awslabs.aws_dataprocessing_mcp_server.utils.consts import (
     EMR_CLUSTER_RESOURCE_TYPE,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -44,18 +45,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class EMREc2ClusterHandler:
     """Handler for Amazon EMR EC2 Cluster operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the EMR EC2 Cluster handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.emr_client = AwsHelper.create_boto3_client('emr')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.emr_client = self.client_factory('emr')
 
         # Register tools
         self.mcp.tool(name='manage_aws_emr_clusters')(self.manage_aws_emr_clusters)
@@ -811,4 +821,4 @@ class EMREc2ClusterHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_emr_clusters: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return self._create_error_response(operation, error_message)
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_ec2_instance_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_ec2_instance_handler.py
@@ -23,11 +23,12 @@ from awslabs.aws_dataprocessing_mcp_server.models.emr_models import (
     ModifyInstanceFleetData,
     ModifyInstanceGroupsData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
 from awslabs.aws_dataprocessing_mcp_server.utils.consts import (
     EMR_INSTANCE_FLEET_RESOURCE_TYPE,
     EMR_INSTANCE_GROUP_RESOURCE_TYPE,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -41,18 +42,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class EMREc2InstanceHandler:
     """Handler for Amazon EMR EC2 Instance operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the EMR EC2 Instance handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.emr_client = AwsHelper.create_boto3_client('emr')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.emr_client = self.client_factory('emr')
 
         # Register tools
         self.mcp.tool(name='manage_aws_emr_ec2_instances')(self.manage_aws_emr_ec2_instances)
@@ -603,7 +613,4 @@ class EMREc2InstanceHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_emr_ec2_instances: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_ec2_steps_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_ec2_steps_handler.py
@@ -20,10 +20,11 @@ from awslabs.aws_dataprocessing_mcp_server.models.emr_models import (
     DescribeStepData,
     ListStepsData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
 from awslabs.aws_dataprocessing_mcp_server.utils.consts import (
     EMR_STEPS_RESOURCE_TYPE,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -37,18 +38,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class EMREc2StepsHandler:
     """Handler for Amazon EMR EC2 Steps operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the EMR EC2 Steps handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.emr_client = AwsHelper.create_boto3_client('emr')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.emr_client = self.client_factory('emr')
 
         # Register tools
         self.mcp.tool(name='manage_aws_emr_ec2_steps')(self.manage_aws_emr_ec2_steps)
@@ -384,7 +394,4 @@ class EMREc2StepsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_emr_ec2_steps: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_serverless_application_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_serverless_application_handler.py
@@ -23,10 +23,11 @@ from awslabs.aws_dataprocessing_mcp_server.models.emr_models import (
     StopApplicationData,
     UpdateApplicationData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
 from awslabs.aws_dataprocessing_mcp_server.utils.consts import (
     EMR_SERVERLESS_APPLICATION_RESOURCE_TYPE,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -40,18 +41,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class EMRServerlessApplicationHandler:
     """Handler for Amazon EMR Serverless Application operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the EMR Serverless Application handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.emr_serverless_client = AwsHelper.create_boto3_client('emr-serverless')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.emr_serverless_client = self.client_factory('emr-serverless')
 
         # Register tools
         self.mcp.tool(name='manage_aws_emr_serverless_applications')(
@@ -618,4 +628,4 @@ class EMRServerlessApplicationHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_emr_serverless_applications: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return self._create_error_response(operation, error_message)
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_serverless_job_run_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/emr/emr_serverless_job_run_handler.py
@@ -21,10 +21,11 @@ from awslabs.aws_dataprocessing_mcp_server.models.emr_models import (
     ListJobRunsData,
     StartJobRunData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
 from awslabs.aws_dataprocessing_mcp_server.utils.consts import (
     EMR_SERVERLESS_JOB_RUN_RESOURCE_TYPE,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -38,18 +39,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class EMRServerlessJobRunHandler:
     """Handler for Amazon EMR Serverless Job Run operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the EMR Serverless Job Run handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.emr_serverless_client = AwsHelper.create_boto3_client('emr-serverless')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.emr_serverless_client = self.client_factory('emr-serverless')
 
         # Register tools
         self.mcp.tool(name='manage_aws_emr_serverless_job_runs')(
@@ -480,4 +490,4 @@ class EMRServerlessJobRunHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_emr_serverless_job_runs: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return self._create_error_response(operation, error_message)
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/crawler_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/crawler_handler.py
@@ -34,7 +34,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.glue_models import (
     UpdateCrawlerData,
     UpdateCrawlerScheduleData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -49,18 +50,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class CrawlerHandler:
     """Handler for Amazon Glue Crawler operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Glue Crawler handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
         # Register tools
         self.mcp.tool(name='manage_aws_glue_crawlers')(self.manage_aws_glue_crawlers)
@@ -255,8 +265,13 @@ class CrawlerHandler:
                 # Verify that the crawler is managed by MCP before deleting
                 # Construct the ARN for the crawler
                 region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                account_id = AwsHelper.get_aws_account_id()
-                crawler_arn = f'arn:aws:glue:{region}:{account_id}:crawler/{crawler_name}'
+                account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                partition = (
+                    AwsHelper.get_aws_partition(self._provided_client_factory)
+                    if self._provided_client_factory
+                    else 'aws'
+                )
+                crawler_arn = f'arn:{partition}:glue:{region}:{account_id}:crawler/{crawler_name}'
 
                 # Get crawler parameters
                 try:
@@ -502,10 +517,7 @@ class CrawlerHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_crawlers: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_classifiers(
         self,
@@ -781,10 +793,7 @@ class CrawlerHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_classifiers: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_crawler_management(
         self,
@@ -985,7 +994,4 @@ class CrawlerHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_crawler_management: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
@@ -23,6 +23,8 @@ from awslabs.aws_dataprocessing_mcp_server.core.glue_data_catalog.data_catalog_h
 from awslabs.aws_dataprocessing_mcp_server.core.glue_data_catalog.data_catalog_table_manager import (
     DataCatalogTableManager,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -36,25 +38,32 @@ from typing import Annotated, Any, Dict, List, Optional
 class GlueDataCatalogHandler:
     """Handler for Amazon Glue Data Catalog operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Glue Data Catalog handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
         self.data_catalog_database_manager = DataCatalogDatabaseManager(
-            self.allow_write, self.allow_sensitive_data_access
+            self.allow_write, self.allow_sensitive_data_access, client_factory=client_factory
         )
         self.data_catalog_table_manager = DataCatalogTableManager(
-            self.allow_write, self.allow_sensitive_data_access
+            self.allow_write, self.allow_sensitive_data_access, client_factory=client_factory
         )
         self.data_catalog_manager = DataCatalogManager(
-            self.allow_write, self.allow_sensitive_data_access
+            self.allow_write, self.allow_sensitive_data_access, client_factory=client_factory
         )
 
         # Register tools
@@ -236,10 +245,7 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_data_catalog_databases: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_data_catalog_tables(
         self,
@@ -436,10 +442,7 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_data_catalog_tables: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_data_catalog_connections(
         self,
@@ -653,10 +656,7 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_data_catalog_connections: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_connection_types(
         self,
@@ -755,10 +755,7 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_connection_types: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_connection_metadata(
         self,
@@ -956,10 +953,7 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_connection_metadata: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_data_catalog_partitions(
         self,
@@ -1157,10 +1151,7 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_data_catalog_partitions: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_data_catalog(
         self,
@@ -1310,7 +1301,4 @@ class GlueDataCatalogHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_data_catalog: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/glue_commons_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/glue_commons_handler.py
@@ -28,7 +28,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.glue_models import (
     PutResourcePolicyData,
     UpdateUsageProfileData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -43,18 +44,27 @@ from typing import Annotated, Any, Dict, Optional
 class GlueCommonsHandler:
     """Handler for Amazon Glue common operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Glue Commons handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
         # Register tools
         self.mcp.tool(name='manage_aws_glue_usage_profiles')(self.manage_aws_glue_usage_profiles)
@@ -206,8 +216,15 @@ class GlueCommonsHandler:
 
                     # Construct the ARN for the usage profile
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    profile_arn = f'arn:aws:glue:{region}:{account_id}:usageProfile/{profile_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    profile_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:usageProfile/{profile_name}'
+                    )
 
                     # Check if the profile is managed by MCP
                     tags = response.get('Tags', {})
@@ -222,10 +239,7 @@ class GlueCommonsHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Usage profile {profile_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -275,8 +289,15 @@ class GlueCommonsHandler:
 
                     # Construct the ARN for the usage profile
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    profile_arn = f'arn:aws:glue:{region}:{account_id}:usageProfile/{profile_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    profile_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:usageProfile/{profile_name}'
+                    )
 
                     # Check if the profile is managed by MCP
                     tags = response.get('Tags', {})
@@ -291,10 +312,7 @@ class GlueCommonsHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Usage profile {profile_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -335,10 +353,7 @@ class GlueCommonsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_usage_profiles: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_security(
         self,
@@ -462,10 +477,7 @@ class GlueCommonsHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Security configuration {config_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -527,10 +539,7 @@ class GlueCommonsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_security: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_encryption(
         self,
@@ -681,10 +690,7 @@ class GlueCommonsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_encryption: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_resource_policies(
         self,
@@ -876,7 +882,4 @@ class GlueCommonsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_resource_policies: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/glue_etl_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/glue_etl_handler.py
@@ -29,7 +29,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.glue_models import (
     StopJobRunData,
     UpdateJobData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -44,18 +45,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class GlueEtlJobsHandler:
     """Handler for Amazon Glue ETL Jobs operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Glue ETL Jobs handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
         # Register tools
         self.mcp.tool(name='manage_aws_glue_jobs')(self.manage_aws_glue_jobs)
@@ -313,8 +323,13 @@ class GlueEtlJobsHandler:
                 # Verify that the job is managed by MCP before deleting
                 # Construct the ARN for the job
                 region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                account_id = AwsHelper.get_aws_account_id()
-                job_arn = f'arn:aws:glue:{region}:{account_id}:job/{job_name}'
+                account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                partition = (
+                    AwsHelper.get_aws_partition(self._provided_client_factory)
+                    if self._provided_client_factory
+                    else 'aws'
+                )
+                job_arn = f'arn:{partition}:glue:{region}:{account_id}:job/{job_name}'
 
                 # Get job parameters
                 try:
@@ -415,8 +430,13 @@ class GlueEtlJobsHandler:
 
                     # Construct the ARN for the job
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    job_arn = f'arn:aws:glue:{region}:{account_id}:job/{job_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    job_arn = f'arn:{partition}:glue:{region}:{account_id}:job/{job_name}'
 
                     # Check if the job is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(
@@ -435,10 +455,7 @@ class GlueEtlJobsHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Job {job_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -704,7 +721,4 @@ class GlueEtlJobsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_jobs_and_runs: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/interactive_sessions_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/interactive_sessions_handler.py
@@ -25,7 +25,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.glue_models import (
     RunStatementData,
     StopSessionData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -40,18 +41,27 @@ from typing import Annotated, Any, Dict, List, Optional
 class GlueInteractiveSessionsHandler:
     """Handler for Amazon Glue Interactive Sessions operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Glue Interactive Sessions handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
         # Register tools
         self.mcp.tool(name='manage_aws_glue_sessions')(self.manage_aws_glue_sessions)
@@ -320,8 +330,15 @@ class GlueInteractiveSessionsHandler:
 
                     # Construct the ARN for the session
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    session_arn = f'arn:aws:glue:{region}:{account_id}:session/{session_id}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    session_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:session/{session_id}'
+                    )
 
                     # Check if the session is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, session_arn, {}):
@@ -335,10 +352,7 @@ class GlueInteractiveSessionsHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Session {session_id} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -440,8 +454,15 @@ class GlueInteractiveSessionsHandler:
 
                     # Construct the ARN for the session
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    session_arn = f'arn:aws:glue:{region}:{account_id}:session/{session_id}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    session_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:session/{session_id}'
+                    )
 
                     # Check if the session is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, session_arn, {}):
@@ -455,10 +476,7 @@ class GlueInteractiveSessionsHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Session {session_id} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -498,10 +516,7 @@ class GlueInteractiveSessionsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_sessions: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_statements(
         self,
@@ -751,7 +766,4 @@ class GlueInteractiveSessionsHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_statements: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/worklows_handler.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/handlers/glue/worklows_handler.py
@@ -27,7 +27,8 @@ from awslabs.aws_dataprocessing_mcp_server.models.glue_models import (
     StartWorkflowRunData,
     StopTriggerData,
 )
-from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper, ClientFactory
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
 from awslabs.aws_dataprocessing_mcp_server.utils.logging_helper import (
     LogLevel,
     log_with_request_id,
@@ -42,18 +43,27 @@ from typing import Annotated, Any, Dict, Optional
 class GlueWorkflowAndTriggerHandler:
     """Handler for Amazon Glue ETL Jobs operations."""
 
-    def __init__(self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False):
+    def __init__(
+        self,
+        mcp,
+        allow_write: bool = False,
+        allow_sensitive_data_access: bool = False,
+        client_factory: Optional[ClientFactory] = None,
+    ):
         """Initialize the Glue ETL Jobs handler.
 
         Args:
             mcp: The MCP server instance
             allow_write: Whether to enable write access (default: False)
             allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+            client_factory: Optional service-aware boto3 client factory
         """
         self.mcp = mcp
         self.allow_write = allow_write
         self.allow_sensitive_data_access = allow_sensitive_data_access
-        self.glue_client = AwsHelper.create_boto3_client('glue')
+        self._provided_client_factory = client_factory
+        self.client_factory = client_factory or AwsHelper.create_boto3_client
+        self.glue_client = self.client_factory('glue')
 
         # Register tools
         self.mcp.tool(name='manage_aws_glue_workflows')(self.manage_aws_glue_workflows)
@@ -213,8 +223,15 @@ class GlueWorkflowAndTriggerHandler:
 
                     # Construct the ARN for the workflow
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    workflow_arn = f'arn:aws:glue:{region}:{account_id}:workflow/{workflow_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    workflow_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:workflow/{workflow_name}'
+                    )
 
                     # Check if the workflow is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, workflow_arn, {}):
@@ -228,10 +245,7 @@ class GlueWorkflowAndTriggerHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Workflow {workflow_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -326,8 +340,15 @@ class GlueWorkflowAndTriggerHandler:
 
                     # Construct the ARN for the workflow
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    workflow_arn = f'arn:aws:glue:{region}:{account_id}:workflow/{workflow_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    workflow_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:workflow/{workflow_name}'
+                    )
 
                     # Check if the workflow is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, workflow_arn, {}):
@@ -341,10 +362,7 @@ class GlueWorkflowAndTriggerHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Workflow {workflow_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -391,10 +409,7 @@ class GlueWorkflowAndTriggerHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_workflows: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)
 
     async def manage_aws_glue_triggers(
         self,
@@ -584,8 +599,15 @@ class GlueWorkflowAndTriggerHandler:
 
                     # Construct the ARN for the trigger
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    trigger_arn = f'arn:aws:glue:{region}:{account_id}:trigger/{trigger_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    trigger_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:trigger/{trigger_name}'
+                    )
 
                     # Check if the trigger is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, trigger_arn, {}):
@@ -599,10 +621,7 @@ class GlueWorkflowAndTriggerHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Trigger {trigger_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -684,8 +703,15 @@ class GlueWorkflowAndTriggerHandler:
 
                     # Construct the ARN for the trigger
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    trigger_arn = f'arn:aws:glue:{region}:{account_id}:trigger/{trigger_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    trigger_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:trigger/{trigger_name}'
+                    )
 
                     # Check if the trigger is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, trigger_arn, {}):
@@ -699,10 +725,7 @@ class GlueWorkflowAndTriggerHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Trigger {trigger_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -734,8 +757,15 @@ class GlueWorkflowAndTriggerHandler:
 
                     # Construct the ARN for the trigger
                     region = AwsHelper.get_or_default_aws_region() or 'us-east-1'
-                    account_id = AwsHelper.get_aws_account_id()
-                    trigger_arn = f'arn:aws:glue:{region}:{account_id}:trigger/{trigger_name}'
+                    account_id = AwsHelper.get_aws_account_id(self._provided_client_factory)
+                    partition = (
+                        AwsHelper.get_aws_partition(self._provided_client_factory)
+                        if self._provided_client_factory
+                        else 'aws'
+                    )
+                    trigger_arn = (
+                        f'arn:{partition}:glue:{region}:{account_id}:trigger/{trigger_name}'
+                    )
 
                     # Check if the trigger is managed by MCP
                     if not AwsHelper.is_resource_mcp_managed(self.glue_client, trigger_arn, {}):
@@ -749,10 +779,7 @@ class GlueWorkflowAndTriggerHandler:
                     if e.response['Error']['Code'] == 'EntityNotFoundException':
                         error_message = f'Trigger {trigger_name} not found'
                         log_with_request_id(ctx, LogLevel.ERROR, error_message)
-                        return CallToolResult(
-                            isError=True,
-                            content=[TextContent(type='text', text=error_message)],
-                        )
+                        return create_error_result(e, error_message)
                     else:
                         raise e
 
@@ -787,7 +814,4 @@ class GlueWorkflowAndTriggerHandler:
         except Exception as e:
             error_message = f'Error in manage_aws_glue_triggers: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_message)
-            return CallToolResult(
-                isError=True,
-                content=[TextContent(type='text', text=error_message)],
-            )
+            return create_error_result(e, error_message)

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/utils/aws_helper.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/utils/aws_helper.py
@@ -30,7 +30,10 @@ from awslabs.aws_dataprocessing_mcp_server import __version__
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
+
+
+ClientFactory = Callable[[str], Any]
 
 
 class AwsHelper:
@@ -99,7 +102,7 @@ class AwsHelper:
     _aws_partition = None
 
     @classmethod
-    def get_aws_account_id(cls) -> str:
+    def get_aws_account_id(cls, client_factory: Optional[ClientFactory] = None) -> str:
         """Get the AWS account ID for the current session.
 
         The account ID is cached after the first call to avoid repeated STS calls.
@@ -107,21 +110,23 @@ class AwsHelper:
         Returns:
             The AWS account ID as a string
         """
-        # Return cached account ID if available
-        if cls._aws_account_id is not None:
+        # Injected clients may use a different AWS identity, so never mix them with the ambient cache.
+        if client_factory is None and cls._aws_account_id is not None:
             return cls._aws_account_id
 
         try:
-            sts_client = boto3.client('sts')
-            cls._aws_account_id = sts_client.get_caller_identity()['Account']
-            return cls._aws_account_id
+            sts_client = client_factory('sts') if client_factory else boto3.client('sts')
+            account_id = sts_client.get_caller_identity()['Account']
+            if client_factory is None:
+                cls._aws_account_id = account_id
+            return account_id
         except Exception:
             # If we can't get the account ID, return a placeholder
             # This is better than nothing for ARN construction
             return 'current-account'
 
     @classmethod
-    def get_aws_partition(cls) -> str:
+    def get_aws_partition(cls, client_factory: Optional[ClientFactory] = None) -> str:
         """Get the AWS partition for the current session.
 
         The partition is cached after the first call to avoid repeated STS calls.
@@ -130,17 +135,19 @@ class AwsHelper:
         Returns:
             The AWS partition as a string
         """
-        # Return cached partition if available
-        if cls._aws_partition is not None:
+        # Injected clients may use a different AWS identity, so never mix them with the ambient cache.
+        if client_factory is None and cls._aws_partition is not None:
             return cls._aws_partition
 
         try:
-            sts_client = boto3.client('sts')
+            sts_client = client_factory('sts') if client_factory else boto3.client('sts')
             # Extract partition from the ARN in the response
             arn = sts_client.get_caller_identity()['Arn']
             # ARN format: arn:partition:service:region:account-id:resource
-            cls._aws_partition = arn.split(':')[1]
-            return cls._aws_partition
+            partition = arn.split(':')[1]
+            if client_factory is None:
+                cls._aws_partition = partition
+            return partition
         except Exception:
             # If we can't get the partition, return the standard partition
             # This is better than nothing for ARN construction
@@ -233,20 +240,24 @@ class AwsHelper:
 
     @staticmethod
     def get_resource_tags_athena_workgroup(
-        athena_client: Any, workgroup_name: str
+        athena_client: Any,
+        workgroup_name: str,
+        client_factory: Optional[ClientFactory] = None,
     ) -> List[Dict[str, str]]:
         """Get tags for an Athena workgroup.
 
         Args:
             athena_client: Athena boto3 client
             workgroup_name: Athena workgroup name
+            client_factory: Optional service-aware boto3 client factory
 
         Returns:
             List of tag dictionaries
         """
         try:
+            partition = AwsHelper.get_aws_partition(client_factory) if client_factory else 'aws'
             response = athena_client.list_tags_for_resource(
-                ResourceARN=f'arn:aws:athena:{AwsHelper.get_or_default_aws_region()}:{AwsHelper.get_aws_account_id()}:workgroup/{workgroup_name}'
+                ResourceARN=f'arn:{partition}:athena:{AwsHelper.get_or_default_aws_region()}:{AwsHelper.get_aws_account_id(client_factory)}:workgroup/{workgroup_name}'
             )
             return response.get('Tags', [])
         except ClientError:
@@ -394,7 +405,11 @@ class AwsHelper:
 
     @classmethod
     def verify_athena_data_catalog_managed_by_mcp(
-        cls, athena_client: Any, name: str, work_group: Optional[str] = None
+        cls,
+        athena_client: Any,
+        name: str,
+        work_group: Optional[str] = None,
+        client_factory: Optional[ClientFactory] = None,
     ) -> Dict[str, Any]:
         """Verify if an Athena data catalog is managed by the MCP server.
 
@@ -404,6 +419,7 @@ class AwsHelper:
             athena_client: Athena boto3 client
             name: Name of the data catalog
             work_group: Optional workgroup name
+            client_factory: Optional service-aware boto3 client factory
 
         Returns:
             Dictionary with verification result:
@@ -425,11 +441,9 @@ class AwsHelper:
             athena_client.get_data_catalog(**get_params)
 
             # Construct the ARN for the data catalog
-            account_id = cls.get_aws_account_id()
+            account_id = cls.get_aws_account_id(client_factory)
             region = cls.get_or_default_aws_region()
-            data_catalog_arn = (
-                f'arn:{cls.get_aws_partition()}:athena:{region}:{account_id}:datacatalog/{name}'
-            )
+            data_catalog_arn = f'arn:{cls.get_aws_partition(client_factory)}:athena:{region}:{account_id}:datacatalog/{name}'
 
             # Get tags for the data catalog
             try:

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/utils/error_helper.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/utils/error_helper.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Error helpers for the Data Processing MCP Server."""
+
+from botocore.exceptions import ClientError
+from mcp.types import CallToolResult, TextContent
+
+
+def create_error_result(exception: Exception, error_message: str) -> CallToolResult:
+    """Create a tool error result, adding structured details for AWS client errors."""
+    content = [TextContent(type='text', text=error_message)]
+
+    if not isinstance(exception, ClientError):
+        return CallToolResult(isError=True, content=content)
+
+    error = exception.response.get('Error') or {}
+    metadata = exception.response.get('ResponseMetadata') or {}
+    return CallToolResult(
+        isError=True,
+        structured_content={
+            'error': {
+                'code': error.get('Code'),
+                'error_type': type(exception).__name__,
+                'message': error.get('Message'),
+                'http_status': metadata.get('HTTPStatusCode'),
+                'request_id': metadata.get('RequestId'),
+            }
+        },
+        content=content,
+    )

--- a/src/aws-dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_database_manager.py
+++ b/src/aws-dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_database_manager.py
@@ -18,10 +18,11 @@ import pytest
 from awslabs.aws_dataprocessing_mcp_server.core.glue_data_catalog.data_catalog_database_manager import (
     DataCatalogDatabaseManager,
 )
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
 from botocore.exceptions import ClientError
 from datetime import datetime
 from mcp.types import CallToolResult
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 
 class TestDataCatalogDatabaseManager:
@@ -49,6 +50,82 @@ class TestDataCatalogDatabaseManager:
         ):
             manager = DataCatalogDatabaseManager(allow_write=True)
             return manager
+
+    def test_uses_supplied_client_factory(self, mock_glue_client):
+        """A supplied client factory creates the manager's Glue client."""
+        client_factory = MagicMock(return_value=mock_glue_client)
+
+        manager = DataCatalogDatabaseManager(client_factory=client_factory)
+
+        assert manager.glue_client is mock_glue_client
+        assert manager._provided_client_factory is client_factory
+        client_factory.assert_called_once_with('glue')
+
+    @pytest.mark.asyncio
+    async def test_default_identity_lookup_uses_ambient_cache(
+        self, mock_ctx, mock_glue_client, monkeypatch
+    ):
+        """Default manager identity lookups preserve ambient account and partition caches."""
+        mock_glue_client.get_database.return_value = {
+            'Database': {'Parameters': {'mcp:managed': 'true'}}
+        }
+        monkeypatch.setattr(AwsHelper, '_aws_account_id', '111111111111')
+        monkeypatch.setattr(AwsHelper, '_aws_partition', 'aws-us-gov')
+
+        with (
+            patch.object(AwsHelper, 'create_boto3_client', return_value=mock_glue_client),
+            patch.object(AwsHelper, 'get_or_default_aws_region', return_value='us-gov-west-1'),
+            patch.object(AwsHelper, 'is_resource_mcp_managed', return_value=True) as is_managed,
+            patch('boto3.client') as ambient_boto3_client,
+        ):
+            manager = DataCatalogDatabaseManager(allow_write=True)
+            result = await manager.delete_database(mock_ctx, database_name='test-db')
+
+        assert result.is_error is False
+        assert manager._provided_client_factory is None
+        ambient_boto3_client.assert_not_called()
+        is_managed.assert_called_once_with(
+            mock_glue_client,
+            'arn:aws-us-gov:glue:us-gov-west-1:111111111111:database/test-db',
+            {'mcp:managed': 'true'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_injected_identity_lookup_bypasses_ambient_cache(
+        self, mock_ctx, mock_glue_client, monkeypatch
+    ):
+        """Injected manager identity lookups use factory STS without mutating ambient caches."""
+        mock_glue_client.get_database.return_value = {
+            'Database': {'Parameters': {'mcp:managed': 'true'}}
+        }
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {
+            'Account': '222222222222',
+            'Arn': 'arn:aws-us-gov:sts::222222222222:assumed-role/test/session',
+        }
+        clients = {'glue': mock_glue_client, 'sts': sts_client}
+        client_factory = MagicMock(side_effect=lambda service_name: clients[service_name])
+        monkeypatch.setattr(AwsHelper, '_aws_account_id', '111111111111')
+        monkeypatch.setattr(AwsHelper, '_aws_partition', 'aws')
+
+        with (
+            patch.object(AwsHelper, 'get_or_default_aws_region', return_value='us-gov-west-1'),
+            patch.object(AwsHelper, 'is_resource_mcp_managed', return_value=True) as is_managed,
+            patch('boto3.client') as ambient_boto3_client,
+        ):
+            manager = DataCatalogDatabaseManager(allow_write=True, client_factory=client_factory)
+            result = await manager.delete_database(mock_ctx, database_name='test-db')
+
+        assert result.is_error is False
+        assert AwsHelper._aws_account_id == '111111111111'
+        assert AwsHelper._aws_partition == 'aws'
+        ambient_boto3_client.assert_not_called()
+        assert client_factory.call_args_list == [call('glue'), call('sts'), call('sts')]
+        is_managed.assert_called_once_with(
+            mock_glue_client,
+            'arn:aws-us-gov:glue:us-gov-west-1:222222222222:database/test-db',
+            {'mcp:managed': 'true'},
+        )
 
     @pytest.mark.asyncio
     async def test_create_database_success(self, manager, mock_ctx, mock_glue_client):
@@ -110,7 +187,8 @@ class TestDataCatalogDatabaseManager:
         ):
             # Mock the Glue client to raise an exception
             error_response = {
-                'Error': {'Code': 'AlreadyExistsException', 'Message': 'Database already exists'}
+                'Error': {'Code': 'AlreadyExistsException', 'Message': 'Database already exists'},
+                'ResponseMetadata': {'HTTPStatusCode': 400, 'RequestId': 'glue-request-id'},
             }
             mock_glue_client.create_database.side_effect = ClientError(
                 error_response, 'CreateDatabase'
@@ -126,6 +204,15 @@ class TestDataCatalogDatabaseManager:
             assert hasattr(result.content[0], 'text')
             assert 'Failed to create database' in result.content[0].text
             assert 'AlreadyExistsException' in result.content[0].text
+            assert result.structured_content == {
+                'error': {
+                    'code': 'AlreadyExistsException',
+                    'error_type': 'ClientError',
+                    'message': 'Database already exists',
+                    'http_status': 400,
+                    'request_id': 'glue-request-id',
+                }
+            }
 
     @pytest.mark.asyncio
     async def test_delete_database_success(self, manager, mock_ctx, mock_glue_client):

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_query_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/athena/test_athena_query_handler.py
@@ -376,7 +376,10 @@ async def test_query_client_error_handling(handler, mock_athena_client):
     """Test error handling when Athena client raises an exception."""
     handler.athena_client = mock_athena_client
     mock_athena_client.get_query_execution.side_effect = ClientError(
-        {'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'}},
+        {
+            'Error': {'Code': 'InvalidRequestException', 'Message': 'Invalid request'},
+            'ResponseMetadata': {'HTTPStatusCode': 400, 'RequestId': 'athena-request-id'},
+        },
         'GetQueryExecution',
     )
 
@@ -387,6 +390,15 @@ async def test_query_client_error_handling(handler, mock_athena_client):
 
     assert response.is_error
     assert 'Error in manage_aws_athena_queries' in response.content[0].text
+    assert response.structured_content == {
+        'error': {
+            'code': 'InvalidRequestException',
+            'error_type': 'ClientError',
+            'message': 'Invalid request',
+            'http_status': 400,
+            'request_id': 'athena-request-id',
+        }
+    }
 
 
 # Named Query Tests

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/commons/test_common_resource_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/commons/test_common_resource_handler.py
@@ -650,7 +650,11 @@ async def test_list_s3_buckets_error_handling(handler, mock_s3_client):
     """Test error handling when listing S3 buckets fails."""
     handler.s3_client = mock_s3_client
     mock_s3_client.list_buckets.side_effect = ClientError(
-        {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}}, 'ListBuckets'
+        {
+            'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'},
+            'ResponseMetadata': {'HTTPStatusCode': 403, 'RequestId': 's3-request-id'},
+        },
+        'ListBuckets',
     )
 
     ctx = Mock()
@@ -659,6 +663,15 @@ async def test_list_s3_buckets_error_handling(handler, mock_s3_client):
 
     assert response.is_error
     assert 'AWS Error' in response.content[0].text
+    assert result.structured_content == {
+        'error': {
+            'code': 'AccessDenied',
+            'error_type': 'ClientError',
+            'message': 'Access denied',
+            'http_status': 403,
+            'request_id': 's3-request-id',
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/emr/test_emr_ec2_cluster_handler.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/emr/test_emr_ec2_cluster_handler.py
@@ -279,7 +279,11 @@ async def test_describe_cluster_aws_error(handler, mock_context):
 
     handler.emr_client = MagicMock()
     handler.emr_client.describe_cluster.side_effect = ClientError(
-        {'Error': {'Code': 'ClusterNotFound', 'Message': 'Cluster not found'}}, 'DescribeCluster'
+        {
+            'Error': {'Code': 'ClusterNotFound', 'Message': 'Cluster not found'},
+            'ResponseMetadata': {'HTTPStatusCode': 404, 'RequestId': 'emr-request-id'},
+        },
+        'DescribeCluster',
     )
 
     response = await handler.manage_aws_emr_clusters(
@@ -288,6 +292,15 @@ async def test_describe_cluster_aws_error(handler, mock_context):
 
     assert response.is_error
     assert 'Error in manage_aws_emr_clusters:' in response.content[0].text
+    assert response.structured_content == {
+        'error': {
+            'code': 'ClusterNotFound',
+            'error_type': 'ClientError',
+            'message': 'Cluster not found',
+            'http_status': 404,
+            'request_id': 'emr-request-id',
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/src/aws-dataprocessing-mcp-server/tests/handlers/test_client_factory.py
+++ b/src/aws-dataprocessing-mcp-server/tests/handlers/test_client_factory.py
@@ -1,0 +1,233 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for caller-provided AWS client factories."""
+
+import pytest
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_data_catalog_handler import (
+    AthenaDataCatalogHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_query_handler import (
+    AthenaQueryHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.athena.athena_workgroup_handler import (
+    AthenaWorkGroupHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.commons.common_resource_handler import (
+    CommonResourceHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.emr.emr_ec2_cluster_handler import (
+    EMREc2ClusterHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.emr.emr_ec2_instance_handler import (
+    EMREc2InstanceHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.emr.emr_ec2_steps_handler import (
+    EMREc2StepsHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.emr.emr_serverless_application_handler import (
+    EMRServerlessApplicationHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.emr.emr_serverless_job_run_handler import (
+    EMRServerlessJobRunHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.crawler_handler import CrawlerHandler
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.data_catalog_handler import (
+    GlueDataCatalogHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.glue_commons_handler import (
+    GlueCommonsHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.glue_etl_handler import GlueEtlJobsHandler
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.interactive_sessions_handler import (
+    GlueInteractiveSessionsHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.handlers.glue.worklows_handler import (
+    GlueWorkflowAndTriggerHandler,
+)
+from awslabs.aws_dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from unittest.mock import MagicMock, call, patch
+
+
+@pytest.mark.parametrize(
+    ('handler_type', 'service_name', 'client_attribute'),
+    [
+        (AthenaQueryHandler, 'athena', 'athena_client'),
+        (AthenaDataCatalogHandler, 'athena', 'athena_client'),
+        (AthenaWorkGroupHandler, 'athena', 'athena_client'),
+        (CrawlerHandler, 'glue', 'glue_client'),
+        (GlueCommonsHandler, 'glue', 'glue_client'),
+        (GlueEtlJobsHandler, 'glue', 'glue_client'),
+        (GlueInteractiveSessionsHandler, 'glue', 'glue_client'),
+        (GlueWorkflowAndTriggerHandler, 'glue', 'glue_client'),
+        (EMREc2ClusterHandler, 'emr', 'emr_client'),
+        (EMREc2InstanceHandler, 'emr', 'emr_client'),
+        (EMREc2StepsHandler, 'emr', 'emr_client'),
+        (EMRServerlessApplicationHandler, 'emr-serverless', 'emr_serverless_client'),
+        (EMRServerlessJobRunHandler, 'emr-serverless', 'emr_serverless_client'),
+    ],
+)
+def test_handler_uses_supplied_client_factory(handler_type, service_name, client_attribute):
+    """AWS-backed handlers request their service client from the supplied factory."""
+    client = MagicMock()
+    client_factory = MagicMock(return_value=client)
+
+    handler = handler_type(MagicMock(), client_factory=client_factory)
+
+    assert getattr(handler, client_attribute) is client
+    assert handler._provided_client_factory is client_factory
+    client_factory.assert_called_once_with(service_name)
+
+
+@pytest.mark.asyncio
+async def test_default_handler_identity_uses_ambient_cache(monkeypatch):
+    """Default handler identity preserves the ambient account cache and aws partition."""
+    glue_client = MagicMock()
+    glue_client.get_crawler.return_value = {'Crawler': {'Parameters': {'mcp:managed': 'true'}}}
+    monkeypatch.setattr(AwsHelper, '_aws_account_id', '111111111111')
+    monkeypatch.setattr(AwsHelper, '_aws_partition', 'aws-us-gov')
+
+    with (
+        patch.object(AwsHelper, 'create_boto3_client', return_value=glue_client),
+        patch.object(AwsHelper, 'get_or_default_aws_region', return_value='us-east-1'),
+        patch.object(AwsHelper, 'is_resource_mcp_managed', return_value=True) as is_managed,
+        patch('boto3.client') as ambient_boto3_client,
+    ):
+        handler = CrawlerHandler(MagicMock(), allow_write=True)
+        result = await handler.manage_aws_glue_crawlers(
+            MagicMock(), operation='delete-crawler', crawler_name='test-crawler'
+        )
+
+    assert result.is_error is False
+    assert handler._provided_client_factory is None
+    ambient_boto3_client.assert_not_called()
+    is_managed.assert_called_once_with(
+        glue_client,
+        'arn:aws:glue:us-east-1:111111111111:crawler/test-crawler',
+        {'mcp:managed': 'true'},
+    )
+
+
+@pytest.mark.parametrize(
+    ('handler_type', 'method_name', 'operation_kwargs', 'resource_suffix'),
+    [
+        (
+            CrawlerHandler,
+            'manage_aws_glue_crawlers',
+            {'operation': 'delete-crawler', 'crawler_name': 'test-crawler'},
+            'crawler/test-crawler',
+        ),
+        (
+            GlueEtlJobsHandler,
+            'manage_aws_glue_jobs',
+            {'operation': 'delete-job', 'job_name': 'test-job'},
+            'job/test-job',
+        ),
+        (
+            GlueInteractiveSessionsHandler,
+            'manage_aws_glue_sessions',
+            {'operation': 'delete-session', 'session_id': 'test-session'},
+            'session/test-session',
+        ),
+        (
+            GlueCommonsHandler,
+            'manage_aws_glue_usage_profiles',
+            {'operation': 'delete-profile', 'profile_name': 'test-profile'},
+            'usageProfile/test-profile',
+        ),
+        (
+            GlueWorkflowAndTriggerHandler,
+            'manage_aws_glue_workflows',
+            {'operation': 'delete-workflow', 'workflow_name': 'test-workflow'},
+            'workflow/test-workflow',
+        ),
+        (
+            GlueWorkflowAndTriggerHandler,
+            'manage_aws_glue_triggers',
+            {'operation': 'delete-trigger', 'trigger_name': 'test-trigger'},
+            'trigger/test-trigger',
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_injected_glue_handler_arns_use_factory_partition(
+    monkeypatch, handler_type, method_name, operation_kwargs, resource_suffix
+):
+    """Injected Glue handler ARNs use factory account and partition identity."""
+    glue_client = MagicMock()
+    sts_client = MagicMock()
+    sts_client.get_caller_identity.return_value = {
+        'Account': '222222222222',
+        'Arn': 'arn:aws-us-gov:sts::222222222222:assumed-role/test/session',
+    }
+    clients = {'glue': glue_client, 'sts': sts_client}
+    client_factory = MagicMock(side_effect=lambda service_name: clients[service_name])
+    monkeypatch.setattr(AwsHelper, '_aws_account_id', '111111111111')
+    monkeypatch.setattr(AwsHelper, '_aws_partition', 'aws')
+
+    with (
+        patch.object(AwsHelper, 'get_or_default_aws_region', return_value='us-gov-west-1'),
+        patch.object(AwsHelper, 'is_resource_mcp_managed', return_value=True) as is_managed,
+        patch('boto3.client') as ambient_boto3_client,
+    ):
+        handler = handler_type(MagicMock(), allow_write=True, client_factory=client_factory)
+        result = await getattr(handler, method_name)(MagicMock(), **operation_kwargs)
+
+    assert result.is_error is False
+    assert AwsHelper._aws_account_id == '111111111111'
+    assert AwsHelper._aws_partition == 'aws'
+    ambient_boto3_client.assert_not_called()
+    assert client_factory.call_args_list == [call('glue'), call('sts'), call('sts')]
+    assert is_managed.call_args.args[1] == (
+        f'arn:aws-us-gov:glue:us-gov-west-1:222222222222:{resource_suffix}'
+    )
+
+
+def test_glue_data_catalog_passes_factory_to_each_manager():
+    """The Glue Data Catalog wrapper preserves one Glue client creation per manager."""
+    glue_client = MagicMock()
+    client_factory = MagicMock(return_value=glue_client)
+
+    handler = GlueDataCatalogHandler(MagicMock(), client_factory=client_factory)
+
+    assert handler.data_catalog_database_manager.glue_client is glue_client
+    assert handler.data_catalog_table_manager.glue_client is glue_client
+    assert handler.data_catalog_manager.glue_client is glue_client
+    assert client_factory.call_args_list == [call('glue'), call('glue'), call('glue')]
+
+
+@pytest.mark.asyncio
+async def test_common_resource_handler_uses_factory_for_lazy_service_clients():
+    """Common resource analysis uses the supplied factory for all lazily created clients."""
+    clients = {
+        'iam': MagicMock(),
+        's3': MagicMock(),
+        'glue': MagicMock(),
+        'athena': MagicMock(),
+        'emr': MagicMock(),
+    }
+    clients['s3'].list_buckets.return_value = {'Buckets': []}
+    client_factory = MagicMock(side_effect=lambda service_name: clients[service_name])
+    handler = CommonResourceHandler(MagicMock(), client_factory=client_factory)
+
+    result = await handler.analyze_s3_usage_for_data_processing(MagicMock())
+
+    assert result.is_error is False
+    assert client_factory.call_args_list == [
+        call('iam'),
+        call('s3'),
+        call('glue'),
+        call('athena'),
+        call('emr'),
+    ]

--- a/src/aws-dataprocessing-mcp-server/tests/utils/test_aws_helper.py
+++ b/src/aws-dataprocessing-mcp-server/tests/utils/test_aws_helper.py
@@ -146,6 +146,21 @@ class TestAwsHelper:
         # Verify that the account ID is not cached
         assert AwsHelper._aws_account_id is None
 
+    def test_get_aws_account_id_with_client_factory_bypasses_ambient_cache(self):
+        """Injected STS clients use their own identity without reading or writing the ambient cache."""
+        AwsHelper._aws_account_id = '111111111111'
+        mock_sts_client = MagicMock()
+        mock_sts_client.get_caller_identity.return_value = {'Account': '222222222222'}
+        client_factory = MagicMock(return_value=mock_sts_client)
+
+        with patch('boto3.client') as mock_boto3_client:
+            account_id = AwsHelper.get_aws_account_id(client_factory)
+
+        assert account_id == '222222222222'
+        assert AwsHelper._aws_account_id == '111111111111'
+        client_factory.assert_called_once_with('sts')
+        mock_boto3_client.assert_not_called()
+
     def test_get_aws_partition_cached(self):
         """Test that get_aws_partition returns the cached partition if available."""
         # Set the cached partition
@@ -190,6 +205,23 @@ class TestAwsHelper:
 
         # Verify that the partition is not cached
         assert AwsHelper._aws_partition is None
+
+    def test_get_aws_partition_with_client_factory_bypasses_ambient_cache(self):
+        """Injected STS clients use their own partition without reading or writing the ambient cache."""
+        AwsHelper._aws_partition = 'aws'
+        mock_sts_client = MagicMock()
+        mock_sts_client.get_caller_identity.return_value = {
+            'Arn': 'arn:aws-us-gov:sts::222222222222:assumed-role/role-name/session-name'
+        }
+        client_factory = MagicMock(return_value=mock_sts_client)
+
+        with patch('boto3.client') as mock_boto3_client:
+            partition = AwsHelper.get_aws_partition(client_factory)
+
+        assert partition == 'aws-us-gov'
+        assert AwsHelper._aws_partition == 'aws'
+        client_factory.assert_called_once_with('sts')
+        mock_boto3_client.assert_not_called()
 
     def test_create_boto3_client_with_region(self):
         """Test that create_boto3_client creates a client with the specified region."""

--- a/src/aws-dataprocessing-mcp-server/tests/utils/test_error_helper.py
+++ b/src/aws-dataprocessing-mcp-server/tests/utils/test_error_helper.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tool error result helpers."""
+
+from awslabs.aws_dataprocessing_mcp_server.utils.error_helper import create_error_result
+from botocore.exceptions import ClientError
+
+
+def test_create_error_result_with_client_error():
+    """ClientError details are exposed without changing the human-readable text."""
+    exception = ClientError(
+        {
+            'Error': {'Code': 'ThrottlingException', 'Message': 'Rate exceeded'},
+            'ResponseMetadata': {'HTTPStatusCode': 429, 'RequestId': 'request-123'},
+        },
+        'StartQueryExecution',
+    )
+
+    result = create_error_result(exception, 'Error in operation: original text')
+
+    assert result.is_error is True
+    assert result.content[0].text == 'Error in operation: original text'
+    assert result.structured_content == {
+        'error': {
+            'code': 'ThrottlingException',
+            'error_type': 'ClientError',
+            'message': 'Rate exceeded',
+            'http_status': 429,
+            'request_id': 'request-123',
+        }
+    }
+
+
+def test_create_error_result_with_missing_client_error_metadata():
+    """Missing AWS response metadata is represented by null values."""
+    exception = ClientError({'Error': {'Code': 'BadRequestException'}}, 'Operation')
+
+    result = create_error_result(exception, str(exception))
+
+    assert result.structured_content == {
+        'error': {
+            'code': 'BadRequestException',
+            'error_type': 'ClientError',
+            'message': None,
+            'http_status': None,
+            'request_id': None,
+        }
+    }
+
+
+def test_create_error_result_with_non_aws_exception():
+    """Non-AWS exceptions keep the existing text-only error shape."""
+    result = create_error_result(ValueError('bad input'), 'Error: bad input')
+
+    assert result.is_error is True
+    assert result.content[0].text == 'Error: bad input'
+    assert result.structured_content is None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #4123

## Summary

### Changes

* Add an optional service-aware `client_factory` to the Data Processing handlers and Glue Data Catalog managers while preserving the existing default boto3 client creation path.
* Keep the caller-provided factory distinct from the resolved service-client factory so default handlers retain the existing ambient STS account/partition cache behavior, while injected factories use their own STS identity without reading or writing those caches.
* Use the injected STS partition when constructing dynamic Glue resource ARNs, including GovCloud and other non-default AWS partitions, while keeping the existing `aws` partition behavior for standalone construction.
* Preserve existing human-readable error text while adding `structured_content.error` with `code`, `error_type`, `message`, `http_status`, and `request_id` for AWS `ClientError` results.
* Document the embedding contract and caller-owned credentials, retry, and timeout configuration. `retryable` and `throttling` are intentionally not exposed because doing so would require defining a stable contract around botocore's internal retry classification.

### User experience

Embedded MCP servers can supply caller-owned AWS clients and deterministically inspect AWS error metadata instead of parsing botocore error strings. Standalone construction keeps its previous client creation, identity-cache, and Glue ARN partition behavior when no factory is supplied.

Focused client-factory regressions and the full package test suite pass, including non-default partition coverage; type, lint, security-threshold, and package-build checks also pass.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).