### PR TITLE
fix(aws-network-mcp-server): pass NextToken when paging transit gateway route tables

### DIFF
--- a/src/aws-network-mcp-server/CHANGELOG.md
+++ b/src/aws-network-mcp-server/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project setup
+
+### Fixed
+
+- `get_all_tgw_routes` now sends `NextToken` when paging transit gateway route tables, so a transit gateway with more than one page of route tables no longer loops forever on page one

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/transit_gateway/get_all_transit_gateway_routes.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/tools/transit_gateway/get_all_transit_gateway_routes.py
@@ -147,7 +147,8 @@ async def get_all_tgw_routes(
                         'Name': 'state',
                         'Values': ['available'],
                     },
-                ]
+                ],
+                NextToken=tg_rt_resp['NextToken'],
             )
             tg_rts += tg_rt_resp['TransitGatewayRouteTables']
 

--- a/src/aws-network-mcp-server/tests/tools/transit_gateway/test_get_all_transit_gateway_routes.py
+++ b/src/aws-network-mcp-server/tests/tools/transit_gateway/test_get_all_transit_gateway_routes.py
@@ -250,6 +250,10 @@ class TestGetAllTransitGatewayRoutes:
         assert 'tgw-rtb-1' in result['routes']
         assert 'tgw-rtb-2' in result['routes']
 
+        # without the token the second call repeats page one, so the loop never ends
+        second_call = mock_ec2_client.describe_transit_gateway_route_tables.call_args_list[1]
+        assert second_call.kwargs['NextToken'] == 'token123'
+
     @patch(
         'awslabs.aws_network_mcp_server.tools.transit_gateway.get_all_transit_gateway_routes.get_aws_client'
     )


### PR DESCRIPTION
`get_all_tgw_routes` loops while the response carries a `NextToken`, but the call inside the loop repeats the same `Filters` and never sends the token, so `describe_transit_gateway_route_tables` returns page one again along with the same token. The condition can't go false, and the tool spins on page one instead of returning.

It only shows up once a transit gateway has more than one page of route tables, which is why a small account never sees it. The whole body sits inside `try` / `except Exception`, and an infinite loop raises nothing, so there's no error either. It just never comes back.

The existing pagination test drove the mock off a `side_effect` list, so the second call returned the second page no matter what was passed and the test passed either way. It now asserts the token reaches that call, and fails with `KeyError: 'NextToken'` without the fix.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
