### PR TITLE
fix(aws-api-mcp-server): Pin mcp version

### DIFF
--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "importlib_resources>=6.0.0",
     "requests>=2.32.4",
     "python-frontmatter>=1.1.0",
-    "fastmcp>=3.4.3",
+    "fastmcp>=3.4.3,<4.0",
     "awscli==1.46.0",
 ]
 license = {text = "Apache-2.0"}

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -8,10 +8,7 @@ description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    # Left on v1 deliberately. fastmcp 3.x (below) depends on fastmcp-slim, which pins
-    # mcp>=1.24.0,<2.0, so declaring mcp>=2.0.0 here is unsatisfiable -- only the unreleased
-    # fastmcp 4.0 lifts that ceiling. Revisit when it ships. See awslabs/mcp#4448.
-    "mcp>=1.23.0",
+    "mcp>=1.23.0,<2.0",
     "pydantic>=2.10.6",
     "boto3>=1.41.0",
     "botocore[crt]>=1.41.0",

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -180,7 +180,7 @@ requires-dist = [
     { name = "importlib-resources", specifier = ">=6.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "lxml", specifier = ">=5.1.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-json-logger", specifier = ">=2.0.7" },

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -176,7 +176,7 @@ requires-dist = [
     { name = "awscli", specifier = "==1.46.0" },
     { name = "boto3", specifier = ">=1.41.0" },
     { name = "botocore", extras = ["crt"], specifier = ">=1.41.0" },
-    { name = "fastmcp", specifier = ">=3.4.3" },
+    { name = "fastmcp", specifier = ">=3.4.3,<4.0" },
     { name = "importlib-resources", specifier = ">=6.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "lxml", specifier = ">=5.1.0" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #4586

## Summary

### Changes

> Please provide a summary of what's being changed

Pin mcp version <2.0 to prevent compatibility issues when using `@latest`

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
