### PR TITLE
chore: release/2026.09.20260908143235

### DIFF
--- a/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
+++ b/src/amazon-bedrock-agentcore-mcp-server/awslabs/amazon_bedrock_agentcore_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-bedrock-agentcore-mcp-server"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
+++ b/src/amazon-bedrock-agentcore-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-bedrock-agentcore-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.2.0"
+version = "0.2.1"
 
 description = "Model Context Protocol (MCP) server for Amazon Bedrock AgentCore services"
 readme = "README.md"

--- a/src/amazon-bedrock-agentcore-mcp-server/uv.lock
+++ b/src/amazon-bedrock-agentcore-mcp-server/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-bedrock-agentcore-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/src/amazon-kendra-index-mcp-server/awslabs/amazon_kendra_index_mcp_server/__init__.py
+++ b/src/amazon-kendra-index-mcp-server/awslabs/amazon_kendra_index_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-kendra-index-mcp-server"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/amazon-kendra-index-mcp-server/pyproject.toml
+++ b/src/amazon-kendra-index-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-kendra-index-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for amazon-kendra-index-mcp-server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-kendra-index-mcp-server/uv.lock
+++ b/src/amazon-kendra-index-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-kendra-index-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/__init__.py
+++ b/src/amazon-mq-mcp-server/awslabs/amazon_mq_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/src/amazon-mq-mcp-server/pyproject.toml
+++ b/src/amazon-mq-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-mq-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "A Model Context Protocol server for AmazonMQ to provision and manage your AMQ brokers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-mq-mcp-server/uv.lock
+++ b/src/amazon-mq-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-mq-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/__init__.py
+++ b/src/amazon-neptune-mcp-server/awslabs/amazon_neptune_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.neptune-mcp-server"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/amazon-neptune-mcp-server/pyproject.toml
+++ b/src/amazon-neptune-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-neptune-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An Amazon Neptune MCP server that allows for fetching status, schema, and querying using openCypher, Gremlin, and SPARQL for Neptune Database and openCypher for Neptune Analytics."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-neptune-mcp-server/uv.lock
+++ b/src/amazon-neptune-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-neptune-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-qbusiness-anonymous-mcp-server/awslabs/amazon_qbusiness_anonymous_mcp_server/__init__.py
+++ b/src/amazon-qbusiness-anonymous-mcp-server/awslabs/amazon_qbusiness_anonymous_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-qbusiness-anonymous-mcp-server"""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/src/amazon-qbusiness-anonymous-mcp-server/pyproject.toml
+++ b/src/amazon-qbusiness-anonymous-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.amazon-qbusiness-anonymous-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.0"
+version = "0.1.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon Q Business anonymous mode application."
 readme = "README.md"

--- a/src/amazon-qbusiness-anonymous-mcp-server/uv.lock
+++ b/src/amazon-qbusiness-anonymous-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-qbusiness-anonymous-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/__init__.py
+++ b/src/amazon-sns-sqs-mcp-server/awslabs/amazon_sns_sqs_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.amazon-sns-sqs-mcp-server"""
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/src/amazon-sns-sqs-mcp-server/pyproject.toml
+++ b/src/amazon-sns-sqs-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-sns-sqs-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "A Model Context Protocol server for Amazon SNS and SQS to provision and manage your messaging services"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-sns-sqs-mcp-server/uv.lock
+++ b/src/amazon-sns-sqs-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-sns-sqs-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/amazon-translate-mcp-server/pyproject.toml
+++ b/src/amazon-translate-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.amazon-translate-mcp-server"
-version = "1.0.6"
+version = "1.0.7"
 description = "A Model Context Protocol server for Amazon Translate to provide text translation, custom terminology management, and batch translation processing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/amazon-translate-mcp-server/uv.lock
+++ b/src/amazon-translate-mcp-server/uv.lock
@@ -85,7 +85,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-amazon-translate-mcp-server"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/__init__.py
+++ b/src/aurora-dsql-mcp-server/awslabs/aurora_dsql_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aurora-dsql-mcp-server"""
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/src/aurora-dsql-mcp-server/pyproject.toml
+++ b/src/aurora-dsql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aurora-dsql-mcp-server"
-version = "1.1.2"
+version = "1.1.3"
 description = "An AWS Labs Model Context Protocol (MCP) server for Aurora DSQL"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aurora-dsql-mcp-server/uv.lock
+++ b/src/aurora-dsql-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aurora-dsql-mcp-server"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-api-mcp-server"""
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-api-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.5.4"
+version = "1.5.5"
 
 description = "Model Context Protocol (MCP) server for interacting with AWS"
 readme = "README.md"

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-api-mcp-server"
-version = "1.5.4"
+version = "1.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },

--- a/src/aws-appsync-mcp-server/awslabs/aws_appsync_mcp_server/__init__.py
+++ b/src/aws-appsync-mcp-server/awslabs/aws_appsync_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS AppSync MCP Server package."""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/aws-appsync-mcp-server/pyproject.toml
+++ b/src/aws-appsync-mcp-server/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "awslabs.aws-appsync-mcp-server"
 
-version = "0.2.0"
+version = "0.2.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS AppSync Service capabilities"
 readme = "README.md"

--- a/src/aws-appsync-mcp-server/uv.lock
+++ b/src/aws-appsync-mcp-server/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-appsync-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-bedrock-custom-model-import-mcp-server/awslabs/aws_bedrock_custom_model_import_mcp_server/__init__.py
+++ b/src/aws-bedrock-custom-model-import-mcp-server/awslabs/aws_bedrock_custom_model_import_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-bedrock-custom-model-import-mcp-server"""
 
-__version__ = '0.0.22'
+__version__ = '0.0.23'

--- a/src/aws-bedrock-custom-model-import-mcp-server/pyproject.toml
+++ b/src/aws-bedrock-custom-model-import-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-bedrock-custom-model-import-mcp-server"
-version = "0.0.22"
+version = "0.0.23"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Custom Model Import"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-bedrock-custom-model-import-mcp-server/uv.lock
+++ b/src/aws-bedrock-custom-model-import-mcp-server/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-bedrock-custom-model-import-mcp-server"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/__init__.py
+++ b/src/aws-dataprocessing-mcp-server/awslabs/aws_dataprocessing_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-dataprocessing-mcp-server"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/aws-dataprocessing-mcp-server/pyproject.toml
+++ b/src/aws-dataprocessing-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-dataprocessing-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.2.0"
+version = "0.2.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for dataprocessing"
 readme = "README.md"

--- a/src/aws-dataprocessing-mcp-server/uv.lock
+++ b/src/aws-dataprocessing-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-dataprocessing-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/__init__.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-documentation-mcp-server"""
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/src/aws-documentation-mcp-server/pyproject.toml
+++ b/src/aws-documentation-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-documentation-mcp-server"
-version = "1.2.0"
+version = "1.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-documentation-mcp-server/uv.lock
+++ b/src/aws-documentation-mcp-server/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-documentation-mcp-server"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/src/aws-for-sap-management-mcp-server/awslabs/aws_for_sap_management_mcp_server/__init__.py
+++ b/src/aws-for-sap-management-mcp-server/awslabs/aws_for_sap_management_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.aws-for-sap-management-mcp-server"""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 MCP_SERVER_VERSION = __version__

--- a/src/aws-for-sap-management-mcp-server/pyproject.toml
+++ b/src/aws-for-sap-management-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-for-sap-management-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Systems Manager for SAP"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-for-sap-management-mcp-server/uv.lock
+++ b/src/aws-for-sap-management-mcp-server/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-for-sap-management-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-healthomics-mcp-server"""
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/src/aws-healthomics-mcp-server/pyproject.toml
+++ b/src/aws-healthomics-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-healthomics-mcp-server"
-version = "0.1.1"
+version = "0.1.2"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS HealthOmics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-healthomics-mcp-server/uv.lock
+++ b/src/aws-healthomics-mcp-server/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-healthomics-mcp-server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/__init__.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-iac-mcp-server"""
 
-__version__ = '1.0.25'
+__version__ = '1.0.26'

--- a/src/aws-iac-mcp-server/pyproject.toml
+++ b/src/aws-iac-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-iac-mcp-server"
-version = "1.0.25"
+version = "1.0.26"
 description = "An Infrastructure as Code MCP server that provides CloudFormation template validation, compliance checking, and deployment troubleshooting capabilities."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-iac-mcp-server/uv.lock
+++ b/src/aws-iac-mcp-server/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-iac-mcp-server"
-version = "1.0.25"
+version = "1.0.26"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/__init__.py
+++ b/src/aws-iot-sitewise-mcp-server/awslabs/aws_iot_sitewise_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-iot-sitewise-mcp-server"""
 
-__version__ = '11.0.22'
+__version__ = '11.0.23'

--- a/src/aws-iot-sitewise-mcp-server/pyproject.toml
+++ b/src/aws-iot-sitewise-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-iot-sitewise-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "11.0.22"
+version = "11.0.23"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-iot-sitewise"
 readme = "README.md"

--- a/src/aws-iot-sitewise-mcp-server/uv.lock
+++ b/src/aws-iot-sitewise-mcp-server/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-iot-sitewise-mcp-server"
-version = "11.0.22"
+version = "11.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-location-mcp-server/pyproject.toml
+++ b/src/aws-location-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-location-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Location Service"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-location-mcp-server/uv.lock
+++ b/src/aws-location-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-location-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/__init__.py
+++ b/src/aws-network-mcp-server/awslabs/aws_network_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-network-mcp-server"""
 
-__version__ = '0.0.16'
+__version__ = '0.0.17'

--- a/src/aws-network-mcp-server/pyproject.toml
+++ b/src/aws-network-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.aws-network-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.16"
+version = "0.0.17"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for aws-network"
 readme = "README.md"

--- a/src/aws-network-mcp-server/uv.lock
+++ b/src/aws-network-mcp-server/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-network-mcp-server"
-version = "0.0.16"
+version = "0.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/__init__.py
+++ b/src/aws-pricing-mcp-server/awslabs/aws_pricing_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs.aws-pricing-mcp-server"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/aws-pricing-mcp-server/pyproject.toml
+++ b/src/aws-pricing-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-pricing-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for official pricing of AWS services"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-pricing-mcp-server/uv.lock
+++ b/src/aws-pricing-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-pricing-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/__init__.py
+++ b/src/aws-transform-mcp-server/awslabs/aws_transform_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.aws-transform-mcp-server."""
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/src/aws-transform-mcp-server/pyproject.toml
+++ b/src/aws-transform-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.aws-transform-mcp-server"
-version = "0.2.1"
+version = "0.2.2"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Transform — manage transformation workspaces, jobs, connectors, HITL tasks, artifacts, and chat"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws-transform-mcp-server/uv.lock
+++ b/src/aws-transform-mcp-server/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-aws-transform-mcp-server"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/__init__.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """awslabs Bedrock Knowledge Base Retrieval MCP Server"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
+++ b/src/bedrock-kb-retrieval-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.bedrock-kb-retrieval-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for Bedrock Knowledge Base Retrieval"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/bedrock-kb-retrieval-mcp-server/uv.lock
+++ b/src/bedrock-kb-retrieval-mcp-server/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-bedrock-kb-retrieval-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/__init__.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/__init__.py
@@ -19,7 +19,7 @@ This Model Context Protocol (MCP) server provides tools for AWS cost optimizatio
 by wrapping boto3 SDK functions for AWS cost optimization services.
 """
 
-__version__ = '0.0.36'
+__version__ = '0.0.37'
 
 # We don't import server here to avoid circular imports
 

--- a/src/billing-cost-management-mcp-server/pyproject.toml
+++ b/src/billing-cost-management-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.billing-cost-management-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.36"
+version = "0.0.37"
 
 description = "A Model Context Protocol (MCP) server that provides tools for AWS Billing and Cost Management by wrapping boto3 SDK functions."
 readme = "README.md"

--- a/src/billing-cost-management-mcp-server/uv.lock
+++ b/src/billing-cost-management-mcp-server/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-billing-cost-management-mcp-server"
-version = "0.0.36"
+version = "0.0.37"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
+++ b/src/ccapi-mcp-server/awslabs/ccapi_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.ccapi-mcp-server"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/ccapi-mcp-server/pyproject.toml
+++ b/src/ccapi-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.ccapi-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS resources via Cloud Control API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ccapi-mcp-server/uv.lock
+++ b/src/ccapi-mcp-server/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-ccapi-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudtrail-mcp-server/awslabs/cloudtrail_mcp_server/__init__.py
+++ b/src/cloudtrail-mcp-server/awslabs/cloudtrail_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.cloudtrail-mcp-server"""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 MCP_SERVER_VERSION = __version__

--- a/src/cloudtrail-mcp-server/pyproject.toml
+++ b/src/cloudtrail-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.cloudtrail-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.0"
+version = "0.1.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudtrail"
 readme = "README.md"

--- a/src/cloudtrail-mcp-server/uv.lock
+++ b/src/cloudtrail-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudtrail-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
+++ b/src/cloudwatch-applicationsignals-mcp-server/awslabs/cloudwatch_applicationsignals_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Application Signals MCP Server."""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
+++ b/src/cloudwatch-applicationsignals-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-applicationsignals-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Application Signals"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-applicationsignals-mcp-server/uv.lock
+++ b/src/cloudwatch-applicationsignals-mcp-server/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-applicationsignals-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.cloudwatch-mcp-server"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 MCP_SERVER_VERSION = __version__

--- a/src/cloudwatch-mcp-server/pyproject.toml
+++ b/src/cloudwatch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.cloudwatch-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for cloudwatch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cloudwatch-mcp-server/uv.lock
+++ b/src/cloudwatch-mcp-server/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-cloudwatch-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
+++ b/src/document-loader-mcp-server/awslabs/document_loader_mcp_server/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Document Loader MCP Server package"""
 
-__version__ = '1.0.21'
+__version__ = '1.0.22'

--- a/src/document-loader-mcp-server/pyproject.toml
+++ b/src/document-loader-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.document-loader-mcp-server"
-version = "1.0.21"
+version = "1.0.22"
 description = "An AWS Labs Model Context Protocol (MCP) server for document parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/document-loader-mcp-server/uv.lock
+++ b/src/document-loader-mcp-server/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-document-loader-mcp-server"
-version = "1.0.21"
+version = "1.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.dynamodb-mcp-server"""
 
-__version__ = '2.1.7'
+__version__ = '2.1.8'

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.dynamodb-mcp-server"
-version = "2.1.7"
+version = "2.1.8"
 description = "The official MCP Server for interacting with AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-dynamodb-mcp-server"
-version = "2.1.7"
+version = "2.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "awslabs-aws-api-mcp-server" },

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/__init__.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.eks-mcp-server"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/eks-mcp-server/pyproject.toml
+++ b/src/eks-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.eks-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for EKS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/eks-mcp-server/uv.lock
+++ b/src/eks-mcp-server/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-eks-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/__init__.py
+++ b/src/elasticache-mcp-server/awslabs/elasticache_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.elasticache-mcp-server"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/elasticache-mcp-server/pyproject.toml
+++ b/src/elasticache-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.elasticache-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon ElastiCache"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/elasticache-mcp-server/uv.lock
+++ b/src/elasticache-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-elasticache-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/healthimaging-mcp-server/awslabs/healthimaging_mcp_server/__init__.py
+++ b/src/healthimaging-mcp-server/awslabs/healthimaging_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS HealthImaging MCP Server."""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/src/healthimaging-mcp-server/pyproject.toml
+++ b/src/healthimaging-mcp-server/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "awslabs.healthimaging-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.0"
+version = "0.1.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for HealthImaging"
 readme = "README.md"

--- a/src/healthimaging-mcp-server/uv.lock
+++ b/src/healthimaging-mcp-server/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-healthimaging-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/__init__.py
+++ b/src/healthlake-mcp-server/awslabs/healthlake_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS HealthLake MCP Server."""
 
-__version__ = '0.0.19'
+__version__ = '0.0.20'

--- a/src/healthlake-mcp-server/pyproject.toml
+++ b/src/healthlake-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.healthlake-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.0.19"
+version = "0.0.20"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for healthlake"
 readme = "README.md"

--- a/src/healthlake-mcp-server/uv.lock
+++ b/src/healthlake-mcp-server/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-healthlake-mcp-server"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/iam-mcp-server/awslabs/iam_mcp_server/__init__.py
+++ b/src/iam-mcp-server/awslabs/iam_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS IAM MCP Server package."""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/iam-mcp-server/pyproject.toml
+++ b/src/iam-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.iam-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for managing AWS IAM resources including users, roles, policies, and permissions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/iam-mcp-server/uv.lock
+++ b/src/iam-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-iam-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/__init__.py
+++ b/src/lambda-tool-mcp-server/awslabs/lambda_tool_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.lambda-tool-mcp-server"""
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/src/lambda-tool-mcp-server/pyproject.toml
+++ b/src/lambda-tool-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.lambda-tool-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Lambda Tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lambda-tool-mcp-server/uv.lock
+++ b/src/lambda-tool-mcp-server/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-lambda-tool-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/memcached-mcp-server/awslabs/memcached_mcp_server/__init__.py
+++ b/src/memcached-mcp-server/awslabs/memcached_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.memcached-mcp-server"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/memcached-mcp-server/pyproject.toml
+++ b/src/memcached-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.memcached-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for Amazon ElastiCache Memcached"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/memcached-mcp-server/uv.lock
+++ b/src/memcached-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-memcached-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },

--- a/src/mssql-mcp-server/awslabs/mssql_mcp_server/__init__.py
+++ b/src/mssql-mcp-server/awslabs/mssql_mcp_server/__init__.py
@@ -20,6 +20,6 @@ from importlib.metadata import version
 try:
     __version__ = version('awslabs.mssql-mcp-server')
 except Exception:
-    __version__ = '0.2.0'
+    __version__ = '0.2.1'
 
 __user_agent__ = f'md/awslabs#mcp#mssql-mcp-server#{__version__}'

--- a/src/mssql-mcp-server/pyproject.toml
+++ b/src/mssql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.mssql-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for Microsoft SQL Server on AWS RDS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mssql-mcp-server/uv.lock
+++ b/src/mssql-mcp-server/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-mssql-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/__init__.py
@@ -14,5 +14,5 @@
 
 """awslabs.mysql_mcp_server"""
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 __user_agent__ = f'awslabs/mcp/mysql_mcp_server/{__version__}'

--- a/src/mysql-mcp-server/pyproject.toml
+++ b/src/mysql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.mysql-mcp-server"
-version = "1.1.1"
+version = "1.1.2"
 description = "An AWS Labs Model Context Protocol (MCP) server for mysql"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mysql-mcp-server/uv.lock
+++ b/src/mysql-mcp-server/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-mysql-mcp-server"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },

--- a/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
+++ b/src/openapi-mcp-server/awslabs/openapi_mcp_server/__init__.py
@@ -15,7 +15,7 @@
 OpenAPI MCP Server - A server that dynamically creates MCP tools and resources from OpenAPI specifications.
 """
 
-__version__ = '1.1.5'
+__version__ = '1.1.6'
 
 
 import inspect

--- a/src/openapi-mcp-server/pyproject.toml
+++ b/src/openapi-mcp-server/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "awslabs.openapi-mcp-server"
-version = "1.1.5"
+version = "1.1.6"
 description = "An AWS Labs Model Context Protocol (MCP) server for OpenAPI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/openapi-mcp-server/uv.lock
+++ b/src/openapi-mcp-server/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-openapi-mcp-server"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/src/oracle-mcp-server/awslabs/oracle_mcp_server/__init__.py
+++ b/src/oracle-mcp-server/awslabs/oracle_mcp_server/__init__.py
@@ -20,6 +20,6 @@ from importlib.metadata import version
 try:
     __version__ = version('awslabs.oracle-mcp-server')
 except Exception:
-    __version__ = '0.2.0'
+    __version__ = '0.2.1'
 
 __user_agent__ = f'md/awslabs#mcp#oracle-mcp-server#{__version__}'

--- a/src/oracle-mcp-server/pyproject.toml
+++ b/src/oracle-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.oracle-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for Oracle Database on AWS RDS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/oracle-mcp-server/uv.lock
+++ b/src/oracle-mcp-server/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-oracle-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },

--- a/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
+++ b/src/postgres-mcp-server/awslabs/postgres_mcp_server/__init__.py
@@ -19,6 +19,6 @@ from importlib.metadata import version
 try:
     __version__ = version('awslabs.postgres-mcp-server')
 except Exception:  # pragma: no cover
-    __version__ = '1.2.0'
+    __version__ = '1.2.1'
 
 __user_agent__ = f'md/awslabs#mcp#postgres-mcp-server#{__version__}'

--- a/src/postgres-mcp-server/pyproject.toml
+++ b/src/postgres-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.postgres-mcp-server"
-version = "1.2.0"
+version = "1.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for postgres"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/postgres-mcp-server/uv.lock
+++ b/src/postgres-mcp-server/uv.lock
@@ -62,7 +62,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-postgres-mcp-server"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiorwlock" },

--- a/src/prometheus-mcp-server/awslabs/prometheus_mcp_server/__init__.py
+++ b/src/prometheus-mcp-server/awslabs/prometheus_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs Prometheus MCP Server."""
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/src/prometheus-mcp-server/pyproject.toml
+++ b/src/prometheus-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.prometheus-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for interacting with AWS Managed Prometheus"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prometheus-mcp-server/uv.lock
+++ b/src/prometheus-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-prometheus-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/redshift-mcp-server/awslabs/redshift_mcp_server/__init__.py
+++ b/src/redshift-mcp-server/awslabs/redshift_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.redshift-mcp-server"""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/src/redshift-mcp-server/pyproject.toml
+++ b/src/redshift-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.redshift-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.0"
+version = "0.1.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for Redshift"
 readme = "README.md"

--- a/src/redshift-mcp-server/uv.lock
+++ b/src/redshift-mcp-server/uv.lock
@@ -28,10 +28,10 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna", marker = "python_full_version < '3.14'" },
-    { name = "sniffio", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -47,7 +47,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "idna", marker = "python_full_version >= '3.14'" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-redshift-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -492,7 +492,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -526,8 +526,8 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "h11", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
-    { name = "truststore", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/db/2ad49878b36af4cff7527c1158b083ad6d9350462f1a35685cc3ebfa7c2b/httpcore2-2.6.0.tar.gz", hash = "sha256:95b692b582402ec49b3d84c2343556e4ac4c0962c8b3d39c48d485b9ecc240ab", size = 65592, upload-time = "2026-07-14T10:48:33.816Z" }
 wheels = [
@@ -543,8 +543,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "h11", marker = "python_full_version >= '3.14'" },
-    { name = "truststore", marker = "python_full_version >= '3.14'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -560,11 +560,11 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
-    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
-    { name = "idna", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
-    { name = "truststore", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version != '3.13.*' or sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/17/1e142bf3c76684232a092e1e4002be07fd3403b1c2dcb15d0012ea300c8f/httpx2-2.6.0.tar.gz", hash = "sha256:5d362fd59562cf2139a60c67bb016587a70b36156a517f176c7cbf1587d1ab22", size = 92736, upload-time = "2026-07-14T10:48:35.12Z" }
 wheels = [
@@ -581,12 +581,12 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
-    { name = "httpcore2", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
-    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
-    { name = "idna", marker = "(python_full_version >= '3.14' and sys_platform != 'emscripten') or (python_full_version >= '3.12' and sys_platform == 'emscripten')" },
-    { name = "truststore", marker = "python_full_version >= '3.14' and sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*' and sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
@@ -1617,8 +1617,8 @@ name = "uvicorn"
 version = "0.34.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
-    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }

--- a/src/s3-tables-mcp-server/awslabs/s3_tables_mcp_server/__init__.py
+++ b/src/s3-tables-mcp-server/awslabs/s3_tables_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/src/s3-tables-mcp-server/pyproject.toml
+++ b/src/s3-tables-mcp-server/pyproject.toml
@@ -2,7 +2,7 @@
 name = "awslabs.s3-tables-mcp-server"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "0.1.0"
+version = "0.1.1"
 
 description = "An AWS Labs Model Context Protocol (MCP) server for awslabs.s3-tables-mcp-server"
 readme = "README.md"

--- a/src/s3-tables-mcp-server/uv.lock
+++ b/src/s3-tables-mcp-server/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-s3-tables-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/__init__.py
+++ b/src/security-agent-mcp-server/awslabs/security_agent_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """AWS Security Agent MCP Server — automated security scanning and penetration testing."""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/security-agent-mcp-server/pyproject.toml
+++ b/src/security-agent-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.security-agent-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Security Agent — automated security scanning, penetration testing, and remediation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/security-agent-mcp-server/uv.lock
+++ b/src/security-agent-mcp-server/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-security-agent-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/__init__.py
+++ b/src/stepfunctions-tool-mcp-server/awslabs/stepfunctions_tool_mcp_server/__init__.py
@@ -14,4 +14,4 @@
 
 """awslabs.stepfunctions-tool-mcp-server"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/src/stepfunctions-tool-mcp-server/pyproject.toml
+++ b/src/stepfunctions-tool-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.stepfunctions-tool-mcp-server"
-version = "0.2.0"  # When updating this version, also update __version__ in awslabs/stepfunctions_tool_mcp_server/server.py
+version = "0.2.1"  # When updating this version, also update __version__ in awslabs/stepfunctions_tool_mcp_server/server.py
 description = "An AWS Labs Model Context Protocol (MCP) server for AWS Step Functions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/stepfunctions-tool-mcp-server/uv.lock
+++ b/src/stepfunctions-tool-mcp-server/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-stepfunctions-tool-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/__init__.py
+++ b/src/timestream-for-influxdb-mcp-server/awslabs/timestream_for_influxdb_mcp_server/__init__.py
@@ -15,4 +15,4 @@
 
 """awslabs.timestream-for-influxdb-mcp-server"""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/src/timestream-for-influxdb-mcp-server/pyproject.toml
+++ b/src/timestream-for-influxdb-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.timestream-for-influxdb-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for Timestream for InfluxDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/timestream-for-influxdb-mcp-server/uv.lock
+++ b/src/timestream-for-influxdb-mcp-server/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-timestream-for-influxdb-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/valkey-mcp-server/awslabs/valkey_mcp_server/__init__.py
+++ b/src/valkey-mcp-server/awslabs/valkey_mcp_server/__init__.py
@@ -16,4 +16,4 @@
 
 from __future__ import annotations
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/src/valkey-mcp-server/pyproject.toml
+++ b/src/valkey-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awslabs.valkey-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "An AWS Labs Model Context Protocol (MCP) server for valkey"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/valkey-mcp-server/uv.lock
+++ b/src/valkey-mcp-server/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "awslabs-valkey-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# release/2026.09.20260908143235

Triggered Release Branch (initiated) by @arnewouters for @arnewouters

## Changes
* amazon-bedrock-agentcore-mcp-server
* amazon-kendra-index-mcp-server
* amazon-mq-mcp-server
* amazon-neptune-mcp-server
* amazon-qbusiness-anonymous-mcp-server
* amazon-sns-sqs-mcp-server
* amazon-translate-mcp-server
* aurora-dsql-mcp-server
* aws-api-mcp-server
* aws-appsync-mcp-server
* aws-bedrock-custom-model-import-mcp-server
* aws-dataprocessing-mcp-server
* aws-documentation-mcp-server
* aws-for-sap-management-mcp-server
* aws-healthomics-mcp-server
* aws-iac-mcp-server
* aws-iot-sitewise-mcp-server
* aws-location-mcp-server
* aws-network-mcp-server
* aws-pricing-mcp-server
* aws-transform-mcp-server
* bedrock-kb-retrieval-mcp-server
* billing-cost-management-mcp-server
* ccapi-mcp-server
* cloudtrail-mcp-server
* cloudwatch-applicationsignals-mcp-server
* cloudwatch-mcp-server
* document-loader-mcp-server
* dynamodb-mcp-server
* eks-mcp-server
* elasticache-mcp-server
* healthimaging-mcp-server
* healthlake-mcp-server
* iam-mcp-server
* lambda-tool-mcp-server
* memcached-mcp-server
* mssql-mcp-server
* mysql-mcp-server
* openapi-mcp-server
* oracle-mcp-server
* postgres-mcp-server
* prometheus-mcp-server
* redshift-mcp-server
* s3-tables-mcp-server
* security-agent-mcp-server
* stepfunctions-tool-mcp-server
* timestream-for-influxdb-mcp-server
* valkey-mcp-server

## Checklist
- [ ] Code changes have been reviewed
- [ ] Distribution packages have been built and tested
- [ ] Documentation has been updated if applicable

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).