### PR TITLE
fix(billing-cost-management-mcp-server): expose bcm-pricing-calc arg …

### DIFF
--- a/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/bcm_pricing_calculator_tools.py
+++ b/src/billing-cost-management-mcp-server/awslabs/billing_cost_management_mcp_server/tools/bcm_pricing_calculator_tools.py
@@ -227,7 +227,40 @@ async def bcm_pricing_calc(
     max_results: Optional[int] = None,
     max_pages: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """FastMCP tool wrapper for BCM Pricing Calculator operations."""
+    """FastMCP tool wrapper for BCM Pricing Calculator operations.
+
+    Args:
+        ctx: The MCP context object.
+        operation: The operation to perform. One of: get_workload_estimate,
+            list_workload_estimates, list_workload_estimate_usage, get_preferences.
+        identifier: The workload estimate identifier. Required for get_workload_estimate
+            and list_workload_estimate_usage.
+        created_after: Filter estimates created after this timestamp
+            (ISO format: YYYY-MM-DDTHH:MM:SS).
+        created_before: Filter estimates created before this timestamp
+            (ISO format: YYYY-MM-DDTHH:MM:SS).
+        expires_after: Filter estimates expiring after this timestamp
+            (ISO format: YYYY-MM-DDTHH:MM:SS).
+        expires_before: Filter estimates expiring before this timestamp
+            (ISO format: YYYY-MM-DDTHH:MM:SS).
+        status_filter: Filter by status (UPDATING, VALID, INVALID, ACTION_NEEDED).
+        name_filter: Filter by name (supports partial matching).
+        name_match_option: Match option for the name filter
+            (EQUALS, STARTS_WITH, CONTAINS). Defaults to CONTAINS.
+        usage_account_id_filter: Filter usage lines by AWS account ID.
+        service_code_filter: Filter usage lines by AWS service code
+            (e.g. AmazonEC2, AmazonS3).
+        usage_type_filter: Filter usage lines by usage type.
+        operation_filter: Filter usage lines by operation name.
+        location_filter: Filter usage lines by location/region.
+        usage_group_filter: Filter usage lines by usage group.
+        next_token: Token for pagination.
+        max_results: Maximum number of results to return.
+        max_pages: Maximum number of API calls (pages) to make.
+
+    Returns:
+        Dict containing the response data.
+    """
     # need this wrapper to improve code coverage as FastMCP decorated methods cannot be tested directly.
     return await bcm_pricing_calc_core(
         ctx,

--- a/src/billing-cost-management-mcp-server/tests/tools/test_aws_bcm_pricing_calculator_tools.py
+++ b/src/billing-cost-management-mcp-server/tests/tools/test_aws_bcm_pricing_calculator_tools.py
@@ -1893,3 +1893,29 @@ class TestBcmPricingCalcCoreFunction:
             'Failed to process AWS Billing and Cost Management Pricing Calculator request'
             in result['message']
         )
+
+
+class TestBcmPricingCalcToolSchema:
+    """Tests that the registered bcm-pricing-calc tool exposes per-argument descriptions.
+
+    Regression guard for the defect where the decorated wrapper carried only a one-line
+    docstring while the ``Args:`` block lived on the undecorated ``bcm_pricing_calc_core``
+    delegate, so FastMCP surfaced no per-parameter descriptions to the model.
+    """
+
+    @pytest.mark.asyncio
+    async def test_every_tool_param_has_schema_description(self):
+        """Every bcm-pricing-calc parameter (excluding ctx) must resolve a description."""
+        tool = await bcm_pricing_calculator_server.get_tool('bcm-pricing-calc')
+        assert tool is not None, 'bcm-pricing-calc tool should be registered'
+        properties = tool.parameters.get('properties', {})
+
+        # ctx is injected by FastMCP and is not part of the exposed input schema.
+        assert 'ctx' not in properties
+
+        assert properties, 'Expected the tool to expose input parameters'
+
+        missing = [
+            name for name, spec in properties.items() if not spec.get('description', '').strip()
+        ]
+        assert not missing, f'Tool params missing schema descriptions: {missing}'


### PR DESCRIPTION
The bcm-pricing-calc tool's decorated wrapper `bcm_pricing_calc` carried only a one-line docstring, while the 18-argument `Args:` block lived on the undecorated `bcm_pricing_calc_core` delegate. FastMCP (griffe) only parses the decorated function's own docstring, so none of the 18 parameter descriptions reached the tool `inputSchema` — leaving the model with no per-argument guidance on any FastMCP version.

Move a Google-style `Args:` block onto the wrapper docstring (enriched with the enum values, ISO date formats, and service-code examples already documented on the delegate functions) so all 18 params now resolve schema descriptions.

Add a regression test asserting every exposed tool parameter (excluding ctx) resolves a non-empty schema description.

<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

The `bcm-pricing-calc` tool's decorated wrapper `bcm_pricing_calc` carried only a one-line docstring, while the full 18-argument `Args:` block lived on the undecorated delegate `bcm_pricing_calc_core`. FastMCP (griffe) only parses the **decorated** function's own docstring, so none of the 18 parameter descriptions were injected into the tool's `inputSchema` — the model received no per-argument guidance. Unlike the other BCM MCP tools, this is broken on every FastMCP version because the docs live on a function FastMCP never sees.

- Move a Google-style `Args:` block onto the `bcm_pricing_calc` wrapper docstring, enriched with the enum values (`status_filter`, `name_match_option`), ISO date formats, and service-code examples already documented on the delegate functions.
- Add a regression test asserting every exposed tool parameter (excluding `ctx`) resolves a non-empty schema description.

The wrapper/delegate split is intentional (it exists so the logic is unit-testable,since FastMCP-decorated functions can't be called directly), so this keeps the structure and only relocates the documentation to the surface FastMCP parses.

### User experience

**Before:** `bcm-pricing-calc`'s `inputSchema` exposed 0 of 18 parameter descriptions. Agents saw only parameter names/types with no guidance on operations, filters, date formats, or enum values.

**After:** all 18 parameters carry descriptions in the `inputSchema` (verified by loading the registered tool; also enforced by the new regression test).

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
