### PR TITLE
fix(aws-documentation-mcp-server): correct read-path output for tables, links, and redirects

### DIFF
--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import httpx
 import os
+import posixpath
 from awslabs.aws_documentation_mcp_server.models import (
     SearchResponse,
     SearchTableResponse,
@@ -64,10 +65,22 @@ DEFAULT_USER_AGENT = (
 )
 
 
+# A path ending in one of these names addresses the same page as its directory.
+_DIRECTORY_INDEX_FILENAMES = frozenset({'index.html', 'index.htm'})
+
+
+def _normalize_path(path: str) -> str:
+    """Reduce a URL path to the page it addresses, so cosmetic rewrites compare equal."""
+    resolved = posixpath.normpath(path or '/')
+    if posixpath.basename(resolved).lower() in _DIRECTORY_INDEX_FILENAMES:
+        resolved = posixpath.dirname(resolved)
+    return resolved.rstrip('/') or '/'
+
+
 def _page_identity(url: str) -> str:
-    """Reduce a URL to host and path, so scheme, query, fragment and trailing slash do not differ."""
+    """Reduce a URL to host and path, so scheme, query, fragment and path spelling do not differ."""
     parsed = httpx.URL(url)
-    return f'{parsed.host.lower()}{parsed.path.rstrip("/") or "/"}'
+    return f'{parsed.host}{_normalize_path(parsed.path)}'
 
 
 def _describe_redirect(url_str: str, response: httpx.Response) -> Optional[str]:
@@ -118,15 +131,19 @@ async def read_documentation_impl(
             await ctx.error(error_msg)
             return error_msg
 
+        # Computed before the status check: a moved page whose old URL now fails still redirected.
+        redirect_note = _describe_redirect(url_str, response)
+
         if response.status_code >= 400:
             error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
+            if redirect_note:
+                error_msg = f'{error_msg}. {redirect_note}'
             logger.error(error_msg)
             await ctx.error(error_msg)
             return error_msg
 
         page_raw = response.text
         content_type = response.headers.get('content-type', '')
-        redirect_note = _describe_redirect(url_str, response)
 
     if is_html_content(page_raw, content_type):
         content = extract_content_from_html(page_raw)
@@ -233,18 +250,23 @@ async def read_sections_impl(
             await ctx.error(error_msg)
             return error_msg
 
+        # Computed before the status check: a moved page whose old URL now fails still redirected.
+        redirect_note = _describe_redirect(url_str, response)
+
         if response.status_code >= 400:
             error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
+            if redirect_note:
+                error_msg = f'{error_msg}. {redirect_note}'
             logger.error(error_msg)
             await ctx.error(error_msg)
             return error_msg
 
         page_raw = response.text
         content_type = response.headers.get('content-type', '')
-        redirect_note = _describe_redirect(url_str, response)
 
     if not is_html_content(page_raw, content_type):
-        return 'Cannot extract sections from non-HTML content. Please use the read_documentation tool instead to get the full document content.'
+        non_html_msg = 'Cannot extract sections from non-HTML content. Please use the read_documentation tool instead to get the full document content.'
+        return f'{non_html_msg} {redirect_note}' if redirect_note else non_html_msg
 
     try:
         filtered_content = extract_sections_from_html(page_raw, section_titles)
@@ -331,8 +353,13 @@ async def search_table_impl(
                 error=error_msg,
             )
 
+        # Computed before the status check: a moved page whose old URL now fails still redirected.
+        redirect_note = _describe_redirect(url_str, response)
+
         if response.status_code >= 400:
             error_msg = f'Failed to fetch {url_str} - status code {response.status_code}'
+            if redirect_note:
+                error_msg = f'{error_msg}. {redirect_note}'
             logger.error(error_msg)
             await ctx.error(error_msg)
             return SearchTableResponse(
@@ -347,9 +374,9 @@ async def search_table_impl(
 
         page_raw = response.text
         content_type = response.headers.get('content-type', '')
-        redirect_note = _describe_redirect(url_str, response)
 
     if not is_html_content(page_raw, content_type):
+        non_html_hint = 'Page content is not HTML. Use read_documentation to view this page.'
         return SearchTableResponse(
             url=url_str,
             section_title=section_title or '',
@@ -357,7 +384,7 @@ async def search_table_impl(
             tables_searched=0,
             tables_with_matches=0,
             results=[],
-            hint='Page content is not HTML. Use read_documentation to view this page.',
+            hint=f'{non_html_hint} {redirect_note}' if redirect_note else non_html_hint,
         )
 
     table_data = parse_html_tables(page_raw, section_title if section_title else None)

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server_utils.py
@@ -64,6 +64,25 @@ DEFAULT_USER_AGENT = (
 )
 
 
+def _page_identity(url: str) -> str:
+    """Reduce a URL to host and path, so scheme, query, fragment and trailing slash do not differ."""
+    parsed = httpx.URL(url)
+    return f'{parsed.host.lower()}{parsed.path.rstrip("/") or "/"}'
+
+
+def _describe_redirect(url_str: str, response: httpx.Response) -> Optional[str]:
+    """Describe where a fetch landed when it did not land on the requested page."""
+    if not response.history:
+        return None
+    landed = str(response.url).split('?', 1)[0]
+    if _page_identity(landed) == _page_identity(url_str):
+        return None
+    return (
+        f'{url_str.split("?", 1)[0]} redirected to {landed}, so this is not the requested page. '
+        'The page may have been renamed; try the redirect target or search for the topic.'
+    )
+
+
 async def read_documentation_impl(
     ctx: Context,
     url_str: str,
@@ -107,6 +126,7 @@ async def read_documentation_impl(
 
         page_raw = response.text
         content_type = response.headers.get('content-type', '')
+        redirect_note = _describe_redirect(url_str, response)
 
     if is_html_content(page_raw, content_type):
         content = extract_content_from_html(page_raw)
@@ -114,7 +134,17 @@ async def read_documentation_impl(
     else:
         content = page_raw
 
+    # Unreadable after a redirect means moved, not missing.
+    if redirect_note and content.startswith('<e>'):
+        error_msg = f'Failed to read {url_str}: {redirect_note}'
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        return error_msg
+
     result = format_documentation_result(url_str, content, start_index, max_length)
+    if redirect_note:
+        # Content from another page must not be cited as the requested one.
+        result = f'<e>{redirect_note}</e>\n\n{result}'
 
     # Log if content was truncated
     if len(content) > start_index + max_length:
@@ -211,6 +241,7 @@ async def read_sections_impl(
 
         page_raw = response.text
         content_type = response.headers.get('content-type', '')
+        redirect_note = _describe_redirect(url_str, response)
 
     if not is_html_content(page_raw, content_type):
         return 'Cannot extract sections from non-HTML content. Please use the read_documentation tool instead to get the full document content.'
@@ -218,10 +249,10 @@ async def read_sections_impl(
     try:
         filtered_content = extract_sections_from_html(page_raw, section_titles)
     except ValueError as e:
-        error_msg = str(e)
+        error_msg = f'{e} {redirect_note}' if redirect_note else str(e)
         logger.error(error_msg)
         await ctx.error(error_msg)
-        raise
+        raise ValueError(error_msg) from e
 
     try:
         markdown = extract_content_from_html(filtered_content)
@@ -231,6 +262,8 @@ async def read_sections_impl(
         if markdown.startswith('<e>') and markdown.endswith('</e>'):
             # strip only the outer wrapper tags
             error_msg = markdown[3:-4]
+            if redirect_note:
+                error_msg = f'{error_msg} {redirect_note}'
             raise ValueError(error_msg)
 
     except Exception as e:
@@ -238,6 +271,10 @@ async def read_sections_impl(
         logger.error(error_msg)
         await ctx.error(error_msg)
         raise
+
+    if redirect_note:
+        # Content from another page must not be cited as the requested one.
+        markdown = f'<e>{redirect_note}</e>\n\n{markdown}'
 
     return markdown
 
@@ -310,6 +347,7 @@ async def search_table_impl(
 
         page_raw = response.text
         content_type = response.headers.get('content-type', '')
+        redirect_note = _describe_redirect(url_str, response)
 
     if not is_html_content(page_raw, content_type):
         return SearchTableResponse(
@@ -332,7 +370,11 @@ async def search_table_impl(
             tables_searched=0,
             tables_with_matches=0,
             results=[],
-            hint='No tables found on this page.',
+            hint=(
+                f'No tables found. {redirect_note}'
+                if redirect_note
+                else 'No tables found on this page.'
+            ),
         )
 
     if 'error' in table_data:
@@ -344,7 +386,11 @@ async def search_table_impl(
             tables_searched=0,
             tables_with_matches=0,
             results=[],
-            hint=f'{table_data["error"]}. Available sections: {sections_list}',
+            hint=(
+                f'{table_data["error"]}. Available sections: {sections_list}. {redirect_note}'
+                if redirect_note
+                else f'{table_data["error"]}. Available sections: {sections_list}'
+            ),
         )
 
     # Handle multi-table response (multiple tables in section or page)
@@ -380,6 +426,9 @@ async def search_table_impl(
             'No rows matched all query words. Try fewer or broader terms, '
             'or check spelling. Each word must appear somewhere in the row.'
         )
+    if redirect_note:
+        # Rows from another page must not be cited as the requested one.
+        hint = f'{redirect_note} {hint}' if hint else redirect_note
 
     return SearchTableResponse(
         url=url_str,

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/table_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/table_utils.py
@@ -20,16 +20,46 @@ from bs4.element import NavigableString
 from typing import Optional
 
 
+# Note, tip, warning and important callouts all carry these classes, on the block and on its title.
+_CALLOUT_CLASSES = ('awsdocs-note-title', 'awsdocs-note')
+_CALLOUT_TITLE_CLASS = 'awsdocs-note-title'
+_HEADING_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+
+
+def _in_callout(element: Tag) -> bool:
+    """Report whether an element belongs to a callout rather than to content."""
+    for candidate in (element, *element.parents):
+        classes = candidate.get('class') or [] if isinstance(candidate, Tag) else []
+        if any(cls in _CALLOUT_CLASSES for cls in classes):
+            return True
+    return False
+
+
 # Delimiting multi-value cells keeps the Nth value in one column aligned with the Nth in the next.
 _VALUE_DELIMITER = '; '
 _BREAK_MARKER = '\x00'  # placeholder for value boundaries; survives get_text(strip=True)
+# A callout inside a cell qualifies the value rather than adding one, so it joins with a space.
+_SOFT_MARKER = '\x01'
 _BREAK_TAGS = ['br', 'p', 'div', 'li', 'dt', 'dd', 'tr']
+
+
+# A callout boundary wins over any block boundary beside it: the callout qualifies the value it
+# follows rather than starting a new one.
+_ADJACENT_MARKERS = re.compile(
+    f'[{_BREAK_MARKER}\\s]*{_SOFT_MARKER}[{_BREAK_MARKER}{_SOFT_MARKER}\\s]*'
+)
 
 
 def _join_values(text: str) -> str:
     """Join marker-separated values with '; ', dropping empty segments."""
-    segments = (segment.strip() for segment in text.split(_BREAK_MARKER))
+    absorbed = _ADJACENT_MARKERS.sub(_SOFT_MARKER, text)
+    segments = (_collapse_soft_breaks(segment) for segment in absorbed.split(_BREAK_MARKER))
     return _VALUE_DELIMITER.join(segment for segment in segments if segment)
+
+
+def _collapse_soft_breaks(segment: str) -> str:
+    """Reduce soft boundaries and surrounding whitespace to single spaces."""
+    return ' '.join(segment.replace(_SOFT_MARKER, ' ').split())
 
 
 def _mark_breaks(cell: Tag) -> None:
@@ -37,15 +67,24 @@ def _mark_breaks(cell: Tag) -> None:
     for tag in cell.find_all(_BREAK_TAGS):
         if not isinstance(tag, Tag):
             continue
+        marker = _SOFT_MARKER if _in_callout(tag) else _BREAK_MARKER
         if tag.name == 'br':
-            tag.replace_with(NavigableString(_BREAK_MARKER))
+            tag.replace_with(NavigableString(marker))
         else:
-            tag.insert_before(NavigableString(_BREAK_MARKER))
-            tag.insert_after(NavigableString(_BREAK_MARKER))
+            tag.insert_before(NavigableString(marker))
+            tag.insert_after(NavigableString(marker))
+
+
+def _strip_callout_titles(cell: Tag) -> None:
+    """Remove 'Note' and 'Important' labels, which are chrome rather than cell content."""
+    for title in cell.find_all(class_=_CALLOUT_TITLE_CLASS):
+        if isinstance(title, Tag):
+            title.decompose()
 
 
 def _cell_text(cell: Tag) -> str:
     """Extract cell text, joining multi-value cells with '; '."""
+    _strip_callout_titles(cell)
     _mark_breaks(cell)
     return _join_values(cell.get_text(strip=True))
 
@@ -53,20 +92,6 @@ def _cell_text(cell: Tag) -> str:
 def _heading_text(heading: Tag) -> str:
     """Extract heading text, dropping markers left behind by cell processing."""
     return _join_values(heading.get_text(strip=True))
-
-
-# Note, tip, warning and important callouts all class their own <h6> title with these.
-_CALLOUT_CLASSES = ('awsdocs-note-title', 'awsdocs-note')
-_HEADING_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
-
-
-def _in_callout(heading: Tag) -> bool:
-    """Report whether a heading is a callout title rather than a content heading."""
-    for element in (heading, *heading.parents):
-        classes = element.get('class') or [] if isinstance(element, Tag) else []
-        if any(cls in _CALLOUT_CLASSES for cls in classes):
-            return True
-    return False
 
 
 def _nearest_heading(table: Tag) -> Optional[Tag]:
@@ -437,6 +462,7 @@ def _cell_to_text(cell: Tag) -> str:
         return _cell_text(cell)
 
     # Build text with markdown links
+    _strip_callout_titles(cell)
     _mark_breaks(cell)
     parts: list[str] = []
     _extract_with_links(cell, parts)

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/table_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/table_utils.py
@@ -19,6 +19,63 @@ from bs4.element import NavigableString
 from typing import Optional
 
 
+# Delimiting multi-value cells keeps the Nth value in one column aligned with the Nth in the next.
+_VALUE_DELIMITER = '; '
+_BREAK_MARKER = '\x00'  # placeholder for value boundaries; survives get_text(strip=True)
+_BREAK_TAGS = ['br', 'p', 'div', 'li', 'dt', 'dd', 'tr']
+
+
+def _join_values(text: str) -> str:
+    """Join marker-separated values with '; ', dropping empty segments."""
+    segments = (segment.strip() for segment in text.split(_BREAK_MARKER))
+    return _VALUE_DELIMITER.join(segment for segment in segments if segment)
+
+
+def _mark_breaks(cell: Tag) -> None:
+    """Insert boundary markers at <br /> and block-element edges inside a cell."""
+    for tag in cell.find_all(_BREAK_TAGS):
+        if not isinstance(tag, Tag):
+            continue
+        if tag.name == 'br':
+            tag.replace_with(NavigableString(_BREAK_MARKER))
+        else:
+            tag.insert_before(NavigableString(_BREAK_MARKER))
+            tag.insert_after(NavigableString(_BREAK_MARKER))
+
+
+def _cell_text(cell: Tag) -> str:
+    """Extract cell text, joining multi-value cells with '; '."""
+    _mark_breaks(cell)
+    return _join_values(cell.get_text(strip=True))
+
+
+def _heading_text(heading: Tag) -> str:
+    """Extract heading text, dropping markers left behind by cell processing."""
+    return _join_values(heading.get_text(strip=True))
+
+
+# Note, tip, warning and important callouts all class their own <h6> title with these.
+_CALLOUT_CLASSES = ('awsdocs-note-title', 'awsdocs-note')
+_HEADING_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+
+
+def _in_callout(heading: Tag) -> bool:
+    """Report whether a heading is a callout title rather than a content heading."""
+    for element in (heading, *heading.parents):
+        classes = element.get('class') or [] if isinstance(element, Tag) else []
+        if any(cls in _CALLOUT_CLASSES for cls in classes):
+            return True
+    return False
+
+
+def _nearest_heading(table: Tag) -> Optional[Tag]:
+    """Find the heading a table sits under, skipping callout titles."""
+    heading = table.find_previous(_HEADING_TAGS)
+    while isinstance(heading, Tag) and _in_callout(heading):
+        heading = heading.find_previous(_HEADING_TAGS)
+    return heading if isinstance(heading, Tag) else None
+
+
 def _safe_span(cell: Tag, attr: str) -> int:
     """Safely parse a colspan/rowspan attribute, returning at least 1."""
     try:
@@ -98,7 +155,7 @@ def parse_html_tables(html: str, section_title: Optional[str] = None) -> Optiona
     for table, sub_heading in tables:
         table_data = _extract_table_data(table)
         if table_data and 'rows' in table_data:
-            table_data['table_heading'] = sub_heading.get_text(strip=True) if sub_heading else None
+            table_data['table_heading'] = _heading_text(sub_heading) if sub_heading else None
             parsed_tables.append(table_data)
 
     if not parsed_tables:
@@ -125,9 +182,8 @@ def _find_all_tables(soup: BeautifulSoup) -> Optional[dict]:
     for table in tables:
         table_data = _extract_table_data(table)
         if table_data and 'rows' in table_data:
-            # Find the nearest heading for this table
-            heading = table.find_previous(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
-            table_data['table_heading'] = heading.get_text(strip=True) if heading else None
+            heading = _nearest_heading(table)
+            table_data['table_heading'] = _heading_text(heading) if heading else None
             parsed_tables.append(table_data)
 
     if not parsed_tables:
@@ -139,7 +195,7 @@ def _find_all_tables(soup: BeautifulSoup) -> Optional[dict]:
 
     return {
         'tables': parsed_tables,
-        'detected_section': heading.get_text(strip=True) if heading else '(all tables)',
+        'detected_section': _heading_text(heading) if isinstance(heading, Tag) else '(all tables)',
     }
 
 
@@ -163,7 +219,7 @@ def _parse_multi_row_thead(header_rows: list[Tag]) -> list[str]:
             # Skip columns already filled by rowspan from above
             while col_idx < len(grid[row_idx]) and grid[row_idx][col_idx]:
                 col_idx += 1
-            text = cell.get_text(strip=True)
+            text = _cell_text(cell)
             colspan = _safe_span(cell, 'colspan')
             rowspan = _safe_span(cell, 'rowspan')
             for r in range(rowspan):
@@ -225,7 +281,7 @@ def _extract_table_data(table: Tag) -> Optional[dict]:
                 if not isinstance(th, Tag):
                     continue
                 colspan = _safe_span(th, 'colspan')
-                text = th.get_text(strip=True)
+                text = _cell_text(th)
                 for i in range(colspan):
                     headers.append(text if i == 0 else f'{text}_{i + 1}')
             headers = _deduplicate_headers(headers)
@@ -236,7 +292,7 @@ def _extract_table_data(table: Tag) -> Optional[dict]:
                 if not isinstance(cell, Tag):
                     continue
                 colspan = _safe_span(cell, 'colspan')
-                text = cell.get_text(strip=True)
+                text = _cell_text(cell)
                 for i in range(colspan):
                     headers.append(text if i == 0 else f'{text}_{i + 1}')
             headers = _deduplicate_headers(headers)
@@ -377,12 +433,13 @@ def _cell_to_text(cell: Tag) -> str:
     # Check if cell contains any links
     links = cell.find_all('a')
     if not links:
-        return cell.get_text(strip=True)
+        return _cell_text(cell)
 
     # Build text with markdown links
+    _mark_breaks(cell)
     parts: list[str] = []
     _extract_with_links(cell, parts)
-    return ' '.join(parts).strip()
+    return _join_values(' '.join(parts))
 
 
 def _extract_with_links(element: Tag, parts: list[str]) -> None:
@@ -395,7 +452,8 @@ def _extract_with_links(element: Tag, parts: list[str]) -> None:
         elif isinstance(child, Tag):
             if child.name == 'a':
                 href = str(child.get('href', ''))
-                text = child.get_text(strip=True)
+                # Join inside the link so markers never straddle the markdown syntax
+                text = _join_values(child.get_text(strip=True))
                 if href and text:
                     parts.append(f'[{text}]({href})')
                 elif text:

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/table_utils.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/table_utils.py
@@ -14,6 +14,7 @@
 """Table parsing and filtering utilities for AWS Documentation MCP Server."""
 
 import re
+from awslabs.aws_documentation_mcp_server.util import has_empty_link_target
 from bs4 import BeautifulSoup, Tag
 from bs4.element import NavigableString
 from typing import Optional
@@ -454,7 +455,7 @@ def _extract_with_links(element: Tag, parts: list[str]) -> None:
                 href = str(child.get('href', ''))
                 # Join inside the link so markers never straddle the markdown syntax
                 text = _join_values(child.get_text(strip=True))
-                if href and text:
+                if href and text and not has_empty_link_target(href):
                     parts.append(f'[{text}]({href})')
                 elif text:
                     parts.append(text)

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/util.py
@@ -21,6 +21,26 @@ from typing import Any, Dict, List, Sequence
 from urllib.parse import quote_plus, urljoin
 
 
+# An unresolved cross-reference leaves an href with no filename, e.g. './.html#anchor'.
+_EMPTY_TARGET_FILENAMES = frozenset({'.html', '.htm'})
+
+
+def has_empty_link_target(href: str) -> bool:
+    """Report whether an href points at a path with no filename."""
+    path = href.split('#', 1)[0].split('?', 1)[0].strip()
+    if not path:
+        return False  # fragment-only link; resolves to the current page
+    return path.rsplit('/', 1)[-1].casefold() in _EMPTY_TARGET_FILENAMES
+
+
+def _unwrap_broken_links(root) -> None:
+    """Replace links whose target has no filename with their own text."""
+    for anchor in root.find_all('a'):
+        href = anchor.get('href')
+        if isinstance(href, str) and has_empty_link_target(href):
+            anchor.unwrap()
+
+
 def extract_content_from_html(html: str) -> str:
     """Extract and convert HTML content to Markdown format.
 
@@ -86,6 +106,8 @@ def extract_content_from_html(html: str) -> str:
             for element in main_content.select(selector):
                 element.decompose()
 
+        _unwrap_broken_links(main_content)
+
         # Define tags to strip - these are elements we don't want in the output
         tags_to_strip = [
             'script',
@@ -128,8 +150,8 @@ def extract_content_from_html(html: str) -> str:
         content = markdownify.markdownify(
             str(main_content),
             heading_style=markdownify.ATX,
-            autolinks=True,
-            default_title=True,
+            autolinks=False,  # markdownify gates this on default_title; keep [url](url)
+            default_title=False,  # would repeat the href as the title: [text](url "url")
             escape_asterisks=True,
             escape_underscores=True,
             newline_style='SPACES',

--- a/src/aws-documentation-mcp-server/tests/test_server_aws.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws.py
@@ -53,6 +53,7 @@ class TestReadDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>Test</h1><p>This is a test.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -81,6 +82,7 @@ class TestReadDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>Test</h1><p>This is a test.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -149,6 +151,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <h2>Introduction</h2>
             <p>This is the introduction.</p>
@@ -194,6 +197,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = (
             '<html><body><h2>Getting Started</h2><p>Neuron content.</p></body></html>'
         )
@@ -233,6 +237,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         # Only h1, no h2 sections
         mock_response.text = (
             '<html><body><h1>Other Section</h1><p>Different content.</p></body></html>'
@@ -254,6 +259,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         # One h2 section exists, one doesn't
         mock_response.text = '<html><body><h2>Found Section</h2><p>Content here.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
@@ -310,6 +316,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <h2>C++ & C# Programming</h2>
             <p>Programming content.</p>
@@ -354,6 +361,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>This is a page<h1/><h2>Best practices</h2><p>Content here.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -374,6 +382,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = 'Plain text content without HTML'
         mock_response.headers = {'content-type': 'text/plain'}
 
@@ -418,6 +427,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h2>Test Section</h2><p>Content.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -441,6 +451,7 @@ class TestReadSections:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <div class="main-content">
                 <h1>S3 Bucket Guide</h1>
@@ -491,6 +502,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'test-query-id',
             'facets': {
@@ -565,6 +577,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'test-query-id',
             'suggestions': [
@@ -659,6 +672,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.side_effect = json.JSONDecodeError('Invalid JSON', '', 0)
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -683,6 +697,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {}  # No suggestions key
 
         with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
@@ -702,6 +717,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'facets': {
                 'aws-docs-search-product': ['Amazon S3'],
@@ -756,6 +772,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'test-query-sections',
             'suggestions': [
@@ -834,6 +851,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'test-query-recommended',
             'suggestions': [
@@ -890,6 +908,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'test-query-rec-edge',
             'suggestions': [
@@ -935,6 +954,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'qid',
             'suggestions': [
@@ -988,6 +1008,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'qid',
             'suggestions': [
@@ -1017,6 +1038,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'qid',
             'suggestions': [
@@ -1052,6 +1074,7 @@ class TestSearchDocumentation:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'queryId': 'qid',
             'suggestions': [
@@ -1095,6 +1118,7 @@ class TestRecommend:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.return_value = {
             'new': {
                 'items': [
@@ -1180,6 +1204,7 @@ class TestRecommend:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.json.side_effect = json.JSONDecodeError('Invalid JSON', '', 0)
 
         with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
@@ -1204,6 +1229,7 @@ class TestSearchTable:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <h2>Service quotas</h2>
             <table><thead><tr><th>Name</th><th>Value</th></tr></thead>
@@ -1272,6 +1298,7 @@ class TestSearchTable:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <h2>Quotas</h2>
             <table><thead><tr><th>Name</th></tr></thead>
@@ -1297,6 +1324,7 @@ class TestSearchTable:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <h2>Real Section</h2>
             <table><thead><tr><th>A</th></tr></thead>
@@ -1321,6 +1349,7 @@ class TestSearchTable:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
             <h2>Section A</h2>
             <table><thead><tr><th>Name</th></tr></thead>

--- a/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_aws_cn.py
@@ -52,6 +52,7 @@ class TestReadDocumentationChina:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>Test</h1><p>This is a test.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -122,6 +123,7 @@ class TestGetAvailableServices:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>AWS Services in China</h1><p>Available services list.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -207,6 +209,7 @@ class TestGetAvailableServices:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = 'Plain text content'
         mock_response.headers = {'content-type': 'text/plain'}
 
@@ -252,6 +255,7 @@ class TestGetAvailableServices:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>AWS Services in China</h1><p>Available services list.</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 

--- a/src/aws-documentation-mcp-server/tests/test_server_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_utils.py
@@ -20,6 +20,7 @@ from awslabs.aws_documentation_mcp_server.server_utils import (
     COMMERCIAL_ALLOWED_DOMAIN_REGEXES,
     DEFAULT_USER_AGENT,
     SEARCH_RESULT_CACHE,
+    _describe_redirect,
     _docs_client,
     add_search_result_cache_item,
     get_query_id_from_cache,
@@ -47,6 +48,7 @@ class TestReadDocumentationImpl:
         # Create a proper mock response
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>Test</h1><p>Content</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -103,6 +105,7 @@ class TestReadDocumentationImpl:
         # Create a proper mock response
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = 'Plain text content'
         mock_response.headers = {'content-type': 'text/plain'}
 
@@ -207,6 +210,7 @@ class TestReadDocumentationImpl:
         # Create a proper mock response
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = (
             '<html><body><h1>Test</h1><p>Long content that exceeds max length</p></body></html>'
         )
@@ -266,6 +270,7 @@ class TestReadDocumentationImpl:
         # Create a proper mock response
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>Test</h1><p>Content</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -338,6 +343,7 @@ class TestReadDocumentationImpl:
         # Create a proper mock response
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h1>Test</h1><p>Content</p></body></html>'
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -398,6 +404,7 @@ class TestReadDocumentationImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = html
         mock_response.headers = {'content-type': 'text/html'}
 
@@ -717,6 +724,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h2>Test Section</h2><table><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>foo</td><td>bar</td></tr></tbody></table></body></html>'
 
         with patch('httpx.AsyncClient') as mock_client_class:
@@ -745,6 +753,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>foo</td></tr></tbody></table></body></html>'
 
         with patch('httpx.AsyncClient') as mock_client_class:
@@ -822,6 +831,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h2>Section</h2><p>No tables here</p></body></html>'
 
         with patch('httpx.AsyncClient') as mock_client_class:
@@ -848,6 +858,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h2>Real Section</h2><table><thead><tr><th>A</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table></body></html>'
 
         with patch('httpx.AsyncClient') as mock_client_class:
@@ -877,6 +888,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body><h2>Quotas</h2><table>
         <thead><tr><th>Name</th><th>Value</th></tr></thead>
         <tbody>
@@ -911,6 +923,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body><h2>Quotas</h2><table>
         <thead><tr><th>Name</th><th>Value</th></tr></thead>
         <tbody><tr><td>foo</td><td>bar</td></tr></tbody></table></body></html>"""
@@ -940,6 +953,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
         <h2>Service quotas</h2>
         <h3>EC2</h3>
@@ -985,6 +999,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '<html><body><h2>Sec</h2><table><thead><tr><th>A</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table></body></html>'
 
         with patch('httpx.AsyncClient') as mock_client_class:
@@ -1010,6 +1025,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
         <h2>Sec</h2>
         <table><thead><tr><th>Name</th></tr></thead>
@@ -1039,6 +1055,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = '{"key": "value"}'
         mock_response.headers = {'content-type': 'application/json'}
 
@@ -1068,6 +1085,7 @@ class TestSearchTableImpl:
         rows_html = ''.join(f'<tr><td>Quota {i}</td><td>active</td></tr>' for i in range(25))
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = f"""<html><body><h2>Quotas</h2><table>
         <thead><tr><th>Name</th><th>Status</th></tr></thead>
         <tbody>{rows_html}</tbody></table></body></html>"""
@@ -1098,6 +1116,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body><h2>Actions</h2><table>
         <thead><tr><th>Action</th><th>Level</th><th>Resource</th></tr></thead>
         <tbody>
@@ -1135,6 +1154,7 @@ class TestSearchTableImpl:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.history = []  # not a redirect
         mock_response.text = """<html><body>
         <h2>Section A</h2>
         <table><thead><tr><th>Name</th></tr></thead>
@@ -1158,3 +1178,258 @@ class TestSearchTableImpl:
             assert result.tables_with_matches == 1
             assert result.results[0].matched_rows == 1
             assert result.section_title != ''
+
+
+class TestRedirectSignal:
+    """A renamed page returned a soft error that read as "not documented"."""
+
+    def _redirected_response(self, text, landed='https://docs.aws.amazon.com/general/latest/gr/'):
+        """Build a 200 response that arrived via a redirect to another page."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = text
+        mock_response.headers = {'content-type': 'text/html'}
+        mock_response.history = [MagicMock()]
+        mock_response.url = landed
+        return mock_response
+
+    def _client_for(self, mock_response):
+        """Patch httpx.AsyncClient so a fetch returns the given response."""
+        patcher = patch('httpx.AsyncClient')
+        mock_client_class = patcher.start()
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+        return patcher
+
+    def test_no_history_is_not_a_redirect(self):
+        """A direct 200 produces no redirect note."""
+        response = MagicMock()
+        response.history = []
+        response.url = 'https://docs.aws.amazon.com/general/latest/gr/ddb.html'
+        assert (
+            _describe_redirect('https://docs.aws.amazon.com/general/latest/gr/ddb.html', response)
+            is None
+        )
+
+    def test_same_page_with_different_query_is_not_a_redirect(self):
+        """The session/query parameters the server appends are not a page change."""
+        response = MagicMock()
+        response.history = [MagicMock()]
+        response.url = 'https://docs.aws.amazon.com/general/latest/gr/ddb.html?session=abc'
+        assert (
+            _describe_redirect('https://docs.aws.amazon.com/general/latest/gr/ddb.html', response)
+            is None
+        )
+
+    def test_different_page_reported(self):
+        """Landing on another page names both the requested and the actual page."""
+        response = MagicMock()
+        response.history = [MagicMock()]
+        response.url = 'https://docs.aws.amazon.com/general/latest/gr/'
+        note = _describe_redirect(
+            'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html?session=abc', response
+        )
+        assert note is not None
+        assert 'dynamodb.html' in note
+        assert 'general/latest/gr/' in note
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_reports_redirect_instead_of_soft_error(self):
+        """An unreadable redirected page returns an explicit failure, not '<e>...</e>'."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(self._redirected_response('<html><body></body></html>'))
+        try:
+            result = await read_documentation_impl(ctx, url, 1000, 0, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert '<e>' not in result
+        assert 'redirected to' in result
+        assert 'general/latest/gr/' in result
+
+    @pytest.mark.asyncio
+    async def test_search_table_hint_names_the_redirect(self):
+        """A false "no tables" on a redirected page says the page moved."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response('<html><body><p>hi</p></body></html>')
+        )
+        try:
+            result = await search_table_impl(ctx, url, None, 'ap-southeast-4', 50, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert result.hint is not None
+        assert 'redirected to' in result.hint
+
+    @pytest.mark.asyncio
+    async def test_read_sections_error_names_the_redirect(self):
+        """A section-less redirected page fails with the redirect named in the message."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response('<html><body><p>hi</p></body></html>')
+        )
+        try:
+            with pytest.raises(ValueError, match='redirected to'):
+                await read_sections_impl(ctx, url, ['Service endpoints'], 'test-uuid')
+        finally:
+            patcher.stop()
+
+    @pytest.mark.parametrize(
+        'requested,landed',
+        [
+            (
+                'https://docs.aws.amazon.com/general/latest/gr/ddb.html',
+                'http://docs.aws.amazon.com/general/latest/gr/ddb.html',
+            ),
+            (
+                'https://docs.aws.amazon.com/general/latest/gr/ddb.html',
+                'https://docs.aws.amazon.com/general/latest/gr/ddb.html#anchor',
+            ),
+            (
+                'https://docs.aws.amazon.com/general/latest/gr/',
+                'https://docs.aws.amazon.com/general/latest/gr',
+            ),
+            (
+                'https://DOCS.aws.amazon.com/general/latest/gr/ddb.html',
+                'https://docs.aws.amazon.com/general/latest/gr/ddb.html',
+            ),
+        ],
+    )
+    def test_cosmetic_url_differences_are_not_a_redirect(self, requested, landed):
+        """Scheme, fragment, trailing slash and host case do not make it another page."""
+        response = MagicMock()
+        response.history = [MagicMock()]
+        response.url = landed
+        assert _describe_redirect(requested, response) is None
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_flags_redirect_that_carried_content(self):
+        """Content from another page is labelled, not silently returned as the requested page."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response(
+                '<html><body><main><h1>General Reference</h1>'
+                '<p>Plenty of readable prose about something else entirely.</p>'
+                '</main></body></html>'
+            )
+        )
+        try:
+            result = await read_documentation_impl(ctx, url, 5000, 0, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'redirected to' in result
+        assert 'General Reference' in result
+
+    @pytest.mark.asyncio
+    async def test_search_table_rows_from_redirected_page_are_flagged(self):
+        """Matching rows found on the wrong page still carry the redirect warning."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response(
+                '<html><body><h2>Service endpoints</h2>'
+                '<table><thead><tr><th>Region</th></tr></thead>'
+                '<tbody><tr><td>ap-southeast-4</td></tr></tbody></table>'
+                '</body></html>'
+            )
+        )
+        try:
+            result = await search_table_impl(ctx, url, None, 'ap-southeast-4', 50, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert result.tables_with_matches == 1
+        assert result.hint is not None
+        assert 'redirected to' in result.hint
+
+    @pytest.mark.asyncio
+    async def test_read_sections_flags_redirect_when_heading_matches(self):
+        """A heading that happens to match on the wrong page does not hide the redirect."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response(
+                '<html><body><h2>Service endpoints</h2>'
+                '<p>Endpoints for a different service.</p></body></html>'
+            )
+        )
+        try:
+            result = await read_sections_impl(ctx, url, ['Service endpoints'], 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'redirected to' in result
+        assert 'different service' in result
+
+    @pytest.mark.asyncio
+    async def test_search_table_section_not_found_names_the_redirect(self):
+        """A missing section on a redirected page says the page moved, not that it lacks the section."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response(
+                '<html><body><h2>Something else</h2>'
+                '<table><thead><tr><th>Region</th></tr></thead>'
+                '<tbody><tr><td>us-east-1</td></tr></tbody></table>'
+                '</body></html>'
+            )
+        )
+        try:
+            result = await search_table_impl(
+                ctx, url, 'Service endpoints', 'us-east-1', 50, 'test-uuid'
+            )
+        finally:
+            patcher.stop()
+        assert result.hint is not None
+        assert 'redirected to' in result.hint
+
+    @pytest.mark.asyncio
+    async def test_direct_fetch_adds_no_redirect_noise(self):
+        """A page reached without a redirect is returned unannotated."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        response = self._redirected_response(
+            '<html><body><main><p>Real content.</p></main></body></html>'
+        )
+        response.history = []
+        response.url = url
+        patcher = self._client_for(response)
+        try:
+            result = await read_documentation_impl(ctx, url, 5000, 0, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'redirected to' not in result
+        assert 'Real content.' in result
+
+    @pytest.mark.asyncio
+    async def test_read_sections_unreadable_section_names_the_redirect(self):
+        """A section that matches but converts to nothing still reports the redirect."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+        patcher = self._client_for(
+            self._redirected_response('<html><body><h2>Service endpoints</h2></body></html>')
+        )
+        try:
+            with (
+                patch(
+                    'awslabs.aws_documentation_mcp_server.server_utils.extract_content_from_html',
+                    return_value='<e>Page failed to be simplified from HTML</e>',
+                ),
+                pytest.raises(ValueError, match='redirected to'),
+            ):
+                await read_sections_impl(ctx, url, ['Service endpoints'], 'test-uuid')
+        finally:
+            patcher.stop()

--- a/src/aws-documentation-mcp-server/tests/test_server_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_server_utils.py
@@ -1301,14 +1301,45 @@ class TestRedirectSignal:
                 'https://DOCS.aws.amazon.com/general/latest/gr/ddb.html',
                 'https://docs.aws.amazon.com/general/latest/gr/ddb.html',
             ),
+            (
+                'https://docs.aws.amazon.com/general/latest/gr//ddb.html',
+                'https://docs.aws.amazon.com/general/latest/gr/ddb.html',
+            ),
+            (
+                'https://docs.aws.amazon.com/general/latest/gr/./ddb.html',
+                'https://docs.aws.amazon.com/general/latest/gr/ddb.html',
+            ),
+            (
+                'https://docs.aws.amazon.com/general/latest/gr/index.html',
+                'https://docs.aws.amazon.com/general/latest/gr/',
+            ),
         ],
     )
     def test_cosmetic_url_differences_are_not_a_redirect(self, requested, landed):
-        """Scheme, fragment, trailing slash and host case do not make it another page."""
+        """Scheme, fragment, host case and path spelling do not make it another page."""
         response = MagicMock()
         response.history = [MagicMock()]
         response.url = landed
         assert _describe_redirect(requested, response) is None
+
+    @pytest.mark.asyncio
+    async def test_cosmetic_path_rewrite_returns_the_content(self):
+        """A slash-normalizing redirect must not turn a good page into a failure."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        url = 'https://docs.aws.amazon.com/general/latest/gr//ddb.html'
+        patcher = self._client_for(
+            self._redirected_response(
+                '<html><body><main><p>DynamoDB endpoints and quotas.</p></main></body></html>',
+                landed='https://docs.aws.amazon.com/general/latest/gr/ddb.html',
+            )
+        )
+        try:
+            result = await read_documentation_impl(ctx, url, 5000, 0, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'redirected to' not in result
+        assert 'DynamoDB endpoints and quotas.' in result
 
     @pytest.mark.asyncio
     async def test_read_documentation_flags_redirect_that_carried_content(self):
@@ -1433,3 +1464,155 @@ class TestRedirectSignal:
                 await read_sections_impl(ctx, url, ['Service endpoints'], 'test-uuid')
         finally:
             patcher.stop()
+
+
+class TestRedirectToDeadPage:
+    """A page that moved and whose target now fails is the case the signal exists for."""
+
+    def _dead_redirect_response(self):
+        """Build a 404 that arrived via a redirect to another page."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = 'Not found'
+        mock_response.headers = {'content-type': 'text/html'}
+        mock_response.history = [MagicMock()]
+        mock_response.url = 'https://docs.aws.amazon.com/general/latest/gr/'
+        return mock_response
+
+    def _client_for(self, mock_response):
+        """Patch httpx.AsyncClient so a fetch returns the given response."""
+        patcher = patch('httpx.AsyncClient')
+        mock_client_class = patcher.start()
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+        return patcher
+
+    URL = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+
+    @pytest.mark.asyncio
+    async def test_read_documentation_status_error_names_the_redirect(self):
+        """A 404 reached by redirect says where the request landed, not just the status."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        patcher = self._client_for(self._dead_redirect_response())
+        try:
+            result = await read_documentation_impl(ctx, self.URL, 5000, 0, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'status code 404' in result
+        assert 'redirected to' in result
+        assert 'general/latest/gr/' in result
+
+    @pytest.mark.asyncio
+    async def test_read_sections_status_error_names_the_redirect(self):
+        """read_sections reports the redirect on a failing status too."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        patcher = self._client_for(self._dead_redirect_response())
+        try:
+            result = await read_sections_impl(ctx, self.URL, ['Service endpoints'], 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'status code 404' in result
+        assert 'redirected to' in result
+
+    @pytest.mark.asyncio
+    async def test_search_table_status_error_names_the_redirect(self):
+        """search_table reports the redirect on a failing status too."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        patcher = self._client_for(self._dead_redirect_response())
+        try:
+            result = await search_table_impl(ctx, self.URL, None, 'us-east-1', 50, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert result.error is not None
+        assert 'status code 404' in result.error
+        assert 'redirected to' in result.error
+
+    @pytest.mark.asyncio
+    async def test_status_error_without_redirect_is_unchanged(self):
+        """A plain 404 keeps its original message."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        response = self._dead_redirect_response()
+        response.history = []
+        response.url = self.URL
+        patcher = self._client_for(response)
+        try:
+            result = await read_documentation_impl(ctx, self.URL, 5000, 0, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert result == f'Failed to fetch {self.URL} - status code 404'
+
+
+class TestRedirectOnNonHtmlContent:
+    """Non-HTML bodies take their own early return, which must carry the redirect too."""
+
+    def _redirected_non_html(self):
+        """Build a 200 plain-text response that arrived via a redirect to another page."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = 'plain text, not a document'
+        mock_response.headers = {'content-type': 'text/plain'}
+        mock_response.history = [MagicMock()]
+        mock_response.url = 'https://docs.aws.amazon.com/general/latest/gr/'
+        return mock_response
+
+    def _client_for(self, mock_response):
+        """Patch httpx.AsyncClient so a fetch returns the given response."""
+        patcher = patch('httpx.AsyncClient')
+        mock_client_class = patcher.start()
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+        return patcher
+
+    URL = 'https://docs.aws.amazon.com/general/latest/gr/dynamodb.html'
+
+    @pytest.mark.asyncio
+    async def test_read_sections_non_html_names_the_redirect(self):
+        """The non-HTML message does not hide that the page moved."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        patcher = self._client_for(self._redirected_non_html())
+        try:
+            result = await read_sections_impl(ctx, self.URL, ['Service endpoints'], 'test-uuid')
+        finally:
+            patcher.stop()
+        assert 'non-HTML content' in result
+        assert 'redirected to' in result
+
+    @pytest.mark.asyncio
+    async def test_search_table_non_html_names_the_redirect(self):
+        """The non-HTML hint does not hide that the page moved."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        patcher = self._client_for(self._redirected_non_html())
+        try:
+            result = await search_table_impl(ctx, self.URL, None, 'us-east-1', 50, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert result.hint is not None
+        assert 'not HTML' in result.hint
+        assert 'redirected to' in result.hint
+
+    @pytest.mark.asyncio
+    async def test_non_html_without_redirect_is_unchanged(self):
+        """A directly fetched non-HTML page keeps its original hint."""
+        ctx = MagicMock(spec=Context)
+        ctx.error = AsyncMock()
+        response = self._redirected_non_html()
+        response.history = []
+        response.url = self.URL
+        patcher = self._client_for(response)
+        try:
+            result = await search_table_impl(ctx, self.URL, None, 'us-east-1', 50, 'test-uuid')
+        finally:
+            patcher.stop()
+        assert result.hint == 'Page content is not HTML. Use read_documentation to view this page.'

--- a/src/aws-documentation-mcp-server/tests/test_table_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_table_utils.py
@@ -1497,8 +1497,7 @@ class TestSingleRowTheadMultiValueHeaders:
 class TestBreakMarkersDoNotLeak:
     """Cell processing mutates the shared tree, so markers must not surface in headings."""
 
-    # A heading living inside an earlier table's cell is marked up when that cell is
-    # parsed, and is then read as the next table's heading.
+    # A heading inside an earlier table's cell is marked up when that cell is parsed.
     _HEADING_IN_A_CELL = """<html><body>
     <table><tbody><tr><td><h3><p>Alpha</p><p>Beta</p></h3></td></tr></tbody></table>
     <table><thead><tr><th>Region</th></tr></thead>
@@ -1554,3 +1553,76 @@ class TestCellLinkTargets:
         assert '[Nova Lite](./nova-lite.html)' in cell
         assert 'Nova Pro' in cell
         assert './.html' not in cell
+
+
+class TestCalloutsInsideCells:
+    """A note inside a cell qualifies the cell's value; it is not another value."""
+
+    _QUOTA_WITH_NOTE = """<html><body>
+    <table><thead><tr><th>Resource</th><th>Quota</th></tr></thead>
+    <tbody><tr><td>File descriptors</td><td>
+        <p>1,024</p>
+        <div class="awsdocs-note">
+            <div class="awsdocs-note-title"><h6>Note</h6></div>
+            <div class="awsdocs-note-text"><p>Managed instances allow 4,096.</p></div>
+        </div>
+    </td></tr></tbody></table>
+    </body></html>"""
+
+    def test_callout_label_is_not_a_value(self):
+        """The word 'Note' is callout chrome and never appears as cell content."""
+        result = parse_html_tables(self._QUOTA_WITH_NOTE, None)
+        assert result is not None
+        assert result['tables'][0]['rows'][0]['Quota'] == '1,024 Managed instances allow 4,096.'
+
+    def test_callout_does_not_create_a_delimited_value(self):
+        """The quota reads as one value, so splitting on '; ' yields a single entry."""
+        result = parse_html_tables(self._QUOTA_WITH_NOTE, None)
+        assert result is not None
+        assert result['tables'][0]['rows'][0]['Quota'].split('; ') == [
+            '1,024 Managed instances allow 4,096.'
+        ]
+
+    def test_genuine_values_still_delimited_when_a_callout_follows(self):
+        """A callout does not suppress the boundaries between real values."""
+        html = """<html><body>
+        <table><thead><tr><th>Endpoint</th></tr></thead>
+        <tbody><tr><td>
+            <p>a.example.com</p><p>b.example.com</p>
+            <div class="awsdocs-note">
+                <div class="awsdocs-note-title"><h6>Note</h6></div>
+                <div class="awsdocs-note-text"><p>FIPS only.</p></div>
+            </div>
+        </td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        values = result['tables'][0]['rows'][0]['Endpoint'].split('; ')
+        assert values == ['a.example.com', 'b.example.com FIPS only.']
+
+    def test_callout_handled_on_the_link_preserving_path(self):
+        """A cell containing links takes a different extraction path with the same rules."""
+        html = """<html><body>
+        <table><thead><tr><th>Quota</th></tr></thead>
+        <tbody><tr><td>
+            <p>1,024</p>
+            <div class="awsdocs-note">
+                <div class="awsdocs-note-title"><h6>Note</h6></div>
+                <div class="awsdocs-note-text"><p>See <a href="./limits.html">limits</a>.</p></div>
+            </div>
+        </td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        cell = result['tables'][0]['rows'][0]['Quota']
+        assert 'Note' not in cell
+        assert '[limits](./limits.html)' in cell
+        assert cell.split('; ') == [cell]
+
+    def test_soft_markers_never_reach_the_output(self):
+        """The internal soft boundary marker is replaced, never emitted."""
+        result = parse_html_tables(self._QUOTA_WITH_NOTE, None)
+        assert result is not None
+        for value in result['tables'][0]['rows'][0].values():
+            assert '\x01' not in value
+            assert '\x00' not in value

--- a/src/aws-documentation-mcp-server/tests/test_table_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_table_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for large table handling in the AWS Documentation MCP Server."""
 
+import pytest
 from awslabs.aws_documentation_mcp_server.table_utils import (
     filter_table_rows,
     parse_html_tables,
@@ -606,6 +607,157 @@ class TestCellToText:
         assert result is not None
         cell_val = result['rows'][0]['Name']
         assert cell_val == '[Link](/x)'
+
+
+class TestBreakDelimitedCells:
+    """Tests for multi-value cells separated by <br /> or block elements."""
+
+    def test_multi_value_cell_joined_with_delimiter(self):
+        """A cell with <br />-separated values joins them with '; '."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Endpoint</th></tr></thead>
+        <tbody><tr><td>s3.us-east-1.amazonaws.com <br /> s3.dualstack.us-east-1.amazonaws.com
+        <br /> s3-fips.us-east-1.amazonaws.com <br /> s3-fips.dualstack.us-east-1.amazonaws.com</td>
+        </tr></tbody></table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Endpoint'] == (
+            's3.us-east-1.amazonaws.com; '
+            's3.dualstack.us-east-1.amazonaws.com; '
+            's3-fips.us-east-1.amazonaws.com; '
+            's3-fips.dualstack.us-east-1.amazonaws.com'
+        )
+
+    def test_adjacent_columns_stay_positionally_aligned(self):
+        """Two multi-value columns split into the same number of aligned values."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Endpoint</th><th>Protocol</th></tr></thead>
+        <tbody><tr>
+            <td>a.example.com<br />b.example.com<br />c.example.com<br />d.example.com</td>
+            <td>HTTP and HTTPS<br />HTTP and HTTPS<br />HTTPS<br />HTTPS</td>
+        </tr></tbody></table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        row = result['rows'][0]
+        endpoints = row['Endpoint'].split('; ')
+        protocols = row['Protocol'].split('; ')
+        assert len(endpoints) == len(protocols) == 4
+        assert dict(zip(endpoints, protocols))['c.example.com'] == 'HTTPS'
+
+    def test_br_spelling_variants(self):
+        """<br />, <br/> and <br> are all treated as value boundaries."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Values</th></tr></thead>
+        <tbody><tr><td>one <br /> two <br/> three <br> four</td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Values'] == 'one; two; three; four'
+
+    def test_consecutive_and_trailing_breaks_produce_no_empty_segments(self):
+        """Doubled, leading and trailing <br /> never yield empty '; ' segments."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Signature</th></tr></thead>
+        <tbody><tr><td>2 &amp; 4<br /><br /><br /></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Signature'] == '2 & 4'
+
+    def test_interior_consecutive_breaks_collapse(self):
+        """Consecutive <br /> between two values collapse to a single delimiter."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Values</th></tr></thead>
+        <tbody><tr><td><br />first<br /><br />second<br /></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Values'] == 'first; second'
+
+    def test_single_value_cell_unchanged(self):
+        """A cell holding one value is byte-identical to the undelimited output."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Endpoint</th><th>Protocol</th></tr></thead>
+        <tbody><tr><td>s3-website.us-gov-east-1.amazonaws.com</td><td>HTTP</td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        row = result['rows'][0]
+        assert row['Endpoint'] == 's3-website.us-gov-east-1.amazonaws.com'
+        assert row['Protocol'] == 'HTTP'
+
+    def test_inline_markup_does_not_introduce_delimiters(self):
+        """Inline tags inside a single value are not treated as boundaries."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Note</th></tr></thead>
+        <tbody><tr><td>Use <code>foo</code> here</td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Note'] == 'Usefoohere'
+
+    def test_multi_value_cell_with_links(self):
+        """<br />-separated links each render as markdown and stay separated."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Docs</th></tr></thead>
+        <tbody><tr><td><a href="/a">Alpha</a><br /><a href="/b">Beta</a></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Docs'] == '[Alpha](/a); [Beta](/b)'
+
+    def test_multi_value_cell_mixing_links_and_prose(self):
+        """A cell alternating prose and links keeps each value on its own segment."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Docs</th></tr></thead>
+        <tbody><tr><td>See <a href="/a">Alpha</a><br />plain value<br />
+        <a href="/b">Beta</a></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        segments = result['rows'][0]['Docs'].split('; ')
+        assert segments == ['See [Alpha](/a)', 'plain value', '[Beta](/b)']
+
+    def test_break_inside_link_text_does_not_break_markdown(self):
+        """A <br /> inside link text stays inside the markdown label."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Docs</th></tr></thead>
+        <tbody><tr><td><a href="/a">Alpha<br />Beta</a></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Docs'] == '[Alpha; Beta](/a)'
+
+    def test_no_marker_leaks_into_output(self):
+        """The internal boundary marker never appears in returned values."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>A</th><th>B</th></tr></thead>
+        <tbody><tr><td><p>one</p><p>two</p></td><td>x<br /><a href="/y">y</a></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        for value in result['rows'][0].values():
+            assert '\x00' not in str(value)
+
+    def test_block_elements_are_value_boundaries(self):
+        """Sibling block elements in one cell are joined rather than fused."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Values</th></tr></thead>
+        <tbody><tr><td><p>first</p><p>second</p></td></tr></tbody>
+        </table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert result['rows'][0]['Values'] == 'first; second'
+
+    def test_multi_value_cell_is_searchable_by_filter(self):
+        """filter_table_rows still matches tokens inside a delimited cell."""
+        html = """<html><body><h2>Sec</h2><table>
+        <thead><tr><th>Endpoint</th></tr></thead>
+        <tbody><tr><td>s3.us-east-1.amazonaws.com<br />s3-fips.us-east-1.amazonaws.com</td></tr>
+        </tbody></table></body></html>"""
+        result = parse_html_tables(html, 'Sec')
+        assert result is not None
+        assert filter_table_rows(result['rows'], 's3-fips.us-east-1.amazonaws.com')
 
 
 class TestTwoTierHeaders:
@@ -1213,3 +1365,154 @@ class TestMaxRowsCapping:
         matches = filter_table_rows(rows, 'RunInstances')
         assert len(matches) == 1
         assert matches[0]['Action'] == 'RunInstances'
+
+
+class TestCalloutHeadingsSkipped:
+    """table_heading came from an adjacent callout."""
+
+    @pytest.mark.parametrize(
+        'callout_class',
+        [
+            'awsdocs-note',
+            'awsdocs-note awsdocs-tip',
+            'awsdocs-note awsdocs-warning',
+            'awsdocs-note awsdocs-important',
+            'awsdocs-tip',
+            'awsdocs-warning',
+            'awsdocs-important',
+        ],
+    )
+    def test_every_callout_variant_skipped(self, callout_class):
+        """Each callout flavour AWS docs emit is skipped, however its div is classed."""
+        html = f"""<html><body>
+        <h2>Real heading</h2>
+        <div class="{callout_class}">
+            <div class="awsdocs-note-title"><h6>Note</h6></div>
+            <p>Advice.</p>
+        </div>
+        <table><thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>Quota</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['table_heading'] == 'Real heading'
+
+    def test_deeply_nested_callout_heading_skipped(self):
+        """A callout title several levels below the classed div is still recognised."""
+        html = """<html><body>
+        <h2>Real heading</h2>
+        <div class="awsdocs-note">
+            <div><section><div><h6>Note</h6></div></section></div>
+        </div>
+        <table><thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>Quota</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['table_heading'] == 'Real heading'
+
+    def test_callout_title_not_used_as_table_heading(self):
+        """A <h6> inside a note/tip callout is skipped in favour of the real heading."""
+        html = """<html><body>
+        <h2>Amazon Bedrock service quotas</h2>
+        <div class="awsdocs-note awsdocs-tip">
+            <div class="awsdocs-note-title"><h6>Tip</h6></div>
+            <p>Some advice.</p>
+        </div>
+        <table><thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>Quota</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['table_heading'] == 'Amazon Bedrock service quotas'
+
+    def test_legitimate_subheading_still_used(self):
+        """A normal h4 outside a callout remains the table_heading."""
+        html = """<html><body>
+        <h2>Section</h2>
+        <h4>Control plane APIs</h4>
+        <table><thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>Quota</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['table_heading'] == 'Control plane APIs'
+
+    def test_all_headings_in_callouts_falls_back_to_none(self):
+        """When every preceding heading is a callout title, table_heading is None."""
+        html = """<html><body>
+        <div class="awsdocs-note"><div class="awsdocs-note-title"><h6>Note</h6></div></div>
+        <table><thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>Quota</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['table_heading'] is None
+
+
+class TestSingleRowTheadMultiValueHeaders:
+    """Multi-value headers in the single-row <thead> path."""
+
+    def test_break_in_single_row_header_delimited(self):
+        """A <br /> inside a single-row <thead> cell is delimited, not fused."""
+        html = """<html><body>
+        <table><thead><tr><th>Endpoint<br />Protocol</th><th>Region</th></tr></thead>
+        <tbody><tr><td>a</td><td>b</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['columns'] == ['Endpoint; Protocol', 'Region']
+
+    def test_block_elements_in_single_row_header_delimited(self):
+        """Sibling <p> values in a single-row <thead> cell are delimited, not fused."""
+        html = """<html><body>
+        <table><thead><tr><th><p>Quota name</p><p>Adjustable</p></th></tr></thead>
+        <tbody><tr><td>a</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['columns'] == ['Quota name; Adjustable']
+
+    def test_colspan_suffixes_use_delimited_text(self):
+        """A colspan header carries the delimited text into its generated suffixes."""
+        html = """<html><body>
+        <table><thead><tr><th colspan="2">Endpoint<br />Protocol</th></tr></thead>
+        <tbody><tr><td>a</td><td>b</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['columns'] == ['Endpoint; Protocol', 'Endpoint; Protocol_2']
+
+    def test_header_link_text_delimited_without_markdown(self):
+        """Header cells take text only, so a link inside one contributes just its text."""
+        html = """<html><body>
+        <table><thead><tr><th><a href="./e.html">Endpoint</a><br />Protocol</th></tr></thead>
+        <tbody><tr><td>a</td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['columns'] == ['Endpoint; Protocol']
+
+
+class TestBreakMarkersDoNotLeak:
+    """Cell processing mutates the shared tree, so markers must not surface in headings."""
+
+    # A heading living inside an earlier table's cell is marked up when that cell is
+    # parsed, and is then read as the next table's heading.
+    _HEADING_IN_A_CELL = """<html><body>
+    <table><tbody><tr><td><h3><p>Alpha</p><p>Beta</p></h3></td></tr></tbody></table>
+    <table><thead><tr><th>Region</th></tr></thead>
+    <tbody><tr><td>us-east-1</td></tr></tbody></table>
+    </body></html>"""
+
+    def test_marker_absent_from_table_heading(self):
+        """table_heading is joined, so no marker reaches the caller."""
+        result = parse_html_tables(self._HEADING_IN_A_CELL, None)
+        assert result is not None
+        assert result['tables'][1]['table_heading'] == 'Alpha; Beta'
+
+    def test_marker_absent_from_detected_section(self):
+        """detected_section is read after cells are marked, so it is joined too."""
+        result = parse_html_tables(self._HEADING_IN_A_CELL, None)
+        assert result is not None
+        assert result['detected_section'] == 'Alpha; Beta'

--- a/src/aws-documentation-mcp-server/tests/test_table_utils.py
+++ b/src/aws-documentation-mcp-server/tests/test_table_utils.py
@@ -1516,3 +1516,41 @@ class TestBreakMarkersDoNotLeak:
         result = parse_html_tables(self._HEADING_IN_A_CELL, None)
         assert result is not None
         assert result['detected_section'] == 'Alpha; Beta'
+
+
+class TestCellLinkTargets:
+    """A cell link to an empty target must not be emitted as markdown."""
+
+    def test_broken_cell_link_renders_as_plain_text(self):
+        """An href with no filename keeps its text and drops the markdown link."""
+        html = """<html><body>
+        <table><thead><tr><th>Model</th></tr></thead>
+        <tbody><tr><td><a href="./.html#nova">Nova Pro</a></td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['rows'][0]['Model'] == 'Nova Pro'
+
+    def test_valid_cell_link_still_markdown(self):
+        """A resolvable cell link is still emitted as [text](href)."""
+        html = """<html><body>
+        <table><thead><tr><th>Model</th></tr></thead>
+        <tbody><tr><td><a href="./nova.html">Nova Pro</a></td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        assert result['tables'][0]['rows'][0]['Model'] == '[Nova Pro](./nova.html)'
+
+    def test_broken_and_valid_links_in_one_cell(self):
+        """Only the unresolvable link loses its markdown; the other survives."""
+        html = """<html><body>
+        <table><thead><tr><th>Model</th></tr></thead>
+        <tbody><tr><td><a href="./.html">Nova Pro</a> and
+        <a href="./nova-lite.html">Nova Lite</a></td></tr></tbody></table>
+        </body></html>"""
+        result = parse_html_tables(html, None)
+        assert result is not None
+        cell = result['tables'][0]['rows'][0]['Model']
+        assert '[Nova Lite](./nova-lite.html)' in cell
+        assert 'Nova Pro' in cell
+        assert './.html' not in cell

--- a/src/aws-documentation-mcp-server/tests/test_util.py
+++ b/src/aws-documentation-mcp-server/tests/test_util.py
@@ -22,6 +22,7 @@ from awslabs.aws_documentation_mcp_server.util import (
     extract_content_from_html,
     extract_sections_from_html,
     format_documentation_result,
+    has_empty_link_target,
     is_html_content,
     parse_recommendation_results,
     url_matches_allowlist,
@@ -867,3 +868,85 @@ class TestExtractSectionsFromHtml:
         assert '<h2>Main Section</h2>' in result
         assert 'First main content' in result
         assert 'Second main content' in result  # Should include both matching sections
+
+
+class TestEmptyLinkTargets:
+    """An unresolved cross-reference became a link to nowhere."""
+
+    @pytest.mark.parametrize(
+        'href',
+        [
+            './.html#cross-region-ip-apac.amazon.nova-pro-v1:0',
+            './.html',
+            '.html',
+            '/bedrock/latest/userguide/.html',
+            '.htm',
+            './.HTML',
+            './.html?highlight=x',
+            '//docs.aws.amazon.com/.html',
+            '  ./.html  ',
+        ],
+    )
+    def test_empty_targets_detected(self, href):
+        """An href whose filename portion is empty is reported as broken."""
+        assert has_empty_link_target(href) is True
+
+    @pytest.mark.parametrize(
+        'href',
+        [
+            './models-region-compatibility.html',
+            'https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html',
+            '#in-page-anchor',
+            '',
+            '/bedrock/latest/userguide/',
+            'endpoints.html#section',
+            'foo/.',  # a directory reference, not a missing filename
+            '..',
+            './',
+            'mailto:someone@example.com',
+            'javascript:void(0)',
+        ],
+    )
+    def test_valid_targets_untouched(self, href):
+        """Ordinary hrefs, directory links and fragment-only links are left alone."""
+        assert has_empty_link_target(href) is False
+
+    def test_broken_link_becomes_plain_text(self):
+        """The link is dropped and its text kept, rather than emitting './.html'."""
+        html = """<html><body><main>
+        <p>Use the <a href="./.html#cross-region-ip-apac">APAC Nova Pro inference profile</a>.</p>
+        </main></body></html>"""
+        result = extract_content_from_html(html)
+        assert 'APAC Nova Pro inference profile' in result
+        assert '.html' not in result
+        assert '](' not in result
+
+    def test_valid_link_still_rendered(self):
+        """A resolvable link in the same paragraph is still emitted as markdown."""
+        html = """<html><body><main>
+        <p>See <a href="./quotas.html">Quotas</a> and <a href="./.html">Nothing</a>.</p>
+        </main></body></html>"""
+        result = extract_content_from_html(html)
+        assert '](./quotas.html' in result
+        assert 'Nothing' in result
+        assert './.html' not in result
+
+
+class TestLinkTitlesNotDuplicated:
+    """A link title that merely repeats the href spends the read budget for nothing."""
+
+    def test_href_not_repeated_as_title(self):
+        """Links render as [text](url), not [text](url "url")."""
+        html = """<html><body><main>
+        <p>See <a href="./quotas.html">Quotas</a>.</p>
+        </main></body></html>"""
+        result = extract_content_from_html(html)
+        assert '[Quotas](./quotas.html)' in result
+
+    def test_authored_title_preserved(self):
+        """A title the page actually authored is still emitted."""
+        html = """<html><body><main>
+        <p>See <a href="./quotas.html" title="Service quotas">Quotas</a>.</p>
+        </main></body></html>"""
+        result = extract_content_from_html(html)
+        assert '[Quotas](./quotas.html "Service quotas")' in result


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

Five correctness fixes in the AWS Documentation MCP Server's HTML-to-markdown read path. All
five were found by reading real `docs.aws.amazon.com` pages through the server and comparing
the output to the rendered page. No API, tool signature, or configuration changes.

### Changes

**1. Multi-value table cells were fused into one string.** `search_table` extracted cell text
with `get_text(strip=True)`, which drops the boundaries between sibling elements. A cell
listing two endpoints came back as `sts.ap-southeast-4.amazonaws.comsts.ap-southeast-4.api.aws`
and the matching protocol cell as `HTTPSHTTPS`. On the pages checked the values are `<p>`
siblings rather than `<br />`, so both are now handled, along with the other block-level tags
that appear inside cells. Values are joined with `; `, which keeps the Nth value in one column
aligned with the Nth value in the next — the alignment is what makes an endpoint table usable.

A note or important callout inside a cell is the one block boundary that does *not* introduce a
value: it qualifies the value it follows. On a quotas page, delimiting it produced
`6,144 characters.; Note; IAM doesn't count white space…` — a two-item list where there is one
value, with the callout's own label as a phantom entry. Callout labels are dropped and callout
prose is joined with a space instead, so that cell now reads
`The size of each managed policy can't exceed 6,144 characters. IAM doesn't count white space…`.

**2. `table_heading` was taken from a callout title.** The heading for a table was resolved with
`find_previous` over `h1`–`h6`. AWS docs pages give note, tip, and important callouts their own
`<h6>` title, so a callout sitting between a section heading and its table won the search and the
table was labeled with the callout's title instead of its section. Callout titles are now skipped
when walking backwards. This also fixes `detected_section` in the same way.

**3. Links whose target has no filename rendered as working links.** Some published pages carry
an anchor whose href has a path but no filename (`./.html#some-anchor`). Those were emitted as
ordinary markdown links, so an agent following one gets a 404 while the output gave no hint the
link was broken. They are now unwrapped to their own text, in both the document read path and
inside table cells.

**4. A page that redirected elsewhere was reported as missing content.** Redirects were already
followed, and every hop was already re-validated against the domain allowlist — so this is not a
"redirects are not followed" bug. The defect is in reporting. A documentation page that no longer
resolves is redirected to its guide's directory index, which is a JavaScript shell with no
extractable prose. That produced three different wrong answers:

- `search_table` returned `{"tables_searched": 0, "hint": "No tables found on this page."}` — a
  confident false statement. The page named in the response does have tables; the page actually
  served does not. This is the worst of the three, because the caller has no reason to doubt it.
- `read_documentation` returned its generic "could not be simplified from HTML" error, which
  reads as "this page is empty" rather than "this is not the page you asked for."
- When the redirect target *did* have prose, that prose was returned under the requested URL with
  nothing marking the substitution — so an agent would cite page A while holding text from page B.

The behaviour is easy to reproduce with `curl -sI`: a request for a path that is not a page in a
guide is answered with a 302 to that guide's index, not a 404. So

```
GET /service-authorization/latest/reference/list_not-a-real-page.html
  -> 302 /service-authorization/latest/reference/     (a script shell, no tables)
```

and `search_table` on that URL reported `"No tables found on this page."` That statement is
literally true of the page it was served and false of the page it names, and a caller has no way
to tell which it means. The stakes are set by what a correct request returns: the EC2 entry in
that guide is `list_ec2.html` and carries five tables. A caller that gets the page name slightly
wrong was told the tables do not exist.

All three cases now carry a note naming the URL requested, the URL actually served, and the
suggestion to try the redirect target or search for the topic. The note is also emitted when the
redirect target itself fails — a page that moved and whose old URL now 404s is precisely the case
the signal exists for, and reporting only the status code loses it.

Legitimate renames are reported too, and that is deliberate:
`/AmazonCloudWatch/latest/monitoring/CloudWatch_Alarms.html` is the correct successor to
`AlarmThatSendsEmail.html`, but an agent that requested the latter must not cite it as the former.
Multi-hop chains are covered, because the comparison is between the requested URL and the final
one rather than any single hop.

Cosmetic differences are not treated as redirects: scheme, host case, fragment, the session query
string the server appends, and path spelling. That last one matters — a request whose path has a
doubled slash, or which names a directory index explicitly, is rewritten by the docs site to the
canonical form, and reporting that as a rename would attach a warning to a page that is exactly
the one that was asked for.

**5. Every link repeated its own URL as a title.** `markdownify` was called with
`default_title=True`, which renders `[text](url "url")` for every anchor that has no authored
title. On the pages checked this duplication was 4–10% of total read output — about 43 KB of
457 KB on the Bedrock user guide page. Since `read_documentation` is bounded by `max_length`,
that is 4–10% of the caller's budget spent restating hrefs. Set to `False`; authored titles are
still emitted. `autolinks` is set to `False` at the same time: `markdownify` gates its autolink
shortcut on `not default_title`, so that option had been dead code, and turning it on with this
change would have silently switched bare links from `[url](url)` to `<url>`.

### User experience

`search_table` on the AWS General Reference STS endpoints table, before:

```json
{"Region": "ap-southeast-4", "Endpoint": "sts.ap-southeast-4.amazonaws.comsts.ap-southeast-4.api.aws", "Protocol": "HTTPSHTTPS"}
```

after:

```json
{"Region": "ap-southeast-4", "Endpoint": "sts.ap-southeast-4.amazonaws.com; sts.ap-southeast-4.api.aws", "Protocol": "HTTPS; HTTPS"}
```

`table_heading` for a table preceded by a note callout, before `"Note"`, after the section
heading the table actually belongs to.

An href with no filename, before `[Cross-region inference](./.html#cross-region-ip-apac...)`
(a link that 404s), after `Cross-region inference` as plain text.

`search_table` on a page that redirects to its guide index, before:

```json
{"tables_searched": 0, "results": [], "hint": "No tables found on this page."}
```

after:

```json
{"tables_searched": 0, "results": [],
 "hint": "No tables found. https://docs.aws.amazon.com/service-authorization/latest/reference/list_not-a-real-page.html redirected to https://docs.aws.amazon.com/service-authorization/latest/reference/, so this is not the requested page. The page may have been renamed; try the redirect target or search for the topic."}
```

`read_documentation` on the same URL, before — the extractor's generic failure string, or another
page's content presented as the requested page's. After, the response leads with:

```
<e>https://docs.aws.amazon.com/service-authorization/latest/reference/list_not-a-real-page.html
redirected to https://docs.aws.amazon.com/service-authorization/latest/reference/, so this is
not the requested page. The page may have been renamed; try the redirect target or search for
the topic.</e>
```

Link output, before `[Amazon Bedrock](https://docs.aws.amazon.com/bedrock/ "https://docs.aws.amazon.com/bedrock/")`,
after `[Amazon Bedrock](https://docs.aws.amazon.com/bedrock/)`.

Tests: 368 passed, 23 skipped (the skips are `@pytest.mark.live`, gated behind `--run-live`).
Coverage 99% overall, with `server_utils.py` at 100% and `table_utils.py` at 98%. `pyright`
reports 0 errors and 0 warnings on the changed files. New tests were checked by mutation testing —
each new assertion was confirmed to fail when the fix it covers is reverted.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [N/A ] Changes are documented

Is this a breaking change? (Y/N) N

Output formatting changes for callers that were receiving fused or mislabeled values, but no
tool, parameter, response schema, or configuration change. A caller parsing a multi-value cell
by string equality against the fused form would need to split on `; ` instead — that form was
not a documented contract and was not usable data.

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
