### PR TITLE
fix(mysql-mcp-server): bind the pool lock to the running event loop

### DIFF
--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/connection/asyncmy_pool_connection.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/connection/asyncmy_pool_connection.py
@@ -19,6 +19,7 @@ It supports both Aurora MySQL and RDS MySQL instances via direct connection
 parameters (host, port, database, user, password) or via AWS Secrets Manager.
 """
 
+import asyncio
 import asyncmy
 import asyncmy.cursors
 import boto3
@@ -133,7 +134,8 @@ class AsyncmyPoolConnection(AbstractDBConnection):
         self.is_test = is_test
         self.ca_bundle_path = ca_bundle_path
         self.pool: Optional[asyncmy.Pool] = None
-        self.rw_lock = RWLock()
+        self._rw_lock: Optional[RWLock] = None
+        self._rw_lock_loop: Optional[asyncio.AbstractEventLoop] = None
         self.created_time = datetime.now()
 
         if is_iam_auth:
@@ -142,6 +144,23 @@ class AsyncmyPoolConnection(AbstractDBConnection):
             # set pool expiry before IAM auth token expiry of 15 minutes
             self.pool_expiry_min = 14
             logger.info(f'Use IAM auth for user: {db_user}')
+
+    @property
+    def rw_lock(self) -> RWLock:
+        """Reader/writer lock bound to the event loop that is running now.
+
+        aiorwlock binds a lock to the loop that first acquires it and refuses
+        every other loop. The startup self-test in server.py runs under
+        asyncio.run() and the MCP server then starts its own loop, so a lock
+        created once in __init__ made the first real query fail with
+        "is bound to a different event loop". A loop that stopped cannot hold
+        the lock any more, so it is simply re-created for the new loop.
+        """
+        loop = asyncio.get_running_loop()
+        if self._rw_lock is None or self._rw_lock_loop is not loop:
+            self._rw_lock = RWLock()
+            self._rw_lock_loop = loop
+        return self._rw_lock
 
     async def initialize_pool(self):
         """Initialize the connection pool."""

--- a/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
+++ b/src/mysql-mcp-server/awslabs/mysql_mcp_server/server.py
@@ -954,8 +954,9 @@ def main():
 
             if db_connection:
                 ctx = DummyCtx()
-                response = asyncio.run(
-                    run_query(
+
+                async def validate_connection():
+                    response = await run_query(
                         'SELECT 1',
                         ctx,
                         ConnectionMethod[args.connection_method],
@@ -963,7 +964,14 @@ def main():
                         args.db_endpoint,
                         args.database,
                     )
-                )
+                    # asyncio.run() tears this loop down; a connection pool
+                    # created here would be unusable under the loop mcp.run()
+                    # starts next. Release it so the first real query opens
+                    # a fresh pool on the server's own loop.
+                    await db_connection.close()
+                    return response
+
+                response = asyncio.run(validate_connection())
                 if (
                     isinstance(response, list)
                     and len(response) == 1

--- a/src/mysql-mcp-server/tests/test_asyncmy_connector.py
+++ b/src/mysql-mcp-server/tests/test_asyncmy_connector.py
@@ -14,6 +14,7 @@
 
 """Tests for AsyncmyPoolConnection with mocked asyncmy."""
 
+import asyncio
 import pytest
 from awslabs.mysql_mcp_server.connection.asyncmy_pool_connection import AsyncmyPoolConnection
 from datetime import datetime, timedelta
@@ -1116,3 +1117,86 @@ class TestCheckConnectionHealth:
             new=AsyncMock(side_effect=RuntimeError('socket reset')),
         ):
             assert await conn.check_connection_health() is False
+
+
+class TestRwLockFollowsEventLoop:
+    """The reader/writer lock must not outlive the event loop that first used it."""
+
+    def _connection(self):
+        return AsyncmyPoolConnection(
+            host='localhost',
+            port=3306,
+            database='testdb',
+            readonly=True,
+            secret_arn='arn:secret',
+            db_user='',
+            region='us-east-1',
+            is_iam_auth=False,
+            is_test=True,
+        )
+
+    def test_lock_is_recreated_for_a_new_event_loop(self):
+        """A lock bound under one asyncio.run() is replaced for the next loop.
+
+        server.py validates under asyncio.run() and then mcp.run() starts a new
+        loop: the lock bound during validation raised "is bound to a different
+        event loop" on the first real query.
+        """
+        conn = self._connection()
+
+        async def use_lock():
+            async with conn.rw_lock.writer_lock:
+                return conn.rw_lock
+
+        first = asyncio.run(use_lock())
+        second = asyncio.run(use_lock())
+
+        assert first is not second
+
+    def test_lock_is_shared_within_one_event_loop(self):
+        """Within one loop every acquisition sees the same lock object."""
+        conn = self._connection()
+
+        async def use_lock_twice():
+            async with conn.rw_lock.writer_lock:
+                first = conn.rw_lock
+            async with conn.rw_lock.reader_lock:
+                second = conn.rw_lock
+            return first is second
+
+        assert asyncio.run(use_lock_twice()) is True
+
+    @patch(
+        'awslabs.mysql_mcp_server.connection.asyncmy_pool_connection.asyncmy.create_pool',
+        new_callable=AsyncMock,
+    )
+    def test_pool_closed_in_one_loop_is_reinitialized_in_the_next(self, mock_create_pool):
+        """A pool released in the validation loop is re-created in the server loop.
+
+        The startup validation closes its pool before asyncio.run() returns; the
+        server loop then opens a fresh one instead of reusing a dead pool.
+        """
+
+        def make_pool():
+            pool = MagicMock()
+            pool.wait_closed = AsyncMock()
+            return pool
+
+        mock_create_pool.side_effect = lambda **kwargs: make_pool()
+        conn = self._connection()
+
+        async def validate_and_release():
+            await conn.initialize_pool()
+            await conn.close()
+
+        async def first_real_query():
+            await conn.check_expiry()
+            return conn.pool
+
+        asyncio.run(validate_and_release())
+        assert conn.pool is None
+
+        pool = asyncio.run(first_real_query())
+
+        assert pool is not None
+        assert mock_create_pool.call_count == 2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #4620

## Summary

### Changes

With `--connection_method MYSQL_WIRE_PROTOCOL` / `MYSQL_WIRE_IAM_PROTOCOL`, `main()` validates the connection by running `SELECT 1` under `asyncio.run()`. That creates the `asyncmy` pool and binds the `aiorwlock.RWLock` in `AsyncmyPoolConnection` to that temporary loop. `mcp.run()` then starts its own loop, and the first real `run_query` / `get_table_schema` failed inside `check_expiry` with `RWLock ... is bound to a different event loop`, right after the "Successfully validated database connection" log line.

- `AsyncmyPoolConnection.rw_lock` is now a property that re-creates the lock when the running loop changed (a loop that stopped cannot hold it); within one loop it is the same object as before.
- The startup validation closes its pool before `asyncio.run()` returns (`await db_connection.close()` inside the same coroutine), so the first real query opens a fresh pool on the server's loop instead of reusing one attached to the dead loop — the lock fix alone would have turned the `RuntimeError` into a broken pool.

Tests (`tests/test_asyncmy_connector.py`): the lock is re-created across two `asyncio.run()` calls, is shared within one loop, and a pool closed in one loop is re-initialized in the next (`asyncmy.create_pool` mocked, called twice). `pytest tests/test_asyncmy_connector.py tests/test_server.py` → all pass; `ruff check` / `ruff format --check` clean.

### User experience

Before: with wire-protocol connections the server logs a successful validation and then every first query from an MCP client crashes with the event-loop `RuntimeError`.

After: validation still runs at startup; the first query opens the pool on the server's loop and serves normally.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented (no user-facing documentation change; behaviour fix only)

Is this a breaking change? (Y/N) N

**RFC issue number**: n/a

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
