### PR TITLE
fix(aws-iac-mcp-server): handle knowledge search results without url

### DIFF
--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/client/aws_knowledge_client.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/client/aws_knowledge_client.py
@@ -80,8 +80,8 @@ def _parse_search_documentation_result(result: CallToolResult) -> List[Knowledge
         KnowledgeResult(
             rank=item['rank_order'],
             title=item['title'],
-            url=item['url'],
-            context=item['context'],
+            url=item.get('url'),
+            context=item.get('context') or item.get('skill_description') or '',
         )
         for item in raw_results
     ]

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/knowledge_models.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/knowledge_models.py
@@ -22,7 +22,7 @@ class KnowledgeResult:
 
     rank: int
     title: str
-    url: str
+    url: Optional[str]
     context: str
 
 

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/server.py
@@ -334,7 +334,7 @@ async def search_cdk_documentation(query: str) -> str:
         - results: Array with single result containing:
             - rank: Search relevance ranking (1 = most relevant, higher is less relevant)
             - title: Document title or filename
-            - url: Source URL of the document
+            - url: Source URL of the document (may be null for non-document results)
             - context: Full or paginated document content
     - next_step_guidance: If present, suggested next actions to take for answering user query
 
@@ -391,7 +391,7 @@ async def search_cloudformation_documentation(query: str) -> str:
       - results: Array with single result containing:
         - rank: Search relevance ranking (1 = most relevant, higher is less relevant)
         - title: Document title or filename
-        - url: Source URL of the document
+        - url: Source URL of the document (may be null for non-document results)
         - context: Full or paginated document content
     - next_step_guidance: If present, suggested next actions to take for answering user query
 
@@ -459,7 +459,7 @@ async def search_cdk_samples_and_constructs(
       - results: Array with single result containing:
         - rank: Search relevance ranking (1 = most relevant, higher is less relevant)
         - title: Document title or filename
-        - url: Source URL of the document
+        - url: Source URL of the document (may be null for non-document results)
         - context: Full or paginated document content
     - next_step_guidance: If present, suggested next actions to take for answering user query
 

--- a/src/aws-iac-mcp-server/tests/client/test_aws_knowledge_client.py
+++ b/src/aws-iac-mcp-server/tests/client/test_aws_knowledge_client.py
@@ -240,8 +240,36 @@ class TestParseSearchResult:
     def test_missing_required_field_in_item(self):
         """Test handling of search result items missing required fields.
 
-        Verifies that search result items missing required fields like
-        'url' or 'context' are rejected with appropriate error messages.
+        Verifies that search result items missing the required 'title' field
+        are rejected with appropriate error messages.
+        """
+        mock_result = MagicMock()
+        mock_result.is_error = False
+        mock_content = TextContent(
+            type='text',
+            text=json.dumps(
+                {
+                    'content': {
+                        'result': [
+                            {
+                                'rank_order': 1,
+                                # Missing title
+                            }
+                        ]
+                    }
+                }
+            ),
+        )
+        mock_result.content = [mock_content]
+
+        with pytest.raises(KeyError):
+            _parse_search_documentation_result(mock_result)
+
+    def test_item_missing_url_and_context(self):
+        """Test handling of search result items without url or context.
+
+        Verifies that an item with neither field parses with url set to None
+        and context set to an empty string, instead of raising KeyError.
         """
         mock_result = MagicMock()
         mock_result.is_error = False
@@ -263,5 +291,51 @@ class TestParseSearchResult:
         )
         mock_result.content = [mock_content]
 
-        with pytest.raises(KeyError):
-            _parse_search_documentation_result(mock_result)
+        parsed = _parse_search_documentation_result(mock_result)
+
+        assert len(parsed) == 1
+        assert parsed[0].url is None
+        assert parsed[0].context == ''
+
+    def test_mixed_document_and_skill_results(self):
+        """Test parsing a result list with both document and skill items.
+
+        Verifies that skill items (rank_order, title, skill_name,
+        skill_description) parse next to document items. Skill items have no
+        url or context, so url is None and context comes from
+        skill_description.
+        """
+        mock_result = MagicMock()
+        mock_result.is_error = False
+        mock_content = TextContent(
+            type='text',
+            text=json.dumps(
+                {
+                    'content': {
+                        'result': [
+                            {
+                                'rank_order': 1,
+                                'title': 'AWS Lambda',
+                                'url': 'https://docs.aws.amazon.com/lambda/',
+                                'context': 'Serverless compute service',
+                            },
+                            {
+                                'rank_order': 2,
+                                'title': 'lambda-skill',
+                                'skill_name': 'lambda-skill',
+                                'skill_description': 'Guidance for Lambda skill usage',
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+        mock_result.content = [mock_content]
+
+        parsed = _parse_search_documentation_result(mock_result)
+
+        assert len(parsed) == 2
+        assert parsed[0].url == 'https://docs.aws.amazon.com/lambda/'
+        assert parsed[0].context == 'Serverless compute service'
+        assert parsed[1].url is None
+        assert parsed[1].context == 'Guidance for Lambda skill usage'


### PR DESCRIPTION
Fixes #3339
Also fixes #4340

## Summary

### Changes

The AWS Knowledge MCP search can return skill results mixed in with document results. A skill result has `rank_order`, `title`, `skill_name` and `skill_description`, but no `url` or `context`. `_parse_search_documentation_result` read `item['url']` and `item['context']` directly, so one skill result raised `KeyError: 'url'` and the whole search failed.

* `KnowledgeResult.url` is now `Optional[str]`
* The parser uses `item.get('url')`, and `context` falls back to `skill_description`
* The docstrings for the three search tools now say `url` can be null
* Tests cover a mixed document and skill payload, and an item with no url or context. The existing missing-field test now checks that `title` is still required

This takes the same approach as #4076 and #4346, which were closed as stale before anyone reviewed them.

### User experience

Before: `search_cdk_documentation` and `search_cloudformation_documentation` fail with `Error calling tool '...': 'url'` whenever the backend includes a skill result, and the user gets no documentation back.

After: the search returns every result. Skill results come back with `"url": null` and their description as `context`.

To check this against real data, I ran the parser on a live response from the Knowledge MCP endpoint. The query `AWS::Lambda::Function` on the `general` topic currently returns one skill result (`aws-lambda-durable-functions`):

```
# base (2b3e77a5)
live items: 10 | without url: ['aws-lambda-durable-functions']
PARSER RAISED: KeyError 'url'

# this branch
live items: 10 | without url: ['aws-lambda-durable-functions']
parsed OK: 10 results
  url=None item -> aws-lambda-durable-functions | context: Builds resilient, long-running, multi-step applications with AWS Lambda durable
```

When I tried the same queries on the `cdk_docs`, `cloudformation` and `cdk_constructs` topics today, they returned only document results. Whether the tools hit this depends on what the backend sends at the time, and the reports in #3339 and #4340 show it has happened on those topics.

Checks run from `src/aws-iac-mcp-server`: `uv run --frozen pytest` (151 passed), `ruff format --check`, `ruff check`, `pyright`, and pre-commit on the changed files.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
