### PR TITLE
fix(aws-iac): retrieve failed deployment operation events

### DIFF
--- a/src/aws-iac-mcp-server/README.md
+++ b/src/aws-iac-mcp-server/README.md
@@ -90,6 +90,13 @@ Validates against the server's bundled cfn-guard security rules.
 #### troubleshoot_cloudformation_deployment
 Analyzes failed CloudFormation stacks and provides resolution guidance.
 
+When recent operation metadata is available, failed events are retrieved for the
+most recent non-rollback operation, so a successful rollback does not hide the
+deployment failure. Failed rollbacks retain the latest operation so their own
+failures remain visible. Rollback-only metadata uses that rollback operation; stacks
+without operation IDs use the existing stack-name lookup. All event pages are
+included in the analysis.
+
 **Use this tool to:**
 - Diagnose deployment failures with pattern matching against 30+ known cases
 - Get CloudTrail deep links and specific resolution steps

--- a/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/tools/cloudformation_deployment_troubleshooter.py
+++ b/src/aws-iac-mcp-server/awslabs/aws_iac_mcp_server/tools/cloudformation_deployment_troubleshooter.py
@@ -133,10 +133,41 @@ class DeploymentTroubleshooter:
             except self.cfn_client.exceptions.ClientError as e:
                 raise Exception(f'Stack {stack_name} not found or inaccessible: {str(e)}')
 
-            # Get failed events only using new API
-            cloudformation_events = self.cfn_client.describe_events(
-                StackName=stack_name, Filters={'FailedEvents': True}
-            )['OperationEvents']
+            # A successful rollback can be the latest operation even when deployment failed.
+            last_operations = stacks[0].get('LastOperations') or []
+            rollback_failed = str(stacks[0].get('StackStatus', '')).endswith('ROLLBACK_FAILED')
+            operation_id = next(
+                (
+                    op['OperationId']
+                    for op in last_operations
+                    if op.get('OperationId')
+                    and (
+                        rollback_failed
+                        or op.get('OperationType') not in ('ROLLBACK', 'CONTINUE_ROLLBACK')
+                    )
+                ),
+                None,
+            )
+            if operation_id is None:
+                operation_id = next(
+                    (op['OperationId'] for op in last_operations if op.get('OperationId')),
+                    None,
+                )
+
+            event_query: Dict[str, Any] = {'Filters': {'FailedEvents': True}}
+            if operation_id:
+                event_query['OperationId'] = operation_id
+            else:
+                event_query['StackName'] = stack_name
+
+            cloudformation_events = []
+            while True:
+                event_page = self.cfn_client.describe_events(**event_query)
+                cloudformation_events.extend(event_page.get('OperationEvents', []))
+                next_token = event_page.get('NextToken')
+                if not next_token:
+                    break
+                event_query['NextToken'] = next_token
 
             # Match events against known failure patterns
             matched_failures = []

--- a/src/aws-iac-mcp-server/tests/tools/test_cloudformation_deployment_troubleshooter.py
+++ b/src/aws-iac-mcp-server/tests/tools/test_cloudformation_deployment_troubleshooter.py
@@ -15,11 +15,153 @@
 """Tests for deployment_troubleshooter module."""
 
 import json
+import pytest
 from awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter import (
     DeploymentTroubleshooter,
 )
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
+
+
+class TestFailedOperationEvents:
+    """Retrieve the failed deployment, not just its successful rollback."""
+
+    @pytest.mark.parametrize(
+        'operation_type', ['CREATE_STACK', 'UPDATE_STACK', 'CREATE_CHANGESET']
+    )
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_selects_deployment_operation_after_rollback(self, mock_client, operation_type):
+        """A completed rollback must not hide the original resource failure."""
+        cfn = Mock()
+        mock_client.side_effect = [cfn, Mock()]
+        cfn.describe_stacks.return_value = {
+            'Stacks': [
+                {
+                    'StackStatus': 'UPDATE_ROLLBACK_COMPLETE',
+                    'LastOperations': [
+                        {'OperationType': 'CONTINUE_ROLLBACK', 'OperationId': 'continue-id'},
+                        {'OperationType': 'ROLLBACK', 'OperationId': 'rollback-id'},
+                        {'OperationType': operation_type, 'OperationId': 'deployment-id'},
+                    ],
+                }
+            ]
+        }
+        failure = {
+            'EventId': 'failed-resource',
+            'ResourceStatus': 'CREATE_FAILED',
+            'ResourceStatusReason': 'Bucket already exists',
+            'ResourceType': 'AWS::S3::Bucket',
+        }
+        cfn.describe_events.side_effect = lambda **kwargs: {
+            'OperationEvents': [failure] if kwargs.get('OperationId') == 'deployment-id' else []
+        }
+
+        result = DeploymentTroubleshooter().troubleshoot_stack_deployment(
+            'test-stack', include_cloudtrail=False
+        )
+
+        assert result['status'] == 'success'
+        assert result['raw_data']['cloudformation_events'] == [failure]
+        assert result['raw_data']['failed_event_count'] == 1
+        cfn.describe_events.assert_called_once_with(
+            OperationId='deployment-id', Filters={'FailedEvents': True}
+        )
+
+    @pytest.mark.parametrize('last_operations', [[], [{}], [{'OperationType': 'UPDATE_STACK'}]])
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_missing_operation_id_falls_back_to_stack(self, mock_client, last_operations):
+        """Older or incomplete stack metadata keeps the StackName query path."""
+        cfn = Mock()
+        mock_client.side_effect = [cfn, Mock()]
+        cfn.describe_stacks.return_value = {
+            'Stacks': [{'StackStatus': 'CREATE_FAILED', 'LastOperations': last_operations}]
+        }
+        cfn.describe_events.return_value = {'OperationEvents': []}
+
+        result = DeploymentTroubleshooter().troubleshoot_stack_deployment(
+            'test-stack', include_cloudtrail=False
+        )
+
+        assert result['status'] == 'success'
+        cfn.describe_events.assert_called_once_with(
+            StackName='test-stack', Filters={'FailedEvents': True}
+        )
+
+    @pytest.mark.parametrize('operation_type', ['ROLLBACK', 'CONTINUE_ROLLBACK'])
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_failed_rollback_operations_are_paginated(self, mock_client, operation_type):
+        """A failed rollback must not be hidden by the preceding deployment."""
+        cfn = Mock()
+        mock_client.side_effect = [cfn, Mock()]
+        cfn.describe_stacks.return_value = {
+            'Stacks': [
+                {
+                    'StackStatus': 'UPDATE_ROLLBACK_FAILED',
+                    'LastOperations': [
+                        {'OperationType': operation_type, 'OperationId': 'rollback-id'},
+                        {'OperationType': 'UPDATE_STACK', 'OperationId': 'deployment-id'},
+                    ],
+                }
+            ]
+        }
+        cfn.describe_events.side_effect = [
+            {'OperationEvents': [{'EventId': 'one'}], 'NextToken': 'page-two'},
+            {'OperationEvents': [{'EventId': 'two'}]},
+        ]
+
+        result = DeploymentTroubleshooter().troubleshoot_stack_deployment(
+            'test-stack', include_cloudtrail=False
+        )
+
+        assert result['status'] == 'success'
+        assert result['raw_data']['failed_event_count'] == 2
+        assert result['raw_data']['cloudformation_events'] == [
+            {'EventId': 'one'},
+            {'EventId': 'two'},
+        ]
+        assert cfn.describe_events.call_args_list[0].kwargs == {
+            'OperationId': 'rollback-id',
+            'Filters': {'FailedEvents': True},
+        }
+        assert cfn.describe_events.call_args_list[1].kwargs == {
+            'OperationId': 'rollback-id',
+            'Filters': {'FailedEvents': True},
+            'NextToken': 'page-two',
+        }
+
+    @patch(
+        'awslabs.aws_iac_mcp_server.tools.cloudformation_deployment_troubleshooter.get_aws_client'
+    )
+    def test_rollback_only_metadata_uses_rollback_operation(self, mock_client):
+        """A stack exposing no deployment operation still has usable metadata."""
+        cfn = Mock()
+        mock_client.side_effect = [cfn, Mock()]
+        cfn.describe_stacks.return_value = {
+            'Stacks': [
+                {
+                    'StackStatus': 'ROLLBACK_COMPLETE',
+                    'LastOperations': [
+                        {'OperationType': 'ROLLBACK', 'OperationId': 'rollback-id'}
+                    ],
+                }
+            ]
+        }
+        cfn.describe_events.return_value = {'OperationEvents': []}
+
+        result = DeploymentTroubleshooter().troubleshoot_stack_deployment(
+            'test-stack', include_cloudtrail=False
+        )
+
+        assert result['status'] == 'success'
+        cfn.describe_events.assert_called_once_with(
+            OperationId='rollback-id', Filters={'FailedEvents': True}
+        )
 
 
 class TestDeploymentTroubleshooterInit:


### PR DESCRIPTION
Fixes #4275

## Summary

### Changes

Scope failed-event queries to the latest available non-rollback CloudFormation operation instead of implicitly querying the latest successful rollback. Preserve the latest operation when rollback itself has failed, fall back to a rollback-only operation or the existing stack-name query when appropriate, and collect all paginated event responses.

### User experience

Before: an unsuccessful deployment followed by a successful rollback could return an empty failure report. Afterwards: the report includes the original deployment's failed resource events, including subsequent pages. Failed rollbacks remain diagnosable.

## Validation

- Regression tests reproduced the operation-scoping/pagination failures on unchanged production code.
- Troubleshooting test module: 29 passed.
- Full aws-iac-mcp-server suite: 158 passed; 98% package coverage. Three warnings originate from existing proxy deprecation/unawaited-coroutine tests.
- Ruff and changed-production-file Pyright: passed.
- Required pre-commit checks, including secret detection and license headers: passed after the hook normalized README line endings.
- Tested offline with mocked AWS clients; no live AWS deployment was provisioned. Operation selection uses the order returned in `LastOperations`.

## Checklist

- [x] I have reviewed the contributing guidelines
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: Not applicable; focused bug fix for #4275.

## Acknowledgment

This is an AI-assisted contribution submitted as a draft for maintainer review. The code and diff were inspected and the checks above were run; it has not yet received human maintainer review.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
